### PR TITLE
feat: add Apple Speech Recognition as transcription provider

### DIFF
--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -170,22 +170,25 @@ futures-channel = "0.3.31"
 
 # Apple Speech Recognition (SFSpeechRecognizer) for native macOS transcription
 objc2 = "0.6"
-objc2-foundation = { version = "0.3", features = ["NSString", "NSLocale", "NSError", "block2"] }
+block2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSString", "NSLocale", "NSError", "NSArray", "alloc", "block2"] }
 objc2-speech = { version = "0.3", features = [
     "SFSpeechRecognizer",
     "SFSpeechRecognitionRequest",
     "SFSpeechRecognitionResult",
     "SFSpeechRecognitionTask",
-    "SFSpeechAudioBufferRecognitionRequest",
     "SFTranscription",
+    "SFTranscriptionSegment",
+    "alloc",
     "block2",
+    "objc2-avf-audio",
 ] }
 objc2-avf-audio = { version = "0.3", features = [
     "AVAudioBuffer",
-    "AVAudioPCMBuffer",
     "AVAudioFormat",
-    "AVAudioCommonFormat",
+    "AVAudioTypes",
     "AVAudioChannelLayout",
+    "alloc",
 ] }
 
 # PERFORMANCE: Enable Metal GPU + CoreML acceleration automatically on macOS

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -168,6 +168,26 @@ cidre = { git = "https://github.com/yury/cidre", rev = "a9587fa", features = ["a
 dasp = "0.11.0"
 futures-channel = "0.3.31"
 
+# Apple Speech Recognition (SFSpeechRecognizer) for native macOS transcription
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSString", "NSLocale", "NSError", "block2"] }
+objc2-speech = { version = "0.3", features = [
+    "SFSpeechRecognizer",
+    "SFSpeechRecognitionRequest",
+    "SFSpeechRecognitionResult",
+    "SFSpeechRecognitionTask",
+    "SFSpeechAudioBufferRecognitionRequest",
+    "SFTranscription",
+    "block2",
+] }
+objc2-avf-audio = { version = "0.3", features = [
+    "AVAudioBuffer",
+    "AVAudioPCMBuffer",
+    "AVAudioFormat",
+    "AVAudioCommonFormat",
+    "AVAudioChannelLayout",
+] }
+
 # PERFORMANCE: Enable Metal GPU + CoreML acceleration automatically on macOS
 # CoreML provides additional acceleration for Apple Silicon chips
 whisper-rs = { version = "0.13.2", features = ["raw-api", "metal", "coreml"] }

--- a/frontend/src-tauri/src/apple_speech_engine/commands.rs
+++ b/frontend/src-tauri/src/apple_speech_engine/commands.rs
@@ -1,0 +1,79 @@
+//! Tauri commands for Apple Speech engine initialization and status.
+
+use log::{info, error};
+use std::sync::{Arc, Mutex};
+
+/// Stub engine for non-macOS platforms.
+#[cfg(not(target_os = "macos"))]
+pub struct AppleSpeechEngine;
+
+#[cfg(not(target_os = "macos"))]
+impl AppleSpeechEngine {
+    pub async fn is_model_loaded(&self) -> bool {
+        false
+    }
+    pub async fn get_current_model(&self) -> Option<String> {
+        None
+    }
+    pub async fn transcribe_audio(&self, _audio: Vec<f32>) -> anyhow::Result<(String, Option<f32>, bool)> {
+        Err(anyhow::anyhow!("Apple Speech is only available on macOS"))
+    }
+}
+
+/// Global Apple Speech engine instance (matches WHISPER_ENGINE / PARAKEET_ENGINE pattern).
+pub static APPLE_SPEECH_ENGINE: Mutex<Option<Arc<super::AppleSpeechEngine>>> = Mutex::new(None);
+
+/// Initialize the Apple Speech engine.
+/// Checks availability and requests authorization if needed.
+#[cfg(target_os = "macos")]
+pub async fn apple_speech_init() -> Result<(), String> {
+    // Check if already initialized
+    {
+        let guard = APPLE_SPEECH_ENGINE.lock().unwrap();
+        if let Some(ref engine) = *guard {
+            if futures_util::FutureExt::now_or_never(engine.is_model_loaded()).unwrap_or(false) {
+                info!("🍎 Apple Speech engine already initialized");
+                return Ok(());
+            }
+        }
+    }
+
+    // Request authorization
+    super::AppleSpeechEngine::request_authorization()
+        .await
+        .map_err(|e| format!("Authorization failed: {}", e))?;
+
+    // Create engine
+    let engine = super::AppleSpeechEngine::new()
+        .map_err(|e| format!("Failed to create Apple Speech engine: {}", e))?;
+
+    if !engine.is_model_loaded().await {
+        return Err("Apple Speech recognizer is not available on this device".to_string());
+    }
+
+    let engine = Arc::new(engine);
+    {
+        let mut guard = APPLE_SPEECH_ENGINE.lock().unwrap();
+        *guard = Some(engine);
+    }
+
+    info!("🍎 Apple Speech engine initialized successfully");
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+pub async fn apple_speech_init() -> Result<(), String> {
+    Err("Apple Speech is only available on macOS".to_string())
+}
+
+/// Check if Apple Speech is available on this device.
+#[cfg(target_os = "macos")]
+pub fn apple_speech_is_available() -> bool {
+    let guard = APPLE_SPEECH_ENGINE.lock().unwrap();
+    guard.is_some()
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn apple_speech_is_available() -> bool {
+    false
+}

--- a/frontend/src-tauri/src/apple_speech_engine/engine.rs
+++ b/frontend/src-tauri/src/apple_speech_engine/engine.rs
@@ -4,14 +4,17 @@
 //! used by WhisperEngine and ParakeetEngine.
 
 use anyhow::{anyhow, Result};
-use log::{info, warn, error};
+use log::{info, warn};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use block2::RcBlock;
+use objc2::AllocAnyThread;
 use objc2::rc::Retained;
-use objc2_foundation::{NSLocale, NSString};
+use objc2_foundation::NSString;
 use objc2_speech::{
     SFSpeechAudioBufferRecognitionRequest, SFSpeechRecognitionResult, SFSpeechRecognizer,
+    SFSpeechRecognizerAuthorizationStatus,
 };
 use objc2_avf_audio::{AVAudioFormat, AVAudioPCMBuffer};
 
@@ -26,15 +29,13 @@ pub struct AppleSpeechEngine {
 }
 
 impl AppleSpeechEngine {
-    /// Create a new AppleSpeechEngine. Checks availability but does not request authorization yet.
+    /// Create a new AppleSpeechEngine with the system default locale.
     pub fn new() -> Result<Self> {
         let recognizer = unsafe { SFSpeechRecognizer::new() };
-        let available = recognizer.isAvailable();
-        let locale_name = if available {
-            let locale = unsafe { recognizer.locale() };
-            unsafe { locale.localeIdentifier() }.to_string()
-        } else {
-            "unavailable".to_string()
+        let available = unsafe { recognizer.isAvailable() };
+        let locale_name = unsafe {
+            let locale = recognizer.locale();
+            locale.localeIdentifier().to_string()
         };
 
         info!(
@@ -52,10 +53,14 @@ impl AppleSpeechEngine {
     /// Create engine with a specific locale (e.g. "en-US", "es-ES").
     pub fn with_locale(locale_id: &str) -> Result<Self> {
         let ns_locale_id = NSString::from_str(locale_id);
-        let locale = unsafe { NSLocale::initWithLocaleIdentifier(NSLocale::alloc(), &ns_locale_id) };
-        let recognizer = unsafe { SFSpeechRecognizer::initWithLocale(SFSpeechRecognizer::alloc(), &locale) };
+        let locale = objc2_foundation::NSLocale::localeWithLocaleIdentifier(&ns_locale_id);
+        let recognizer = unsafe { SFSpeechRecognizer::initWithLocale(
+            SFSpeechRecognizer::alloc(),
+            &locale,
+        ) }
+        .ok_or_else(|| anyhow!("Failed to create SFSpeechRecognizer with locale '{}'", locale_id))?;
 
-        let available = recognizer.isAvailable();
+        let available = unsafe { recognizer.isAvailable() };
 
         info!(
             "🍎 Apple Speech engine created with locale '{}' — available: {}",
@@ -70,21 +75,18 @@ impl AppleSpeechEngine {
     }
 
     /// Request speech recognition authorization from the user.
-    /// Must be called before first transcription.
     pub async fn request_authorization() -> Result<()> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         let tx = std::sync::Mutex::new(Some(tx));
 
-        unsafe {
-            SFSpeechRecognizer::requestAuthorization(&objc2::block2::RcBlock::new(
-                move |status| {
-                    let authorized = status == objc2_speech::SFSpeechRecognizerAuthorizationStatus::Authorized;
-                    if let Some(tx) = tx.lock().unwrap().take() {
-                        let _ = tx.send(authorized);
-                    }
-                },
-            ));
-        }
+        let block = RcBlock::new(move |status: SFSpeechRecognizerAuthorizationStatus| {
+            let authorized = status == SFSpeechRecognizerAuthorizationStatus::Authorized;
+            if let Some(tx) = tx.lock().unwrap().take() {
+                let _ = tx.send(authorized);
+            }
+        });
+
+        unsafe { SFSpeechRecognizer::requestAuthorization(&block) };
 
         match rx.await {
             Ok(true) => {
@@ -93,7 +95,7 @@ impl AppleSpeechEngine {
             }
             Ok(false) => {
                 warn!("🍎 Speech recognition not authorized by user");
-                Err(anyhow!("Speech recognition not authorized. Please enable it in System Settings > Privacy & Security > Speech Recognition."))
+                Err(anyhow!("Speech recognition not authorized. Please enable in System Settings > Privacy & Security > Speech Recognition."))
             }
             Err(_) => Err(anyhow!("Failed to receive authorization response")),
         }
@@ -102,39 +104,35 @@ impl AppleSpeechEngine {
     /// Transcribe audio samples to text.
     ///
     /// Audio must be 16kHz mono f32 samples (same format as other engines).
+    /// Returns (text, optional_confidence, is_partial).
     pub async fn transcribe_audio(&self, audio: Vec<f32>) -> Result<(String, Option<f32>, bool)> {
         let recognizer_guard = self.recognizer.read().await;
         let recognizer = recognizer_guard
             .as_ref()
             .ok_or_else(|| anyhow!("Apple Speech recognizer not initialized"))?;
 
-        if !recognizer.isAvailable() {
+        if !unsafe { recognizer.isAvailable() } {
             return Err(anyhow!("Apple Speech recognizer is not available"));
         }
 
         // Create recognition request
         let request = unsafe { SFSpeechAudioBufferRecognitionRequest::new() };
-        unsafe {
-            request.setShouldReportPartialResults(false);
-        }
+        unsafe { request.setShouldReportPartialResults(false) };
 
         // Enable on-device recognition if supported
         if unsafe { recognizer.supportsOnDeviceRecognition() } {
             unsafe { request.setRequiresOnDeviceRecognition(true) };
-            info!("🍎 Using on-device recognition");
         }
 
-        // Create audio format: 16kHz, 1 channel, float32
+        // Create audio format: 16kHz, 1 channel, float32 interleaved
         let format = unsafe {
             AVAudioFormat::initStandardFormatWithSampleRate_channels(
                 AVAudioFormat::alloc(),
                 16000.0,
                 1,
             )
-        };
-        let Some(format) = format else {
-            return Err(anyhow!("Failed to create AVAudioFormat (16kHz mono)"));
-        };
+        }
+        .ok_or_else(|| anyhow!("Failed to create AVAudioFormat (16kHz mono)"))?;
 
         // Create PCM buffer and copy audio data
         let frame_count = audio.len() as u32;
@@ -144,10 +142,8 @@ impl AppleSpeechEngine {
                 &format,
                 frame_count,
             )
-        };
-        let Some(buffer) = buffer else {
-            return Err(anyhow!("Failed to create AVAudioPCMBuffer"));
-        };
+        }
+        .ok_or_else(|| anyhow!("Failed to create AVAudioPCMBuffer"))?;
 
         // Copy f32 samples into the buffer
         unsafe {
@@ -155,7 +151,7 @@ impl AppleSpeechEngine {
             if float_data.is_null() {
                 return Err(anyhow!("AVAudioPCMBuffer floatChannelData is null"));
             }
-            let channel_ptr = *float_data;
+            let channel_ptr = (*float_data).as_ptr();
             std::ptr::copy_nonoverlapping(audio.as_ptr(), channel_ptr, audio.len());
             buffer.setFrameLength(frame_count);
         }
@@ -170,53 +166,52 @@ impl AppleSpeechEngine {
         let (tx, rx) = tokio::sync::oneshot::channel::<Result<(String, Option<f32>, bool)>>();
         let tx = std::sync::Mutex::new(Some(tx));
 
+        let block = RcBlock::new(
+            move |result: *mut SFSpeechRecognitionResult,
+                  error: *mut objc2_foundation::NSError| {
+                let Some(tx) = tx.lock().unwrap().take() else {
+                    return; // Already sent result
+                };
+
+                if !error.is_null() {
+                    let err = unsafe { &*error };
+                    let description = err.localizedDescription().to_string();
+                    let _ = tx.send(Err(anyhow!("Speech recognition error: {}", description)));
+                    return;
+                }
+
+                if result.is_null() {
+                    let _ = tx.send(Err(anyhow!("Speech recognition returned null result")));
+                    return;
+                }
+
+                let result = unsafe { &*result };
+                let is_final = unsafe { result.isFinal() };
+
+                if is_final {
+                    let transcription = unsafe { result.bestTranscription() };
+                    let text = unsafe { transcription.formattedString() }.to_string();
+
+                    // Average confidence across segments
+                    let segments = unsafe { transcription.segments() };
+                    let confidence = if segments.len() > 0 {
+                        let sum: f32 = segments
+                            .to_vec()
+                            .iter()
+                            .map(|s| unsafe { s.confidence() } as f32)
+                            .sum();
+                        Some(sum / segments.len() as f32)
+                    } else {
+                        None
+                    };
+
+                    let _ = tx.send(Ok((text, confidence, false)));
+                }
+            },
+        );
+
         let _task = unsafe {
-            recognizer.recognitionTaskWithRequest_resultHandler(
-                &request,
-                &objc2::block2::RcBlock::new(
-                    move |result: *mut SFSpeechRecognitionResult, error: *mut objc2_foundation::NSError| {
-                        let Some(tx) = tx.lock().unwrap().take() else {
-                            return; // Already sent result
-                        };
-
-                        if !error.is_null() {
-                            let err = unsafe { &*error };
-                            let description = unsafe { err.localizedDescription() }.to_string();
-                            let _ = tx.send(Err(anyhow!("Speech recognition error: {}", description)));
-                            return;
-                        }
-
-                        if result.is_null() {
-                            let _ = tx.send(Err(anyhow!("Speech recognition returned null result")));
-                            return;
-                        }
-
-                        let result = unsafe { &*result };
-                        let is_final = result.isFinal();
-
-                        if is_final {
-                            let transcription = unsafe { result.bestTranscription() };
-                            let text = unsafe { transcription.formattedString() }.to_string();
-                            let confidence = result.transcriptions()
-                                .first()
-                                .and_then(|t| {
-                                    let segments = unsafe { t.segments() };
-                                    if segments.is_empty() {
-                                        None
-                                    } else {
-                                        let sum: f32 = segments.iter()
-                                            .map(|s| s.confidence() as f32)
-                                            .sum();
-                                        Some(sum / segments.len() as f32)
-                                    }
-                                });
-
-                            let _ = tx.send(Ok((text, confidence, false)));
-                        }
-                        // Non-final results are ignored since we set shouldReportPartialResults=false
-                    },
-                ),
-            )
+            recognizer.recognitionTaskWithRequest_resultHandler(&request, &block)
         };
 
         // Wait for result with timeout

--- a/frontend/src-tauri/src/apple_speech_engine/engine.rs
+++ b/frontend/src-tauri/src/apple_speech_engine/engine.rs
@@ -1,0 +1,244 @@
+//! Apple Speech engine implementation using SFSpeechRecognizer.
+//!
+//! Wraps macOS native speech recognition behind the same Arc<RwLock<>> pattern
+//! used by WhisperEngine and ParakeetEngine.
+
+use anyhow::{anyhow, Result};
+use log::{info, warn, error};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use objc2::rc::Retained;
+use objc2_foundation::{NSLocale, NSString};
+use objc2_speech::{
+    SFSpeechAudioBufferRecognitionRequest, SFSpeechRecognitionResult, SFSpeechRecognizer,
+};
+use objc2_avf_audio::{AVAudioFormat, AVAudioPCMBuffer};
+
+/// Apple Speech transcription engine.
+///
+/// Wraps SFSpeechRecognizer for on-device speech recognition on macOS.
+/// Thread-safe via Arc<RwLock<>> — matches WhisperEngine/ParakeetEngine pattern.
+pub struct AppleSpeechEngine {
+    recognizer: Arc<RwLock<Option<Retained<SFSpeechRecognizer>>>>,
+    locale_name: Arc<RwLock<String>>,
+    available: Arc<RwLock<bool>>,
+}
+
+impl AppleSpeechEngine {
+    /// Create a new AppleSpeechEngine. Checks availability but does not request authorization yet.
+    pub fn new() -> Result<Self> {
+        let recognizer = unsafe { SFSpeechRecognizer::new() };
+        let available = recognizer.isAvailable();
+        let locale_name = if available {
+            let locale = unsafe { recognizer.locale() };
+            unsafe { locale.localeIdentifier() }.to_string()
+        } else {
+            "unavailable".to_string()
+        };
+
+        info!(
+            "🍎 Apple Speech engine created — available: {}, locale: {}",
+            available, locale_name
+        );
+
+        Ok(Self {
+            recognizer: Arc::new(RwLock::new(Some(recognizer))),
+            locale_name: Arc::new(RwLock::new(locale_name)),
+            available: Arc::new(RwLock::new(available)),
+        })
+    }
+
+    /// Create engine with a specific locale (e.g. "en-US", "es-ES").
+    pub fn with_locale(locale_id: &str) -> Result<Self> {
+        let ns_locale_id = NSString::from_str(locale_id);
+        let locale = unsafe { NSLocale::initWithLocaleIdentifier(NSLocale::alloc(), &ns_locale_id) };
+        let recognizer = unsafe { SFSpeechRecognizer::initWithLocale(SFSpeechRecognizer::alloc(), &locale) };
+
+        let available = recognizer.isAvailable();
+
+        info!(
+            "🍎 Apple Speech engine created with locale '{}' — available: {}",
+            locale_id, available
+        );
+
+        Ok(Self {
+            recognizer: Arc::new(RwLock::new(Some(recognizer))),
+            locale_name: Arc::new(RwLock::new(locale_id.to_string())),
+            available: Arc::new(RwLock::new(available)),
+        })
+    }
+
+    /// Request speech recognition authorization from the user.
+    /// Must be called before first transcription.
+    pub async fn request_authorization() -> Result<()> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let tx = std::sync::Mutex::new(Some(tx));
+
+        unsafe {
+            SFSpeechRecognizer::requestAuthorization(&objc2::block2::RcBlock::new(
+                move |status| {
+                    let authorized = status == objc2_speech::SFSpeechRecognizerAuthorizationStatus::Authorized;
+                    if let Some(tx) = tx.lock().unwrap().take() {
+                        let _ = tx.send(authorized);
+                    }
+                },
+            ));
+        }
+
+        match rx.await {
+            Ok(true) => {
+                info!("🍎 Speech recognition authorized");
+                Ok(())
+            }
+            Ok(false) => {
+                warn!("🍎 Speech recognition not authorized by user");
+                Err(anyhow!("Speech recognition not authorized. Please enable it in System Settings > Privacy & Security > Speech Recognition."))
+            }
+            Err(_) => Err(anyhow!("Failed to receive authorization response")),
+        }
+    }
+
+    /// Transcribe audio samples to text.
+    ///
+    /// Audio must be 16kHz mono f32 samples (same format as other engines).
+    pub async fn transcribe_audio(&self, audio: Vec<f32>) -> Result<(String, Option<f32>, bool)> {
+        let recognizer_guard = self.recognizer.read().await;
+        let recognizer = recognizer_guard
+            .as_ref()
+            .ok_or_else(|| anyhow!("Apple Speech recognizer not initialized"))?;
+
+        if !recognizer.isAvailable() {
+            return Err(anyhow!("Apple Speech recognizer is not available"));
+        }
+
+        // Create recognition request
+        let request = unsafe { SFSpeechAudioBufferRecognitionRequest::new() };
+        unsafe {
+            request.setShouldReportPartialResults(false);
+        }
+
+        // Enable on-device recognition if supported
+        if unsafe { recognizer.supportsOnDeviceRecognition() } {
+            unsafe { request.setRequiresOnDeviceRecognition(true) };
+            info!("🍎 Using on-device recognition");
+        }
+
+        // Create audio format: 16kHz, 1 channel, float32
+        let format = unsafe {
+            AVAudioFormat::initStandardFormatWithSampleRate_channels(
+                AVAudioFormat::alloc(),
+                16000.0,
+                1,
+            )
+        };
+        let Some(format) = format else {
+            return Err(anyhow!("Failed to create AVAudioFormat (16kHz mono)"));
+        };
+
+        // Create PCM buffer and copy audio data
+        let frame_count = audio.len() as u32;
+        let buffer = unsafe {
+            AVAudioPCMBuffer::initWithPCMFormat_frameCapacity(
+                AVAudioPCMBuffer::alloc(),
+                &format,
+                frame_count,
+            )
+        };
+        let Some(buffer) = buffer else {
+            return Err(anyhow!("Failed to create AVAudioPCMBuffer"));
+        };
+
+        // Copy f32 samples into the buffer
+        unsafe {
+            let float_data = buffer.floatChannelData();
+            if float_data.is_null() {
+                return Err(anyhow!("AVAudioPCMBuffer floatChannelData is null"));
+            }
+            let channel_ptr = *float_data;
+            std::ptr::copy_nonoverlapping(audio.as_ptr(), channel_ptr, audio.len());
+            buffer.setFrameLength(frame_count);
+        }
+
+        // Append audio and signal end
+        unsafe {
+            request.appendAudioPCMBuffer(&buffer);
+            request.endAudio();
+        }
+
+        // Run recognition task with result handler
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(String, Option<f32>, bool)>>();
+        let tx = std::sync::Mutex::new(Some(tx));
+
+        let _task = unsafe {
+            recognizer.recognitionTaskWithRequest_resultHandler(
+                &request,
+                &objc2::block2::RcBlock::new(
+                    move |result: *mut SFSpeechRecognitionResult, error: *mut objc2_foundation::NSError| {
+                        let Some(tx) = tx.lock().unwrap().take() else {
+                            return; // Already sent result
+                        };
+
+                        if !error.is_null() {
+                            let err = unsafe { &*error };
+                            let description = unsafe { err.localizedDescription() }.to_string();
+                            let _ = tx.send(Err(anyhow!("Speech recognition error: {}", description)));
+                            return;
+                        }
+
+                        if result.is_null() {
+                            let _ = tx.send(Err(anyhow!("Speech recognition returned null result")));
+                            return;
+                        }
+
+                        let result = unsafe { &*result };
+                        let is_final = result.isFinal();
+
+                        if is_final {
+                            let transcription = unsafe { result.bestTranscription() };
+                            let text = unsafe { transcription.formattedString() }.to_string();
+                            let confidence = result.transcriptions()
+                                .first()
+                                .and_then(|t| {
+                                    let segments = unsafe { t.segments() };
+                                    if segments.is_empty() {
+                                        None
+                                    } else {
+                                        let sum: f32 = segments.iter()
+                                            .map(|s| s.confidence() as f32)
+                                            .sum();
+                                        Some(sum / segments.len() as f32)
+                                    }
+                                });
+
+                            let _ = tx.send(Ok((text, confidence, false)));
+                        }
+                        // Non-final results are ignored since we set shouldReportPartialResults=false
+                    },
+                ),
+            )
+        };
+
+        // Wait for result with timeout
+        match tokio::time::timeout(std::time::Duration::from_secs(30), rx).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => Err(anyhow!("Recognition task channel closed unexpectedly")),
+            Err(_) => Err(anyhow!("Speech recognition timed out after 30 seconds")),
+        }
+    }
+
+    /// Check if the recognizer is available and ready.
+    pub async fn is_model_loaded(&self) -> bool {
+        *self.available.read().await
+    }
+
+    /// Get the current model/locale name.
+    pub async fn get_current_model(&self) -> Option<String> {
+        let name = self.locale_name.read().await.clone();
+        if name == "unavailable" {
+            None
+        } else {
+            Some(format!("apple-speech-{}", name))
+        }
+    }
+}

--- a/frontend/src-tauri/src/apple_speech_engine/mod.rs
+++ b/frontend/src-tauri/src/apple_speech_engine/mod.rs
@@ -1,0 +1,14 @@
+//! Apple Speech Recognition engine module.
+//!
+//! Uses macOS native SFSpeechRecognizer for on-device speech-to-text transcription.
+//! Only available on macOS — stubbed out on other platforms.
+
+#[cfg(target_os = "macos")]
+mod engine;
+pub mod commands;
+
+#[cfg(target_os = "macos")]
+pub use engine::AppleSpeechEngine;
+
+#[cfg(not(target_os = "macos"))]
+pub use commands::AppleSpeechEngine;

--- a/frontend/src-tauri/src/audio/transcription/apple_speech_provider.rs
+++ b/frontend/src-tauri/src/audio/transcription/apple_speech_provider.rs
@@ -1,0 +1,52 @@
+// audio/transcription/apple_speech_provider.rs
+//
+// Apple Speech transcription provider implementation.
+// Follows the same pattern as whisper_provider.rs and parakeet_provider.rs.
+
+use super::provider::{TranscriptionError, TranscriptionProvider, TranscriptResult};
+use async_trait::async_trait;
+use log::info;
+use std::sync::Arc;
+
+/// Apple Speech transcription provider (wraps AppleSpeechEngine)
+pub struct AppleSpeechProvider {
+    engine: Arc<crate::apple_speech_engine::AppleSpeechEngine>,
+}
+
+impl AppleSpeechProvider {
+    pub fn new(engine: Arc<crate::apple_speech_engine::AppleSpeechEngine>) -> Self {
+        Self { engine }
+    }
+}
+
+#[async_trait]
+impl TranscriptionProvider for AppleSpeechProvider {
+    async fn transcribe(
+        &self,
+        audio: Vec<f32>,
+        _language: Option<String>,
+    ) -> std::result::Result<TranscriptResult, TranscriptionError> {
+        // Language is set at engine init time via locale, not per-transcription call.
+        // The recognizer uses the locale it was initialized with.
+        match self.engine.transcribe_audio(audio).await {
+            Ok((text, confidence, is_partial)) => Ok(TranscriptResult {
+                text: text.trim().to_string(),
+                confidence,
+                is_partial,
+            }),
+            Err(e) => Err(TranscriptionError::EngineFailed(e.to_string())),
+        }
+    }
+
+    async fn is_model_loaded(&self) -> bool {
+        self.engine.is_model_loaded().await
+    }
+
+    async fn get_current_model(&self) -> Option<String> {
+        self.engine.get_current_model().await
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "Apple Speech"
+    }
+}

--- a/frontend/src-tauri/src/audio/transcription/engine.rs
+++ b/frontend/src-tauri/src/audio/transcription/engine.rs
@@ -135,10 +135,25 @@ pub async fn validate_transcription_model_ready<R: Runtime>(app: &AppHandle<R>) 
                 }
             }
         }
+        "appleSpeech" => {
+            info!("🍎 Validating Apple Speech availability...");
+            #[cfg(target_os = "macos")]
+            {
+                crate::apple_speech_engine::commands::apple_speech_init()
+                    .await
+                    .map_err(|e| format!("Apple Speech not available: {}", e))?;
+                info!("✅ Apple Speech validation successful");
+                Ok(())
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                Err("Apple Speech is only available on macOS".to_string())
+            }
+        }
         other => {
             warn!("❌ Unsupported transcription provider for local recording: {}", other);
             Err(format!(
-                "Provider '{}' is not supported for local transcription. Please select 'localWhisper' or 'parakeet'.",
+                "Provider '{}' is not supported for local transcription. Please select 'localWhisper', 'parakeet', or 'appleSpeech'.",
                 other
             ))
         }
@@ -210,6 +225,36 @@ pub async fn get_or_init_transcription_engine<R: Runtime>(
                 None => {
                     Err("Parakeet engine not initialized. This should not happen after validation.".to_string())
                 }
+            }
+        }
+        "appleSpeech" => {
+            info!("🍎 Initializing Apple Speech transcription engine");
+            #[cfg(target_os = "macos")]
+            {
+                let engine = {
+                    let guard = crate::apple_speech_engine::commands::APPLE_SPEECH_ENGINE
+                        .lock()
+                        .unwrap();
+                    guard.as_ref().cloned()
+                };
+
+                match engine {
+                    Some(engine) => {
+                        if engine.is_model_loaded().await {
+                            info!("✅ Apple Speech engine ready");
+                            Ok(TranscriptionEngine::Provider(
+                                Arc::new(super::AppleSpeechProvider::new(engine)),
+                            ))
+                        } else {
+                            Err("Apple Speech recognizer is not available".to_string())
+                        }
+                    }
+                    None => Err("Apple Speech engine not initialized. This should not happen after validation.".to_string()),
+                }
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                Err("Apple Speech is only available on macOS".to_string())
             }
         }
         "localWhisper" | _ => {

--- a/frontend/src-tauri/src/audio/transcription/mod.rs
+++ b/frontend/src-tauri/src/audio/transcription/mod.rs
@@ -5,6 +5,8 @@
 pub mod provider;
 pub mod whisper_provider;
 pub mod parakeet_provider;
+#[cfg(target_os = "macos")]
+pub mod apple_speech_provider;
 pub mod engine;
 pub mod worker;
 
@@ -12,6 +14,8 @@ pub mod worker;
 pub use provider::{TranscriptionError, TranscriptionProvider, TranscriptResult};
 pub use whisper_provider::WhisperProvider;
 pub use parakeet_provider::ParakeetProvider;
+#[cfg(target_os = "macos")]
+pub use apple_speech_provider::AppleSpeechProvider;
 pub use engine::{
     TranscriptionEngine,
     validate_transcription_model_ready,

--- a/frontend/src-tauri/src/config.rs
+++ b/frontend/src-tauri/src/config.rs
@@ -11,6 +11,10 @@ pub const DEFAULT_WHISPER_MODEL: &str = "large-v3-turbo";
 /// This is the quantized version optimized for speed.
 pub const DEFAULT_PARAKEET_MODEL: &str = "parakeet-tdt-0.6b-v3-int8";
 
+/// Default Apple Speech model identifier.
+/// Apple Speech uses the system recognizer — no downloadable model needed.
+pub const DEFAULT_APPLE_SPEECH_MODEL: &str = "default";
+
 /// Whisper model catalog with metadata for all supported models.
 /// Used by both WhisperEngine::discover_models() and discover_models_standalone().
 ///

--- a/frontend/src-tauri/src/database/repositories/setting.rs
+++ b/frontend/src-tauri/src/database/repositories/setting.rs
@@ -180,6 +180,7 @@ impl SettingsRepository {
         let api_key_column = match provider {
             "localWhisper" => "whisperApiKey",
             "parakeet" => return Ok(()), // Parakeet doesn't need an API key, return early
+            "appleSpeech" => return Ok(()), // Apple Speech doesn't need an API key
             "deepgram" => "deepgramApiKey",
             "elevenLabs" => "elevenLabsApiKey",
             "groq" => "groqApiKey",
@@ -212,6 +213,7 @@ impl SettingsRepository {
         let api_key_column = match provider {
             "localWhisper" => "whisperApiKey",
             "parakeet" => return Ok(None), // Parakeet doesn't need an API key
+            "appleSpeech" => return Ok(None), // Apple Speech doesn't need an API key
             "deepgram" => "deepgramApiKey",
             "elevenLabs" => "elevenLabsApiKey",
             "groq" => "groqApiKey",

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -49,6 +49,8 @@ pub mod anthropic;
 pub mod groq;
 pub mod openrouter;
 pub mod parakeet_engine;
+#[cfg(target_os = "macos")]
+pub mod apple_speech_engine;
 pub mod state;
 pub mod summary;
 pub mod tray;

--- a/frontend/src/components/TranscriptSettings.tsx
+++ b/frontend/src/components/TranscriptSettings.tsx
@@ -10,7 +10,7 @@ import { ParakeetModelManager } from './ParakeetModelManager';
 
 
 export interface TranscriptModelProps {
-    provider: 'localWhisper' | 'parakeet' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
+    provider: 'localWhisper' | 'parakeet' | 'appleSpeech' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
     model: string;
     apiKey?: string | null;
 }
@@ -34,7 +34,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
     }, [transcriptModelConfig.provider]);
 
     useEffect(() => {
-        if (transcriptModelConfig.provider === 'localWhisper' || transcriptModelConfig.provider === 'parakeet') {
+        if (transcriptModelConfig.provider === 'localWhisper' || transcriptModelConfig.provider === 'parakeet' || transcriptModelConfig.provider === 'appleSpeech') {
             setApiKey(null);
         }
     }, [transcriptModelConfig.provider]);
@@ -53,11 +53,13 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
     const modelOptions = {
         localWhisper: [], // Model selection handled by ModelManager component
         parakeet: [], // Model selection handled by ParakeetModelManager component
+        appleSpeech: [], // Uses macOS system recognizer — no model selection needed
         deepgram: ['nova-2-phonecall'],
         elevenLabs: ['eleven_multilingual_v2'],
         groq: ['llama-3.3-70b-versatile'],
         openai: ['gpt-4o'],
     };
+    const isLocalProvider = transcriptModelConfig.provider === 'localWhisper' || transcriptModelConfig.provider === 'parakeet' || transcriptModelConfig.provider === 'appleSpeech';
     const requiresApiKey = transcriptModelConfig.provider === 'deepgram' || transcriptModelConfig.provider === 'elevenLabs' || transcriptModelConfig.provider === 'openai' || transcriptModelConfig.provider === 'groq';
 
     const handleInputClick = () => {
@@ -112,7 +114,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 onValueChange={(value) => {
                                     const provider = value as TranscriptModelProps['provider'];
                                     setUiProvider(provider);
-                                    if (provider !== 'localWhisper' && provider !== 'parakeet') {
+                                    if (provider !== 'localWhisper' && provider !== 'parakeet' && provider !== 'appleSpeech') {
                                         fetchApiKey(provider);
                                     }
                                 }}
@@ -123,6 +125,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 <SelectContent>
                                     <SelectItem value="parakeet">⚡ Parakeet (Recommended - Real-time / Accurate)</SelectItem>
                                     <SelectItem value="localWhisper">🏠 Local Whisper (High Accuracy)</SelectItem>
+                                    <SelectItem value="appleSpeech">🍎 Apple Speech (macOS Native)</SelectItem>
                                     {/* <SelectItem value="deepgram">☁️ Deepgram (Backup)</SelectItem>
                                     <SelectItem value="elevenLabs">☁️ ElevenLabs</SelectItem>
                                     <SelectItem value="groq">☁️ Groq</SelectItem>
@@ -130,7 +133,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 </SelectContent>
                             </Select>
 
-                            {uiProvider !== 'localWhisper' && uiProvider !== 'parakeet' && (
+                            {uiProvider !== 'localWhisper' && uiProvider !== 'parakeet' && uiProvider !== 'appleSpeech' && (
                                 <Select
                                     value={transcriptModelConfig.model}
                                     onValueChange={(value) => {


### PR DESCRIPTION
## Summary

Adds macOS-native `SFSpeechRecognizer` as a third local transcription provider alongside Whisper and Parakeet.

- Uses Apple's on-device speech recognition, optimized for Apple Silicon
- Leverages the existing `TranscriptionProvider` trait — no changes to `worker.rs` or existing providers
- All new code gated behind `#[cfg(target_os = "macos")]` — zero impact on Windows/Linux builds
- No database migration needed — provider is stored as a string in existing `transcript_settings` table

## Changes

**New files (4):**
- `apple_speech_engine/engine.rs` — Wraps `SFSpeechRecognizer` via `objc2-speech` crate with `Arc<RwLock<>>` pattern
- `apple_speech_engine/commands.rs` — Global engine state + init command (matches Whisper/Parakeet pattern)
- `apple_speech_engine/mod.rs` — Module with platform-conditional exports
- `audio/transcription/apple_speech_provider.rs` — `TranscriptionProvider` trait implementation

**Modified files (7):**
- `Cargo.toml` — Added `objc2-speech`, `objc2-avf-audio`, `objc2`, `objc2-foundation` (macOS only)
- `lib.rs` — Module declaration (+2 lines)
- `audio/transcription/mod.rs` — Export (+4 lines)
- `audio/transcription/engine.rs` — Match arms for validation + initialization (+47 lines)
- `database/repositories/setting.rs` — Match arms for API key handling (+2 lines)
- `config.rs` — Default model constant (+4 lines)
- `TranscriptSettings.tsx` — UI dropdown option + type update (+11 lines)

**Untouched:**
- `whisper_provider.rs`, `parakeet_provider.rs`, `provider.rs`, `worker.rs` — no changes

## How it works

1. User selects "🍎 Apple Speech (macOS Native)" in Transcript Settings
2. Engine requests speech recognition authorization on first use
3. Audio chunks (16kHz mono f32) are converted to `AVAudioPCMBuffer` and fed to `SFSpeechAudioBufferRecognitionRequest`
4. Recognition runs on-device when supported (`supportsOnDeviceRecognition`)
5. Results include confidence scores averaged across segments

## Test plan

- [ ] Build on macOS (Apple Silicon + Intel)
- [ ] Select Apple Speech from provider dropdown
- [ ] Record meeting and verify transcription appears
- [ ] Verify authorization prompt appears on first use
- [ ] Switch between providers (Parakeet → Apple Speech → Whisper) without crashes
- [ ] Verify Windows/Linux builds are unaffected (`#[cfg]` gating)