### PR TITLE
feat: external integration API (URL scheme + macOS distributed notifications)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
         "@remirror/react": "^3.0.1",
         "@tanstack/react-virtual": "^3.13.13",
         "@tauri-apps/api": "^2.6.0",
+        "@tauri-apps/plugin-deep-link": "^2",
         "@tauri-apps/plugin-fs": "^2.4.0",
         "@tauri-apps/plugin-notification": "~2.3.1",
         "@tauri-apps/plugin-os": "^2.3.2",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -153,6 +153,7 @@ tauri-plugin-store = "2.4.0"
 tauri-plugin-notification = "2.3.1"
 tauri-plugin-updater = "2.3.0"
 tauri-plugin-process = "2.3.0"
+tauri-plugin-deep-link = "2"
 
 # macOS-specific dependencies with Metal GPU acceleration
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/frontend/src-tauri/Info.plist
+++ b/frontend/src-tauri/Info.plist
@@ -10,5 +10,16 @@
     <string>This application needs permission to capture system audio output for meeting transcription and recording.</string>
     <key>com.apple.security.device.audio-input</key>
     <true/>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>com.meetily.ai</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>meetily</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -39,7 +39,7 @@ pub use super::transcription::TranscriptUpdate;
 static IS_RECORDING: AtomicBool = AtomicBool::new(false);
 
 // Global recording manager and transcription task to keep them alive during recording
-static RECORDING_MANAGER: Mutex<Option<RecordingManager>> = Mutex::new(None);
+pub(crate) static RECORDING_MANAGER: Mutex<Option<RecordingManager>> = Mutex::new(None);
 static TRANSCRIPTION_TASK: Mutex<Option<JoinHandle<()>>> = Mutex::new(None);
 
 // Listener ID for proper cleanup - prevents microphone from staying active after recording stops
@@ -222,12 +222,14 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
             now.format("%Y-%m-%d_%H-%M-%S")
         )
     });
+    let effective_meeting_name_for_notification = effective_meeting_name.clone();
     manager.set_meeting_name(Some(effective_meeting_name));
 
     // Set up error callback
     let app_for_error = app.clone();
     manager.set_error_callback(move |error| {
         let _ = app_for_error.emit("recording-error", error.user_message());
+        crate::distributed_notifications::post_recording_error(&error.user_message());
     });
 
     // Start recording with resolved devices (replaces start_recording_with_defaults_and_auto_save call)
@@ -293,6 +295,7 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
         "devices": ["Default Microphone", "Default System Audio"],
         "workers": 3
     })).map_err(|e| e.to_string())?;
+    crate::distributed_notifications::post_recording_started(&effective_meeting_name_for_notification);
 
     // Update tray menu to reflect recording state
     crate::tray::update_tray_menu(&app);
@@ -390,12 +393,14 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
             now.format("%Y-%m-%d_%H-%M-%S")
         )
     });
+    let effective_meeting_name_for_notification = effective_meeting_name.clone();
     manager.set_meeting_name(Some(effective_meeting_name));
 
     // Set up error callback
     let app_for_error = app.clone();
     manager.set_error_callback(move |error| {
         let _ = app_for_error.emit("recording-error", error.user_message());
+        crate::distributed_notifications::post_recording_error(&error.user_message());
     });
 
     // Start recording with specified devices and auto_save setting
@@ -464,6 +469,7 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
         ],
         "workers": 3
     })).map_err(|e| e.to_string())?;
+    crate::distributed_notifications::post_recording_started(&effective_meeting_name_for_notification);
 
     // Update tray menu to reflect recording state
     crate::tray::update_tray_menu(&app);
@@ -882,6 +888,10 @@ pub async fn stop_recording<R: Runtime>(
         }),
     )
     .map_err(|e| e.to_string())?;
+    crate::distributed_notifications::post_recording_stopped(
+        meeting_name_str.as_deref().unwrap_or(""),
+        folder_path_str.as_deref().unwrap_or(""),
+    );
 
     // Update tray menu to reflect stopped state
     crate::tray::update_tray_menu(&app);

--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -371,6 +371,31 @@ pub fn start_transcription_task<R: Runtime>(
                     "🎉 ALL {} chunks processed successfully - ZERO chunks lost!",
                     final_completed
                 );
+
+                // Emit transcription-all-complete event and distributed notification
+                // This fires after ALL workers have finished, unlike transcription-queue-complete
+                // which fires when chunks are queued but before processing completes.
+                let _ = app.emit("transcription-all-complete", serde_json::json!({
+                    "total_chunks": final_completed,
+                    "message": format!("All {} chunks transcribed successfully", final_completed)
+                }));
+
+                // Post distributed notification for external listeners
+                // Access recording manager to get meeting name and folder path
+                if let Ok(manager_guard) = crate::audio::recording_commands::RECORDING_MANAGER.lock() {
+                    if let Some(manager) = manager_guard.as_ref() {
+                        let meeting_name = manager.get_meeting_name()
+                            .unwrap_or_default();
+                        let folder_path = manager.get_meeting_folder()
+                            .map(|p| p.to_string_lossy().to_string())
+                            .unwrap_or_default();
+                        crate::distributed_notifications::post_transcription_completed(
+                            &meeting_name,
+                            &folder_path,
+                        );
+                    }
+                }
+
                 break;
             } else if verification_attempts < MAX_VERIFICATION_ATTEMPTS {
                 verification_attempts += 1;

--- a/frontend/src-tauri/src/distributed_notifications.rs
+++ b/frontend/src-tauri/src/distributed_notifications.rs
@@ -1,0 +1,146 @@
+// distributed_notifications.rs
+//
+// macOS Distributed Notifications for external integration.
+// Posts events to NSDistributedNotificationCenter so external apps
+// can react to Meetily recording lifecycle events.
+//
+// This module is separate from the user-facing `notifications/` module,
+// which handles OS toast notifications with consent management.
+// Distributed notifications are developer-facing IPC events.
+
+use std::collections::HashMap;
+
+/// Post a distributed notification that recording has started.
+pub fn post_recording_started(meeting_name: &str) {
+    let mut info = HashMap::new();
+    info.insert("meeting_name".to_string(), meeting_name.to_string());
+    post_distributed_notification("com.meetily.ai.recording.started", &info);
+}
+
+/// Post a distributed notification that recording has stopped.
+pub fn post_recording_stopped(meeting_name: &str, folder_path: &str) {
+    let mut info = HashMap::new();
+    info.insert("meeting_name".to_string(), meeting_name.to_string());
+    info.insert("folder_path".to_string(), folder_path.to_string());
+    post_distributed_notification("com.meetily.ai.recording.stopped", &info);
+}
+
+/// Post a distributed notification that a recording error occurred.
+pub fn post_recording_error(error: &str) {
+    let mut info = HashMap::new();
+    info.insert("error".to_string(), error.to_string());
+    post_distributed_notification("com.meetily.ai.recording.error", &info);
+}
+
+/// Post a distributed notification that transcription has completed.
+pub fn post_transcription_completed(meeting_name: &str, folder_path: &str) {
+    let mut info = HashMap::new();
+    info.insert("meeting_name".to_string(), meeting_name.to_string());
+    info.insert("folder_path".to_string(), folder_path.to_string());
+    post_distributed_notification("com.meetily.ai.transcription.completed", &info);
+}
+
+#[cfg(target_os = "macos")]
+fn post_distributed_notification(name: &str, user_info: &HashMap<String, String>) {
+    use objc::runtime::{Class, Object};
+    use objc::{msg_send, sel, sel_impl};
+
+    log::info!("📡 Posting distributed notification: {}", name);
+
+    unsafe {
+        // SAFETY: NSDistributedNotificationCenter is a well-known Foundation class
+        // that is always available on macOS. defaultCenter returns a singleton.
+        let center_class = match Class::get("NSDistributedNotificationCenter") {
+            Some(cls) => cls,
+            None => {
+                log::warn!("NSDistributedNotificationCenter class not found");
+                return;
+            }
+        };
+        let center: *mut Object = msg_send![center_class, defaultCenter];
+        if center.is_null() {
+            log::warn!("NSDistributedNotificationCenter defaultCenter returned null");
+            return;
+        }
+
+        // SAFETY: NSString is a well-known Foundation class. initWithBytes:length:encoding:
+        // creates a new NSString from a UTF-8 byte buffer. NSUTF8StringEncoding = 4.
+        let nsstring_class = match Class::get("NSString") {
+            Some(cls) => cls,
+            None => {
+                log::warn!("NSString class not found");
+                return;
+            }
+        };
+
+        let name_nsstring = create_nsstring(nsstring_class, name);
+        if name_nsstring.is_null() {
+            log::warn!("Failed to create NSString for notification name");
+            return;
+        }
+
+        // SAFETY: NSMutableDictionary is a well-known Foundation class.
+        // We create a mutable dictionary and populate it with the user_info entries.
+        let dict_class = match Class::get("NSMutableDictionary") {
+            Some(cls) => cls,
+            None => {
+                log::warn!("NSMutableDictionary class not found");
+                return;
+            }
+        };
+        let dict: *mut Object = msg_send![dict_class, new];
+        if dict.is_null() {
+            log::warn!("Failed to create NSMutableDictionary");
+            return;
+        }
+
+        for (key, value) in user_info {
+            let key_ns = create_nsstring(nsstring_class, key);
+            let val_ns = create_nsstring(nsstring_class, value);
+            if !key_ns.is_null() && !val_ns.is_null() {
+                // SAFETY: setObject:forKey: is a standard NSMutableDictionary method.
+                let _: () = msg_send![dict, setObject: val_ns forKey: key_ns];
+            }
+        }
+
+        // SAFETY: postNotificationName:object:userInfo:deliverImmediately: is the standard
+        // method for posting distributed notifications. deliverImmediately:YES ensures
+        // the notification is delivered even if the app is in the background.
+        let null_ptr: *mut Object = std::ptr::null_mut();
+        let yes: bool = true;
+        let _: () = msg_send![
+            center,
+            postNotificationName: name_nsstring
+            object: null_ptr
+            userInfo: dict
+            deliverImmediately: yes
+        ];
+
+        log::info!("📡 Distributed notification posted: {}", name);
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn create_nsstring(nsstring_class: &objc::runtime::Class, s: &str) -> *mut objc::runtime::Object {
+    use objc::{msg_send, sel, sel_impl};
+
+    let bytes = s.as_bytes();
+    // SAFETY: alloc + initWithBytes:length:encoding: is the standard way to create an
+    // NSString from a Rust &str. NSUTF8StringEncoding = 4.
+    let alloc: *mut objc::runtime::Object = msg_send![nsstring_class, alloc];
+    if alloc.is_null() {
+        return std::ptr::null_mut();
+    }
+    let nsstring: *mut objc::runtime::Object = msg_send![
+        alloc,
+        initWithBytes: bytes.as_ptr()
+        length: bytes.len()
+        encoding: 4usize // NSUTF8StringEncoding
+    ];
+    nsstring
+}
+
+#[cfg(not(target_os = "macos"))]
+fn post_distributed_notification(_name: &str, _user_info: &HashMap<String, String>) {
+    // Distributed notifications are macOS-only. No-op on other platforms.
+}

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub mod audio;
 pub mod config;
 pub mod console_utils;
 pub mod database;
+pub mod distributed_notifications;
 pub mod notifications;
 pub mod ollama;
 pub mod onboarding;
@@ -59,7 +60,7 @@ use audio::{list_audio_devices, AudioDevice, trigger_audio_permission};
 use log::{error as log_error, info as log_info};
 use notifications::commands::NotificationManagerState;
 use std::sync::Arc;
-use tauri::{AppHandle, Manager, Runtime};
+use tauri::{AppHandle, Emitter, Listener, Manager, Runtime};
 use tokio::sync::RwLock;
 
 static RECORDING_FLAG: AtomicBool = AtomicBool::new(false);
@@ -387,6 +388,167 @@ pub fn get_language_preference_internal() -> Option<String> {
     LANGUAGE_PREFERENCE.lock().ok().map(|lang| lang.clone())
 }
 
+/// Handle incoming deep-link URLs for external integration.
+/// Routes meetily:// URLs to existing recording commands.
+fn handle_deep_link<R: Runtime>(app: &AppHandle<R>, url_str: &str) {
+    let parsed = match url::Url::parse(url_str) {
+        Ok(u) => u,
+        Err(e) => {
+            log::warn!("📥 Malformed deep-link URL '{}': {}", url_str, e);
+            return;
+        }
+    };
+
+    // meetily://start-recording parses as host="start-recording"
+    let command = parsed.host_str().unwrap_or("");
+
+    // Extract optional ?name= query parameter
+    let meeting_name: Option<String> = parsed
+        .query_pairs()
+        .find(|(key, _)| key == "name")
+        .map(|(_, value)| value.to_string());
+
+    log::info!(
+        "📥 Deep-link command: '{}', meeting_name: {:?}",
+        command,
+        meeting_name
+    );
+
+    let app_clone = app.clone();
+    match command {
+        "start-recording" => {
+            tauri::async_runtime::spawn(async move {
+                log::info!("📥 Deep-link: Starting recording...");
+                match audio::recording_commands::start_recording_with_meeting_name(
+                    app_clone.clone(),
+                    meeting_name,
+                )
+                .await
+                {
+                    Ok(_) => {
+                        log::info!("📥 Deep-link: Recording started successfully");
+                        tray::update_tray_menu(&app_clone);
+                    }
+                    Err(e) => {
+                        // Silent failure — log and ignore (fire-and-forget semantics)
+                        log::warn!("📥 Deep-link: Failed to start recording: {}", e);
+                    }
+                }
+            });
+        }
+        "stop-recording" => {
+            tauri::async_runtime::spawn(async move {
+                log::info!("📥 Deep-link: Stopping recording...");
+
+                if !audio::recording_commands::is_recording().await {
+                    log::info!("📥 Deep-link: Not recording, ignoring stop command");
+                    return;
+                }
+
+                // Generate save path using same pattern as tray.rs
+                let save_path = match app_clone.path().app_data_dir() {
+                    Ok(dir) => {
+                        let timestamp =
+                            chrono::Local::now().format("%Y-%m-%dT%H-%M-%S").to_string();
+                        dir.join(format!("recording-{}.wav", timestamp))
+                            .to_string_lossy()
+                            .to_string()
+                    }
+                    Err(e) => {
+                        log::warn!("📥 Deep-link: Failed to get app data dir: {}", e);
+                        return;
+                    }
+                };
+
+                match audio::recording_commands::stop_recording(
+                    app_clone.clone(),
+                    audio::recording_commands::RecordingArgs { save_path },
+                )
+                .await
+                {
+                    Ok(_) => {
+                        log::info!("📥 Deep-link: Recording stopped successfully");
+                        RECORDING_FLAG.store(false, Ordering::SeqCst);
+                        tray::update_tray_menu(&app_clone);
+                        // Trigger frontend post-processing (same as tray.rs)
+                        if let Err(e) = app_clone.emit("recording-stop-complete", true) {
+                            log::warn!(
+                                "📥 Deep-link: Failed to emit recording-stop-complete: {}",
+                                e
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!("📥 Deep-link: Failed to stop recording: {}", e);
+                    }
+                }
+            });
+        }
+        "toggle-recording" => {
+            tauri::async_runtime::spawn(async move {
+                log::info!("📥 Deep-link: Toggle recording...");
+                if audio::recording_commands::is_recording().await {
+                    // Stop flow — same as stop-recording
+                    let save_path = match app_clone.path().app_data_dir() {
+                        Ok(dir) => {
+                            let timestamp =
+                                chrono::Local::now().format("%Y-%m-%dT%H-%M-%S").to_string();
+                            dir.join(format!("recording-{}.wav", timestamp))
+                                .to_string_lossy()
+                                .to_string()
+                        }
+                        Err(e) => {
+                            log::warn!("📥 Deep-link: Failed to get app data dir: {}", e);
+                            return;
+                        }
+                    };
+
+                    match audio::recording_commands::stop_recording(
+                        app_clone.clone(),
+                        audio::recording_commands::RecordingArgs { save_path },
+                    )
+                    .await
+                    {
+                        Ok(_) => {
+                            log::info!("📥 Deep-link: Toggle → stopped recording");
+                            RECORDING_FLAG.store(false, Ordering::SeqCst);
+                            tray::update_tray_menu(&app_clone);
+                            if let Err(e) = app_clone.emit("recording-stop-complete", true) {
+                                log::warn!(
+                                    "📥 Deep-link: Failed to emit recording-stop-complete: {}",
+                                    e
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            log::warn!("📥 Deep-link: Failed to stop recording: {}", e);
+                        }
+                    }
+                } else {
+                    // Start flow — same as start-recording
+                    match audio::recording_commands::start_recording_with_meeting_name(
+                        app_clone.clone(),
+                        meeting_name,
+                    )
+                    .await
+                    {
+                        Ok(_) => {
+                            log::info!("📥 Deep-link: Toggle → started recording");
+                            tray::update_tray_menu(&app_clone);
+                        }
+                        Err(e) => {
+                            log::warn!("📥 Deep-link: Failed to start recording: {}", e);
+                        }
+                    }
+                }
+            });
+        }
+        _ => {
+            log::warn!("📥 Deep-link: Unknown command '{}'", command);
+        }
+    }
+}
+
 pub fn run() {
     log::set_max_level(log::LevelFilter::Info);
 
@@ -396,6 +558,7 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_deep_link::init())
         .manage(whisper_engine::parallel_commands::ParallelProcessorState::new())
         .manage(Arc::new(RwLock::new(
             None::<notifications::manager::NotificationManager<tauri::Wry>>,
@@ -493,6 +656,22 @@ pub fn run() {
             } else {
                 log::warn!("Failed to resolve resource directory for templates");
             }
+
+            // Register deep-link URL handler for external integration
+            // Handles meetily://start-recording, meetily://stop-recording, meetily://toggle-recording
+            log::info!("Registering deep-link URL handler...");
+            let app_handle_for_deep_link = _app.handle().clone();
+            _app.handle().listen("deep-link://new-url", move |event| {
+                if let Ok(urls) = serde_json::from_str::<Vec<String>>(event.payload()) {
+                    for url_str in urls {
+                        log::info!("📥 Deep-link URL received: {}", url_str);
+                        handle_deep_link(&app_handle_for_deep_link, &url_str);
+                    }
+                } else {
+                    log::warn!("Failed to parse deep-link event payload: {}", event.payload());
+                }
+            });
+            log::info!("Deep-link URL handler registered");
 
             Ok(())
         })

--- a/frontend/src-tauri/src/summary/mod.rs
+++ b/frontend/src-tauri/src/summary/mod.rs
@@ -38,17 +38,21 @@ pub mod summary_engine;
 pub mod template_commands;
 pub mod templates;
 
-// Re-export Tauri commands (with their generated __cmd__ variants)
+// Re-export Tauri commands (with their generated __cmd__ and __tauri_command_name__ variants)
 pub use commands::{
     __cmd__api_cancel_summary, __cmd__api_get_summary, __cmd__api_process_transcript,
-    __cmd__api_save_meeting_summary, api_cancel_summary, api_get_summary,
+    __cmd__api_save_meeting_summary, __tauri_command_name_api_cancel_summary,
+    __tauri_command_name_api_get_summary, __tauri_command_name_api_process_transcript,
+    __tauri_command_name_api_save_meeting_summary, api_cancel_summary, api_get_summary,
     api_process_transcript, api_save_meeting_summary,
 };
 
 // Re-export template commands
 pub use template_commands::{
     __cmd__api_get_template_details, __cmd__api_list_templates, __cmd__api_validate_template,
-    api_get_template_details, api_list_templates, api_validate_template,
+    __tauri_command_name_api_get_template_details, __tauri_command_name_api_list_templates,
+    __tauri_command_name_api_validate_template, api_get_template_details, api_list_templates,
+    api_validate_template,
 };
 
 // Re-export commonly used items

--- a/frontend/src-tauri/src/summary/summary_engine/mod.rs
+++ b/frontend/src-tauri/src/summary/summary_engine/mod.rs
@@ -12,10 +12,15 @@ pub use client::{generate_with_builtin, is_sidecar_healthy, shutdown_sidecar_gra
 pub use commands::{
     __cmd__builtin_ai_cancel_download, __cmd__builtin_ai_delete_model,
     __cmd__builtin_ai_download_model, __cmd__builtin_ai_get_available_summary_model,
-    __cmd__builtin_ai_get_model_info, __cmd__builtin_ai_get_recommended_model, __cmd__builtin_ai_is_model_ready,
-    __cmd__builtin_ai_list_models, builtin_ai_cancel_download, builtin_ai_delete_model, builtin_ai_download_model,
-    builtin_ai_get_available_summary_model, builtin_ai_get_model_info, builtin_ai_get_recommended_model, builtin_ai_is_model_ready,
-    builtin_ai_list_models, init_model_manager, ModelManagerState,
+    __cmd__builtin_ai_get_model_info, __cmd__builtin_ai_get_recommended_model,
+    __cmd__builtin_ai_is_model_ready, __cmd__builtin_ai_list_models,
+    __tauri_command_name_builtin_ai_cancel_download, __tauri_command_name_builtin_ai_delete_model,
+    __tauri_command_name_builtin_ai_download_model, __tauri_command_name_builtin_ai_get_available_summary_model,
+    __tauri_command_name_builtin_ai_get_model_info, __tauri_command_name_builtin_ai_get_recommended_model,
+    __tauri_command_name_builtin_ai_is_model_ready, __tauri_command_name_builtin_ai_list_models,
+    builtin_ai_cancel_download, builtin_ai_delete_model, builtin_ai_download_model,
+    builtin_ai_get_available_summary_model, builtin_ai_get_model_info, builtin_ai_get_recommended_model,
+    builtin_ai_is_model_ready, builtin_ai_list_models, init_model_manager, ModelManagerState,
 };
 pub use model_manager::{ModelInfo, ModelStatus};
 pub use models::{get_available_models, get_default_model, get_model_by_name, ModelDef};

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -65,6 +65,7 @@
                         "notification:allow-is-permission-granted",
                         "updater:default",
                         "process:default",
+                        "deep-link:default",
                         {
                             "identifier": "fs:scope",
                             "allow": [
@@ -111,6 +112,11 @@
         }
     },
     "plugins": {
+        "deep-link": {
+            "desktop": {
+                "schemes": ["meetily"]
+            }
+        },
         "updater": {
             "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEVDQTYzMUQ3ODc5N0M4MkEKUldRcXlKZUgxekdtN09DRkVWSHNpZlJseEVOUmpNd1dDSTNaLzZ3MXJGTnY3WW1pdnlOYjBpbkIK",
             "endpoints": [


### PR DESCRIPTION
## Summary

- Add `meetily://` URL scheme for external control via `tauri-plugin-deep-link` (start, stop, toggle recording)
- Add macOS distributed notifications (`NSDistributedNotificationCenter`) broadcasting 4 recording lifecycle events
- All commands route to existing recording infrastructure — no new recording logic, no UI changes

## Inbound API (URL Scheme)

| URL | Action |
|-----|--------|
| `meetily://start-recording` | Start recording with default devices |
| `meetily://start-recording?name=Team%20Standup` | Start with custom meeting name |
| `meetily://stop-recording` | Stop recording and save |
| `meetily://toggle-recording` | Start if idle, stop if recording |

## Outbound API (macOS Distributed Notifications)

| Notification | Payload |
|-------------|---------|
| `com.meetily.ai.recording.started` | `{ meeting_name }` |
| `com.meetily.ai.recording.stopped` | `{ meeting_name, folder_path }` |
| `com.meetily.ai.recording.error` | `{ error }` |
| `com.meetily.ai.transcription.completed` | `{ meeting_name, folder_path }` |

## Files changed

- `Cargo.toml` — added `tauri-plugin-deep-link`
- `tauri.conf.json` — deep-link plugin config + permission
- `Info.plist` — `CFBundleURLTypes` for `meetily://` scheme
- `package.json` — added `@tauri-apps/plugin-deep-link`
- **New** `distributed_notifications.rs` — macOS `NSDistributedNotificationCenter` via `objc` FFI
- `lib.rs` — deep-link plugin registration + URL handler routing
- `recording_commands.rs` — distributed notification posts at all event emission sites
- `transcription/worker.rs` — `transcription-all-complete` event + notification at true completion

## Test plan

- [x] `cargo check` passes
- [x] `pnpm run tauri:build` produces working `.app` bundle
- [x] `open "meetily://start-recording?name=Test"` starts recording
- [x] `open "meetily://stop-recording"` stops recording
- [x] `open "meetily://toggle-recording"` toggles correctly
- [x] Distributed notification listener receives `recording.started` with correct payload
- [x] Distributed notification listener receives `recording.stopped` with `meeting_name` + `folder_path`
- [x] `stop-recording` when not recording is a silent no-op
- [x] `start-recording` when already recording is a silent no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)