### PR TITLE
feat: add speaker diarization service using pyannote.audio

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -78,6 +78,7 @@ class DatabaseManager:
                     audio_start_time REAL,
                     audio_end_time REAL,
                     duration REAL,
+                    speaker TEXT,
                     FOREIGN KEY (meeting_id) REFERENCES meetings(id)
                 )
             """)
@@ -95,7 +96,11 @@ class DatabaseManager:
                 cursor.execute("ALTER TABLE transcripts ADD COLUMN duration REAL")
             except sqlite3.OperationalError:
                 pass  # Column already exists
-            
+            try:
+                cursor.execute("ALTER TABLE transcripts ADD COLUMN speaker TEXT")
+            except sqlite3.OperationalError:
+                pass  # Column already exists
+
             # Create summary_processes table (keeping existing functionality)
             cursor.execute("""
                 CREATE TABLE IF NOT EXISTS summary_processes (
@@ -388,20 +393,21 @@ class DatabaseManager:
 
     async def save_meeting_transcript(self, meeting_id: str, transcript: str, timestamp: str,
                                      summary: str = "", action_items: str = "", key_points: str = "",
-                                     audio_start_time: float = None, audio_end_time: float = None, duration: float = None):
-        """Save a transcript for a meeting with optional recording-relative timestamps"""
+                                     audio_start_time: float = None, audio_end_time: float = None,
+                                     duration: float = None, speaker: str = None):
+        """Save a transcript for a meeting with optional recording-relative timestamps and speaker"""
         try:
             with sqlite3.connect(self.db_path) as conn:
                 cursor = conn.cursor()
 
-                # Save transcript with NEW timestamp fields for playback sync
+                # Save transcript with timestamp fields and speaker for playback sync
                 cursor.execute("""
                     INSERT INTO transcripts (
                         meeting_id, transcript, timestamp, summary, action_items, key_points,
-                        audio_start_time, audio_end_time, duration
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        audio_start_time, audio_end_time, duration, speaker
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """, (meeting_id, transcript, timestamp, summary, action_items, key_points,
-                      audio_start_time, audio_end_time, duration))
+                      audio_start_time, audio_end_time, duration, speaker))
 
                 conn.commit()
                 return True
@@ -424,9 +430,9 @@ class DatabaseManager:
                 if not meeting:
                     return None
                 
-                # Get all transcripts for this meeting with NEW timestamp fields
+                # Get all transcripts for this meeting with timestamp fields and speaker
                 cursor = await conn.execute("""
-                    SELECT transcript, timestamp, audio_start_time, audio_end_time, duration
+                    SELECT transcript, timestamp, audio_start_time, audio_end_time, duration, speaker
                     FROM transcripts
                     WHERE meeting_id = ?
                 """, (meeting_id,))
@@ -441,10 +447,10 @@ class DatabaseManager:
                         'id': meeting_id,
                         'text': transcript[0],
                         'timestamp': transcript[1],
-                        # NEW: Recording-relative timestamps for playback sync
                         'audio_start_time': transcript[2],
                         'audio_end_time': transcript[3],
-                        'duration': transcript[4]
+                        'duration': transcript[4],
+                        'speaker': transcript[5]
                     } for transcript in transcripts]
                 }
         except Exception as e:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -62,6 +62,7 @@ class Transcript(BaseModel):
     audio_start_time: Optional[float] = None
     audio_end_time: Optional[float] = None
     duration: Optional[float] = None
+    speaker: Optional[str] = None
 
 class MeetingResponse(BaseModel):
     id: str
@@ -526,7 +527,7 @@ async def save_transcript(request: SaveTranscriptRequest):
         # Save the meeting with folder path (if provided)
         await db.save_meeting(meeting_id, request.meeting_title, folder_path=request.folder_path)
 
-        # Save each transcript segment with NEW timestamp fields for playback sync
+        # Save each transcript segment with timestamp fields and speaker
         for transcript in request.transcripts:
             await db.save_meeting_transcript(
                 meeting_id=meeting_id,
@@ -535,10 +536,10 @@ async def save_transcript(request: SaveTranscriptRequest):
                 summary="",
                 action_items="",
                 key_points="",
-                # NEW: Recording-relative timestamps for audio-transcript synchronization
                 audio_start_time=transcript.audio_start_time,
                 audio_end_time=transcript.audio_end_time,
-                duration=transcript.duration
+                duration=transcript.duration,
+                speaker=transcript.speaker
             )
 
         logger.info("Transcripts saved successfully")

--- a/backend/diarization_service/Dockerfile
+++ b/backend/diarization_service/Dockerfile
@@ -1,0 +1,50 @@
+# Diarization Service Dockerfile
+# Speaker diarization using pyannote.audio + Whisper transcription via whisper.cpp
+
+FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+
+LABEL maintainer="Meetily"
+LABEL description="Speaker diarization service using pyannote.audio"
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    python3.10 \
+    python3-pip \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN groupadd --gid 1000 appuser && \
+    useradd --uid 1000 --gid 1000 --shell /bin/bash --create-home appuser
+
+WORKDIR /app
+
+# Copy requirements first for caching
+COPY requirements.txt /app/requirements.txt
+
+# Install Python dependencies
+RUN pip3 install --no-cache-dir --upgrade pip && \
+    pip3 install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . /app/diarization_service/
+
+# Set ownership
+RUN chown -R appuser:appuser /app
+
+# Switch to non-root user
+USER appuser
+
+# Expose port
+EXPOSE 8179
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:8179/health || exit 1
+
+# Run the service
+CMD ["python3", "-m", "uvicorn", "diarization_service.main:app", "--host", "0.0.0.0", "--port", "8179"]

--- a/backend/diarization_service/__init__.py
+++ b/backend/diarization_service/__init__.py
@@ -1,0 +1,1 @@
+# Diarization Service - Speaker identification for meeting transcription

--- a/backend/diarization_service/audio_utils.py
+++ b/backend/diarization_service/audio_utils.py
@@ -1,0 +1,70 @@
+"""Audio utility functions for format conversion."""
+import subprocess
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class AudioConverter:
+    """Handles audio format conversion using ffmpeg."""
+
+    @staticmethod
+    def convert_to_wav(
+        input_path: str,
+        output_path: str,
+        sample_rate: int = 16000,
+        channels: int = 1
+    ) -> bool:
+        """
+        Convert audio file to WAV format suitable for diarization.
+
+        Args:
+            input_path: Path to input audio file
+            output_path: Path to output WAV file
+            sample_rate: Target sample rate (default 16kHz for pyannote)
+            channels: Number of audio channels (default 1 for mono)
+
+        Returns:
+            True if conversion successful, False otherwise
+        """
+        try:
+            cmd = [
+                "ffmpeg",
+                "-i", input_path,
+                "-ar", str(sample_rate),
+                "-ac", str(channels),
+                "-y",  # Overwrite output
+                output_path
+            ]
+
+            result = subprocess.run(
+                cmd,
+                check=True,
+                capture_output=True,
+                text=True
+            )
+
+            logger.debug(f"Audio conversion successful: {input_path} -> {output_path}")
+            return True
+
+        except subprocess.CalledProcessError as e:
+            logger.error(f"FFmpeg conversion failed: {e.stderr}")
+            return False
+        except FileNotFoundError:
+            logger.error("FFmpeg not found. Please install ffmpeg.")
+            return False
+        except Exception as e:
+            logger.error(f"Audio conversion error: {e}")
+            return False
+
+    @staticmethod
+    def cleanup_temp_file(file_path: str) -> None:
+        """Safely remove a temporary file."""
+        try:
+            if file_path and os.path.exists(file_path):
+                os.remove(file_path)
+                logger.debug(f"Cleaned up temp file: {file_path}")
+        except Exception as e:
+            logger.warning(f"Failed to cleanup temp file {file_path}: {e}")

--- a/backend/diarization_service/config.py
+++ b/backend/diarization_service/config.py
@@ -1,0 +1,56 @@
+"""Configuration for the diarization service."""
+import os
+import torch
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DiarizationConfig:
+    """Configuration for transcription and diarization services."""
+
+    # Whisper.cpp server settings
+    whisper_server_url: str = field(
+        default_factory=lambda: os.getenv("WHISPER_SERVER_URL", "http://localhost:8178")
+    )
+
+    # Pyannote diarization settings
+    diarization_pipeline_name: str = field(
+        default_factory=lambda: os.getenv(
+            "DIARIZATION_PIPELINE",
+            "pyannote/speaker-diarization-3.1"
+        )
+    )
+    hf_auth_token: Optional[str] = field(
+        default_factory=lambda: os.getenv("HF_AUTH_TOKEN", "")
+    )
+
+    # Audio conversion settings (for diarization)
+    audio_convert_sample_rate: int = 16000
+    audio_convert_channels: int = 1
+
+    # Speaker embedding persistence directory (optional, for cross-chunk tracking)
+    speaker_embedding_dir: Optional[str] = field(
+        default_factory=lambda: os.getenv("SPEAKER_EMBEDDING_DIR", "")
+    )
+
+    # Device settings
+    device_str: str = field(init=False)
+
+    def __post_init__(self):
+        """Detect available device after initialization."""
+        if torch.cuda.is_available():
+            self.device_str = "cuda"
+            logger.info("CUDA available - using GPU for diarization")
+        else:
+            self.device_str = "cpu"
+            logger.info("CUDA not available - using CPU for diarization")
+
+        if not self.hf_auth_token:
+            logger.warning(
+                "HF_AUTH_TOKEN not set. Pyannote models require authentication. "
+                "Set HF_AUTH_TOKEN environment variable with your Hugging Face token."
+            )

--- a/backend/diarization_service/diarization.py
+++ b/backend/diarization_service/diarization.py
@@ -1,0 +1,105 @@
+"""Speaker diarization service using pyannote.audio."""
+import logging
+from typing import List, Dict, Any, Optional
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class DiarizationService:
+    """
+    Speaker diarization service using pyannote.audio.
+
+    Identifies different speakers in audio and returns time-stamped speaker turns.
+    """
+
+    def __init__(self, pipeline_name: str, auth_token: Optional[str], device: str = "cpu"):
+        """
+        Initialize the diarization service.
+
+        Args:
+            pipeline_name: Hugging Face model name (e.g., 'pyannote/speaker-diarization-3.1')
+            auth_token: Hugging Face authentication token
+            device: Device to run on ('cuda' or 'cpu')
+        """
+        self.pipeline_name = pipeline_name
+        self.auth_token = auth_token
+        self.device = torch.device(device)
+        self.pipeline = None
+        self._load_pipeline()
+
+    def _load_pipeline(self) -> None:
+        """Load the pyannote diarization pipeline."""
+        try:
+            from pyannote.audio import Pipeline
+
+            logger.info(f"Loading diarization pipeline: {self.pipeline_name}")
+
+            if not self.auth_token:
+                logger.warning(
+                    "No HF auth token provided. Pipeline loading may fail for gated models."
+                )
+
+            # pyannote.audio 3.x uses 'use_auth_token' parameter
+            self.pipeline = Pipeline.from_pretrained(
+                self.pipeline_name,
+                use_auth_token=self.auth_token if self.auth_token else None
+            )
+
+            # Move pipeline to appropriate device
+            if self.device.type == "cuda":
+                self.pipeline = self.pipeline.to(self.device)
+                logger.info("Diarization pipeline moved to GPU")
+
+            logger.info("Diarization pipeline loaded successfully")
+
+        except Exception as e:
+            logger.error(f"Failed to load diarization pipeline: {e}")
+            self.pipeline = None
+
+    @property
+    def is_available(self) -> bool:
+        """Check if diarization pipeline is available."""
+        return self.pipeline is not None
+
+    def get_speaker_turns(self, audio_path: str, num_speakers: Optional[int] = None) -> List[Dict[str, Any]]:
+        """
+        Perform speaker diarization on an audio file.
+
+        Args:
+            audio_path: Path to the audio file (should be WAV 16kHz mono)
+            num_speakers: Optional hint for number of speakers (constrains pyannote output)
+
+        Returns:
+            List of speaker turns with format:
+            [{"speaker": "SPEAKER_00", "start": 0.5, "end": 2.3}, ...]
+        """
+        if not self.is_available:
+            logger.warning("Diarization pipeline not available")
+            return []
+
+        try:
+            logger.info(f"Running diarization on: {audio_path}" +
+                       (f" (num_speakers={num_speakers})" if num_speakers else ""))
+
+            # Run diarization with optional speaker count constraint
+            if num_speakers:
+                diarization_result = self.pipeline(audio_path, num_speakers=num_speakers)
+            else:
+                diarization_result = self.pipeline(audio_path)
+
+            # Extract speaker turns
+            speaker_turns = []
+            for turn, _, speaker_label in diarization_result.itertracks(yield_label=True):
+                speaker_turns.append({
+                    "speaker": speaker_label,
+                    "start": turn.start,
+                    "end": turn.end
+                })
+
+            logger.info(f"Diarization complete: {len(speaker_turns)} speaker turns found")
+            return speaker_turns
+
+        except Exception as e:
+            logger.error(f"Diarization failed: {e}")
+            return []

--- a/backend/diarization_service/main.py
+++ b/backend/diarization_service/main.py
@@ -1,0 +1,325 @@
+"""
+Diarization Service - FastAPI application for transcription with speaker identification.
+
+This service acts as a wrapper around whisper.cpp, adding speaker diarization
+using pyannote.audio. It provides a compatible API for existing clients while
+enriching the output with speaker labels.
+
+Ports:
+    - 8179: This diarization service
+    - 8178: Whisper.cpp server (called internally)
+"""
+import os
+import uuid
+import shutil
+import logging
+from pathlib import Path
+from typing import Optional
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, UploadFile, File, Form, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+from .config import DiarizationConfig
+from .processor import AudioProcessor
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - [%(filename)s:%(lineno)d] - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+logger = logging.getLogger(__name__)
+
+# Global processor instance
+processor: Optional[AudioProcessor] = None
+
+# Temp directory for uploaded files
+UPLOAD_DIR = Path("/tmp/diarization_uploads")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Application lifespan handler - initialize and cleanup resources."""
+    global processor
+
+    logger.info("=" * 60)
+    logger.info("Starting Diarization Service")
+    logger.info("=" * 60)
+
+    # Create upload directory
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    logger.info(f"Upload directory: {UPLOAD_DIR}")
+
+    # Initialize processor
+    try:
+        config = DiarizationConfig()
+        processor = AudioProcessor(config)
+        logger.info("AudioProcessor initialized successfully")
+    except Exception as e:
+        logger.error(f"Failed to initialize AudioProcessor: {e}")
+        # Continue anyway - health endpoint will report degraded status
+
+    logger.info("=" * 60)
+    logger.info("Diarization Service Ready")
+    logger.info("=" * 60)
+
+    yield
+
+    # Cleanup
+    logger.info("Shutting down Diarization Service")
+    if UPLOAD_DIR.exists():
+        try:
+            shutil.rmtree(UPLOAD_DIR)
+            logger.info("Cleaned up upload directory")
+        except Exception as e:
+            logger.warning(f"Failed to cleanup upload directory: {e}")
+
+
+app = FastAPI(
+    title="Diarization Service",
+    description="Transcription with speaker diarization using Whisper + Pyannote",
+    version="1.0.0",
+    lifespan=lifespan
+)
+
+# Configure CORS
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/")
+async def root():
+    """Root endpoint - basic service info."""
+    return {
+        "service": "Diarization Service",
+        "version": "2.0.0",
+        "features": {
+            "speaker_tracking": "Consistent speaker IDs across chunks using embeddings"
+        },
+        "endpoints": {
+            "/health": "Service health check",
+            "/inference": "Transcribe with diarization (pass session_id for cross-chunk tracking)",
+            "/transcribe": "Transcribe with diarization",
+            "/session/{session_id}/speakers": "Get speaker summary for a session",
+            "/session/{session_id}": "DELETE to clear session data"
+        }
+    }
+
+
+@app.get("/health")
+async def health():
+    """Health check endpoint with detailed status."""
+    global processor
+
+    whisper_ok = False
+    diarization_ok = False
+    speaker_tracking_ok = False
+
+    if processor:
+        # Check whisper server
+        whisper_ok = await processor.whisper_client.health_check()
+        diarization_ok = processor.diarization_available
+        speaker_tracking_ok = processor.speaker_tracking_available
+
+    status = "ok" if (whisper_ok and diarization_ok) else (
+        "degraded" if whisper_ok else "error"
+    )
+
+    return {
+        "status": status,
+        "services": {
+            "whisper_server": "ok" if whisper_ok else "unavailable",
+            "diarization": "ok" if diarization_ok else "unavailable",
+            "speaker_tracking": "ok" if speaker_tracking_ok else "unavailable"
+        },
+        "config": {
+            "whisper_url": processor.config.whisper_server_url if processor else None,
+            "diarization_model": processor.config.diarization_pipeline_name if processor else None,
+            "device": processor.config.device_str if processor else None
+        }
+    }
+
+
+@app.post("/inference")
+async def inference(
+    file: UploadFile = File(...),
+    response_format: str = Form("json"),
+    diarize: bool = Form(True),
+    temperature: Optional[str] = Form("0.0"),
+    session_id: Optional[str] = Form(None),
+    num_speakers: Optional[int] = Form(None),
+):
+    """
+    Transcribe audio with optional speaker diarization.
+
+    This endpoint is compatible with the whisper.cpp /inference API,
+    but adds speaker diarization when diarize=True.
+
+    Args:
+        file: Audio file to transcribe
+        response_format: Response format (only 'json' supported)
+        diarize: Enable speaker diarization (default True)
+        temperature: Whisper temperature parameter (passed through)
+        session_id: Optional session/meeting ID for consistent speaker tracking across chunks.
+                   Pass the same session_id for all chunks of the same meeting to maintain
+                   consistent speaker labels (SPEAKER_00, SPEAKER_01, etc.) throughout.
+        num_speakers: Optional hint for number of speakers. If provided, won't create more
+                     than this many speakers (helps avoid false speaker creation).
+
+    Returns:
+        JSON with transcription segments including speaker labels
+    """
+    global processor
+
+    if not processor:
+        raise HTTPException(
+            status_code=503,
+            detail="Service not initialized"
+        )
+
+    # Save uploaded file
+    file_id = str(uuid.uuid4())
+    file_ext = Path(file.filename).suffix if file.filename else ".wav"
+    temp_path = UPLOAD_DIR / f"{file_id}{file_ext}"
+
+    try:
+        # Save uploaded file
+        with open(temp_path, "wb") as f:
+            content = await file.read()
+            f.write(content)
+
+        logger.info(f"Processing file: {file.filename} ({len(content)} bytes)" +
+                   (f" [session: {session_id}]" if session_id else "") +
+                   (f" [speakers: {num_speakers}]" if num_speakers else ""))
+
+        # Process audio with optional session tracking
+        segments = await processor.process_audio(
+            audio_path=str(temp_path),
+            enable_diarization=diarize,
+            session_id=session_id,
+            num_speakers=num_speakers
+        )
+
+        if not segments:
+            logger.warning("No segments returned from processing")
+            return JSONResponse(
+                status_code=200,
+                content={"segments": [], "text": ""}
+            )
+
+        # Build response
+        full_text = " ".join(seg["text"] for seg in segments if seg.get("text"))
+
+        return {
+            "segments": segments,
+            "text": full_text
+        }
+
+    except Exception as e:
+        logger.error(f"Processing failed: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Processing failed: {str(e)}"
+        )
+
+    finally:
+        # Cleanup uploaded file
+        if temp_path.exists():
+            try:
+                temp_path.unlink()
+            except Exception as e:
+                logger.warning(f"Failed to cleanup temp file: {e}")
+
+
+@app.post("/transcribe")
+async def transcribe(
+    file: UploadFile = File(...),
+    diarize: bool = Form(True),
+    session_id: Optional[str] = Form(None),
+):
+    """
+    Transcribe audio with speaker diarization.
+
+    Simplified endpoint that always returns diarized transcription.
+
+    Args:
+        file: Audio file to transcribe
+        diarize: Enable speaker diarization (default True)
+        session_id: Optional session/meeting ID for consistent speaker tracking
+
+    Returns:
+        JSON with transcription segments including speaker labels
+    """
+    return await inference(file=file, response_format="json", diarize=diarize, session_id=session_id)
+
+
+@app.get("/session/{session_id}/speakers")
+async def get_session_speakers(session_id: str):
+    """
+    Get speaker information for a session.
+
+    Returns summary of all speakers detected in the session,
+    including their total speaking duration and number of chunks.
+
+    Args:
+        session_id: Session/meeting ID
+
+    Returns:
+        List of speaker summaries
+    """
+    global processor
+
+    if not processor:
+        raise HTTPException(status_code=503, detail="Service not initialized")
+
+    speakers = processor.get_session_speakers(session_id)
+
+    return {
+        "session_id": session_id,
+        "speakers": speakers,
+        "speaker_count": len(speakers)
+    }
+
+
+@app.delete("/session/{session_id}")
+async def clear_session(session_id: str):
+    """
+    Clear speaker tracking data for a session.
+
+    Call this when a meeting ends to free memory.
+    Embeddings are also removed from disk if persistence is enabled.
+
+    Args:
+        session_id: Session/meeting ID to clear
+
+    Returns:
+        Confirmation message
+    """
+    global processor
+
+    if not processor:
+        raise HTTPException(status_code=503, detail="Service not initialized")
+
+    processor.clear_session(session_id)
+
+    return {
+        "status": "ok",
+        "message": f"Session {session_id} cleared"
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(
+        "main:app",
+        host="0.0.0.0",
+        port=8179,
+        reload=False
+    )

--- a/backend/diarization_service/processor.py
+++ b/backend/diarization_service/processor.py
@@ -1,0 +1,237 @@
+"""Main audio processing service that combines transcription and diarization."""
+import os
+import logging
+from typing import List, Dict, Any, Optional
+
+from .config import DiarizationConfig
+from .audio_utils import AudioConverter
+from .diarization import DiarizationService
+from .whisper_client import WhisperClient
+from .speaker_tracker import SpeakerTracker
+
+logger = logging.getLogger(__name__)
+
+
+class AudioProcessor:
+    """
+    Main service that orchestrates transcription and diarization.
+
+    Workflow:
+    1. Receive audio file
+    2. Forward to whisper.cpp for transcription
+    3. Run pyannote for speaker diarization
+    4. Use speaker tracker for consistent IDs across chunks (if session_id provided)
+    5. Merge results by time overlap
+    6. Return segments with speaker labels
+    """
+
+    def __init__(self, config: DiarizationConfig):
+        """
+        Initialize the audio processor.
+
+        Args:
+            config: Configuration object with settings
+        """
+        self.config = config
+        self.audio_converter = AudioConverter()
+
+        # Initialize whisper client
+        self.whisper_client = WhisperClient(config.whisper_server_url)
+
+        # Initialize diarization service
+        self.diarization_service = DiarizationService(
+            pipeline_name=config.diarization_pipeline_name,
+            auth_token=config.hf_auth_token,
+            device=config.device_str
+        )
+
+        # Initialize speaker tracker for cross-chunk consistency
+        persist_dir = config.speaker_embedding_dir if config.speaker_embedding_dir else None
+        self.speaker_tracker = SpeakerTracker(
+            auth_token=config.hf_auth_token,
+            device=config.device_str,
+            persist_dir=persist_dir
+        )
+
+        logger.info(f"AudioProcessor initialized")
+        logger.info(f"  Whisper server: {config.whisper_server_url}")
+        logger.info(f"  Diarization available: {self.diarization_service.is_available}")
+        logger.info(f"  Speaker tracking available: {self.speaker_tracker.is_available}")
+        logger.info(f"  Device: {config.device_str}")
+
+    @property
+    def diarization_available(self) -> bool:
+        """Check if diarization is available."""
+        return self.diarization_service.is_available
+
+    @property
+    def speaker_tracking_available(self) -> bool:
+        """Check if speaker tracking is available."""
+        return self.speaker_tracker.is_available
+
+    async def process_audio(
+        self,
+        audio_path: str,
+        enable_diarization: bool = True,
+        session_id: Optional[str] = None,
+        num_speakers: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Process audio file with transcription and optional diarization.
+
+        Args:
+            audio_path: Path to the audio file
+            enable_diarization: Whether to run speaker diarization
+            session_id: Optional session/meeting ID for cross-chunk speaker tracking
+
+        Returns:
+            List of segments with format:
+            [{"text": "Hello", "start": 0.0, "end": 1.5, "speaker": "SPEAKER_00"}, ...]
+        """
+        temp_wav_path: Optional[str] = None
+
+        try:
+            # Step 1: Get transcription from whisper.cpp
+            logger.info("Step 1: Transcribing audio with Whisper")
+            whisper_segments = await self.whisper_client.transcribe(audio_path)
+
+            if not whisper_segments:
+                logger.warning("Whisper returned no segments")
+                return []
+
+            logger.info(f"Got {len(whisper_segments)} segments from Whisper")
+
+            # Step 2: Run diarization if enabled and available
+            diarization_turns: List[Dict[str, Any]] = []
+
+            if enable_diarization and self.diarization_service.is_available:
+                logger.info("Step 2: Running speaker diarization")
+
+                # Convert audio to WAV format for pyannote (16kHz mono)
+                base, _ = os.path.splitext(audio_path)
+                temp_wav_path = f"{base}_diarization.wav"
+
+                conversion_success = self.audio_converter.convert_to_wav(
+                    input_path=audio_path,
+                    output_path=temp_wav_path,
+                    sample_rate=self.config.audio_convert_sample_rate,
+                    channels=self.config.audio_convert_channels
+                )
+
+                if conversion_success:
+                    diarization_turns = self.diarization_service.get_speaker_turns(
+                        temp_wav_path,
+                        num_speakers=num_speakers
+                    )
+                    logger.info(f"Got {len(diarization_turns)} speaker turns")
+
+                    # Step 2b: Apply speaker tracking for consistent IDs
+                    if session_id and self.speaker_tracker.is_available and diarization_turns:
+                        logger.info(f"Step 2b: Applying speaker tracking for session {session_id}" +
+                                   (f" (max {num_speakers} speakers)" if num_speakers else ""))
+                        diarization_turns = self.speaker_tracker.assign_speakers(
+                            session_id=session_id,
+                            audio_path=temp_wav_path,
+                            diarization_turns=diarization_turns,
+                            num_speakers=num_speakers
+                        )
+                else:
+                    logger.warning("Audio conversion failed, skipping diarization")
+            else:
+                if not enable_diarization:
+                    logger.info("Diarization disabled by request")
+                else:
+                    logger.warning("Diarization not available")
+
+            # Step 3: Merge transcription with speaker labels
+            logger.info("Step 3: Merging results")
+            merged_segments = self._merge_results(whisper_segments, diarization_turns)
+
+            logger.info(f"Processing complete: {len(merged_segments)} segments")
+            return merged_segments
+
+        except Exception as e:
+            logger.error(f"Audio processing failed: {e}")
+            return []
+
+        finally:
+            # Cleanup temp WAV file
+            if temp_wav_path:
+                self.audio_converter.cleanup_temp_file(temp_wav_path)
+
+    def _merge_results(
+        self,
+        whisper_segments: List[Dict[str, Any]],
+        diarization_turns: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """
+        Merge Whisper transcription segments with speaker diarization.
+
+        Uses maximum time overlap to assign speakers to segments.
+
+        Args:
+            whisper_segments: Transcription segments from Whisper
+            diarization_turns: Speaker turns from pyannote
+
+        Returns:
+            Merged segments with speaker labels
+        """
+        if not diarization_turns:
+            # No diarization available - return segments with UNKNOWN speaker
+            logger.info("No diarization turns, marking all segments as UNKNOWN")
+            return [
+                {**seg, "speaker": "UNKNOWN"}
+                for seg in whisper_segments
+            ]
+
+        merged = []
+
+        for seg in whisper_segments:
+            seg_start = seg.get("start", 0.0)
+            seg_end = seg.get("end", 0.0)
+
+            best_speaker = "UNKNOWN"
+            max_overlap = 0.0
+
+            # Find the speaker with maximum time overlap
+            for turn in diarization_turns:
+                turn_start = turn["start"]
+                turn_end = turn["end"]
+
+                # Calculate overlap
+                overlap_start = max(seg_start, turn_start)
+                overlap_end = min(seg_end, turn_end)
+                overlap_duration = max(0.0, overlap_end - overlap_start)
+
+                if overlap_duration > max_overlap:
+                    max_overlap = overlap_duration
+                    best_speaker = turn["speaker"]
+
+            merged.append({
+                "text": seg.get("text", "").strip(),
+                "start": seg_start,
+                "end": seg_end,
+                "speaker": best_speaker
+            })
+
+        return merged
+
+    async def transcribe_only(self, audio_path: str) -> List[Dict[str, Any]]:
+        """
+        Transcribe audio without diarization.
+
+        Args:
+            audio_path: Path to the audio file
+
+        Returns:
+            List of transcription segments (no speaker labels)
+        """
+        return await self.whisper_client.transcribe(audio_path)
+
+    def get_session_speakers(self, session_id: str) -> List[Dict[str, Any]]:
+        """Get summary of speakers in a session."""
+        return self.speaker_tracker.get_session_speakers(session_id)
+
+    def clear_session(self, session_id: str):
+        """Clear a session's speaker tracking data."""
+        self.speaker_tracker.clear_session(session_id)

--- a/backend/diarization_service/requirements.txt
+++ b/backend/diarization_service/requirements.txt
@@ -1,0 +1,16 @@
+# Diarization Service Dependencies
+
+fastapi>=0.115.0
+uvicorn[standard]>=0.34.0
+python-multipart>=0.0.9
+httpx>=0.27.0
+
+# PyTorch < 2.6 required (2.6+ has weights_only=True default breaking pyannote)
+torch<2.6
+torchaudio<2.6
+
+# Pin huggingface_hub to version supporting use_auth_token (pre-0.23)
+huggingface_hub>=0.20.0,<0.23.0
+
+# Pyannote for speaker diarization
+pyannote.audio>=3.1.0,<4.0

--- a/backend/diarization_service/speaker_tracker.py
+++ b/backend/diarization_service/speaker_tracker.py
@@ -1,0 +1,411 @@
+"""Session-based speaker tracking using embeddings for consistent speaker IDs across chunks."""
+import logging
+import numpy as np
+from typing import Dict, List, Any, Optional, Tuple
+from dataclasses import dataclass, field
+from pathlib import Path
+import json
+import torch
+
+logger = logging.getLogger(__name__)
+
+# Similarity threshold for matching speakers (cosine similarity)
+SPEAKER_MATCH_THRESHOLD = 0.60
+
+# Minimum duration (seconds) to persist embedding (skip noisy short segments)
+MIN_DURATION_TO_PERSIST = 1.5
+
+
+@dataclass
+class SpeakerProfile:
+    """Speaker profile with embedding and metadata."""
+    speaker_id: str
+    embeddings: List[np.ndarray] = field(default_factory=list)
+    total_duration: float = 0.0
+    chunk_count: int = 0
+
+    @property
+    def centroid(self) -> Optional[np.ndarray]:
+        """Get the centroid (average) embedding for this speaker."""
+        if not self.embeddings:
+            return None
+        return np.mean(self.embeddings, axis=0)
+
+    def add_embedding(self, embedding: np.ndarray, duration: float = 0.0):
+        """Add a new embedding observation, weighted by duration."""
+        self.embeddings.append(embedding)
+        self.total_duration += duration
+        self.chunk_count += 1
+
+        # Keep only last N embeddings to prevent memory bloat
+        max_embeddings = 50
+        if len(self.embeddings) > max_embeddings:
+            # Keep embeddings with best coverage - simple approach: keep recent ones
+            self.embeddings = self.embeddings[-max_embeddings:]
+
+
+class SessionSpeakerStore:
+    """In-memory store for speaker profiles per session."""
+
+    def __init__(self, persist_dir: Optional[str] = None):
+        """
+        Initialize the session store.
+
+        Args:
+            persist_dir: Optional directory to persist embeddings between restarts
+        """
+        self.sessions: Dict[str, Dict[str, SpeakerProfile]] = {}
+        self.persist_dir = Path(persist_dir) if persist_dir else None
+
+        if self.persist_dir:
+            self.persist_dir.mkdir(parents=True, exist_ok=True)
+            logger.info(f"Speaker embedding persistence enabled: {self.persist_dir}")
+
+    def get_session(self, session_id: str) -> Dict[str, SpeakerProfile]:
+        """Get or create a session's speaker profiles."""
+        if session_id not in self.sessions:
+            # Try to load from disk if persistence is enabled
+            if self.persist_dir:
+                self._load_session(session_id)
+
+            if session_id not in self.sessions:
+                self.sessions[session_id] = {}
+                logger.info(f"Created new session: {session_id}")
+
+        return self.sessions[session_id]
+
+    def get_next_speaker_id(self, session_id: str) -> str:
+        """Get the next available speaker ID for a session."""
+        profiles = self.get_session(session_id)
+        return f"SPEAKER_{len(profiles):02d}"
+
+    def add_speaker(self, session_id: str, speaker_id: str, embedding: np.ndarray, duration: float = 0.0):
+        """Add or update a speaker profile."""
+        profiles = self.get_session(session_id)
+
+        if speaker_id not in profiles:
+            profiles[speaker_id] = SpeakerProfile(speaker_id=speaker_id)
+            logger.debug(f"Session {session_id}: Created new speaker {speaker_id}")
+
+        profiles[speaker_id].add_embedding(embedding, duration)
+
+    def save_session(self, session_id: str):
+        """Persist session embeddings to disk."""
+        if not self.persist_dir:
+            return
+
+        profiles = self.get_session(session_id)
+        if not profiles:
+            return
+
+        session_file = self.persist_dir / f"{session_id}.npz"
+
+        try:
+            # Save embeddings as numpy arrays
+            data = {}
+            for speaker_id, profile in profiles.items():
+                if profile.centroid is not None:
+                    data[f"{speaker_id}_centroid"] = profile.centroid
+                    data[f"{speaker_id}_duration"] = np.array([profile.total_duration])
+                    data[f"{speaker_id}_count"] = np.array([profile.chunk_count])
+
+            np.savez(session_file, **data)
+            logger.info(f"Saved session {session_id} with {len(profiles)} speakers")
+        except Exception as e:
+            logger.error(f"Failed to save session {session_id}: {e}")
+
+    def _load_session(self, session_id: str):
+        """Load session embeddings from disk."""
+        if not self.persist_dir:
+            return
+
+        session_file = self.persist_dir / f"{session_id}.npz"
+
+        if not session_file.exists():
+            return
+
+        try:
+            data = np.load(session_file)
+            profiles = {}
+
+            # Find all speaker IDs
+            speaker_ids = set()
+            for key in data.files:
+                if key.endswith("_centroid"):
+                    speaker_ids.add(key.replace("_centroid", ""))
+
+            for speaker_id in speaker_ids:
+                centroid = data.get(f"{speaker_id}_centroid")
+                duration = data.get(f"{speaker_id}_duration", [0.0])[0]
+                count = int(data.get(f"{speaker_id}_count", [1])[0])
+
+                if centroid is not None:
+                    profile = SpeakerProfile(speaker_id=speaker_id)
+                    profile.embeddings = [centroid]  # Start with centroid
+                    profile.total_duration = duration
+                    profile.chunk_count = count
+                    profiles[speaker_id] = profile
+
+            self.sessions[session_id] = profiles
+            logger.info(f"Loaded session {session_id} with {len(profiles)} speakers")
+        except Exception as e:
+            logger.error(f"Failed to load session {session_id}: {e}")
+
+    def clear_session(self, session_id: str):
+        """Clear a session from memory and optionally disk."""
+        if session_id in self.sessions:
+            del self.sessions[session_id]
+
+        if self.persist_dir:
+            session_file = self.persist_dir / f"{session_id}.npz"
+            if session_file.exists():
+                session_file.unlink()
+
+
+class SpeakerTracker:
+    """
+    Tracks speakers across audio chunks using embedding similarity.
+
+    Uses pyannote's embedding model to extract speaker voice prints
+    and matches them across chunks for consistent speaker IDs.
+    """
+
+    def __init__(self, auth_token: Optional[str], device: str = "cpu", persist_dir: Optional[str] = None):
+        """
+        Initialize the speaker tracker.
+
+        Args:
+            auth_token: Hugging Face auth token
+            device: Device to run on ('cuda' or 'cpu')
+            persist_dir: Directory to persist embeddings
+        """
+        self.auth_token = auth_token
+        self.device = torch.device(device)
+        self.embedding_model = None
+        self.store = SessionSpeakerStore(persist_dir)
+
+        self._load_embedding_model()
+
+    def _load_embedding_model(self):
+        """Load the speaker embedding model."""
+        try:
+            from pyannote.audio import Model, Inference
+
+            logger.info("Loading speaker embedding model...")
+
+            # Use pyannote's embedding model
+            model = Model.from_pretrained(
+                "pyannote/embedding",
+                use_auth_token=self.auth_token
+            )
+
+            self.embedding_model = Inference(
+                model,
+                window="whole"
+            )
+
+            # Move to device
+            if self.device.type == "cuda":
+                self.embedding_model.model = self.embedding_model.model.to(self.device)
+
+            logger.info("Speaker embedding model loaded successfully")
+
+        except Exception as e:
+            logger.error(f"Failed to load embedding model: {e}")
+            self.embedding_model = None
+
+    @property
+    def is_available(self) -> bool:
+        """Check if embedding model is available."""
+        return self.embedding_model is not None
+
+    def extract_embedding(self, audio_path: str, start: float, end: float) -> Optional[np.ndarray]:
+        """
+        Extract speaker embedding from an audio segment.
+
+        Args:
+            audio_path: Path to audio file
+            start: Start time in seconds
+            end: End time in seconds
+
+        Returns:
+            Speaker embedding vector or None if extraction fails
+        """
+        if not self.is_available:
+            return None
+
+        try:
+            from pyannote.core import Segment
+
+            # Extract embedding for the segment
+            segment = Segment(start, end)
+            embedding = self.embedding_model.crop(audio_path, segment)
+
+            return embedding.flatten()
+
+        except Exception as e:
+            logger.debug(f"Embedding extraction failed for {start:.2f}-{end:.2f}: {e}")
+            return None
+
+    def cosine_similarity(self, a: np.ndarray, b: np.ndarray) -> float:
+        """Calculate cosine similarity between two embeddings."""
+        norm_a = np.linalg.norm(a)
+        norm_b = np.linalg.norm(b)
+
+        if norm_a == 0 or norm_b == 0:
+            return 0.0
+
+        return float(np.dot(a, b) / (norm_a * norm_b))
+
+    def find_matching_speaker(
+        self,
+        session_id: str,
+        embedding: np.ndarray
+    ) -> Tuple[Optional[str], float]:
+        """
+        Find the best matching speaker in the session.
+
+        Args:
+            session_id: Session/meeting ID
+            embedding: Speaker embedding to match
+
+        Returns:
+            Tuple of (speaker_id, similarity_score) or (None, 0.0) if no match
+        """
+        profiles = self.store.get_session(session_id)
+
+        best_match = None
+        best_similarity = 0.0
+
+        for speaker_id, profile in profiles.items():
+            centroid = profile.centroid
+            if centroid is None:
+                continue
+
+            similarity = self.cosine_similarity(embedding, centroid)
+
+            if similarity > best_similarity:
+                best_similarity = similarity
+                best_match = speaker_id
+
+        return best_match, best_similarity
+
+    def assign_speakers(
+        self,
+        session_id: str,
+        audio_path: str,
+        diarization_turns: List[Dict[str, Any]],
+        num_speakers: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Assign consistent speaker IDs to diarization turns using embeddings.
+
+        Args:
+            session_id: Session/meeting ID for tracking
+            audio_path: Path to the audio file
+            diarization_turns: Speaker turns from pyannote diarization
+                              [{"speaker": "SPEAKER_00", "start": 0.5, "end": 2.3}, ...]
+
+        Returns:
+            Updated turns with consistent speaker IDs across chunks
+        """
+        if not self.is_available or not diarization_turns:
+            logger.warning("Speaker tracking not available, returning original turns")
+            return diarization_turns
+
+        logger.info(f"Assigning speakers for session {session_id}, {len(diarization_turns)} turns")
+
+        # Group turns by local speaker label to extract better embeddings
+        local_speaker_turns: Dict[str, List[Dict]] = {}
+        for turn in diarization_turns:
+            local_label = turn["speaker"]
+            if local_label not in local_speaker_turns:
+                local_speaker_turns[local_label] = []
+            local_speaker_turns[local_label].append(turn)
+
+        # Map local speaker labels to session-consistent labels
+        label_mapping: Dict[str, str] = {}
+
+        for local_label, turns in local_speaker_turns.items():
+            # Find the longest segment for this speaker (better embedding quality)
+            best_turn = max(turns, key=lambda t: t["end"] - t["start"])
+            duration = best_turn["end"] - best_turn["start"]
+
+            # Skip very short segments
+            if duration < 0.5:
+                logger.debug(f"Skipping short segment for {local_label}: {duration:.2f}s")
+                label_mapping[local_label] = local_label
+                continue
+
+            # Extract embedding
+            embedding = self.extract_embedding(
+                audio_path,
+                best_turn["start"],
+                best_turn["end"]
+            )
+
+            if embedding is None:
+                logger.debug(f"Could not extract embedding for {local_label}")
+                label_mapping[local_label] = local_label
+                continue
+
+            # Find matching speaker in session
+            match_id, similarity = self.find_matching_speaker(session_id, embedding)
+
+            if match_id and similarity >= SPEAKER_MATCH_THRESHOLD:
+                # Found a match - use existing speaker ID
+                label_mapping[local_label] = match_id
+                logger.debug(f"Matched {local_label} -> {match_id} (similarity: {similarity:.3f})")
+
+                # Only persist embedding if duration is good (skip noisy short segments)
+                if duration >= MIN_DURATION_TO_PERSIST:
+                    self.store.add_speaker(session_id, match_id, embedding, duration)
+            else:
+                # Check if we've hit the speaker limit (if user specified num_speakers)
+                profiles = self.store.get_session(session_id)
+                if num_speakers and len(profiles) >= num_speakers:
+                    # At limit - assign to best match even if below threshold
+                    if match_id:
+                        label_mapping[local_label] = match_id
+                        logger.debug(f"At speaker limit, using best match: {local_label} -> {match_id} (similarity: {similarity:.3f})")
+                    else:
+                        label_mapping[local_label] = "SPEAKER_00"
+                else:
+                    # New speaker
+                    new_id = self.store.get_next_speaker_id(session_id)
+                    label_mapping[local_label] = new_id
+                    logger.info(f"New speaker: {local_label} -> {new_id} (best similarity: {similarity:.3f})")
+
+                    # Only persist if duration is good
+                    if duration >= MIN_DURATION_TO_PERSIST:
+                        self.store.add_speaker(session_id, new_id, embedding, duration)
+
+        # Apply mapping to all turns
+        updated_turns = []
+        for turn in diarization_turns:
+            updated_turn = turn.copy()
+            updated_turn["speaker"] = label_mapping.get(turn["speaker"], turn["speaker"])
+            updated_turns.append(updated_turn)
+
+        # Persist session
+        self.store.save_session(session_id)
+
+        return updated_turns
+
+    def get_session_speakers(self, session_id: str) -> List[Dict[str, Any]]:
+        """Get summary of speakers in a session."""
+        profiles = self.store.get_session(session_id)
+
+        return [
+            {
+                "speaker_id": speaker_id,
+                "total_duration": profile.total_duration,
+                "chunk_count": profile.chunk_count
+            }
+            for speaker_id, profile in profiles.items()
+        ]
+
+    def clear_session(self, session_id: str):
+        """Clear a session's speaker data."""
+        self.store.clear_session(session_id)
+        logger.info(f"Cleared session: {session_id}")

--- a/backend/diarization_service/whisper_client.py
+++ b/backend/diarization_service/whisper_client.py
@@ -1,0 +1,111 @@
+"""Client for communicating with whisper.cpp server."""
+import logging
+import httpx
+from typing import List, Dict, Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class WhisperClient:
+    """
+    Client for the whisper.cpp HTTP server.
+
+    Forwards audio to the whisper.cpp server and returns transcription segments.
+    """
+
+    def __init__(self, server_url: str, timeout: float = 300.0):
+        """
+        Initialize the Whisper client.
+
+        Args:
+            server_url: URL of the whisper.cpp server (e.g., 'http://localhost:8178')
+            timeout: Request timeout in seconds (default 5 minutes for long audio)
+        """
+        self.server_url = server_url.rstrip("/")
+        self.timeout = timeout
+
+    async def transcribe(self, audio_path: str) -> List[Dict[str, Any]]:
+        """
+        Send audio to whisper.cpp server for transcription.
+
+        Args:
+            audio_path: Path to the audio file
+
+        Returns:
+            List of transcription segments with format:
+            [{"text": "Hello world", "start": 0.0, "end": 1.5}, ...]
+        """
+        try:
+            logger.info(f"Sending audio to Whisper server: {self.server_url}")
+
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                with open(audio_path, "rb") as audio_file:
+                    files = {"file": ("audio.wav", audio_file, "audio/wav")}
+                    data = {
+                        "response_format": "verbose_json",
+                        "temperature": "0.0",
+                    }
+
+                    response = await client.post(
+                        f"{self.server_url}/inference",
+                        files=files,
+                        data=data
+                    )
+                    response.raise_for_status()
+
+            result = response.json()
+            logger.debug(f"Whisper raw response keys: {result.keys() if isinstance(result, dict) else type(result)}")
+            segments = self._parse_whisper_response(result)
+
+            logger.info(f"Whisper transcription complete: {len(segments)} segments")
+            if segments:
+                logger.debug(f"First segment: start={segments[0].get('start')}, end={segments[0].get('end')}")
+            return segments
+
+        except httpx.TimeoutException:
+            logger.error("Whisper server request timed out")
+            return []
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Whisper server HTTP error: {e.response.status_code}")
+            return []
+        except Exception as e:
+            logger.error(f"Whisper transcription failed: {e}")
+            return []
+
+    def _parse_whisper_response(self, response: dict) -> List[Dict[str, Any]]:
+        """
+        Parse the whisper.cpp server response into segments.
+
+        The whisper.cpp server returns different formats depending on configuration.
+        This handles the common formats.
+        """
+        segments = []
+
+        # Handle different response formats from whisper.cpp
+        if "segments" in response:
+            # Standard segments format
+            for seg in response["segments"]:
+                segments.append({
+                    "text": seg.get("text", "").strip(),
+                    "start": seg.get("start", 0.0),
+                    "end": seg.get("end", 0.0)
+                })
+        elif "text" in response:
+            # Simple text response (no timestamps)
+            # Create a single segment
+            segments.append({
+                "text": response["text"].strip(),
+                "start": 0.0,
+                "end": 0.0
+            })
+
+        return segments
+
+    async def health_check(self) -> bool:
+        """Check if the Whisper server is available."""
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                response = await client.get(f"{self.server_url}/")
+                return response.status_code == 200
+        except Exception:
+            return False


### PR DESCRIPTION
## Summary
- Add a new `backend/diarization_service/` that wraps whisper.cpp transcription with speaker identification using [pyannote.audio](https://github.com/pyannote/pyannote-audio)
- Cross-chunk speaker tracking via voice embeddings keeps speaker IDs consistent throughout a meeting session
- Add `speaker` field to backend transcript storage (`db.py`) and API model (`main.py`)

## How it works

The diarization service runs as a sidecar to the existing whisper.cpp server:

```
Audio file → Diarization Service (:8179)
                ├─ Forward to Whisper (:8178) → timestamped segments
                ├─ Run pyannote diarization → speaker turns
                ├─ Match speakers via embedding similarity (cross-chunk)
                └─ Merge → segments with speaker labels
```

### Endpoints
| Endpoint | Method | Description |
|----------|--------|-------------|
| `/inference` | POST | Transcribe with diarization (compatible with whisper.cpp API) |
| `/transcribe` | POST | Simplified transcription endpoint |
| `/health` | GET | Service health with per-component status |
| `/session/{id}/speakers` | GET | Speaker summary for a session |
| `/session/{id}` | DELETE | Clear session speaker data |

### Configuration (environment variables)
| Variable | Default | Description |
|----------|---------|-------------|
| `WHISPER_SERVER_URL` | `http://localhost:8178` | Whisper.cpp server URL |
| `HF_AUTH_TOKEN` | _(required)_ | Hugging Face token for pyannote gated models |
| `DIARIZATION_PIPELINE` | `pyannote/speaker-diarization-3.1` | Diarization model |
| `SPEAKER_EMBEDDING_DIR` | _(disabled)_ | Directory to persist speaker embeddings |

### New files
```
backend/diarization_service/
├── Dockerfile            # Standalone container
├── requirements.txt      # Pinned deps (torch<2.6, huggingface_hub<0.23)
├── main.py               # FastAPI app with endpoints
├── config.py             # Env-var based configuration
├── processor.py          # Orchestrates transcription + diarization
├── diarization.py        # pyannote.audio pipeline wrapper
├── speaker_tracker.py    # Cross-chunk speaker consistency via embeddings
├── whisper_client.py     # HTTP client for whisper.cpp server
└── audio_utils.py        # FFmpeg audio conversion utilities
```

### Backend changes
- `db.py`: Added `speaker TEXT` column to transcripts table (with migration)
- `main.py`: Added `speaker` field to `Transcript` model and save flow

## Related Issues
Addresses #230, #226, #56

## Testing
- [x] Service starts and initializes pyannote pipeline on GPU
- [x] `/inference` endpoint returns segments with speaker labels
- [x] Speaker IDs remain consistent across multiple audio chunks within a session
- [x] Graceful degradation when diarization model unavailable (returns `UNKNOWN` speaker)
- [x] Backend DB migration adds `speaker` column without breaking existing data

## Technical Notes
- `torch<2.6` pin is required because PyTorch 2.6+ changed `weights_only=True` default which breaks pyannote model loading
- `huggingface_hub<0.23` pin is required because 0.23+ deprecated the `use_auth_token` parameter used by pyannote
- pyannote models are gated on Hugging Face and require accepting the license + auth token

🤖 Generated with [Claude Code](https://claude.com/claude-code)