### PR TITLE
docs: fix macOS path case in custom templates README

### DIFF
--- a/frontend/src-tauri/templates/README.md
+++ b/frontend/src-tauri/templates/README.md
@@ -47,7 +47,7 @@ Each template JSON file follows this schema:
 
 Users can add custom templates to the application data directory:
 
-- **macOS**: `~/Library/Application Support/Meetily/templates/`
+- **macOS**: `~/Library/Application Support/meetily/templates/`
 - **Windows**: `%APPDATA%\Meetily\templates\`
 - **Linux**: `~/.config/Meetily/templates/`
 


### PR DESCRIPTION
## Summary

Fixes the macOS custom templates path in `frontend/src-tauri/templates/README.md` to use lowercase `meetily` instead of uppercase `Meetily`.

**Before:** `~/Library/Application Support/Meetily/templates/`
**After:** `~/Library/Application Support/meetily/templates/`

## Test Plan

- [ ] Readme displays correct macOS path

Fixes #458
