### PR TITLE
docs(templates): match app-data dir name to productName "meetily" (#458)

### DIFF
--- a/frontend/src-tauri/templates/README.md
+++ b/frontend/src-tauri/templates/README.md
@@ -47,9 +47,9 @@ Each template JSON file follows this schema:
 
 Users can add custom templates to the application data directory:
 
-- **macOS**: `~/Library/Application Support/Meetily/templates/`
-- **Windows**: `%APPDATA%\Meetily\templates\`
-- **Linux**: `~/.config/Meetily/templates/`
+- **macOS**: `~/Library/Application Support/meetily/templates/`
+- **Windows**: `%APPDATA%\meetily\templates\`
+- **Linux**: `~/.config/meetily/templates/`
 
 Custom templates override built-in templates with the same filename.
 


### PR DESCRIPTION
Closes #458.

## Summary

The custom-templates README at \`frontend/src-tauri/templates/README.md\` listed \`Meetily\` (capital M) for the application data directory on all three platforms. The actual directory name is \`meetily\` (lowercase), derived from \`tauri.conf.json\` \`productName: \"meetily\"\` via Tauri's \`app_data_dir()\`. Following the README sent users to a non-existent path on all three OSes.

\`\`\`diff
-- **macOS**: \`~/Library/Application Support/Meetily/templates/\`
-- **Windows**: \`%APPDATA%\\Meetily\\templates\\\`
-- **Linux**: \`~/.config/Meetily/templates/\`
+- **macOS**: \`~/Library/Application Support/meetily/templates/\`
+- **Windows**: \`%APPDATA%\\meetily\\templates\\\`
+- **Linux**: \`~/.config/meetily/templates/\`
\`\`\`

The reporter flagged the macOS line specifically; Windows and Linux have the same case bug for the same reason (Tauri derives the directory from \`productName\` on every platform), so all three are corrected together. If you'd prefer to keep the PR strictly to the macOS line per the issue scope, happy to drop the other two — just let me know.