### PR TITLE
fix(audio/linux): stabilize pipeline during concurrent capture (48 kHz + skip enum while recording)

### DIFF
--- a/frontend/src-tauri/src/audio/device_monitor.rs
+++ b/frontend/src-tauri/src/audio/device_monitor.rs
@@ -194,6 +194,22 @@ impl AudioDeviceMonitor {
                 }
             }
 
+            // While actively recording on Linux, skip the enumeration entirely.
+            // cpal's ALSA probe during `list_audio_devices()` perturbs the
+            // PipeWire graph and produces audible fuzz on the in-flight
+            // capture stream. Mid-recording disconnects are still caught
+            // immediately by the cpal stream's own error callback, so
+            // skipping the periodic poll doesn't lose the reconnection flow
+            // — it only delays detection of *new* devices becoming
+            // available, which doesn't matter until the user stops recording
+            // and re-opens the picker.
+            #[cfg(target_os = "linux")]
+            {
+                if crate::audio::recording_commands::is_recording().await {
+                    continue;
+                }
+            }
+
             // Get current device list
             let current_devices = match list_audio_devices().await {
                 Ok(devices) => devices,

--- a/frontend/src-tauri/src/audio/device_monitor.rs
+++ b/frontend/src-tauri/src/audio/device_monitor.rs
@@ -166,7 +166,21 @@ impl AudioDeviceMonitor {
         stop_signal: Arc<tokio::sync::Notify>,
     ) {
         let mut last_device_list = Vec::new();
-        let check_interval = Duration::from_secs(2); // Poll every 2 seconds
+
+        // On Linux, `list_audio_devices()` goes through cpal's ALSA backend and
+        // probes every ALSA PCM (dmix:*, dsnoop:*, route:*, iec958:*, hw:*,
+        // plughw:*). Each probe opens/closes a PipeWire node via pipewire-alsa
+        // and jitters the whole audio graph — which shows up as audible fuzz
+        // in the active recording and in any concurrent Teams/Zoom/WebRTC
+        // call. A 2 s poll is fine on CoreAudio/WASAPI but way too aggressive
+        // on pipewire-alsa. Fall back to a 30 s interval on Linux; the cpal
+        // stream's error callback still catches actual device disconnects
+        // immediately, so polling only matters for detecting newly-available
+        // devices in the picker, which doesn't need to be instant.
+        #[cfg(target_os = "linux")]
+        let check_interval = Duration::from_secs(30);
+        #[cfg(not(target_os = "linux"))]
+        let check_interval = Duration::from_secs(2);
 
         loop {
             // Check for stop signal with timeout

--- a/frontend/src-tauri/src/audio/devices/configuration.rs
+++ b/frontend/src-tauri/src/audio/devices/configuration.rs
@@ -107,6 +107,77 @@ pub fn parse_audio_device(name: &str) -> Result<AudioDevice> {
     AudioDevice::from_name(name)
 }
 
+/// Pick a preferred `SupportedStreamConfig` for an input device.
+///
+/// On Linux, strongly prefer 48 kHz. PipeWire's graph runs at 48 kHz by
+/// default; opening a client at any other rate (cpal's ALSA default is
+/// often 44.1 kHz on pipewire-alsa) forces pipewire-alsa to insert a
+/// resampler. The resampled client then runs at a small internal quantum
+/// (observed 256 frames) and drags every other audio client — Teams,
+/// Zoom, browser WebRTC — into the same small quantum, producing audible
+/// fuzz/glitches. See pw-top: `QUANT=256 RATE=44100` on the `alsa_capture.*`
+/// node vs. `QUANT=512-1024 RATE=48000` on the rest of the graph.
+///
+/// On macOS/Windows, fall back to cpal's `default_input_config()`.
+#[cfg(not(target_os = "windows"))]
+fn preferred_input_config(device: &cpal::Device) -> Result<cpal::SupportedStreamConfig> {
+    use cpal::traits::DeviceTrait;
+
+    let default_cfg = device
+        .default_input_config()
+        .map_err(|e| anyhow!("Failed to get default input config: {}", e))?;
+
+    #[cfg(target_os = "linux")]
+    {
+        use log::info;
+        const TARGET_RATE: u32 = 48_000;
+        let device_name = device.name().unwrap_or_else(|_| "<unknown>".into());
+
+        if default_cfg.sample_rate().0 == TARGET_RATE {
+            return Ok(default_cfg);
+        }
+
+        // Look through supported input configs for a range matching the
+        // default's channel count / sample format that also covers 48 kHz.
+        // Matching channels+format keeps us close to what cpal's default
+        // picker chose — we only adjust the sample rate.
+        if let Ok(supported) = device.supported_input_configs() {
+            for cfg in supported {
+                if cfg.channels() == default_cfg.channels()
+                    && cfg.sample_format() == default_cfg.sample_format()
+                    && cfg.min_sample_rate().0 <= TARGET_RATE
+                    && cfg.max_sample_rate().0 >= TARGET_RATE
+                {
+                    info!(
+                        "🎚️ audio: preferring 48 kHz over default {} Hz on '{}' to match PipeWire graph rate",
+                        default_cfg.sample_rate().0,
+                        device_name,
+                    );
+                    return Ok(cfg.with_sample_rate(cpal::SampleRate(TARGET_RATE)));
+                }
+            }
+        }
+
+        info!(
+            "🎚️ audio: device '{}' doesn't expose a 48 kHz input config matching the default ({} Hz, {} ch, {:?}) — keeping default",
+            device_name,
+            default_cfg.sample_rate().0,
+            default_cfg.channels(),
+            default_cfg.sample_format(),
+        );
+    }
+
+    Ok(default_cfg)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn preferred_output_config(device: &cpal::Device) -> Result<cpal::SupportedStreamConfig> {
+    use cpal::traits::DeviceTrait;
+    device
+        .default_output_config()
+        .map_err(|e| anyhow!("Failed to get default output config: {}", e))
+}
+
 /// Get device and config for audio operations
 pub async fn get_device_and_config(
     audio_device: &AudioDevice,
@@ -127,10 +198,8 @@ pub async fn get_device_and_config(
                 for device in host.input_devices()? {
                     if let Ok(name) = device.name() {
                         if name == audio_device.name {
-                            let default_config = device
-                                .default_input_config()
-                                .map_err(|e| anyhow!("Failed to get default input config: {}", e))?;
-                            return Ok((device, default_config));
+                            let config = preferred_input_config(&device)?;
+                            return Ok((device, config));
                         }
                     }
                 }
@@ -143,10 +212,8 @@ pub async fn get_device_and_config(
                     for device in host.output_devices()? {
                         if let Ok(name) = device.name() {
                             if name == audio_device.name {
-                                let default_config = device
-                                    .default_output_config()
-                                    .map_err(|e| anyhow!("Failed to get output config: {}", e))?;
-                                return Ok((device, default_config));
+                                let config = preferred_output_config(&device)?;
+                                return Ok((device, config));
                             }
                         }
                     }
@@ -154,15 +221,15 @@ pub async fn get_device_and_config(
 
                 #[cfg(target_os = "linux")]
                 {
-                    // For Linux, we use PulseAudio monitor sources for system audio
+                    // For Linux, we use PulseAudio monitor sources for system audio.
+                    // Monitor sources are *input* PCMs in ALSA terms, so the same
+                    // 48 kHz preference applies.
                     if let Ok(pulse_host) = cpal::host_from_id(cpal::HostId::Alsa) {
                         for device in pulse_host.input_devices()? {
                             if let Ok(name) = device.name() {
                                 if name == audio_device.name {
-                                    let default_config = device
-                                        .default_input_config()
-                                        .map_err(|e| anyhow!("Failed to get default input config: {}", e))?;
-                                    return Ok((device, default_config));
+                                    let config = preferred_input_config(&device)?;
+                                    return Ok((device, config));
                                 }
                             }
                         }

--- a/frontend/src-tauri/src/audio/level_monitor.rs
+++ b/frontend/src-tauri/src/audio/level_monitor.rs
@@ -11,6 +11,38 @@ use serde::Serialize;
 
 use super::audio_processing::audio_to_mono;
 
+/// On Linux, try to bump the device's default input config up to 48 kHz to
+/// match PipeWire's graph rate. Returns `None` if the device doesn't expose a
+/// 48 kHz config that matches the default's channel count / sample format,
+/// in which case the caller keeps the default. See
+/// `audio::devices::configuration::preferred_input_config` for rationale.
+fn pick_linux_48k_input_config(device: &cpal::Device) -> Option<cpal::SupportedStreamConfig> {
+    #[cfg(target_os = "linux")]
+    {
+        const TARGET_RATE: u32 = 48_000;
+        let default_cfg = device.default_input_config().ok()?;
+        if default_cfg.sample_rate().0 == TARGET_RATE {
+            return None;
+        }
+        if let Ok(supported) = device.supported_input_configs() {
+            for cfg in supported {
+                if cfg.channels() == default_cfg.channels()
+                    && cfg.sample_format() == default_cfg.sample_format()
+                    && cfg.min_sample_rate().0 <= TARGET_RATE
+                    && cfg.max_sample_rate().0 >= TARGET_RATE
+                {
+                    return Some(cfg.with_sample_rate(cpal::SampleRate(TARGET_RATE)));
+                }
+            }
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = device;
+    }
+    None
+}
+
 #[derive(Debug, Serialize, Clone)]
 pub struct AudioLevelData {
     pub device_name: String,
@@ -172,13 +204,21 @@ impl AudioLevelMonitor {
     ) -> Result<cpal::Stream> {
         let device_name = device_name.to_string();
 
-        // Determine if this is an input or output device and get appropriate config
-        let (config, is_input) = if let Ok(input_config) = device.default_input_config() {
-            (input_config, true)
-        } else if let Ok(output_config) = device.default_output_config() {
-            (output_config, false)
-        } else {
-            return Err(anyhow::anyhow!("Failed to get any config for device: {}", device_name));
+        // Determine if this is an input or output device and get appropriate config.
+        // On Linux, prefer 48 kHz to match PipeWire's graph rate — otherwise
+        // pipewire-alsa inserts a resampler that runs at 256-frame quantum and
+        // drags every other audio client into that quantum (audible fuzz on
+        // concurrent Teams/Zoom/browser WebRTC calls).
+        let (config, is_input) = {
+            let input_cfg = pick_linux_48k_input_config(device)
+                .or_else(|| device.default_input_config().ok());
+            if let Some(c) = input_cfg {
+                (c, true)
+            } else if let Ok(output_config) = device.default_output_config() {
+                (output_config, false)
+            } else {
+                return Err(anyhow::anyhow!("Failed to get any config for device: {}", device_name));
+            }
         };
 
         let sample_rate = config.sample_rate().0;


### PR DESCRIPTION
## Description

Follow-up to #434. The cpal `BufferSize::Fixed(1024)` change in #434 reduced the severity of the concurrent-capture glitching (see #433) but didn't fully eliminate it. Real-world testing with `pw-top` surfaced two further root causes, both addressed here:

### 1. cpal was opening the mic at 44.1 kHz instead of 48 kHz

`pw-top` while recording showed Meetily's capture nodes at:

```
R   97    256  44100  ...  F32LE 2 44100  + alsa_capture.meetily
R  108    256  44100  ...  F32LE 2 44100  + alsa_capture.meetily
```

— while literally everything else on the system (Teams, Chromium WebRTC, alsa outputs) runs at 48000 Hz. cpal's ALSA backend picks `44100` as the default for `pipewire`/`default` PCMs on many PipeWire setups; pipewire-alsa then inserts a resampler whose **internal quantum is 256 frames**. That small quantum propagates through the graph and drags Teams/WebRTC into stutter territory.

Fix: on Linux, look through `supported_input_configs()` for a range matching the default's channel count and sample format that also covers 48 kHz, and request it via `with_sample_rate(48_000)`. Matching channels+format keeps us in the envelope cpal's own default picker chose so the stream still opens cleanly. Falls back to default if no 48 kHz config is available. Applied in both `audio/devices/configuration.rs::preferred_input_config` and `audio/level_monitor.rs::pick_linux_48k_input_config` (the level monitor opens a second stream on the same device and was also at 44.1 kHz — see the two `alsa_capture.meetily` rows in pw-top).

Log confirmation from a post-fix run:
```
🎚️ audio: preferring 48 kHz over default 44100 Hz on 'default' to match PipeWire graph rate
Audio config - Sample rate: 48000, Channels: 2, Format: F32
```

### 2. device_monitor was re-enumerating ALSA every 2 s during recording

`device_monitor::monitor_loop` polls `list_audio_devices()` every 2 s to detect hotplug. On Linux that goes through cpal's ALSA backend, which probes **every** ALSA PCM on the system — `dmix:*`, `dsnoop:*`, `route:*`, `iec958:*`, `hw:*`, `plughw:*`, etc. Each probe opens and closes a PipeWire node via pipewire-alsa and jitters the whole audio graph. Side effects:

- A burst of `ALSA lib pcm_dmix.c: unable to open slave` / `ALSA lib pcm_route.c: Found no matching channel map` warnings in stderr every 2 s.
- Audible fuzz on the active capture stream and on concurrent Teams/Zoom/WebRTC calls synchronized with those bursts.

Tester confirmed each burst of warnings corresponded exactly to an audible fuzz event.

Two-part fix:

- **Slow the interval to 30 s on Linux.** On CoreAudio/WASAPI the equivalent enumeration is cheap, so 2 s is fine there. On Linux the probe cost is real. 30 s is still fast enough for picker UX.
- **Skip the enumeration entirely while `IS_RECORDING` is true.** The cpal stream's own error callback catches mid-recording disconnects and triggers the existing reconnection flow, so polling during recording is redundant — the only thing we lose is detection of *new* devices becoming available while recording, which doesn't matter until the user stops and re-opens the picker.

Result from a post-fix recording session: zero ALSA warning bursts during recording, zero fuzz.

All changes Linux-only via `#[cfg(target_os = \"linux\")]`; macOS CoreAudio and Windows WASAPI paths are untouched.

## Related Issue
Fully closes #433 (PR #434 partially addressed it; this finishes the job).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] All tests pass (`cargo check` passes, no new warnings)

### Manual test (Fedora 43, NVIDIA 580 open, KDE Wayland, PipeWire + pipewire-pulse + pipewire-alsa)

Without this PR (just the baseline #434 cpal-buffer fix):
- `pw-top` shows `alsa_capture.meetily` at `RATE=44100 QUANT=256`.
- Every ~2 s, a burst of `unable to open slave` / `no matching channel map` ALSA warnings in stderr.
- Each burst correlates with audible fuzz on a concurrent MS Teams call.

With this PR applied:
- `pw-top` shows `alsa_capture.meetily` at `RATE=48000` (matches the rest of the graph).
- Log shows `🎚️ audio: preferring 48 kHz over default 44100 Hz on 'default' to match PipeWire graph rate` during stream creation.
- During recording: **zero** `unable to open slave` / `no matching channel map` bursts.
- Concurrent Teams audio stays clean for the full duration of the recording; fuzz is eliminated.

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

(Internal audio-subsystem changes, no user-facing config or API surface.)

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)
N/A — audio-only symptom. Reproducible diagnostic signal is `pw-top` showing matching rate/quantum between the Meetily capture nodes and the rest of the graph, and the absence of ALSA warning bursts in stderr while recording.

## Additional Notes

**Why three separate commits rather than one squash?** Each commit addresses a distinct root cause uncovered during iterative pw-top / stderr diagnosis. Happy to squash on request.

**Interaction with #434:** this PR builds on top of #434 (cpal buffer `Fixed(1024)`). The 48 kHz preference is what actually stops pipewire-alsa from inserting a small-quantum resampler in the first place; the buffer fix from #434 gives additional headroom for PipeWire's graph. Together they address the three stacked causes of the original symptom in #433 (rate mismatch → resampler → small quantum → graph starvation, plus the buffer-size request and the periodic enumeration churn).

**Tradeoff on the \"skip poll while recording\" change:** during recording we stop noticing when a *new* input device appears in the system (e.g. plugging in a second USB mic). That's acceptable because the picker is inherently not shown mid-recording and will re-enumerate on next open. Device *loss* during recording is still caught by the cpal error callback.