### PR TITLE
fix: dynamically check model availability based on selected provider

### DIFF
--- a/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
+++ b/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
@@ -121,7 +121,7 @@ impl WhisperEngine {
                     .join("models")
             }
         };
-        
+
         log::info!("WhisperEngine using models directory: {}", models_dir.display());
         log::info!("Debug mode: {}", cfg!(debug_assertions));
 
@@ -146,7 +146,7 @@ impl WhisperEngine {
 
         #[cfg(feature = "openmp")]
         log::info!("OpenMP parallel processing: enabled");
-        
+
         let engine = Self {
             models_dir,
             current_context: Arc::new(RwLock::new(None)),
@@ -162,17 +162,20 @@ impl WhisperEngine {
             // Initialize active downloads tracking
             active_downloads: Arc::new(RwLock::new(HashSet::new())),
         };
-        
+
         Ok(engine)
     }
-    
+
     pub async fn discover_models(&self) -> Result<Vec<ModelInfo>> {
         let models_dir = &self.models_dir;
         let mut models = Vec::new();
         // Use centralized model catalog from config.rs
         let model_configs = WHISPER_MODEL_CATALOG;
 
+        let mut known_filenames = std::collections::HashSet::new();
+
         for &(name, filename, size_mb, accuracy, speed, description) in model_configs {
+            known_filenames.insert(filename.to_string());
             let model_path = models_dir.join(filename);
             let status = if model_path.exists() {
                 // Check if file size is reasonable (at least 1MB for a valid model)
@@ -232,7 +235,7 @@ impl WhisperEngine {
             } else {
                 ModelStatus::Missing
             };
-            
+
             let model_info = ModelInfo {
                 name: name.to_string(),
                 path: model_path,
@@ -242,20 +245,83 @@ impl WhisperEngine {
                 status,
                 description: description.to_string(),
             };
-            
+
             models.push(model_info);
         }
-        
+
+        // Scan for custom models in the directory
+        if models_dir.exists() {
+            if let Ok(mut entries) = tokio::fs::read_dir(models_dir).await {
+                while let Ok(Some(entry)) = entries.next_entry().await {
+                    let path = entry.path();
+                    if path.is_file() {
+                        if let Some(extension) = path.extension() {
+                            if extension == "bin" {
+                                if let Some(file_name_os) = path.file_name() {
+                                    let filename = file_name_os.to_string_lossy().to_string();
+
+                                    // Skip known models
+                                    if !known_filenames.contains(&filename) {
+                                        if let Ok(metadata) = std::fs::metadata(&path) {
+                                            let file_size_bytes = metadata.len();
+                                            let file_size_mb = (file_size_bytes / (1024 * 1024)) as u32;
+
+                                            // Extract a clean name (remove ggml- prefix if present, and .bin suffix)
+                                            let mut clean_name = filename.strip_suffix(".bin").unwrap_or(&filename).to_string();
+                                            if clean_name.starts_with("ggml-") {
+                                                clean_name = clean_name.strip_prefix("ggml-").unwrap().to_string();
+                                            }
+
+                                            let status = if file_size_mb > 1 {
+                                                match self.validate_model_file(&path).await {
+                                                    Ok(_) => ModelStatus::Available,
+                                                    Err(_) => {
+                                                        log::warn!("Custom model file {} appears corrupted (failed validation)", filename);
+                                                        ModelStatus::Corrupted {
+                                                            file_size: file_size_bytes,
+                                                            expected_min_size: 1024 * 1024
+                                                        }
+                                                    }
+                                                }
+                                            } else {
+                                                ModelStatus::Corrupted {
+                                                    file_size: file_size_bytes,
+                                                    expected_min_size: 1024 * 1024
+                                                }
+                                            };
+
+                                            let model_info = ModelInfo {
+                                                name: clean_name.clone(),
+                                                path: path.clone(),
+                                                size_mb: file_size_mb,
+                                                accuracy: "Unknown".to_string(), // Custom models
+                                                speed: "Unknown".to_string(),
+                                                status,
+                                                description: format!("Custom model: {}", filename),
+                                            };
+
+                                            log::info!("Discovered custom model: {}", clean_name);
+                                            models.push(model_info);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         // Update internal cache
         let mut available_models = self.available_models.write().await;
         available_models.clear();
         for model in &models {
             available_models.insert(model.name.clone(), model.clone());
         }
-        
+
         Ok(models)
     }
-    
+
     pub async fn load_model(&self, model_name: &str) -> Result<()> {
         let models = self.available_models.read().await;
         let model_info = models.get(model_name)
@@ -358,11 +424,11 @@ impl WhisperEngine {
     pub async fn get_current_model(&self) -> Option<String> {
         self.current_model.read().await.clone()
     }
-    
+
     pub async fn is_model_loaded(&self) -> bool {
         self.current_context.read().await.is_some()
     }
-    
+
     // Enhanced function to clean repetitive text patterns and meaningless outputs
     fn clean_repetitive_text(text: &str) -> String {
         if text.is_empty() {
@@ -511,7 +577,7 @@ impl WhisperEngine {
 
         repeated_words as f32 / total_words
     }
-    
+
     /// Transcribe audio with streaming support for partial results and adaptive quality
     pub async fn transcribe_audio_with_confidence(&self, audio_data: Vec<f32>, language: Option<String>) -> Result<(String, f32, bool)> {
         let ctx_lock = self.current_context.read().await;
@@ -802,7 +868,7 @@ impl WhisperEngine {
 
         Ok(cleaned_result)
     }
-    
+
     pub async fn get_models_directory(&self) -> PathBuf {
         self.models_dir.clone()
     }
@@ -893,7 +959,7 @@ impl WhisperEngine {
             }
         }
     }
-    
+
     pub async fn download_model(&self, model_name: &str, progress_callback: Option<Box<dyn Fn(u8) + Send>>) -> Result<()> {
         log::info!("Starting download for model: {}", model_name);
 
@@ -940,21 +1006,21 @@ impl WhisperEngine {
 
             _ => return Err(anyhow!("Unsupported model: {}", model_name))
         };
-        
+
         log::info!("Model URL for {}: {}", model_name, model_url);
-        
+
         // Generate correct filename - all models follow ggml-{model_name}.bin pattern
         let filename = format!("ggml-{}.bin", model_name);
         let file_path = self.models_dir.join(&filename);
-        
+
         log::info!("Downloading to file path: {}", file_path.display());
-        
+
         // Create models directory if it doesn't exist
         if !self.models_dir.exists() {
             fs::create_dir_all(&self.models_dir).await
                 .map_err(|e| anyhow!("Failed to create models directory: {}", e))?;
         }
-        
+
         // Update model status to downloading
         {
             let mut models = self.available_models.write().await;
@@ -962,14 +1028,14 @@ impl WhisperEngine {
                 model_info.status = ModelStatus::Downloading { progress: 0 };
             }
         }
-        
+
         log::info!("Creating HTTP client and starting request...");
         let client = Client::new();
-        
+
         log::info!("Sending GET request to: {}", model_url);
         let response = client.get(model_url).send().await
             .map_err(|e| anyhow!("Failed to start download: {}", e))?;
-        
+
         log::info!("Received response with status: {}", response.status());
         if !response.status().is_success() {
             // Remove from active downloads on error
@@ -977,19 +1043,19 @@ impl WhisperEngine {
             active.remove(model_name);
             return Err(anyhow!("Download failed with status: {}", response.status()));
         }
-        
+
         let total_size = response.content_length().unwrap_or(0);
         log::info!("Response successful, content length: {} bytes ({:.1} MB)", total_size, total_size as f64 / (1024.0 * 1024.0));
-        
+
         if total_size == 0 {
             log::warn!("Content length is 0 or unknown - download may not show accurate progress");
         }
-        
+
         let mut file = fs::File::create(&file_path).await
             .map_err(|e| anyhow!("Failed to create file: {}", e))?;
-        
+
         log::info!("File created successfully at: {}", file_path.display());
-        
+
         // Stream download with real progress reporting
         log::info!("Starting streaming download...");
         log::info!("Expected size: {:.1} MB", total_size as f64 / (1024.0 * 1024.0));
@@ -1060,7 +1126,7 @@ impl WhisperEngine {
         }
 
         log::info!("Streaming download completed: {} bytes", downloaded);
-        
+
         // Ensure 100% progress is always reported
         {
             let mut models = self.available_models.write().await;
@@ -1068,16 +1134,16 @@ impl WhisperEngine {
                 model_info.status = ModelStatus::Downloading { progress: 100 };
             }
         }
-        
+
         if let Some(ref callback) = progress_callback {
             callback(100);
         }
-        
+
         file.flush().await
             .map_err(|e| anyhow!("Failed to flush file: {}", e))?;
-        
+
         log::info!("Download completed for model: {}", model_name);
-        
+
         // Update model status to available
         {
             let mut models = self.available_models.write().await;
@@ -1095,7 +1161,7 @@ impl WhisperEngine {
 
         Ok(())
     }
-    
+
     pub async fn cancel_download(&self, model_name: &str) -> Result<()> {
         log::info!("Cancelling download for model: {}", model_name);
 

--- a/frontend/src/hooks/useRecordingStart.ts
+++ b/frontend/src/hooks/useRecordingStart.ts
@@ -34,7 +34,7 @@ export function useRecordingStart(
 
   const { clearTranscripts, setMeetingTitle } = useTranscripts();
   const { setIsMeetingActive } = useSidebar();
-  const { selectedDevices } = useConfig();
+  const { selectedDevices, transcriptModelConfig } = useConfig();
   const { setStatus } = useRecordingState();
 
   // Generate meeting title with timestamp
@@ -49,22 +49,29 @@ export function useRecordingStart(
     return `Meeting ${day}_${month}_${year}_${hours}_${minutes}_${seconds}`;
   }, []);
 
-  // Check if Parakeet transcription model is ready
-  const checkParakeetReady = useCallback(async (): Promise<boolean> => {
+  // Check if the selected transcription model is ready
+  const checkModelReady = useCallback(async (): Promise<boolean> => {
     try {
-      await invoke('parakeet_init');
-      const hasModels = await invoke<boolean>('parakeet_has_available_models');
-      return hasModels;
+      if (transcriptModelConfig.provider === 'whisper') {
+        return await invoke<boolean>('whisper_has_available_models');
+      } else {
+        await invoke('parakeet_init');
+        return await invoke<boolean>('parakeet_has_available_models');
+      }
     } catch (error) {
-      console.error('Failed to check Parakeet status:', error);
+      console.error(`Failed to check ${transcriptModelConfig.provider} status:`, error);
       return false;
     }
-  }, []);
+  }, [transcriptModelConfig.provider]);
 
-  // Check if any model is currently downloading
+  // Check if any model for the current provider is downloading
   const checkIfModelDownloading = useCallback(async (): Promise<boolean> => {
     try {
-      const models = await invoke<any[]>('parakeet_get_available_models');
+      const command = transcriptModelConfig.provider === 'whisper'
+        ? 'whisper_get_available_models'
+        : 'parakeet_get_available_models';
+
+      const models = await invoke<any[]>(command);
       const isDownloading = models.some(m =>
         m.status && (
           typeof m.status === 'object'
@@ -74,19 +81,19 @@ export function useRecordingStart(
       );
       return isDownloading;
     } catch (error) {
-      console.error('Failed to check model download status:', error);
+      console.error(`Failed to check ${transcriptModelConfig.provider} download status:`, error);
       return false; // Default to not downloading (will show error + modal)
     }
-  }, []);
+  }, [transcriptModelConfig.provider]);
 
   // Handle manual recording start (from button click)
   const handleRecordingStart = useCallback(async () => {
     try {
-      console.log('handleRecordingStart called - checking Parakeet model status');
+      console.log('handleRecordingStart called - checking model status');
 
-      // Check if Parakeet transcription model is ready before starting
-      const parakeetReady = await checkParakeetReady();
-      if (!parakeetReady) {
+      // Check if transcription model is ready before starting
+      const isModelReady = await checkModelReady();
+      if (!isModelReady) {
         const isDownloading = await checkIfModelDownloading();
         if (isDownloading) {
           toast.info('Model download in progress', {
@@ -106,7 +113,7 @@ export function useRecordingStart(
         return;
       }
 
-      console.log('Parakeet ready - setting up meeting title and state');
+      console.log('Model ready - setting up meeting title and state');
 
       const randomTitle = generateMeetingTitle();
       setMeetingTitle(randomTitle);
@@ -141,7 +148,7 @@ export function useRecordingStart(
       // Re-throw so RecordingControls can handle device-specific errors
       throw error;
     }
-  }, [generateMeetingTitle, setMeetingTitle, setIsRecording, clearTranscripts, setIsMeetingActive, checkParakeetReady, checkIfModelDownloading, selectedDevices, showModal, setStatus]);
+  }, [generateMeetingTitle, setMeetingTitle, setIsRecording, clearTranscripts, setIsMeetingActive, checkModelReady, checkIfModelDownloading, selectedDevices, showModal, setStatus]);
 
   // Check for autoStartRecording flag and start recording automatically
   useEffect(() => {
@@ -153,9 +160,9 @@ export function useRecordingStart(
           setIsAutoStarting(true);
           sessionStorage.removeItem('autoStartRecording'); // Clear the flag
 
-          // Check if Parakeet transcription model is ready before starting
-          const parakeetReady = await checkParakeetReady();
-          if (!parakeetReady) {
+          // Check if transcription model is ready before starting
+          const isModelReady = await checkModelReady();
+          if (!isModelReady) {
             const isDownloading = await checkIfModelDownloading();
             if (isDownloading) {
               toast.info('Model download in progress', {
@@ -224,7 +231,7 @@ export function useRecordingStart(
     setIsRecording,
     clearTranscripts,
     setIsMeetingActive,
-    checkParakeetReady,
+    checkModelReady,
     checkIfModelDownloading,
     showModal,
     setStatus,
@@ -238,12 +245,12 @@ export function useRecordingStart(
         return;
       }
 
-      console.log('Direct start from sidebar - checking Parakeet model status');
+      console.log('Direct start from sidebar - checking model status');
       setIsAutoStarting(true);
 
-      // Check if Parakeet transcription model is ready before starting
-      const parakeetReady = await checkParakeetReady();
-      if (!parakeetReady) {
+      // Check if transcription model is ready before starting
+      const isModelReady = await checkModelReady();
+      if (!isModelReady) {
         const isDownloading = await checkIfModelDownloading();
         if (isDownloading) {
           toast.info('Model download in progress', {
@@ -313,7 +320,7 @@ export function useRecordingStart(
     setIsRecording,
     clearTranscripts,
     setIsMeetingActive,
-    checkParakeetReady,
+    checkModelReady,
     checkIfModelDownloading,
     showModal,
     setStatus,


### PR DESCRIPTION
This PR fixes an issue where the "Start Recording" button would be disabled, complaining about a missing transcription model, even when a Whisper model was successfully downloaded and selected. 

The bug was caused by a hardcoded check for `parakeet_has_available_models` in `useRecordingStart.ts`. This has been updated to dynamically check the model status based on the selected `transcriptModelConfig.provider`.

Additionally, the Whisper engine's `discover_models` method has been enhanced to automatically detect any custom `.bin` model files placed in the `models` directory, rather than strictly relying on the hardcoded catalog.