### PR TITLE
fix(summary): prevent BlockNote rendering crashes with patch + boundary

### DIFF
--- a/frontend/patches/prosemirror-view@1.41.8.patch
+++ b/frontend/patches/prosemirror-view@1.41.8.patch
@@ -1,0 +1,73 @@
+diff --git a/dist/index.cjs b/dist/index.cjs
+index ce89be47cebd61a79c6039950f6dcd10df0e3c7e..d1baf2b64f4b54c7f7abc0cc3653debd71503562 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -1263,7 +1263,12 @@ var MarkViewDesc = function (_ViewDesc3) {
+     value: function create(parent, mark, inline, view) {
+       var custom = view.nodeViews[mark.type.name];
+       var spec = custom && custom(mark, view, inline);
+-      if (!spec || !spec.dom) spec = prosemirrorModel.DOMSerializer.renderSpec(document, mark.type.spec.toDOM(mark, inline), null, mark.attrs);
++      if (!spec || !spec.dom) {
++        var toDOMResult_pm_fix_m = mark.type.spec.toDOM(mark, inline);
++        spec = toDOMResult_pm_fix_m && toDOMResult_pm_fix_m.dom
++          ? toDOMResult_pm_fix_m
++          : prosemirrorModel.DOMSerializer.renderSpec(document, toDOMResult_pm_fix_m, null, mark.attrs);
++      }
+       return new MarkViewDesc(parent, mark, spec.dom, spec.contentDOM || spec.dom, spec);
+     }
+   }]);
+@@ -1464,9 +1469,15 @@ var NodeViewDesc = function (_ViewDesc4) {
+       if (node.isText) {
+         if (!dom) dom = document.createTextNode(node.text);else if (dom.nodeType != 3) throw new RangeError("Text must be rendered as a DOM text node");
+       } else if (!dom) {
+-        var _spec = prosemirrorModel.DOMSerializer.renderSpec(document, node.type.spec.toDOM(node), null, node.attrs);
+-        dom = _spec.dom;
+-        contentDOM = _spec.contentDOM;
++        var toDOMResult_pm_fix_n = node.type.spec.toDOM(node);
++        if (toDOMResult_pm_fix_n && toDOMResult_pm_fix_n.dom) {
++          dom = toDOMResult_pm_fix_n.dom;
++          contentDOM = toDOMResult_pm_fix_n.contentDOM;
++        } else {
++          var _spec = prosemirrorModel.DOMSerializer.renderSpec(document, toDOMResult_pm_fix_n, null, node.attrs);
++          dom = _spec.dom;
++          contentDOM = _spec.contentDOM;
++        }
+       }
+       if (!contentDOM && !node.isText && dom.nodeName != "BR") {
+         if (!dom.hasAttribute("contenteditable")) dom.contentEditable = "false";
+diff --git a/dist/index.js b/dist/index.js
+index 2f19364145a8bb8c0f44c738d58271c76078e6f9..86ad7d3bd83cff1a9d10790e021a2098c5d21bd4 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1226,8 +1226,12 @@ class MarkViewDesc extends ViewDesc {
+     static create(parent, mark, inline, view) {
+         let custom = view.nodeViews[mark.type.name];
+         let spec = custom && custom(mark, view, inline);
+-        if (!spec || !spec.dom)
+-            spec = DOMSerializer.renderSpec(document, mark.type.spec.toDOM(mark, inline), null, mark.attrs);
++        if (!spec || !spec.dom) {
++            const toDOMResult_pm_fix = mark.type.spec.toDOM(mark, inline);
++            spec = toDOMResult_pm_fix && toDOMResult_pm_fix.dom
++                ? toDOMResult_pm_fix
++                : DOMSerializer.renderSpec(document, toDOMResult_pm_fix, null, mark.attrs);
++        }
+         return new MarkViewDesc(parent, mark, spec.dom, spec.contentDOM || spec.dom, spec);
+     }
+     parseRule() {
+@@ -1307,8 +1311,14 @@ class NodeViewDesc extends ViewDesc {
+                 throw new RangeError("Text must be rendered as a DOM text node");
+         }
+         else if (!dom) {
+-            let spec = DOMSerializer.renderSpec(document, node.type.spec.toDOM(node), null, node.attrs);
+-            ({ dom, contentDOM } = spec);
++            const toDOMResult_pm_fix = node.type.spec.toDOM(node);
++            if (toDOMResult_pm_fix && toDOMResult_pm_fix.dom) {
++                dom = toDOMResult_pm_fix.dom;
++                contentDOM = toDOMResult_pm_fix.contentDOM;
++            } else {
++                let spec = DOMSerializer.renderSpec(document, toDOMResult_pm_fix, null, node.attrs);
++                ({ dom, contentDOM } = spec);
++            }
+         }
+         if (!contentDOM && !node.isText && dom.nodeName != "BR") { // Chrome gets confused by <br contenteditable=false>
+             if (!dom.hasAttribute("contenteditable"))

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+patchedDependencies:
+  prosemirror-view@1.41.8: patches/prosemirror-view@1.41.8.patch

--- a/frontend/src/components/AISummary/BlockNoteSummaryView.tsx
+++ b/frontend/src/components/AISummary/BlockNoteSummaryView.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef, forwardRef, useImperativeHand
 import dynamic from 'next/dynamic';
 import { Summary, SummaryDataResponse, SummaryFormat, BlockNoteBlock } from '@/types';
 import { AISummary } from './index';
+import { SummaryErrorBoundary } from './SummaryErrorBoundary';
 import { Block } from '@blocknote/core';
 import { useCreateBlockNote } from '@blocknote/react';
 import { BlockNoteView } from '@blocknote/shadcn';
@@ -80,9 +81,15 @@ export const BlockNoteSummaryView = forwardRef<BlockNoteSummaryViewRef, BlockNot
   const [isSaving, setIsSaving] = useState(false);
   const isContentLoaded = useRef(false);
 
-  // Create BlockNote editor for markdown parsing
+  // Create BlockNote editor for markdown parsing.
+  //
+  // `placeholder` is disabled because BlockNote 0.36's placeholder
+  // plugin produces a DecorationSource that's missing `localsInner`,
+  // which crashes prosemirror-view's DecorationGroup.locals() during
+  // the initial editor mount.
   const editor = useCreateBlockNote({
-    initialContent: undefined
+    initialContent: undefined,
+    disableExtensions: ['placeholder'],
   });
 
   // Parse markdown to blocks when format is markdown
@@ -219,18 +226,23 @@ export const BlockNoteSummaryView = forwardRef<BlockNoteSummaryViewRef, BlockNot
   if (format === 'blocknote') {
     console.log('🎨 Rendering BLOCKNOTE format (direct)');
     return (
-      <div className="flex flex-col w-full">
-        <div className="w-full">
-          <Editor
-            initialContent={data.summary_json}
-            onChange={(blocks) => {
-              console.log('📝 Editor blocks changed:', blocks.length);
-              handleEditorChange(blocks);
-            }}
-            editable={true}
-          />
+      <SummaryErrorBoundary
+        rawMarkdown={data?.markdown}
+        onRetry={onRegenerateSummary}
+      >
+        <div className="flex flex-col w-full">
+          <div className="w-full">
+            <Editor
+              initialContent={data.summary_json}
+              onChange={(blocks) => {
+                console.log('📝 Editor blocks changed:', blocks.length);
+                handleEditorChange(blocks);
+              }}
+              editable={true}
+            />
+          </div>
         </div>
-      </div>
+      </SummaryErrorBoundary>
     );
   }
 
@@ -238,20 +250,25 @@ export const BlockNoteSummaryView = forwardRef<BlockNoteSummaryViewRef, BlockNot
   if (format === 'markdown') {
     console.log('🎨 Rendering MARKDOWN format (parsed to BlockNote)');
     return (
-      <div className="flex flex-col w-full">
-        <div className="w-full">
-          <BlockNoteView
-            editor={editor}
-            editable={true}
-            onChange={() => {
-              if (isContentLoaded.current) {
-                handleEditorChange(editor.document);
-              }
-            }}
-            theme="light"
-          />
+      <SummaryErrorBoundary
+        rawMarkdown={data?.markdown}
+        onRetry={onRegenerateSummary}
+      >
+        <div className="flex flex-col w-full">
+          <div className="w-full">
+            <BlockNoteView
+              editor={editor}
+              editable={true}
+              onChange={() => {
+                if (isContentLoaded.current) {
+                  handleEditorChange(editor.document);
+                }
+              }}
+              theme="light"
+            />
+          </div>
         </div>
-      </div>
+      </SummaryErrorBoundary>
     );
   }
 

--- a/frontend/src/components/AISummary/SummaryErrorBoundary.tsx
+++ b/frontend/src/components/AISummary/SummaryErrorBoundary.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Component, ReactNode } from "react";
+
+interface Props {
+  /** Raw markdown to show in the fallback when rendering fails. */
+  rawMarkdown?: string;
+  /** Optional retry handler (e.g. trigger a regenerate). */
+  onRetry?: () => void;
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+/**
+ * Catches render-phase errors thrown by the summary view (e.g. BlockNote
+ * choking on otherwise-valid block input). Without this, a bad summary
+ * takes down the entire meeting page with Next.js's generic
+ * "Application error: a client-side exception has occurred" overlay.
+ *
+ * The fallback shows the raw markdown so the user still has access to
+ * the summary content and can decide whether to regenerate.
+ */
+export class SummaryErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: { componentStack?: string }) {
+    console.error("SummaryErrorBoundary caught:", error, info.componentStack);
+  }
+
+  private handleRetry = () => {
+    this.setState({ error: null });
+    this.props.onRetry?.();
+  };
+
+  render() {
+    if (!this.state.error) {
+      return this.props.children;
+    }
+
+    return (
+      <div className="flex flex-col gap-3 p-4 border border-amber-300 bg-amber-50 rounded">
+        <div className="text-sm text-amber-900">
+          <strong>Couldn&apos;t render this summary.</strong> The model output
+          contained something the editor couldn&apos;t parse. The raw text is
+          shown below.
+        </div>
+        {this.props.rawMarkdown ? (
+          <pre className="text-xs whitespace-pre-wrap bg-white p-3 rounded border border-amber-200 max-h-96 overflow-auto">
+            {this.props.rawMarkdown}
+          </pre>
+        ) : null}
+        {this.props.onRetry ? (
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            className="self-start text-sm px-3 py-1 rounded bg-amber-600 text-white hover:bg-amber-700"
+          >
+            Regenerate summary
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
## Description

The summary editor crashes for some meetings with a `Cannot read properties of undefined (reading 'localsInner')` or `dom is undefined` error originating in prosemirror-view, taking down the entire meeting page. This PR adds three independent layers of defense:

1. **Patch `prosemirror-view` to honor `{dom, contentDOM}` toDOM specs.** BlockNote 0.36's node specs sometimes return a `{dom, contentDOM}` shape from `toDOM`, but upstream prosemirror-view unconditionally forwards the result to `DOMSerializer.renderSpec`, which throws when given that shape. The patch checks for the shape and uses it directly when present.

2. **Disable BlockNote's `placeholder` plugin.** BlockNote 0.36's placeholder plugin produces a `DecorationSource` that's missing `localsInner`, which crashes `DecorationGroup.locals()` in prosemirror-view during the initial editor mount. We have no UX dependency on the placeholder, so disabling it is the cleanest fix.

3. **Wrap the editor in `SummaryErrorBoundary`.** Even with (1) and (2), any future regression in the editor stack would otherwise take down the whole page. The boundary catches render failures and shows a fallback with the raw markdown plus a retry button, so a single bad summary can't break navigation.

## Files

- `frontend/patches/prosemirror-view@1.41.8.patch` — new pnpm patch (also patches `dist/index.cjs` and `dist/index.js`)
- `frontend/pnpm-workspace.yaml` — registers the patch via `patchedDependencies`
- `frontend/src/components/AISummary/BlockNoteSummaryView.tsx` — `disableExtensions: ['placeholder']` and wraps both render paths in the boundary
- `frontend/src/components/AISummary/SummaryErrorBoundary.tsx` — new class component with fallback UI

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x] Manual testing performed — opened previously-crashing meetings and verified the editor renders; intentionally threw inside `Editor` to confirm the boundary catches and the rest of the UI stays interactive.
- [ ] Unit tests added — N/A (boundary is exercised through manual fault injection; patch is a third-party dependency hot-fix).

## Checklist

- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for the non-obvious parts (placeholder disable + patch rationale)
- [x] No documentation needed