### PR TITLE
fix(audio/linux): pin cpal buffer_size to avoid PipeWire quantum shrink

### DIFF
--- a/frontend/src-tauri/src/audio/stream.rs
+++ b/frontend/src-tauri/src/audio/stream.rs
@@ -239,13 +239,34 @@ impl AudioStream {
         config: &SupportedStreamConfig,
         capture: AudioCapture,
     ) -> Result<Stream> {
-        let config_copy = config.clone();
+        let mut stream_config: cpal::StreamConfig = config.clone().into();
+
+        // On Linux (PipeWire / PulseAudio via pipewire-alsa), cpal's default
+        // buffer size tends to be very small, which forces PipeWire to shrink
+        // its global quantum. That causes xruns in other apps sharing the mic
+        // (Teams, Zoom, browser WebRTC), showing up as glitchy audio/video.
+        // 1024 frames ≈ 21 ms @ 48 kHz — comfortable for transcription and
+        // non-disruptive to concurrent PipeWire clients.
+        #[cfg(target_os = "linux")]
+        {
+            if let cpal::SupportedBufferSize::Range { min, max } = config.buffer_size() {
+                let desired: u32 = 1024;
+                let clamped = desired.clamp(*min, *max);
+                stream_config.buffer_size = cpal::BufferSize::Fixed(clamped);
+                info!(
+                    "🎚️ Stream: Linux buffer_size override → Fixed({}) (device range {}..={})",
+                    clamped, min, max
+                );
+            } else {
+                info!("🎚️ Stream: Linux buffer_size range unknown, leaving Default");
+            }
+        }
 
         let stream = match config.sample_format() {
             cpal::SampleFormat::F32 => {
                 let capture_clone = capture.clone();
                 device.build_input_stream(
-                    &config_copy.into(),
+                    &stream_config,
                     move |data: &[f32], _: &cpal::InputCallbackInfo| {
                         capture.process_audio_data(data);
                     },
@@ -258,7 +279,7 @@ impl AudioStream {
             cpal::SampleFormat::I16 => {
                 let capture_clone = capture.clone();
                 device.build_input_stream(
-                    &config_copy.into(),
+                    &stream_config,
                     move |data: &[i16], _: &cpal::InputCallbackInfo| {
                         let f32_data: Vec<f32> = data.iter()
                             .map(|&sample| sample as f32 / i16::MAX as f32)
@@ -274,7 +295,7 @@ impl AudioStream {
             cpal::SampleFormat::I32 => {
                 let capture_clone = capture.clone();
                 device.build_input_stream(
-                    &config_copy.into(),
+                    &stream_config,
                     move |data: &[i32], _: &cpal::InputCallbackInfo| {
                         let f32_data: Vec<f32> = data.iter()
                             .map(|&sample| sample as f32 / i32::MAX as f32)
@@ -290,7 +311,7 @@ impl AudioStream {
             cpal::SampleFormat::I8 => {
                 let capture_clone = capture.clone();
                 device.build_input_stream(
-                    &config_copy.into(),
+                    &stream_config,
                     move |data: &[i8], _: &cpal::InputCallbackInfo| {
                         let f32_data: Vec<f32> = data.iter()
                             .map(|&sample| sample as f32 / i8::MAX as f32)


### PR DESCRIPTION
## Description
On Linux (PipeWire + `pipewire-alsa`), cpal's `BufferSize::Default` in `frontend/src-tauri/src/audio/stream.rs::build_stream()` results in a very small ALSA period. PipeWire responds by shrinking its **global clock quantum** to match, which starves every other audio client sharing the mic — Microsoft Teams, Zoom, Discord, browser WebRTC — and manifests as glitchy audio and desynced video for the duration of a Meetily recording.

This PR explicitly requests `BufferSize::Fixed(1024)` on Linux only (~21 ms @ 48 kHz), clamped to the device's advertised `SupportedBufferSize::Range`. Comfortable headroom for PipeWire's graph with no user-visible latency added to transcription.

Change is gated on `#[cfg(target_os = "linux")]`; macOS CoreAudio and Windows WASAPI paths are untouched. Existing `BufferSize::Default` behavior is preserved for devices whose supported range is `Unknown`.

Diff is confined to a single function (`build_stream`) in `audio/stream.rs` — no API changes, no new dependencies.

## Related Issue
Fixes #433

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] All tests pass (`cargo check` passes with no new warnings)

### Manual test
1. Fedora 43, PipeWire + `pipewire-pulse`, NVIDIA.
2. Join an MS Teams call.
3. `pw-top` in a separate terminal — Teams node ERR column is 0.
4. Start recording in Meetily (patched build).
5. Rust logs show `🎚️ Stream: Linux buffer_size override → Fixed(1024) (device range ..=..)`.
6. Teams audio stays clean; `pw-top` ERR column on the Teams node remains 0.

Before the patch, ERR climbs immediately on recording start and Teams audio visibly glitches.

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

(Change is internal; no user-facing config or behavior change beyond the fixed bug.)

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)
N/A — audio-only symptom. Reproducible diagnostic signal is the ERR column in `pw-top` climbing on concurrent audio nodes while recording.

## Additional Notes
**Root-cause summary for reviewers**: cpal's `BufferSize::Default` on pipewire-alsa hits a well-known class of PipeWire behavior — the graph quantum is negotiated to the smallest requested period across all clients, and small-buffer clients drag the whole graph down. This is app-side-only to fix (cpal has no way to know the user wants a larger-than-minimum buffer, and PipeWire has no policy to override the client's ask).

**Why 1024?** It's the smallest power-of-two that comfortably accommodates typical PipeWire graphs (often configured at 1024 or 2048 at 48 kHz on Fedora/Ubuntu defaults) without forcing a renegotiation. If a device advertises a `min` higher than 1024, the `clamp` keeps us inside the supported range.

**Alternatives considered**:
- `BufferSize::Default` + a runtime check for the global PipeWire quantum — more code, less reliable (racy if quantum changes after stream creation).
- Setting `WEBKIT_DISABLE_DMABUF_RENDERER=1` — unrelated; that's a separate fix for a Tauri/WebKitGTK rendering issue on NVIDIA and does not affect audio.
- Telling users to run `pw-metadata -n settings 0 clock.force-quantum 1024` — works as a workaround but isn't discoverable and affects the whole system.