### PR TITLE
fix(linux): disable WebKitGTK DMABUF renderer to prevent blank window

### DIFF
--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -10,6 +10,20 @@ fn main() {
     std::env::set_var("RUST_LOG", "info");
     env_logger::init();
 
+    // On Linux, WebKitGTK's DMABUF renderer is unreliable on common GPU/driver
+    // combinations (notably NVIDIA proprietary drivers and several Wayland
+    // compositors), producing a blank white window on launch. Disabling DMABUF
+    // falls back to the stable renderer and fixes the blank-window case with
+    // negligible visual/performance cost for a desktop app of this scope.
+    // Only set the flag if the user hasn't already chosen a value, so anyone
+    // debugging WebKit rendering can still override it from the environment.
+    #[cfg(target_os = "linux")]
+    {
+        if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
+    }
+
     // Async logger will be initialized lazily when first needed (after Tauri runtime starts)
     log::info!("Starting application...");
     app_lib::run();


### PR DESCRIPTION
## Description
On Linux, Meetily often launches to a blank white window because WebKitGTK's DMABUF-based renderer fails to initialize on common setups — notably machines with NVIDIA proprietary drivers and some Wayland compositors. When DMABUF init fails, WebKitGTK silently falls back to rendering nothing, so the app appears to start but shows no UI.

This PR sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` in `main()` before anything else runs (so it's in the environment before WebKitGTK's WebProcess forks), only on Linux, and only if the user hasn't already chosen a value. The existing workaround of manually wrapping the launcher (`Exec=env WEBKIT_DISABLE_DMABUF_RENDERER=1 ...`) stops being necessary out-of-the-box, but anyone debugging WebKitGTK rendering can still override it via the environment.

Scope is minimal — 14 lines in `main.rs` behind `#[cfg(target_os = "linux")]`. macOS and Windows paths are completely untouched.

## Related Issue
Fixes #435

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] All tests pass (`cargo check` passes, no new warnings)

### Manual test
1. Fedora 43, NVIDIA (open 580.x), KDE Wayland.
2. Build the AppImage (`pnpm tauri build`).
3. Launch via Gearlever — UI renders immediately, no env var required.
4. `env WEBKIT_DISABLE_DMABUF_RENDERER=0 ./meetily_*.AppImage` still reproduces the blank-window bug, confirming the override path works as intended for debugging.

Pre-patch, step 3 produced a blank white window (the symptom from #435).

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

(The workaround flag is now implicit. If desired in a follow-up, README could mention it as an override for debugging, but that's optional.)

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)
N/A — symptom is literally a blank window. The presence of a rendered UI after the patch is itself the evidence.

## Additional Notes
**Why in `main()` rather than AppImage/launcher wrapping?** Setting it in Rust gets it into the environment for all Linux builds (AppImage, .deb, .rpm, dev builds) with a single source of truth. AppImage-only wrapping would miss `.deb` users; `.desktop` file wrapping is fragile and lost on reinstall.

**Why `if var_os.is_none()`?** Preserves the ability to unset or invert the flag from the shell (`WEBKIT_DISABLE_DMABUF_RENDERER=0 meetily`) which is useful for reproducing the original bug or testing newer WebKitGTK that may have fixed DMABUF.

**Is this safe long-term?** DMABUF is the newer, supposedly-faster WebKitGTK rendering path. Disabling it drops back to the stable renderer. For a desktop app of Meetily's scope (no heavy video, no complex 3D), the performance delta is imperceptible. The day WebKitGTK's DMABUF path is reliable across NVIDIA + Wayland, this flag can be removed; until then, it's the only way to ship a Linux build that works on first launch.

**Not related** to PR #434 (PipeWire quantum / cpal buffer size) — that's a separate Linux audio fix. Both can land independently.