### PR TITLE
fix(audio/linux): filter raw ALSA PCM names from device picker

### DIFF
--- a/frontend/src-tauri/src/audio/devices/discovery.rs
+++ b/frontend/src-tauri/src/audio/devices/discovery.rs
@@ -27,10 +27,19 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
         }
     };
 
-    // Add any additional devices from the default host
+    // Add any additional devices from the default host.
+    // On Linux, skip raw ALSA PCM profile entries that would reintroduce the
+    // `front:CARD=X,DEV=0` / `surround51:CARD=X` / `hw:CARD=X` noise the
+    // platform enumerator already filtered out.
     if let Ok(other_devices) = host.devices() {
         for device in other_devices {
             if let Ok(name) = device.name() {
+                #[cfg(target_os = "linux")]
+                {
+                    if !platform::is_user_facing_linux_device(&name) {
+                        continue;
+                    }
+                }
                 if !devices.iter().any(|d| d.name == name) {
                     devices.push(AudioDevice::new(name, DeviceType::Output));
                 }

--- a/frontend/src-tauri/src/audio/devices/platform/linux.rs
+++ b/frontend/src-tauri/src/audio/devices/platform/linux.rs
@@ -3,26 +3,62 @@ use cpal::traits::{DeviceTrait, HostTrait};
 
 use crate::audio::devices::configuration::{AudioDevice, DeviceType};
 
-/// Configure Linux audio devices using ALSA/PulseAudio
+/// Decide whether a Linux device name is worth showing to the user.
+///
+/// On PipeWire/PulseAudio systems, cpal's ALSA backend enumerates every raw
+/// ALSA PCM (`sysdefault:CARD=X`, `front:CARD=X,DEV=0`, `surround51:CARD=X`,
+/// `iec958:CARD=X`, `hw:CARD=X`, etc.). None of these are meaningful choices
+/// — the user should pick a logical endpoint (`pipewire`, `default`, `pulse`)
+/// and let PipeWire route to the currently selected source/sink.
+///
+/// Returns true when `name` should appear in the picker.
+pub fn is_user_facing_linux_device(name: &str) -> bool {
+    // Always-show logical endpoints.
+    const LOGICAL: &[&str] = &["default", "pipewire", "pulse", "jack", "sysdefault"];
+    if LOGICAL.contains(&name) {
+        return true;
+    }
+
+    // Raw ALSA PCM profile entries — hide.
+    const RAW_ALSA_PREFIXES: &[&str] = &[
+        "front:", "rear:", "center_lfe:", "side:",
+        "surround21:", "surround40:", "surround41:",
+        "surround50:", "surround51:", "surround71:",
+        "iec958:", "hdmi:", "dmix:", "dsnoop:",
+        "hw:", "plughw:", "plug:",
+        "sysdefault:",
+    ];
+    if RAW_ALSA_PREFIXES.iter().any(|p| name.starts_with(p)) {
+        return false;
+    }
+
+    // Otherwise keep — covers PulseAudio/PipeWire named nodes like
+    // `alsa_input.usb-Rode_NT-USB-00.pro-input-0` and anything else cpal
+    // surfaces that doesn't match the raw-ALSA pattern.
+    true
+}
+
+/// Configure Linux audio devices using ALSA / PulseAudio / PipeWire.
 pub fn configure_linux_audio(host: &cpal::Host) -> Result<Vec<AudioDevice>> {
     let mut devices = Vec::new();
 
-    // Add input devices
+    // Microphones.
     for device in host.input_devices()? {
         if let Ok(name) = device.name() {
-            devices.push(AudioDevice::new(name, DeviceType::Input));
+            if is_user_facing_linux_device(&name) {
+                devices.push(AudioDevice::new(name, DeviceType::Input));
+            }
         }
     }
 
-    // Add PulseAudio monitor sources for system audio
-    if let Ok(pulse_host) = cpal::host_from_id(cpal::HostId::Alsa) {
-        for device in pulse_host.input_devices()? {
+    // Monitor sources = system-audio capture (meeting participants).
+    if let Ok(alsa_host) = cpal::host_from_id(cpal::HostId::Alsa) {
+        for device in alsa_host.input_devices()? {
             if let Ok(name) = device.name() {
-                // Check if it's a monitor source
-                if name.contains("monitor") {
+                if name.contains("monitor") && is_user_facing_linux_device(&name) {
                     devices.push(AudioDevice::new(
                         format!("{} (System Audio)", name),
-                        DeviceType::Output
+                        DeviceType::Output,
                     ));
                 }
             }

--- a/frontend/src-tauri/src/audio/devices/platform/mod.rs
+++ b/frontend/src-tauri/src/audio/devices/platform/mod.rs
@@ -17,4 +17,4 @@ pub use windows::{configure_windows_audio, get_windows_device};
 pub use macos::configure_macos_audio;
 
 #[cfg(target_os = "linux")]
-pub use linux::configure_linux_audio;
+pub use linux::{configure_linux_audio, is_user_facing_linux_device};


### PR DESCRIPTION
## Description
On PipeWire / PulseAudio Linux (essentially every modern desktop distro), cpal's ALSA backend enumerates every raw ALSA PCM, so Meetily's device pickers fill up with noise like `sysdefault:CARD=NTUSB`, `front:CARD=NTUSB,DEV=0`, `surround51:CARD=Generic`, `iec958:CARD=Generic`, `hw:CARD=X`, etc. Users can't tell which entry is which physical device, and most of them are just channel-layout / subdevice aliases of the same card.

This PR introduces a Linux-only predicate `is_user_facing_linux_device()` that filters that noise out of both enumeration paths:

- `audio/devices/platform/linux.rs::configure_linux_audio()` — the primary enumerator for mics and monitor sources.
- `audio/devices/discovery.rs::list_audio_devices()` — the fallback loop that would otherwise reintroduce the raw names as `DeviceType::Output`.

What we **keep**:
- Logical endpoints: `default`, `pipewire`, `pulse`, `jack`, `sysdefault` — these route through PipeWire/PulseAudio to whatever the user has selected as their default source/sink.
- PulseAudio/PipeWire named nodes when cpal surfaces them (e.g. `alsa_input.usb-Rode_NT-USB-00.pro-input-0`).

What we **hide**:
- `front:`, `rear:`, `center_lfe:`, `side:`
- `surround21:`, `surround40:`, `surround41:`, `surround50:`, `surround51:`, `surround71:`
- `iec958:`, `hdmi:`, `dmix:`, `dsnoop:`, `hw:`, `plughw:`, `plug:`, `sysdefault:`

Linux-only (`#[cfg(target_os = \"linux\")]` on the discovery-side filter; the platform module itself is already Linux-gated). macOS and Windows enumeration is unchanged.

Pure-ALSA systems (no PipeWire/Pulse) still see `default` and any cpal-surfaced entries that don't match the raw-ALSA prefixes, so they're not worse off than before.

## Related Issue
Fixes #437

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] All tests pass (`cargo check` passes; no new warnings)

### Manual test
1. Fedora 43, PipeWire + `pipewire-pulse`, multiple USB audio devices (RODE NT-USB Pro, SteelSeries Arctis, generic USB).
2. Before the patch: device picker shows ~20 entries including `sysdefault:CARD=NTUSB`, `front:CARD=NTUSB,DEV=0`, `surround40/51/71:CARD=Generic`, `iec958:*`, etc.
3. After the patch: picker reduced to the logical endpoints (`default`, `pipewire`, `sysdefault`) plus any named PipeWire/Pulse nodes cpal exposes. Selecting `pipewire` or `default` records correctly from the user's selected system default.

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

(Behavior change is a UX cleanup; no config or API surface changes.)

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)
See #437 for the \"before\" screenshot. \"After\" is the same picker with only `default` / `pipewire` / `sysdefault` (+ any named node), which does not warrant a screenshot on its own.

## Additional Notes
**Why not pactl-sourced names?** A fuller fix would query `pactl list sources` and present human-readable descriptions (e.g. \"RODE NT-USB Pro\" rather than `alsa_input.usb-Rode_NT-USB-00.pro-input-0`). That's a larger change: those PulseAudio source names aren't directly openable via cpal's ALSA backend, so it'd require a mapping layer that binds the friendly-name UI back to a cpal-usable device handle. Keeping this PR scoped to \"stop showing the noise\" — a follow-up can layer the friendly-names UX on top.

**Independent of PR #434 and #436** (PipeWire quantum and WebKit DMABUF fixes). All three can land in any order.