### PR TITLE
fix(build): unblock Tauri build on Linux with AMD ROCm

### DIFF
--- a/frontend/build-gpu.sh
+++ b/frontend/build-gpu.sh
@@ -105,14 +105,18 @@ if [ ! -d "$HELPER_DIR" ]; then
 fi
 
 # Determine llama-helper features
-# Note: llama-cpp-2 does NOT support coreml, only metal/cuda/vulkan
-# So for macOS Apple Silicon (which returns 'coreml' for Whisper), use 'metal' for llama-helper
+# Whisper and llama-cpp-2 name the same backend differently:
+#   coreml  (whisper-rs, macOS) -> metal (llama-cpp-2 has no CoreML)
+#   hipblas (whisper-rs, AMD)   -> rocm  (llama-cpp-2's name for the same backend)
 HELPER_FEATURES=""
 if [ -n "$TAURI_GPU_FEATURE" ]; then
     LLAMA_FEATURE="$TAURI_GPU_FEATURE"
     if [ "$LLAMA_FEATURE" = "coreml" ]; then
         LLAMA_FEATURE="metal"
         echo -e "${YELLOW}   Note: llama-cpp-2 doesn't support CoreML, using Metal instead${NC}"
+    elif [ "$LLAMA_FEATURE" = "hipblas" ]; then
+        LLAMA_FEATURE="rocm"
+        echo -e "${YELLOW}   Note: llama-cpp-2 names ROCm 'rocm' (whisper-rs calls it 'hipblas')${NC}"
     fi
     HELPER_FEATURES="--features $LLAMA_FEATURE"
 fi

--- a/frontend/dev-gpu.sh
+++ b/frontend/dev-gpu.sh
@@ -97,14 +97,18 @@ if [ ! -d "$HELPER_DIR" ]; then
 fi
 
 # Determine llama-helper features
-# Note: llama-cpp-2 does NOT support coreml, only metal/cuda/vulkan
-# So for macOS Apple Silicon (which returns 'coreml' for Whisper), use 'metal' for llama-helper
+# Whisper and llama-cpp-2 name the same backend differently:
+#   coreml  (whisper-rs, macOS) -> metal (llama-cpp-2 has no CoreML)
+#   hipblas (whisper-rs, AMD)   -> rocm  (llama-cpp-2's name for the same backend)
 HELPER_FEATURES=""
 if [ -n "$TAURI_GPU_FEATURE" ] && [ "$TAURI_GPU_FEATURE" != "none" ]; then
     LLAMA_FEATURE="$TAURI_GPU_FEATURE"
     if [ "$LLAMA_FEATURE" = "coreml" ]; then
         LLAMA_FEATURE="metal"
         echo -e "${YELLOW}   Note: llama-cpp-2 doesn't support CoreML, using Metal instead${NC}"
+    elif [ "$LLAMA_FEATURE" = "hipblas" ]; then
+        LLAMA_FEATURE="rocm"
+        echo -e "${YELLOW}   Note: llama-cpp-2 names ROCm 'rocm' (whisper-rs calls it 'hipblas')${NC}"
     fi
     HELPER_FEATURES="--features $LLAMA_FEATURE"
 fi

--- a/frontend/src-tauri/src/summary/mod.rs
+++ b/frontend/src-tauri/src/summary/mod.rs
@@ -38,17 +38,24 @@ pub mod summary_engine;
 pub mod template_commands;
 pub mod templates;
 
-// Re-export Tauri commands (with their generated __cmd__ variants)
+// Re-export Tauri commands. Each `#[tauri::command]` generates two adjacent items:
+//   - `__cmd__<fn>`            (legacy marker module)
+//   - `__tauri_command_name_<fn>` (macro used by `generate_handler!` lookup)
+// Both must be re-exported here so `summary::<fn>` registration in lib.rs resolves.
 pub use commands::{
     __cmd__api_cancel_summary, __cmd__api_get_summary, __cmd__api_process_transcript,
-    __cmd__api_save_meeting_summary, api_cancel_summary, api_get_summary,
+    __cmd__api_save_meeting_summary, __tauri_command_name_api_cancel_summary,
+    __tauri_command_name_api_get_summary, __tauri_command_name_api_process_transcript,
+    __tauri_command_name_api_save_meeting_summary, api_cancel_summary, api_get_summary,
     api_process_transcript, api_save_meeting_summary,
 };
 
 // Re-export template commands
 pub use template_commands::{
     __cmd__api_get_template_details, __cmd__api_list_templates, __cmd__api_validate_template,
-    api_get_template_details, api_list_templates, api_validate_template,
+    __tauri_command_name_api_get_template_details, __tauri_command_name_api_list_templates,
+    __tauri_command_name_api_validate_template, api_get_template_details, api_list_templates,
+    api_validate_template,
 };
 
 // Re-export commonly used items

--- a/frontend/src-tauri/src/summary/summary_engine/mod.rs
+++ b/frontend/src-tauri/src/summary/summary_engine/mod.rs
@@ -13,7 +13,12 @@ pub use commands::{
     __cmd__builtin_ai_cancel_download, __cmd__builtin_ai_delete_model,
     __cmd__builtin_ai_download_model, __cmd__builtin_ai_get_available_summary_model,
     __cmd__builtin_ai_get_model_info, __cmd__builtin_ai_get_recommended_model, __cmd__builtin_ai_is_model_ready,
-    __cmd__builtin_ai_list_models, builtin_ai_cancel_download, builtin_ai_delete_model, builtin_ai_download_model,
+    __cmd__builtin_ai_list_models,
+    __tauri_command_name_builtin_ai_cancel_download, __tauri_command_name_builtin_ai_delete_model,
+    __tauri_command_name_builtin_ai_download_model, __tauri_command_name_builtin_ai_get_available_summary_model,
+    __tauri_command_name_builtin_ai_get_model_info, __tauri_command_name_builtin_ai_get_recommended_model,
+    __tauri_command_name_builtin_ai_is_model_ready, __tauri_command_name_builtin_ai_list_models,
+    builtin_ai_cancel_download, builtin_ai_delete_model, builtin_ai_download_model,
     builtin_ai_get_available_summary_model, builtin_ai_get_model_info, builtin_ai_get_recommended_model, builtin_ai_is_model_ready,
     builtin_ai_list_models, init_model_manager, ModelManagerState,
 };

--- a/llama-helper/Cargo.toml
+++ b/llama-helper/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-llama-cpp-2 = "0.1.128"
+llama-cpp-2 = "0.1.146"
 encoding_rs = "0.8"
 
 [features]
@@ -15,6 +15,7 @@ default = []
 metal = ["llama-cpp-2/metal"]
 cuda = ["llama-cpp-2/cuda"]
 vulkan = ["llama-cpp-2/vulkan"]
+rocm = ["llama-cpp-2/rocm"]
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
## Summary
- Adds AMD ROCm support to `llama-helper` (bumps `llama-cpp-2` 0.1.128 → 0.1.146 to pick up the `rocm` feature; maps `hipblas → rocm` in `build-gpu.sh` / `dev-gpu.sh` alongside the existing `coreml → metal` mapping).
- Restores re-export of the `__tauri_command_name_*` markers in the `summary` modules so `tauri::generate_handler!` resolves commands registered via `summary::<fn>` from `lib.rs` under current `tauri-macros` (2.6.1).

## Repro of the original failure
On Linux with an AMD ROCm GPU, `./build-gpu.sh` first fails at the llama-helper step:

```
error: the package 'llama-helper' does not contain this feature: hipblas
```

After that fix, the next build fails with:

```
error[E0433]: cannot find `__tauri_command_name_api_process_transcript` in `summary`
```

— because `summary/mod.rs` only re-exports the legacy `__cmd__*` symbols. `tauri-macros` 2.6.1 emits both `__cmd__<fn>` and `__tauri_command_name_<fn>`, and `generate_handler!` looks up the latter.

## Test plan
- [x] `./build-gpu.sh` with auto-detected `hipblas` → llama-helper builds with ROCm.
- [x] `TAURI_GPU_FEATURE=vulkan ./build-gpu.sh` → full build produces `target/release/bundle/{deb,appimage}/meetily_0.3.0_amd64.*`.
- [ ] macOS Apple Silicon — `coreml → metal` mapping unchanged.
- [ ] NVIDIA CUDA — unchanged.
- [ ] Windows / Vulkan — unchanged.

## Out of scope (not addressed here)
- On Arch with `libclang` 22 as the system default, `whisper-rs-sys` bindgen produces opaque structs (`whisper_full_params` collapses to just `_address`). Building locally required `LIBCLANG_PATH=/usr/lib/llvm21/lib`. That looks like an upstream `whisper-rs 0.13.2` / `whisper-rs-sys 0.11.1` incompatibility with modern libclang and is left for a separate change (probably a `whisper-rs` bump).
- On AMD ROCm 7.x, `whisper-rs`'s vendored `whisper.cpp` cannot compile with `--features hipblas` (uses the older `hipblasGemmEx` signature). Vulkan is the working AMD path with this `whisper-rs` version; a `whisper-rs` bump would also resolve that.