### PR TITLE
fix: correct macOS templates path case in README (#458)

### DIFF
--- a/frontend/src-tauri/templates/README.md
+++ b/frontend/src-tauri/templates/README.md
@@ -47,7 +47,7 @@ Each template JSON file follows this schema:
 
 Users can add custom templates to the application data directory:
 
-- **macOS**: `~/Library/Application Support/Meetily/templates/`
+- **macOS**: `~/Library/Application Support/meetily/templates/`
 - **Windows**: `%APPDATA%\Meetily\templates\`
 - **Linux**: `~/.config/Meetily/templates/`
 


### PR DESCRIPTION
## Summary
- Fixed macOS custom templates path in `frontend/src-tauri/templates/README.md`
- Changed `Meetily` → `meetily` in the path per macOS convention

## Issue
#458: Typo in macOS custom templates path (Meetily → meetily)

## Testing
Verified the file content after fix:
- Before: `~/Library/Application Support/Meetily/templates/`
- After: `~/Library/Application Support/meetily/templates/`

Closes #458