### PR TITLE
fix(frontend): stabilize BlockNote ProseMirror resolution [skip ci]

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,3 +1,8 @@
+const path = require('path');
+const tiptapPmResolveBase = path.dirname(require.resolve('@tiptap/pm/model'));
+const resolveFromTiptapPm = (pkg) =>
+  require.resolve(pkg, { paths: [tiptapPmResolveBase] });
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false, // Disabled for BlockNote compatibility
@@ -17,6 +22,26 @@ const nextConfig = {
         fs: false,
         path: false,
         os: false,
+      };
+
+      // Keep ProseMirror single-instanced for BlockNote/Tiptap.
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        '@blocknote/core$': require.resolve('@blocknote/core'),
+        '@blocknote/react$': require.resolve('@blocknote/react'),
+        '@blocknote/shadcn$': require.resolve('@blocknote/shadcn'),
+        'prosemirror-model': resolveFromTiptapPm('prosemirror-model'),
+        'prosemirror-state': resolveFromTiptapPm('prosemirror-state'),
+        'prosemirror-view': resolveFromTiptapPm('prosemirror-view'),
+        'prosemirror-transform': resolveFromTiptapPm('prosemirror-transform'),
+        'prosemirror-tables': resolveFromTiptapPm('prosemirror-tables'),
+        'prosemirror-schema-list': resolveFromTiptapPm('prosemirror-schema-list'),
+        'prosemirror-keymap': resolveFromTiptapPm('prosemirror-keymap'),
+        'prosemirror-commands': resolveFromTiptapPm('prosemirror-commands'),
+        'prosemirror-history': resolveFromTiptapPm('prosemirror-history'),
+        'prosemirror-inputrules': resolveFromTiptapPm('prosemirror-inputrules'),
+        'prosemirror-gapcursor': resolveFromTiptapPm('prosemirror-gapcursor'),
+        'prosemirror-dropcursor': resolveFromTiptapPm('prosemirror-dropcursor'),
       };
     }
     return config;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -86,6 +86,15 @@
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.25.71"
     },
+    "pnpm": {
+        "overrides": {
+            "prosemirror-model": "1.25.3",
+            "prosemirror-state": "1.4.3",
+            "prosemirror-view": "1.41.3",
+            "prosemirror-transform": "1.10.4",
+            "prosemirror-tables": "1.8.1"
+        }
+    },
     "devDependencies": {
         "@tailwindcss/typography": "^0.5.15",
         "@tauri-apps/cli": "^2.1.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -449,24 +449,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.33':
     resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.33':
     resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.33':
     resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.33':
     resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
@@ -1593,30 +1597,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.1':
     resolution: {integrity: sha512-mNA5dbbqPqDUdTIwdUYYuhO2GvIe9UnB2r0VU2njxBOS3Opbx4gKNC5yP0Iu4rYmEmqdlwry9VzGZQ3wq9dyFg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.1':
     resolution: {integrity: sha512-fZj3Gwq+6fUs305T5WQiD5iSGJw+j/4w/HGmk4sHDAcy+rp9zU5eaxB7nOyz5/I/nkNAuKPqfp6uIbiUBXkBCw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.1':
     resolution: {integrity: sha512-XFxGxOvHM7jjeD6ozCKdGfhzJ7lERYDGZl1/Kb4fsvchaJsfLJ981TlyTG8Qy/gFq+f5GitH3bfrX9JAkjPEyw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.1':
     resolution: {integrity: sha512-d5C2/Zm+68v7R9wTuTCjRQEVrWjcdMkJBZ1+rXse+QdMMlTB9+u9PDNDLw9PQflWxYLaYZ7tjxxL9Nb9II6PbA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.1':
     resolution: {integrity: sha512-YdeVWFAR1pTXzUU6NLstPq4G6OLxuDrXCXEBdmBH+5EZIDXUx0D2kJlz3+YjpazkKvAzYpgziTsyRagls0OfRQ==}
@@ -2964,8 +2973,8 @@ packages:
   prosemirror-menu@1.3.2:
     resolution: {integrity: sha512-6VgUJTYod0nMBlCaYJGhXGLu7Gt4AvcwcOq0YfJCY/6Uh+3S7UsWhpy6rJFCBFOmonq1hD8KyWOtZhkppd4YPg==}
 
-  prosemirror-model@1.25.6:
-    resolution: {integrity: sha512-RIm+e9BiqAaJ1mRECv3vR3C+VG8ELoTTI+47tVudGi82yLnFOx3G/p/iSPK1HmHQdKhkkrJ68NJqxh7S+FBVmQ==}
+  prosemirror-model@1.25.3:
+    resolution: {integrity: sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==}
 
   prosemirror-paste-rules@3.0.0:
     resolution: {integrity: sha512-p2ayp2xtSTtDPZutoxZyK6UKJhJk0hEpIfdfVYfd3DSENE1Lyrcg96pju+ClgwXlTjPUykXx5DrsfRbHCY+gGQ==}
@@ -2980,8 +2989,8 @@ packages:
   prosemirror-schema-list@1.5.1:
     resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
 
-  prosemirror-state@1.4.4:
-    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+  prosemirror-state@1.4.3:
+    resolution: {integrity: sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==}
 
   prosemirror-suggest@3.0.0:
     resolution: {integrity: sha512-cEYnJHOAnQ+ET7PKY1tY8SMSpyR2rQAuYfPEmVtet0V9exgHAeiaSEzyBcCSeLesxXJRIv8b9cofyqoqyMjlEw==}
@@ -2990,8 +2999,8 @@ packages:
       prosemirror-state: ^1.4.2
       prosemirror-view: ^1.33.8
 
-  prosemirror-tables@1.8.5:
-    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
+  prosemirror-tables@1.8.1:
+    resolution: {integrity: sha512-DAgDoUYHCcc6tOGpLVPSU1k84kCUWTWnfWX3UDy2Delv4ryH0KqTD6RBI6k4yi9j9I8gl3j8MkPpRD/vWPZbug==}
 
   prosemirror-trailing-node@3.0.0:
     resolution: {integrity: sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==}
@@ -3000,11 +3009,11 @@ packages:
       prosemirror-state: ^1.4.2
       prosemirror-view: ^1.33.8
 
-  prosemirror-transform@1.12.0:
-    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
+  prosemirror-transform@1.10.4:
+    resolution: {integrity: sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==}
 
-  prosemirror-view@1.41.8:
-    resolution: {integrity: sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==}
+  prosemirror-view@1.41.3:
+    resolution: {integrity: sha512-SqMiYMUQNNBP9kfPhLO8WXEk/fon47vc52FQsUiJzTBuyjKgEcoAwMyF04eQ4WZ2ArMn7+ReypYL60aKngbACQ==}
 
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
@@ -3634,12 +3643,12 @@ snapshots:
       emoji-mart: 5.6.0
       hast-util-from-dom: 5.0.1
       prosemirror-dropcursor: 1.8.2
-      prosemirror-highlight: 0.13.1(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.6)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
-      prosemirror-model: 1.25.6
-      prosemirror-state: 1.4.4
-      prosemirror-tables: 1.8.5
-      prosemirror-transform: 1.12.0
-      prosemirror-view: 1.41.8
+      prosemirror-highlight: 0.13.1(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.41.3)
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-tables: 1.8.1
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.3
       rehype-format: 5.0.1
       rehype-parse: 9.0.1
       rehype-remark: 10.0.1
@@ -3650,7 +3659,7 @@ snapshots:
       remark-stringify: 11.0.0
       unified: 11.0.5
       uuid: 8.3.2
-      y-prosemirror: 1.3.7(prosemirror-model@1.25.6)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)
+      y-prosemirror: 1.3.7(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.3)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)
       y-protocols: 1.0.7(yjs@13.6.30)
       yjs: 13.6.30
     transitivePeerDependencies:
@@ -4989,15 +4998,15 @@ snapshots:
       prosemirror-history: 1.5.0
       prosemirror-inputrules: 1.5.1
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.6
-      prosemirror-paste-rules: 3.0.0(prosemirror-model@1.25.6)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)
+      prosemirror-model: 1.25.3
+      prosemirror-paste-rules: 3.0.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.3)
       prosemirror-schema-list: 1.5.1
-      prosemirror-state: 1.4.4
-      prosemirror-suggest: 3.0.0(prosemirror-model@1.25.6)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)
-      prosemirror-tables: 1.8.5
-      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.6)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)
-      prosemirror-transform: 1.12.0
-      prosemirror-view: 1.41.8
+      prosemirror-state: 1.4.3
+      prosemirror-suggest: 3.0.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.3)
+      prosemirror-tables: 1.8.1
+      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.3)
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.3
 
   '@remirror/preset-core@3.0.2(@remirror/pm@3.0.1)(@types/node@20.19.41)':
     dependencies:
@@ -5447,14 +5456,14 @@ snapshots:
       prosemirror-keymap: 1.2.3
       prosemirror-markdown: 1.13.4
       prosemirror-menu: 1.3.2
-      prosemirror-model: 1.25.6
+      prosemirror-model: 1.25.3
       prosemirror-schema-basic: 1.2.4
       prosemirror-schema-list: 1.5.1
-      prosemirror-state: 1.4.4
-      prosemirror-tables: 1.8.5
-      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.6)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)
-      prosemirror-transform: 1.12.0
-      prosemirror-view: 1.41.8
+      prosemirror-state: 1.4.3
+      prosemirror-tables: 1.8.1
+      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.3)
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.3
 
   '@tiptap/react@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -6791,136 +6800,136 @@ snapshots:
 
   prosemirror-changeset@2.4.1:
     dependencies:
-      prosemirror-transform: 1.12.0
+      prosemirror-transform: 1.10.4
 
   prosemirror-collab@1.3.1:
     dependencies:
-      prosemirror-state: 1.4.4
+      prosemirror-state: 1.4.3
 
   prosemirror-commands@1.7.1:
     dependencies:
-      prosemirror-model: 1.25.6
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.12.0
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
 
   prosemirror-dropcursor@1.8.2:
     dependencies:
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.12.0
-      prosemirror-view: 1.41.8
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.3
 
   prosemirror-gapcursor@1.4.1:
     dependencies:
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.6
-      prosemirror-state: 1.4.4
-      prosemirror-view: 1.41.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
-  prosemirror-highlight@0.13.1(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.6)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8):
+  prosemirror-highlight@0.13.1(@shikijs/types@3.2.1)(@types/hast@3.0.4)(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.41.3):
     optionalDependencies:
       '@shikijs/types': 3.2.1
       '@types/hast': 3.0.4
-      prosemirror-model: 1.25.6
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.12.0
-      prosemirror-view: 1.41.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.3
 
   prosemirror-history@1.5.0:
     dependencies:
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.12.0
-      prosemirror-view: 1.41.8
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.3
       rope-sequence: 1.3.4
 
   prosemirror-inputrules@1.5.1:
     dependencies:
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.12.0
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
 
   prosemirror-keymap@1.2.3:
     dependencies:
-      prosemirror-state: 1.4.4
+      prosemirror-state: 1.4.3
       w3c-keyname: 2.2.8
 
   prosemirror-markdown@1.13.4:
     dependencies:
       '@types/markdown-it': 14.1.2
       markdown-it: 14.1.1
-      prosemirror-model: 1.25.6
+      prosemirror-model: 1.25.3
 
   prosemirror-menu@1.3.2:
     dependencies:
       crelt: 1.0.6
       prosemirror-commands: 1.7.1
       prosemirror-history: 1.5.0
-      prosemirror-state: 1.4.4
+      prosemirror-state: 1.4.3
 
-  prosemirror-model@1.25.6:
+  prosemirror-model@1.25.3:
     dependencies:
       orderedmap: 2.1.1
 
-  prosemirror-paste-rules@3.0.0(prosemirror-model@1.25.6)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8):
+  prosemirror-paste-rules@3.0.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.3):
     dependencies:
       '@babel/runtime': 7.29.2
       '@remirror/core-constants': 3.0.0
       '@remirror/core-helpers': 4.0.0
       escape-string-regexp: 4.0.0
-      prosemirror-model: 1.25.6
-      prosemirror-state: 1.4.4
-      prosemirror-view: 1.41.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-schema-basic@1.2.4:
     dependencies:
-      prosemirror-model: 1.25.6
+      prosemirror-model: 1.25.3
 
   prosemirror-schema-list@1.5.1:
     dependencies:
-      prosemirror-model: 1.25.6
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.12.0
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
 
-  prosemirror-state@1.4.4:
+  prosemirror-state@1.4.3:
     dependencies:
-      prosemirror-model: 1.25.6
-      prosemirror-transform: 1.12.0
-      prosemirror-view: 1.41.8
+      prosemirror-model: 1.25.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.3
 
-  prosemirror-suggest@3.0.0(prosemirror-model@1.25.6)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8):
+  prosemirror-suggest@3.0.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.3):
     dependencies:
       '@babel/runtime': 7.29.2
       '@remirror/core-constants': 3.0.0
       '@remirror/core-helpers': 4.0.0
       '@remirror/types': 2.0.0
       escape-string-regexp: 4.0.0
-      prosemirror-model: 1.25.6
-      prosemirror-state: 1.4.4
-      prosemirror-view: 1.41.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
-  prosemirror-tables@1.8.5:
+  prosemirror-tables@1.8.1:
     dependencies:
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.6
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.12.0
-      prosemirror-view: 1.41.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.3
 
-  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.6)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8):
+  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.3):
     dependencies:
       '@remirror/core-constants': 3.0.0
       escape-string-regexp: 4.0.0
-      prosemirror-model: 1.25.6
-      prosemirror-state: 1.4.4
-      prosemirror-view: 1.41.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
-  prosemirror-transform@1.12.0:
+  prosemirror-transform@1.10.4:
     dependencies:
-      prosemirror-model: 1.25.6
+      prosemirror-model: 1.25.3
 
-  prosemirror-view@1.41.8:
+  prosemirror-view@1.41.3:
     dependencies:
-      prosemirror-model: 1.25.6
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.12.0
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
 
   proxy-from-env@2.1.0: {}
 
@@ -7460,12 +7469,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  y-prosemirror@1.3.7(prosemirror-model@1.25.6)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30):
+  y-prosemirror@1.3.7(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.41.3)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30):
     dependencies:
       lib0: 0.2.117
-      prosemirror-model: 1.25.6
-      prosemirror-state: 1.4.4
-      prosemirror-view: 1.41.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
       y-protocols: 1.0.7(yjs@13.6.30)
       yjs: 13.6.30
 

--- a/frontend/src/components/AISummary/BlockNoteSummaryView.tsx
+++ b/frontend/src/components/AISummary/BlockNoteSummaryView.tsx
@@ -7,6 +7,7 @@ import { AISummary } from './index';
 import { Block } from '@blocknote/core';
 import { useCreateBlockNote } from '@blocknote/react';
 import { BlockNoteView } from '@blocknote/shadcn';
+import { blocksToMarkdownSafely } from '@/lib/blocknote-markdown';
 import "@blocknote/shadcn/style.css";
 
 // Dynamically import BlockNote Editor to avoid SSR issues
@@ -139,13 +140,20 @@ export const BlockNoteSummaryView = forwardRef<BlockNoteSummaryViewRef, BlockNot
     try {
       console.log('💾 Saving BlockNote content...');
 
-      // Generate markdown from current blocks
-      const markdown = await editor.blocksToMarkdownLossy(currentBlocks);
-
-      onSave({
-        markdown: markdown,
-        summary_json: currentBlocks as unknown as BlockNoteBlock[]
+      // Generate markdown from current blocks; preserve BlockNote JSON even if markdown conversion fails.
+      const markdownResult = await blocksToMarkdownSafely(editor, currentBlocks, {
+        source: 'BlockNoteSummaryView.handleSave',
       });
+
+      const saveData: { markdown?: string; summary_json?: BlockNoteBlock[] } = {
+        summary_json: currentBlocks as unknown as BlockNoteBlock[]
+      };
+
+      if (markdownResult.markdown !== undefined) {
+        saveData.markdown = markdownResult.markdown;
+      }
+
+      onSave(saveData);
 
       setIsDirty(false);
       console.log('✅ Save successful');
@@ -169,18 +177,28 @@ export const BlockNoteSummaryView = forwardRef<BlockNoteSummaryViewRef, BlockNot
         // For markdown format - use the main editor
         if (format === 'markdown' && editor) {
           console.log('📝 Using markdown editor, blocks:', editor.document.length);
-          const markdown = await editor.blocksToMarkdownLossy(editor.document);
-          console.log('📝 Generated markdown length:', markdown.length);
-          return markdown;
+          const markdownResult = await blocksToMarkdownSafely(editor, editor.document, {
+            source: 'BlockNoteSummaryView.getMarkdown.markdown',
+            fallbackMarkdown: data?.markdown,
+          });
+          console.log('📝 Generated markdown length:', markdownResult.markdown?.length || 0);
+          return markdownResult.markdown || '';
         }
 
         // For blocknote format - use currentBlocks state
         if (format === 'blocknote') {
           console.log('📝 BlockNote format, currentBlocks:', currentBlocks.length);
-          if (currentBlocks.length > 0 && editor) {
-            const markdown = await editor.blocksToMarkdownLossy(currentBlocks);
-            console.log('📝 Generated markdown from blocks, length:', markdown.length);
-            return markdown;
+          const blocks = currentBlocks.length > 0
+            ? currentBlocks
+            : (data?.summary_json as unknown as Block[] | undefined) || [];
+
+          if (blocks.length > 0 && editor) {
+            const markdownResult = await blocksToMarkdownSafely(editor, blocks, {
+              source: 'BlockNoteSummaryView.getMarkdown.blocknote',
+              fallbackMarkdown: data?.markdown,
+            });
+            console.log('📝 Generated markdown from blocks, length:', markdownResult.markdown?.length || 0);
+            return markdownResult.markdown || '';
           }
           // Fallback: if we have the original data with markdown
           if (data?.markdown) {

--- a/frontend/src/components/BlockNoteEditor/Editor.tsx
+++ b/frontend/src/components/BlockNoteEditor/Editor.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useEffect } from "react";
-import { PartialBlock, Block } from "@blocknote/core";
+import { useEffect, useRef } from "react";
+import type { PartialBlock, Block } from "@blocknote/core";
+import { useCreateBlockNote } from "@blocknote/react";
+import { BlockNoteView } from "@blocknote/shadcn";
 import "@blocknote/shadcn/style.css";
 import "@blocknote/core/fonts/inter.css";
 
@@ -18,25 +20,27 @@ export default function Editor({ initialContent, onChange, editable = true }: Ed
     editable
   });
 
-  // Lazy import to avoid SSR issues
-  const { useCreateBlockNote } = require("@blocknote/react");
-  const { BlockNoteView } = require("@blocknote/shadcn");
-
   const editor = useCreateBlockNote({
     initialContent: initialContent as PartialBlock[] | undefined,
   });
 
   console.log('📝 EDITOR: BlockNote editor created successfully');
 
-  // Expose blocksToMarkdown method
-  (editor as any).blocksToMarkdownLossy = async (blocks: Block[]) => {
-    try {
-      return await editor.blocksToMarkdownLossy(blocks);
-    } catch (error) {
-      console.error('❌ EDITOR: Failed to convert blocks to markdown:', error);
-      return '';
-    }
-  };
+  // Expose blocksToMarkdown method with error handling, wrapping only once.
+  const originalBlocksToMarkdownRef = useRef<typeof editor.blocksToMarkdownLossy | null>(null);
+  useEffect(() => {
+    if (originalBlocksToMarkdownRef.current) return;
+
+    originalBlocksToMarkdownRef.current = editor.blocksToMarkdownLossy.bind(editor);
+    (editor as any).blocksToMarkdownLossy = async (blocks: Block[]) => {
+      try {
+        return await originalBlocksToMarkdownRef.current!(blocks);
+      } catch (error) {
+        console.error('❌ EDITOR: Failed to convert blocks to markdown:', error);
+        return '';
+      }
+    };
+  }, [editor]);
 
   // Handle content changes
   useEffect(() => {

--- a/frontend/src/components/BlockNoteEditor/Editor.tsx
+++ b/frontend/src/components/BlockNoteEditor/Editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import type { PartialBlock, Block } from "@blocknote/core";
 import { useCreateBlockNote } from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/shadcn";
@@ -25,22 +25,6 @@ export default function Editor({ initialContent, onChange, editable = true }: Ed
   });
 
   console.log('📝 EDITOR: BlockNote editor created successfully');
-
-  // Expose blocksToMarkdown method with error handling, wrapping only once.
-  const originalBlocksToMarkdownRef = useRef<typeof editor.blocksToMarkdownLossy | null>(null);
-  useEffect(() => {
-    if (originalBlocksToMarkdownRef.current) return;
-
-    originalBlocksToMarkdownRef.current = editor.blocksToMarkdownLossy.bind(editor);
-    (editor as any).blocksToMarkdownLossy = async (blocks: Block[]) => {
-      try {
-        return await originalBlocksToMarkdownRef.current!(blocks);
-      } catch (error) {
-        console.error('❌ EDITOR: Failed to convert blocks to markdown:', error);
-        return '';
-      }
-    };
-  }, [editor]);
 
   // Handle content changes
   useEffect(() => {

--- a/frontend/src/lib/blocknote-markdown.ts
+++ b/frontend/src/lib/blocknote-markdown.ts
@@ -1,0 +1,39 @@
+import type { Block } from "@blocknote/core";
+
+interface MarkdownCapableEditor {
+  blocksToMarkdownLossy: (blocks: Block[]) => Promise<string>;
+}
+
+interface MarkdownConversionOptions {
+  source: string;
+  fallbackMarkdown?: string;
+}
+
+interface MarkdownConversionResult {
+  markdown?: string;
+  ok: boolean;
+}
+
+export async function blocksToMarkdownSafely(
+  editor: MarkdownCapableEditor,
+  blocks: Block[],
+  options: MarkdownConversionOptions,
+): Promise<MarkdownConversionResult> {
+  try {
+    return {
+      markdown: await editor.blocksToMarkdownLossy(blocks),
+      ok: true,
+    };
+  } catch (error) {
+    console.error("Failed to convert BlockNote blocks to markdown", {
+      source: options.source,
+      blocksCount: blocks.length,
+      error,
+    });
+
+    return {
+      markdown: options.fallbackMarkdown,
+      ok: false,
+    };
+  }
+}

--- a/frontend/tests/lib/blocknote-markdown.test.ts
+++ b/frontend/tests/lib/blocknote-markdown.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { blocksToMarkdownSafely } from "../../src/lib/blocknote-markdown";
+
+describe("blocksToMarkdownSafely", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("returns markdown when conversion succeeds", async () => {
+    const editor = {
+      blocksToMarkdownLossy: mock(async () => "# Summary"),
+    };
+
+    const result = await blocksToMarkdownSafely(editor, [] as any, {
+      source: "test-success",
+    });
+
+    expect(result).toEqual({
+      markdown: "# Summary",
+      ok: true,
+    });
+    expect(editor.blocksToMarkdownLossy).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns fallback markdown when conversion throws", async () => {
+    const error = new Error("conversion failed");
+    const editor = {
+      blocksToMarkdownLossy: mock(async () => {
+        throw error;
+      }),
+    };
+    const consoleError = mock(() => {});
+    console.error = consoleError as any;
+
+    const result = await blocksToMarkdownSafely(editor, [{ id: "block-1" }] as any, {
+      source: "test-fallback",
+      fallbackMarkdown: "existing markdown",
+    });
+
+    expect(result).toEqual({
+      markdown: "existing markdown",
+      ok: false,
+    });
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to convert BlockNote blocks to markdown",
+      {
+        source: "test-fallback",
+        blocksCount: 1,
+        error,
+      },
+    );
+  });
+
+  test("omits markdown when conversion throws without fallback", async () => {
+    const editor = {
+      blocksToMarkdownLossy: mock(async () => {
+        throw new Error("conversion failed");
+      }),
+    };
+    console.error = mock(() => {}) as any;
+
+    const result = await blocksToMarkdownSafely(editor, [] as any, {
+      source: "test-empty-fallback",
+    });
+
+    expect(result).toEqual({
+      markdown: undefined,
+      ok: false,
+    });
+  });
+});


### PR DESCRIPTION
## Description
Fixes the BlockNote editor runtime crashes caused by duplicated or mismatched ProseMirror dependencies after a clean install.

This PR pins the ProseMirror packages used by BlockNote to known-good versions and adds webpack aliases so BlockNote and ProseMirror resolve through single module instances. It also replaces render-time BlockNote `require()` calls with static imports and ensures `blocksToMarkdownLossy` is wrapped only once to avoid recursive wrapper buildup during editor reuse.

## Related Issue
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] All tests pass

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [ ] Branch is up to date with devtest
- [ ] No merge conflicts

## Screenshots (if applicable)
N/A

## Additional Notes
Verified with a clean dependency install and production build. The lockfile now resolves BlockNote’s ProseMirror dependencies consistently, which should make the fix reproducible across developer machines