### PR TITLE
fix: make analytics opt-in by default [skip ci]

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -23,7 +23,7 @@ Meetily is built on the principle that your meeting data should remain private a
 ## Usage Analytics
 
 ### What We Collect
-To improve Meetily and ensure optimal performance, we collect minimal, anonymized usage data:
+Usage analytics is optional and off by default. When you choose to enable it, Meetily collects minimal, anonymized usage data:
 
 **Application Usage:**
 - Feature usage patterns (which tools you use most)
@@ -46,7 +46,7 @@ We never collect:
 - ❌ LLM conversations or AI-generated content
 
 ### Why We Collect This Data
-This analytics collection is necessary for:
+When enabled, analytics helps us with:
 - **Product Quality**: Identifying and fixing bugs that impact user experience
 - **Performance Optimization**: Understanding resource usage and system bottlenecks
 - **Security**: Detecting potential security issues and vulnerabilities
@@ -55,6 +55,7 @@ This analytics collection is necessary for:
 
 ### Analytics Implementation
 - **Provider**: PostHog (privacy-focused analytics platform)
+- **Default**: Off by default; analytics starts only after you enable it in settings
 - **Anonymization**: All data linked to generated user IDs only - no personal identification
 - **Data retention**: 12 months maximum, then automatically deleted
 - **Encryption**: All data encrypted in transit using industry-standard protocols
@@ -72,7 +73,7 @@ If you choose to use external LLM providers:
 ### Analytics Service (Optional)
 - **PostHog**: Used for usage analytics when enabled
 - **Data**: Only anonymized usage patterns, no meeting content
-- **Control**: Completely optional and user-controlled
+- **Control**: Completely optional, off by default, and user-controlled
 
 ## Your Privacy Rights
 
@@ -84,6 +85,7 @@ If you choose to use external LLM providers:
 
 ### Analytics Transparency
 - **Open source**: Full analytics implementation available for review in our source code
+- **Opt-in**: New and existing installs have analytics disabled until you turn it on
 - **Questions**: Contact us for any analytics-related concerns
 
 ## Data Security

--- a/frontend/src-tauri/src/analytics/analytics.rs
+++ b/frontend/src-tauri/src/analytics/analytics.rs
@@ -6,6 +6,34 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 use chrono::{DateTime, Utc};
 
+const SENSITIVE_ANALYTICS_KEYS: &[&str] = &[
+    "meeting_title",
+    "meetingTitle",
+    "meeting_name",
+    "meetingName",
+    "file_name",
+    "filename",
+    "file_path",
+    "folder_path",
+    "path",
+    "source_path",
+    "meeting_folder_path",
+    "device_name",
+    "user_agent",
+];
+
+fn sanitize_analytics_properties(mut properties: HashMap<String, String>) -> HashMap<String, String> {
+    properties.retain(|key, _| !SENSITIVE_ANALYTICS_KEYS.contains(&key.as_str()));
+    properties
+}
+
+fn meeting_started_properties(meeting_id: &str) -> HashMap<String, String> {
+    let mut properties = HashMap::new();
+    properties.insert("meeting_id".to_string(), meeting_id.to_string());
+    properties.insert("timestamp".to_string(), chrono::Utc::now().to_rfc3339());
+    properties
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AnalyticsConfig {
     pub api_key: String,
@@ -79,7 +107,7 @@ impl AnalyticsClient {
         // Store user ID for future events
         *self.user_id.lock().await = Some(user_id.clone());
 
-        let properties = properties.unwrap_or_default();
+        let properties = sanitize_analytics_properties(properties.unwrap_or_default());
         
         let mut event = Event::new("$identify", &user_id);
         
@@ -113,7 +141,7 @@ impl AnalyticsClient {
         };
 
         let event_name = event_name.to_string();
-        let mut properties = properties.unwrap_or_default();
+        let mut properties = sanitize_analytics_properties(properties.unwrap_or_default());
 
         // Add app version to all events
         properties.insert("app_version".to_string(), env!("CARGO_PKG_VERSION").to_string());
@@ -207,13 +235,8 @@ impl AnalyticsClient {
     }
 
     // Meeting-specific event tracking methods
-    pub async fn track_meeting_started(&self, meeting_id: &str, meeting_title: &str) -> Result<(), String> {
-        let mut properties = HashMap::new();
-        properties.insert("meeting_id".to_string(), meeting_id.to_string());
-        properties.insert("meeting_title".to_string(), meeting_title.to_string());
-        properties.insert("timestamp".to_string(), chrono::Utc::now().to_rfc3339());
-        
-        self.track_event("meeting_started", Some(properties)).await
+    pub async fn track_meeting_started(&self, meeting_id: &str) -> Result<(), String> {
+        self.track_event("meeting_started", Some(meeting_started_properties(meeting_id))).await
     }
 
     pub async fn track_recording_started(&self, meeting_id: &str) -> Result<(), String> {
@@ -411,6 +434,7 @@ impl AnalyticsClient {
             }
         };
         
+        let properties = sanitize_analytics_properties(properties);
         let mut event = Event::new("$set", &user_id);
         
         // Add user properties
@@ -431,4 +455,67 @@ impl AnalyticsClient {
 // Helper function to create analytics client from config
 pub async fn create_analytics_client(config: AnalyticsConfig) -> AnalyticsClient {
     AnalyticsClient::new(config).await
-} 
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn analytics_properties_drop_sensitive_meeting_metadata() {
+        let mut properties = HashMap::new();
+        properties.insert("meeting_title".to_string(), "Board Strategy".to_string());
+        properties.insert("meetingTitle".to_string(), "Board Strategy".to_string());
+        properties.insert("meeting_name".to_string(), "Client Call".to_string());
+        properties.insert("meetingName".to_string(), "Client Call".to_string());
+        properties.insert("file_name".to_string(), "acquisition.wav".to_string());
+        properties.insert("filename".to_string(), "acquisition.wav".to_string());
+        properties.insert("file_path".to_string(), "C:\\meetings\\acquisition.wav".to_string());
+        properties.insert("folder_path".to_string(), "C:\\meetings".to_string());
+        properties.insert("path".to_string(), "C:\\meetings\\acquisition.wav".to_string());
+        properties.insert("source_path".to_string(), "C:\\imports\\source.wav".to_string());
+        properties.insert("meeting_folder_path".to_string(), "C:\\meetings\\private".to_string());
+        properties.insert("device_name".to_string(), "Jane's AirPods".to_string());
+        properties.insert("user_agent".to_string(), "Mozilla/5.0".to_string());
+        properties.insert("meeting_id".to_string(), "meeting-123".to_string());
+        properties.insert("duration_seconds".to_string(), "125".to_string());
+        properties.insert("segments_count".to_string(), "42".to_string());
+        properties.insert("model_name".to_string(), "parakeet".to_string());
+        properties.insert("platform".to_string(), "Windows".to_string());
+
+        let sanitized = sanitize_analytics_properties(properties);
+
+        for key in [
+            "meeting_title",
+            "meetingTitle",
+            "meeting_name",
+            "meetingName",
+            "file_name",
+            "filename",
+            "file_path",
+            "folder_path",
+            "path",
+            "source_path",
+            "meeting_folder_path",
+            "device_name",
+            "user_agent",
+        ] {
+            assert!(!sanitized.contains_key(key), "sensitive key remained: {}", key);
+        }
+
+        assert_eq!(sanitized.get("meeting_id"), Some(&"meeting-123".to_string()));
+        assert_eq!(sanitized.get("duration_seconds"), Some(&"125".to_string()));
+        assert_eq!(sanitized.get("segments_count"), Some(&"42".to_string()));
+        assert_eq!(sanitized.get("model_name"), Some(&"parakeet".to_string()));
+        assert_eq!(sanitized.get("platform"), Some(&"Windows".to_string()));
+    }
+
+    #[test]
+    fn meeting_started_properties_do_not_include_title() {
+        let properties = meeting_started_properties("meeting-123");
+
+        assert_eq!(properties.get("meeting_id"), Some(&"meeting-123".to_string()));
+        assert!(properties.contains_key("timestamp"));
+        assert!(!properties.contains_key("meeting_title"));
+    }
+}

--- a/frontend/src-tauri/src/analytics/commands.rs
+++ b/frontend/src-tauri/src/analytics/commands.rs
@@ -58,14 +58,14 @@ pub async fn identify_user(user_id: String, properties: Option<HashMap<String, S
 }
 
 #[command]
-pub async fn track_meeting_started(meeting_id: String, meeting_title: String) -> Result<(), String> {
+pub async fn track_meeting_started(meeting_id: String) -> Result<(), String> {
     let client = {
         let guard = ANALYTICS_CLIENT.lock().unwrap();
         guard.as_ref().cloned()
     };
     
     if let Some(client) = client {
-        client.track_meeting_started(&meeting_id, &meeting_title).await
+        client.track_meeting_started(&meeting_id).await
     } else {
         Err("Analytics client not initialized".to_string())
     }

--- a/frontend/src-tauri/src/analytics/commands.rs
+++ b/frontend/src-tauri/src/analytics/commands.rs
@@ -9,7 +9,7 @@ static ANALYTICS_CLIENT: std::sync::Mutex<Option<Arc<AnalyticsClient>>> = std::s
 #[command]
 pub async fn init_analytics() -> Result<(), String> {
     let config = AnalyticsConfig {
-        api_key: "phc_cohhHPgfQfnNWl33THRRpCftuRtWx2k5svtKrkpFb04".to_string(),
+        api_key: "phc_Aa9PqeCkDkVbtbRsYjtmHANBfcscjCVupxZwrtL5vZ77".to_string(),
         host: Some("https://us.i.posthog.com".to_string()),
         enabled: true,
     };

--- a/frontend/src-tauri/src/lib_old_complex.rs
+++ b/frontend/src-tauri/src/lib_old_complex.rs
@@ -1861,10 +1861,10 @@ async fn identify_user(user_id: String, properties: Option<std::collections::Has
 }
 
 #[tauri::command]
-async fn track_meeting_started(meeting_id: String, meeting_title: String) -> Result<(), String> {
+async fn track_meeting_started(meeting_id: String) -> Result<(), String> {
     unsafe {
         if let Some(client) = &ANALYTICS_CLIENT {
-            client.track_meeting_started(&meeting_id, &meeting_title).await
+            client.track_meeting_started(&meeting_id).await
         } else {
             Err("Analytics client not initialized".to_string())
         }

--- a/frontend/src/components/AnalyticsConsentSwitch.tsx
+++ b/frontend/src/components/AnalyticsConsentSwitch.tsx
@@ -8,6 +8,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { Analytics } from '@/lib/analytics';
 import AnalyticsDataModal from './AnalyticsDataModal';
 
+const ANALYTICS_DEFAULT_OFF_MIGRATION_KEY = 'analyticsDefaultOffMigrationV1';
 
 export default function AnalyticsConsentSwitch() {
   const { setIsAnalyticsOptedIn, isAnalyticsOptedIn } = useContext(AnalyticsContext);
@@ -77,10 +78,11 @@ export default function AnalyticsConsentSwitch() {
       const store = await load('analytics.json', {
         autoSave: false,
         defaults: {
-          analyticsOptedIn: true
+          analyticsOptedIn: false
         }
       });
       await store.set('analyticsOptedIn', enabled);
+      await store.set(ANALYTICS_DEFAULT_OFF_MIGRATION_KEY, true);
       await store.save();
 
       if (enabled) {
@@ -96,7 +98,6 @@ export default function AnalyticsConsentSwitch() {
           platform: 'tauri',
           first_seen: new Date().toISOString(),
           os: navigator.platform,
-          user_agent: navigator.userAgent,
         });
 
         // Start analytics session with the same user ID
@@ -158,7 +159,7 @@ export default function AnalyticsConsentSwitch() {
         <div>
           <h3 className="text-base font-semibold text-gray-800 mb-2">Usage Analytics</h3>
           <p className="text-sm text-gray-600 mb-4">
-            Help us improve Meetily by sharing anonymous usage data. No personal content is collected—everything stays on your device.
+            Usage analytics is off by default. You can turn it on to share anonymous product and performance data; no personal content is collected.
           </p>
         </div>
 
@@ -166,7 +167,7 @@ export default function AnalyticsConsentSwitch() {
           <div>
             <h4 className="font-semibold text-gray-800">Enable Analytics</h4>
             <p className="text-sm text-gray-600">
-              {isProcessing ? 'Updating...' : 'Anonymous usage patterns only'}
+              {isProcessing ? 'Updating...' : 'Off unless you choose to enable it'}
             </p>
           </div>
           <div className="flex items-center gap-2 ml-4">

--- a/frontend/src/components/AnalyticsDataModal.tsx
+++ b/frontend/src/components/AnalyticsDataModal.tsx
@@ -19,7 +19,7 @@ export default function AnalyticsDataModal({ isOpen, onClose, onConfirmDisable }
         <div className="flex items-center justify-between p-6 border-b border-gray-200">
           <div className="flex items-center gap-3">
             <Shield className="w-6 h-6 text-blue-600" />
-            <h2 className="text-xl font-semibold text-gray-900">What We Collect</h2>
+            <h2 className="text-xl font-semibold text-gray-900">What Analytics Collects</h2>
           </div>
           <button
             onClick={onClose}
@@ -37,14 +37,14 @@ export default function AnalyticsDataModal({ isOpen, onClose, onConfirmDisable }
               <Info className="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" />
               <div className="text-sm text-green-800">
                 <p className="font-semibold mb-1">Your Privacy is Protected</p>
-                <p>We collect <strong>anonymous usage data only</strong>. No meeting content, names, or personal information is ever collected.</p>
+                <p>Analytics is off by default. If you enable it, we collect <strong>anonymous usage data only</strong>. No meeting content, names, file paths, or personal information is ever collected.</p>
               </div>
             </div>
           </div>
 
           {/* Data Categories */}
           <div className="space-y-4">
-            <h3 className="text-lg font-semibold text-gray-900">Data We Collect:</h3>
+            <h3 className="text-lg font-semibold text-gray-900">Data We Collect When Enabled:</h3>
 
             {/* Model Preferences */}
             <div className="border border-gray-200 rounded-lg p-4">
@@ -108,6 +108,7 @@ export default function AnalyticsDataModal({ isOpen, onClose, onConfirmDisable }
             <h4 className="font-semibold text-red-900 mb-2">What We DON'T Collect:</h4>
             <ul className="text-sm text-red-800 space-y-1 ml-4">
               <li>• ❌ Meeting names or titles</li>
+              <li>• ❌ File names, file paths, or meeting folders</li>
               <li>• ❌ Meeting transcripts or content</li>
               <li>• ❌ Audio recordings</li>
               <li>• ❌ Device names (only types: Bluetooth/Wired)</li>

--- a/frontend/src/components/AnalyticsProvider.tsx
+++ b/frontend/src/components/AnalyticsProvider.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, ReactNode, useRef, useState, createContext } from 're
 import Analytics from '@/lib/analytics';
 import { load } from '@tauri-apps/plugin-store';
 
+const ANALYTICS_DEFAULT_OFF_MIGRATION_KEY = 'analyticsDefaultOffMigrationV1';
 
 interface AnalyticsProviderProps {
   children: ReactNode;
@@ -15,12 +16,12 @@ interface AnalyticsContextType {
 }
 
 export const AnalyticsContext = createContext<AnalyticsContextType>({
-  isAnalyticsOptedIn: true,
+  isAnalyticsOptedIn: false,
   setIsAnalyticsOptedIn: () => { },
 });
 
 export default function AnalyticsProvider({ children }: AnalyticsProviderProps) {
-  const [isAnalyticsOptedIn, setIsAnalyticsOptedIn] = useState(true);
+  const [isAnalyticsOptedIn, setIsAnalyticsOptedIn] = useState(false);
   const initialized = useRef(false);
 
   useEffect(() => {
@@ -33,18 +34,28 @@ export default function AnalyticsProvider({ children }: AnalyticsProviderProps) 
       const store = await load('analytics.json', {
         autoSave: false,
         defaults: {
-          analyticsOptedIn: true
+          analyticsOptedIn: false
         }
       });
+
       if (!(await store.has('analyticsOptedIn'))) {
-        await store.set('analyticsOptedIn', true);
+        await store.set('analyticsOptedIn', false);
       }
-      const analyticsOptedIn = await store.get('analyticsOptedIn')
+
+      let analyticsOptedIn = await store.get<boolean>('analyticsOptedIn');
+      if (!(await store.has(ANALYTICS_DEFAULT_OFF_MIGRATION_KEY))) {
+        analyticsOptedIn = false;
+        await store.set('analyticsOptedIn', false);
+        await store.set(ANALYTICS_DEFAULT_OFF_MIGRATION_KEY, true);
+        await store.save();
+      } else if (analyticsOptedIn !== true) {
+        analyticsOptedIn = false;
+      }
 
       setIsAnalyticsOptedIn(analyticsOptedIn as boolean);
       // Fix: Use fresh value from store, not stale state
       if (analyticsOptedIn) {
-        initAnalytics2();
+        await initAnalytics2();
       }
     }
 
@@ -66,7 +77,7 @@ export default function AnalyticsProvider({ children }: AnalyticsProviderProps) 
       const store = await load('analytics.json', {
         autoSave: false,
         defaults: {
-          analyticsOptedIn: true
+          analyticsOptedIn: false
         }
       });
       await store.set('platform', deviceInfo.platform);
@@ -87,7 +98,6 @@ export default function AnalyticsProvider({ children }: AnalyticsProviderProps) 
         os_version: deviceInfo.os_version,
         architecture: deviceInfo.architecture,
         first_seen: new Date().toISOString(),
-        user_agent: navigator.userAgent,
       });
 
       // Start analytics session with platform info
@@ -138,4 +148,4 @@ export default function AnalyticsProvider({ children }: AnalyticsProviderProps) 
   }, [isAnalyticsOptedIn]);
 
   return <AnalyticsContext.Provider value={{ isAnalyticsOptedIn, setIsAnalyticsOptedIn }}>{children}</AnalyticsContext.Provider>;
-} 
+}

--- a/frontend/src/components/DeviceSelection.tsx
+++ b/frontend/src/components/DeviceSelection.tsx
@@ -147,7 +147,6 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
     // Track device selection analytics with enhanced metadata
     const metadata = getDeviceMetadata(deviceName);
     Analytics.track('microphone_selected', {
-      device_name: deviceName,
       device_category: metadata.category,
       is_bluetooth: metadata.isBluetooth.toString(),
       has_system_audio: (!!selectedDevices.systemDevice).toString()
@@ -165,7 +164,6 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
     // Track device selection analytics with enhanced metadata
     const metadata = getDeviceMetadata(deviceName);
     Analytics.track('system_audio_selected', {
-      device_name: deviceName,
       device_category: metadata.category,
       is_bluetooth: metadata.isBluetooth.toString(),
       has_microphone: (!!selectedDevices.micDevice).toString()

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -531,11 +531,11 @@ export class Analytics {
   }
 
   // Meeting-specific tracking methods
-  static async trackMeetingStarted(meetingId: string, meetingTitle: string): Promise<void> {
+  static async trackMeetingStarted(meetingId: string): Promise<void> {
     if (!this.initialized) return;
 
     try {
-      await invoke('track_meeting_started', { meetingId, meetingTitle });
+      await invoke('track_meeting_started', { meetingId });
     } catch (error) {
       console.error('Failed to track meeting started:', error);
     }
@@ -833,4 +833,4 @@ export class Analytics {
   }
 }
 
-export default Analytics; 
+export default Analytics;


### PR DESCRIPTION
## Description
- Makes usage analytics opt-in by default for new installs.
- Adds a one-time migration that turns analytics off for existing users.
- Removes meeting titles from `meeting_started` analytics events.
- Adds defensive analytics property sanitization for sensitive fields such as meeting titles, file names, paths, device names, and user agent.
- Removes raw device names from device-selection analytics.
- Updates privacy/settings copy to match the new default-off analytics behavior.

## Related Issue
Fixes #448

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [x] Unit tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass

Notes:
- `bun run build` passed.
- `git diff --check` passed.
- `cargo test -p meetily analytics` was attempted, but the run is blocked before analytics tests compile by an existing `whisper-rs-sys` CMake/MSBuild failure.

## Documentation
- [x] Documentation updated
- [ ] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [ ] Added comments for complex code
- [ ] Updated README if needed
- [ ] Branch is up to date with devtest
- [ ] No merge conflicts

## Screenshots (if applicable)
Not applicable.

## Additional Notes
- Analytics remains available when users explicitly enable it.
- Opaque `meeting_id` analytics is still allowed; human-readable meeting metadata is not sent.