### PR TITLE
feat(tray): hide main window to tray on close instead of exiting

### DIFF
--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -496,6 +496,18 @@ pub fn run() {
 
             Ok(())
         })
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                if window.label() == "main" {
+                    api.prevent_close();
+                    if let Err(e) = window.hide() {
+                        log::error!("Failed to hide main window on close request: {}", e);
+                    } else {
+                        log::info!("Main window hidden to tray on close request");
+                    }
+                }
+            }
+        })
         .invoke_handler(tauri::generate_handler![
             start_recording,
             stop_recording,


### PR DESCRIPTION
## Description

Meetily already ships a fully-wired system tray (start/stop recording, open window, quit), but closing the main window currently terminates the entire app, including any active recording. That's a footgun: a single accidental close ends the meeting.

This PR intercepts the main window's `CloseRequested` event and hides the window instead of letting it close. The tray icon persists, so users can re-open the window or quit explicitly from the tray menu.

## Behavior

- **Close button (X)** → window hides; app keeps running in tray; recording continues
- **Tray → Quit** → still exits cleanly (unchanged)
- **Other windows** → unaffected; only the `main` window is intercepted

## Files

- `frontend/src-tauri/src/lib.rs` — adds a single `on_window_event` handler (12 lines)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x] Manual testing on Linux — closed window with active recording; verified recording continued and window reopened via tray; verified Quit still exits.
- [ ] macOS / Windows verification welcome from maintainers.

## Follow-ups (not in this PR)

- A user preference toggle for `close = exit` vs `close = hide` would let people who prefer the old behavior opt back in. Happy to do this in a follow-up if maintainers want it.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed the code
- [x] No documentation needed (behavior change is intuitive and matches the existing tray menu)