### PR TITLE
feat: Meeting Domain prompt support for Whisper (vocabulary hints via initial_prompt)

### DIFF
--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -544,6 +544,9 @@ async fn run_import<R: Runtime>(
     let processable_count = processable_segments.len();
     info!("Processing {} segments (after splitting)", processable_count);
 
+    // Resolve meeting-domain prompt once for the whole batch.
+    let initial_prompt = crate::current_meeting_domain_prompt();
+
     // Process each speech segment
     let mut all_transcripts: Vec<(String, f64, f64)> = Vec::new();
     let mut total_confidence = 0.0f32;
@@ -589,7 +592,7 @@ async fn run_import<R: Runtime>(
         } else {
             let engine = whisper_engine.as_ref().unwrap();
             let (text, conf, _) = engine
-                .transcribe_audio_with_confidence(segment.samples.clone(), language.clone())
+                .transcribe_audio_with_confidence(segment.samples.clone(), language.clone(), initial_prompt.clone())
                 .await
                 .map_err(|e| anyhow!("Whisper transcription failed on segment {}: {}", i, e))?;
             (text, conf)

--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -335,6 +335,9 @@ async fn run_retranscription<R: Runtime>(
     let processable_count = processable_segments.len();
     info!("Processing {} segments (after splitting)", processable_count);
 
+    // Resolve meeting-domain prompt once for the whole batch.
+    let initial_prompt = crate::current_meeting_domain_prompt();
+
     // Process each speech segment with progress updates
     let mut all_transcripts: Vec<(String, f64, f64)> = Vec::new(); // (text, start_ms, end_ms)
     let mut total_confidence = 0.0f32;
@@ -378,7 +381,7 @@ async fn run_retranscription<R: Runtime>(
         } else {
             let engine = whisper_engine.as_ref().unwrap();
             let (text, conf, _) = engine
-                .transcribe_audio_with_confidence(segment.samples.clone(), language.clone())
+                .transcribe_audio_with_confidence(segment.samples.clone(), language.clone(), initial_prompt.clone())
                 .await
                 .map_err(|e| anyhow!("Whisper transcription failed on segment {}: {}", i, e))?;
             (text, conf)

--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -94,6 +94,7 @@ pub async fn start_retranscription<R: Runtime>(
     language: Option<String>,
     model: Option<String>,
     provider: Option<String>,
+    meeting_domain: Option<String>,
 ) -> Result<RetranscriptionResult> {
     // Acquire guard - ensures flag is cleared even on panic/early return
     let _guard = RetranscriptionGuard::acquire().map_err(|e| anyhow!(e))?;
@@ -102,7 +103,7 @@ pub async fn start_retranscription<R: Runtime>(
     RETRANSCRIPTION_CANCELLED.store(false, Ordering::SeqCst);
 
     let use_parakeet = provider.as_deref() == Some("parakeet");
-    let result = run_retranscription(app.clone(), meeting_id.clone(), meeting_folder_path, language, model, provider).await;
+    let result = run_retranscription(app.clone(), meeting_id.clone(), meeting_folder_path, language, model, provider, meeting_domain).await;
 
     // Unload the engine after the batch job (success, failure, or cancellation)
     super::common::unload_engine_after_batch(use_parakeet).await;
@@ -176,6 +177,7 @@ async fn run_retranscription<R: Runtime>(
     language: Option<String>,
     model: Option<String>,
     provider: Option<String>,
+    meeting_domain: Option<String>,
 ) -> Result<RetranscriptionResult> {
     let folder_path = PathBuf::from(&meeting_folder_path);
     let audio_path = find_audio_file(&folder_path)?;
@@ -336,7 +338,13 @@ async fn run_retranscription<R: Runtime>(
     info!("Processing {} segments (after splitting)", processable_count);
 
     // Resolve meeting-domain prompt once for the whole batch.
-    let initial_prompt = crate::current_meeting_domain_prompt();
+    // The dialog passes an explicit choice (None / empty = no prompt for this run),
+    // overriding the global selectedDomain so users can opt out per enhance.
+    let initial_prompt = meeting_domain
+        .as_deref()
+        .map(str::trim)
+        .filter(|d| !d.is_empty())
+        .and_then(|d| crate::meeting_domain::load_prompt(d).ok().flatten());
 
     // Process each speech segment with progress updates
     let mut all_transcripts: Vec<(String, f64, f64)> = Vec::new(); // (text, start_ms, end_ms)
@@ -786,6 +794,7 @@ pub async fn start_retranscription_command<R: Runtime>(
     language: Option<String>,
     model: Option<String>,
     provider: Option<String>,
+    meeting_domain: Option<String>,
 ) -> Result<RetranscriptionStarted, String> {
 
     // Check if retranscription is already in progress (guard will be acquired in start_retranscription)
@@ -805,6 +814,7 @@ pub async fn start_retranscription_command<R: Runtime>(
             language,
             model,
             provider,
+            meeting_domain,
         )
         .await;
 

--- a/frontend/src-tauri/src/audio/transcription/whisper_provider.rs
+++ b/frontend/src-tauri/src/audio/transcription/whisper_provider.rs
@@ -24,9 +24,10 @@ impl TranscriptionProvider for WhisperProvider {
         audio: Vec<f32>,
         language: Option<String>,
     ) -> std::result::Result<TranscriptResult, TranscriptionError> {
+        let initial_prompt = crate::current_meeting_domain_prompt();
         match self
             .engine
-            .transcribe_audio_with_confidence(audio, language)
+            .transcribe_audio_with_confidence(audio, language, initial_prompt)
             .await
         {
             Ok((text, confidence, is_partial)) => Ok(TranscriptResult {

--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -447,9 +447,10 @@ async fn transcribe_chunk_with_provider<R: Runtime>(
         TranscriptionEngine::Whisper(whisper_engine) => {
             // Get language preference from global state
             let language = crate::get_language_preference_internal();
+            let initial_prompt = crate::current_meeting_domain_prompt();
 
             match whisper_engine
-                .transcribe_audio_with_confidence(speech_samples, language)
+                .transcribe_audio_with_confidence(speech_samples, language, initial_prompt)
                 .await
             {
                 Ok((text, confidence, is_partial)) => {

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -54,6 +54,7 @@ pub mod summary;
 pub mod tray;
 pub mod utils;
 pub mod whisper_engine;
+pub mod meeting_domain;
 
 use audio::{list_audio_devices, AudioDevice, trigger_audio_permission};
 use log::{error as log_error, info as log_info};
@@ -67,6 +68,13 @@ static RECORDING_FLAG: AtomicBool = AtomicBool::new(false);
 // Global language preference storage (default to "auto-translate" for automatic translation to English)
 static LANGUAGE_PREFERENCE: std::sync::LazyLock<StdMutex<String>> =
     std::sync::LazyLock::new(|| StdMutex::new("auto-translate".to_string()));
+
+// Global meeting domain preference storage. Empty string = no domain selected.
+// The selected domain name maps to a `.txt` file in the meeting domain
+// directory, whose content is sent to Whisper as `initial_prompt` to bias
+// transcription toward domain-specific vocabulary.
+static MEETING_DOMAIN: std::sync::LazyLock<StdMutex<String>> =
+    std::sync::LazyLock::new(|| StdMutex::new(String::new()));
 
 #[derive(Debug, Deserialize)]
 struct RecordingArgs {
@@ -387,6 +395,99 @@ pub fn get_language_preference_internal() -> Option<String> {
     LANGUAGE_PREFERENCE.lock().ok().map(|lang| lang.clone())
 }
 
+#[tauri::command]
+async fn set_meeting_domain(domain: String) -> Result<(), String> {
+    let mut guard = MEETING_DOMAIN
+        .lock()
+        .map_err(|e| format!("Failed to set meeting domain: {}", e))?;
+    log_info!("Setting meeting domain to: '{}'", domain);
+    *guard = domain;
+    Ok(())
+}
+
+#[tauri::command]
+async fn get_meeting_domain() -> Result<String, String> {
+    MEETING_DOMAIN
+        .lock()
+        .map(|g| g.clone())
+        .map_err(|e| format!("Failed to read meeting domain: {}", e))
+}
+
+/// Internal helper used by transcription providers to look up the currently
+/// selected meeting domain. Returns an empty string when none is selected.
+pub fn get_meeting_domain_internal() -> String {
+    MEETING_DOMAIN
+        .lock()
+        .map(|g| g.clone())
+        .unwrap_or_default()
+}
+
+/// Load the prompt text for the currently selected meeting domain, if any.
+/// Returns `None` when no domain is selected or the file is missing/empty.
+/// Use this at whisper call sites to populate `initial_prompt`.
+pub fn current_meeting_domain_prompt() -> Option<String> {
+    let domain = get_meeting_domain_internal();
+    if domain.is_empty() {
+        return None;
+    }
+    meeting_domain::load_prompt(&domain).ok().flatten()
+}
+
+#[tauri::command]
+async fn list_meeting_domains() -> Result<Vec<String>, String> {
+    meeting_domain::list_domains().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn get_meeting_domain_content(name: String) -> Result<Option<String>, String> {
+    meeting_domain::get_domain_content(&name).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn save_meeting_domain(name: String, content: String) -> Result<(), String> {
+    meeting_domain::save_domain(&name, &content).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn delete_meeting_domain(name: String) -> Result<(), String> {
+    meeting_domain::delete_domain(&name).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn open_meeting_domains_folder() -> Result<(), String> {
+    let dir = meeting_domain::primary_dir()
+        .ok_or_else(|| "meeting domain directory not initialized".to_string())?;
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create directory: {}", e))?;
+    }
+    let folder_path = dir.to_string_lossy().to_string();
+
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("explorer")
+            .arg(&folder_path)
+            .spawn()
+            .map_err(|e| format!("Failed to open folder: {}", e))?;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg(&folder_path)
+            .spawn()
+            .map_err(|e| format!("Failed to open folder: {}", e))?;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::process::Command::new("xdg-open")
+            .arg(&folder_path)
+            .spawn()
+            .map_err(|e| format!("Failed to open folder: {}", e))?;
+    }
+
+    log_info!("Opened meeting domains folder: {}", folder_path);
+    Ok(())
+}
+
 pub fn run() {
     log::set_max_level(log::LevelFilter::Info);
 
@@ -438,6 +539,9 @@ pub fn run() {
 
             // Set models directory to use app_data_dir (unified storage location)
             whisper_engine::commands::set_models_directory(&_app.handle());
+
+            // Set meeting-domain prompt directory under app_data_dir/domains/
+            meeting_domain::set_domain_directory(&_app.handle());
 
             // Initialize Whisper engine on startup
             tauri::async_runtime::spawn(async {
@@ -665,6 +769,14 @@ pub fn run() {
             audio::recording_preferences::get_audio_backend_info,
             // Language preference commands
             set_language_preference,
+            // Meeting domain prompt commands
+            set_meeting_domain,
+            get_meeting_domain,
+            list_meeting_domains,
+            get_meeting_domain_content,
+            save_meeting_domain,
+            delete_meeting_domain,
+            open_meeting_domains_folder,
             // Notification system commands
             notifications::commands::get_notification_settings,
             notifications::commands::set_notification_settings,

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -54,6 +54,7 @@ pub mod summary;
 pub mod tray;
 pub mod utils;
 pub mod whisper_engine;
+pub mod meeting_domain;
 
 use audio::{list_audio_devices, AudioDevice, trigger_audio_permission};
 use log::{error as log_error, info as log_info};
@@ -67,6 +68,13 @@ static RECORDING_FLAG: AtomicBool = AtomicBool::new(false);
 // Global language preference storage (default to "auto-translate" for automatic translation to English)
 static LANGUAGE_PREFERENCE: std::sync::LazyLock<StdMutex<String>> =
     std::sync::LazyLock::new(|| StdMutex::new("auto-translate".to_string()));
+
+// Global meeting domain preference storage. Empty string = no domain selected.
+// The selected domain name maps to a `.txt` file in the meeting domain
+// directory, whose content is sent to Whisper as `initial_prompt` to bias
+// transcription toward domain-specific vocabulary.
+static MEETING_DOMAIN: std::sync::LazyLock<StdMutex<String>> =
+    std::sync::LazyLock::new(|| StdMutex::new(String::new()));
 
 #[derive(Debug, Deserialize)]
 struct RecordingArgs {
@@ -387,6 +395,99 @@ pub fn get_language_preference_internal() -> Option<String> {
     LANGUAGE_PREFERENCE.lock().ok().map(|lang| lang.clone())
 }
 
+#[tauri::command]
+async fn set_meeting_domain(domain: String) -> Result<(), String> {
+    let mut guard = MEETING_DOMAIN
+        .lock()
+        .map_err(|e| format!("Failed to set meeting domain: {}", e))?;
+    log_info!("Setting meeting domain to: '{}'", domain);
+    *guard = domain;
+    Ok(())
+}
+
+#[tauri::command]
+async fn get_meeting_domain() -> Result<String, String> {
+    MEETING_DOMAIN
+        .lock()
+        .map(|g| g.clone())
+        .map_err(|e| format!("Failed to read meeting domain: {}", e))
+}
+
+/// Internal helper used by transcription providers to look up the currently
+/// selected meeting domain. Returns an empty string when none is selected.
+pub fn get_meeting_domain_internal() -> String {
+    MEETING_DOMAIN
+        .lock()
+        .map(|g| g.clone())
+        .unwrap_or_default()
+}
+
+/// Load the prompt text for the currently selected meeting domain, if any.
+/// Returns `None` when no domain is selected or the file is missing/empty.
+/// Use this at whisper call sites to populate `initial_prompt`.
+pub fn current_meeting_domain_prompt() -> Option<String> {
+    let domain = get_meeting_domain_internal();
+    if domain.is_empty() {
+        return None;
+    }
+    meeting_domain::load_prompt(&domain).ok().flatten()
+}
+
+#[tauri::command]
+async fn list_meeting_domains() -> Result<Vec<String>, String> {
+    meeting_domain::list_domains().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn get_meeting_domain_content(name: String) -> Result<Option<String>, String> {
+    meeting_domain::get_domain_content(&name).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn save_meeting_domain(name: String, content: String) -> Result<(), String> {
+    meeting_domain::save_domain(&name, &content).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn delete_meeting_domain(name: String) -> Result<(), String> {
+    meeting_domain::delete_domain(&name).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn open_meeting_domains_folder() -> Result<(), String> {
+    let dir = meeting_domain::primary_dir()
+        .ok_or_else(|| "meeting domain directory not initialized".to_string())?;
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir).map_err(|e| format!("Failed to create directory: {}", e))?;
+    }
+    let folder_path = dir.to_string_lossy().to_string();
+
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("explorer")
+            .arg(&folder_path)
+            .spawn()
+            .map_err(|e| format!("Failed to open folder: {}", e))?;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg(&folder_path)
+            .spawn()
+            .map_err(|e| format!("Failed to open folder: {}", e))?;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::process::Command::new("xdg-open")
+            .arg(&folder_path)
+            .spawn()
+            .map_err(|e| format!("Failed to open folder: {}", e))?;
+    }
+
+    log_info!("Opened meeting domains folder: {}", folder_path);
+    Ok(())
+}
+
 pub fn run() {
     log::set_max_level(log::LevelFilter::Info);
 
@@ -453,6 +554,9 @@ pub fn run() {
 
             // Set models directory to use app_data_dir (unified storage location)
             whisper_engine::commands::set_models_directory(&_app.handle());
+
+            // Set meeting-domain prompt directory under app_data_dir/domains/
+            meeting_domain::set_domain_directory(&_app.handle());
 
             // Initialize Whisper engine on startup
             tauri::async_runtime::spawn(async {
@@ -692,6 +796,14 @@ pub fn run() {
             audio::recording_preferences::get_audio_backend_info,
             // Language preference commands
             set_language_preference,
+            // Meeting domain prompt commands
+            set_meeting_domain,
+            get_meeting_domain,
+            list_meeting_domains,
+            get_meeting_domain_content,
+            save_meeting_domain,
+            delete_meeting_domain,
+            open_meeting_domains_folder,
             // Notification system commands
             notifications::commands::get_notification_settings,
             notifications::commands::set_notification_settings,

--- a/frontend/src-tauri/src/meeting_domain/mod.rs
+++ b/frontend/src-tauri/src/meeting_domain/mod.rs
@@ -1,0 +1,354 @@
+// Meeting domain prompt management.
+//
+// A "meeting domain" is a plain-text vocabulary hint file used to bias
+// Whisper transcription via `whisper_full_params.initial_prompt`. Each
+// domain is one `.txt` file named after the domain (e.g. `tekni.txt`).
+//
+// Files are looked up in two locations:
+// 1. Primary: `<app_data_dir>/domains/` — matches the convention used by
+//    `whisper_engine::commands::set_models_directory`.
+// 2. Secondary: `~/.meetily/domains/` — convenient manual edit location
+//    (also supported via a symlink to the primary directory).
+//
+// Whisper's `initial_prompt` is capped around 224 tokens; we truncate
+// prompts at ~1000 characters as a conservative char-based approximation
+// and log a warning when truncation kicks in.
+
+use anyhow::{Context, Result};
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use tauri::{AppHandle, Manager, Runtime};
+
+/// Approximate cap for `initial_prompt`. Whisper itself enforces ~224 tokens;
+/// 1000 chars is a safe overestimate for Latin scripts including Scandinavian.
+pub const MAX_PROMPT_CHARS: usize = 1000;
+
+const DOMAINS_SUBDIR: &str = "domains";
+const SECONDARY_HOME_SUBDIR: &str = ".meetily/domains";
+
+/// Primary domains directory (under Tauri's app_data_dir). Set during app
+/// startup via [`set_domain_directory`], mirroring the models directory pattern.
+static DOMAIN_DIR: Mutex<Option<PathBuf>> = Mutex::new(None);
+
+/// Initialize the primary domain directory and create it if missing.
+///
+/// Call this from the Tauri `setup` hook, similar to
+/// `whisper_engine::commands::set_models_directory`.
+pub fn set_domain_directory<R: Runtime>(app: &AppHandle<R>) {
+    let app_data_dir = match app.path().app_data_dir() {
+        Ok(dir) => dir,
+        Err(e) => {
+            log::error!("Failed to resolve app_data_dir for meeting domains: {}", e);
+            return;
+        }
+    };
+
+    let domains_dir = app_data_dir.join(DOMAINS_SUBDIR);
+
+    if !domains_dir.exists() {
+        if let Err(e) = std::fs::create_dir_all(&domains_dir) {
+            log::error!(
+                "Failed to create meeting domain directory at {}: {}",
+                domains_dir.display(),
+                e
+            );
+            return;
+        }
+    }
+
+    log::info!("Meeting domain directory set to: {}", domains_dir.display());
+
+    if let Ok(mut guard) = DOMAIN_DIR.lock() {
+        *guard = Some(domains_dir);
+    }
+}
+
+/// Primary domain directory, if it has been initialized.
+pub fn primary_dir() -> Option<PathBuf> {
+    DOMAIN_DIR.lock().ok().and_then(|g| g.clone())
+}
+
+/// Secondary domain directory under the user's home (`~/.meetily/domains/`).
+/// Returned only when the path actually exists, so callers can scan it safely.
+pub fn secondary_dir() -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    let dir = home.join(SECONDARY_HOME_SUBDIR);
+    if dir.is_dir() {
+        Some(dir)
+    } else {
+        None
+    }
+}
+
+/// List available domain names (filenames without `.txt`) from both
+/// directories. Names from [`primary_dir`] take precedence on conflict.
+pub fn list_domains() -> Result<Vec<String>> {
+    let mut names: BTreeSet<String> = BTreeSet::new();
+
+    for dir in [secondary_dir(), primary_dir()].into_iter().flatten() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(it) => it,
+            Err(e) => {
+                log::warn!("Could not read domain directory {}: {}", dir.display(), e);
+                continue;
+            }
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("txt") {
+                continue;
+            }
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                if !stem.is_empty() {
+                    names.insert(stem.to_string());
+                }
+            }
+        }
+    }
+
+    Ok(names.into_iter().collect())
+}
+
+/// Validate that a domain name is safe to use as a filename. Rejects names
+/// that contain path separators, parent traversal, NUL bytes, or that start
+/// with a dot (hidden files). Returns the trimmed, validated name.
+pub fn validate_domain_name(name: &str) -> Result<String> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("domain name is empty");
+    }
+    if trimmed.len() > 64 {
+        anyhow::bail!("domain name is too long (max 64 chars)");
+    }
+    if trimmed.starts_with('.') {
+        anyhow::bail!("domain name must not start with '.'");
+    }
+    for ch in trimmed.chars() {
+        match ch {
+            '/' | '\\' | '\0' => anyhow::bail!("domain name contains invalid character: {:?}", ch),
+            c if c.is_control() => anyhow::bail!("domain name contains control character"),
+            _ => {}
+        }
+    }
+    if trimmed == ".." || trimmed.contains("..") {
+        anyhow::bail!("domain name must not contain '..'");
+    }
+    Ok(trimmed.to_string())
+}
+
+fn primary_dir_required() -> Result<PathBuf> {
+    primary_dir().ok_or_else(|| anyhow::anyhow!("meeting domain directory not initialized"))
+}
+
+/// Read the raw content of a domain file (no truncation, for editing in UI).
+/// Returns `Ok(None)` if the file does not exist.
+pub fn get_domain_content(name: &str) -> Result<Option<String>> {
+    let name = validate_domain_name(name)?;
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(p) = primary_dir() {
+        candidates.push(p.join(format!("{name}.txt")));
+    }
+    if let Some(p) = secondary_dir() {
+        candidates.push(p.join(format!("{name}.txt")));
+    }
+    let Some(path) = candidates.into_iter().find(|p| p.is_file()) else {
+        return Ok(None);
+    };
+    let text = std::fs::read_to_string(&path)
+        .with_context(|| format!("reading domain file {}", path.display()))?;
+    Ok(Some(text))
+}
+
+/// Write (create or overwrite) a domain file in the primary directory.
+pub fn save_domain(name: &str, content: &str) -> Result<()> {
+    let name = validate_domain_name(name)?;
+    let dir = primary_dir_required()?;
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("creating domain dir {}", dir.display()))?;
+    let path = dir.join(format!("{name}.txt"));
+    std::fs::write(&path, content)
+        .with_context(|| format!("writing domain file {}", path.display()))?;
+    log::info!("Saved meeting domain '{}' to {}", name, path.display());
+    Ok(())
+}
+
+/// Delete a domain file from the primary directory. Files in the secondary
+/// (`~/.meetily/domains/`) directory are left alone — those are user-managed.
+pub fn delete_domain(name: &str) -> Result<()> {
+    let name = validate_domain_name(name)?;
+    let dir = primary_dir_required()?;
+    let path = dir.join(format!("{name}.txt"));
+    if !path.exists() {
+        return Ok(());
+    }
+    std::fs::remove_file(&path)
+        .with_context(|| format!("deleting domain file {}", path.display()))?;
+    log::info!("Deleted meeting domain '{}' ({})", name, path.display());
+    Ok(())
+}
+
+/// Load and prepare the prompt text for `domain`. Returns:
+/// - `Ok(None)` if no file exists or the file is empty/whitespace-only.
+/// - `Ok(Some(text))` truncated to [`MAX_PROMPT_CHARS`] with a warning logged
+///   when the original was longer.
+///
+/// Resolution order: primary directory first, then secondary.
+pub fn load_prompt(domain: &str) -> Result<Option<String>> {
+    let domain = domain.trim();
+    if domain.is_empty() {
+        return Ok(None);
+    }
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(p) = primary_dir() {
+        candidates.push(p.join(format!("{domain}.txt")));
+    }
+    if let Some(p) = secondary_dir() {
+        candidates.push(p.join(format!("{domain}.txt")));
+    }
+
+    let Some(path) = candidates.into_iter().find(|p| p.is_file()) else {
+        log::debug!("No prompt file found for meeting domain '{}'", domain);
+        return Ok(None);
+    };
+
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("reading prompt file {}", path.display()))?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let char_count = trimmed.chars().count();
+    let prompt = if char_count > MAX_PROMPT_CHARS {
+        log::warn!(
+            "Meeting domain '{}' prompt is {} chars (>{} cap); truncating",
+            domain,
+            char_count,
+            MAX_PROMPT_CHARS
+        );
+        trimmed.chars().take(MAX_PROMPT_CHARS).collect::<String>()
+    } else {
+        trimmed.to_string()
+    };
+
+    log::info!(
+        "Loaded meeting domain '{}' prompt ({} chars) from {}",
+        domain,
+        prompt.chars().count(),
+        path.display()
+    );
+
+    Ok(Some(prompt))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::Mutex as StdMutex;
+    use tempfile::TempDir;
+
+    // Tests share the static DOMAIN_DIR, so they must run serially.
+    static TEST_LOCK: StdMutex<()> = StdMutex::new(());
+
+    fn set_primary_for_test(dir: PathBuf) {
+        *DOMAIN_DIR.lock().unwrap() = Some(dir);
+    }
+
+    fn clear_primary_for_test() {
+        *DOMAIN_DIR.lock().unwrap() = None;
+    }
+
+    #[test]
+    fn load_prompt_returns_none_for_empty_name() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let result = load_prompt("").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn load_prompt_returns_none_when_file_missing() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let tmp = TempDir::new().unwrap();
+        set_primary_for_test(tmp.path().to_path_buf());
+        let result = load_prompt("nonexistent").unwrap();
+        assert!(result.is_none());
+        clear_primary_for_test();
+    }
+
+    #[test]
+    fn load_prompt_truncates_long_content() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let tmp = TempDir::new().unwrap();
+        let long_text = "a".repeat(MAX_PROMPT_CHARS + 500);
+        fs::write(tmp.path().join("big.txt"), &long_text).unwrap();
+        set_primary_for_test(tmp.path().to_path_buf());
+
+        let result = load_prompt("big").unwrap().unwrap();
+        assert_eq!(result.chars().count(), MAX_PROMPT_CHARS);
+        clear_primary_for_test();
+    }
+
+    #[test]
+    fn list_domains_includes_txt_files_only() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("tekni.txt"), "Tekni Gruppen").unwrap();
+        fs::write(tmp.path().join("localfood.txt"), "Local Food").unwrap();
+        fs::write(tmp.path().join("ignore.md"), "ignored").unwrap();
+        set_primary_for_test(tmp.path().to_path_buf());
+
+        let domains = list_domains().unwrap();
+        assert!(domains.contains(&"tekni".to_string()));
+        assert!(domains.contains(&"localfood".to_string()));
+        assert!(!domains.iter().any(|d| d == "ignore"));
+        clear_primary_for_test();
+    }
+
+    #[test]
+    fn validate_domain_name_rejects_unsafe_inputs() {
+        assert!(validate_domain_name("").is_err());
+        assert!(validate_domain_name("   ").is_err());
+        assert!(validate_domain_name(".hidden").is_err());
+        assert!(validate_domain_name("../etc").is_err());
+        assert!(validate_domain_name("foo/bar").is_err());
+        assert!(validate_domain_name("foo\\bar").is_err());
+        assert!(validate_domain_name("foo\0bar").is_err());
+        assert!(validate_domain_name(&"x".repeat(65)).is_err());
+        assert_eq!(validate_domain_name("  tekni  ").unwrap(), "tekni");
+        assert!(validate_domain_name("local-food_v2").is_ok());
+    }
+
+    #[test]
+    fn save_and_delete_domain_roundtrip() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let tmp = TempDir::new().unwrap();
+        set_primary_for_test(tmp.path().to_path_buf());
+
+        save_domain("acme", "Acme Corp, Wile E. Coyote").unwrap();
+        let content = get_domain_content("acme").unwrap().unwrap();
+        assert!(content.contains("Acme Corp"));
+
+        let domains = list_domains().unwrap();
+        assert!(domains.contains(&"acme".to_string()));
+
+        delete_domain("acme").unwrap();
+        assert!(get_domain_content("acme").unwrap().is_none());
+
+        clear_primary_for_test();
+    }
+
+    #[test]
+    fn load_prompt_returns_none_for_whitespace_only() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("blank.txt"), "   \n\t  \n").unwrap();
+        set_primary_for_test(tmp.path().to_path_buf());
+
+        let result = load_prompt("blank").unwrap();
+        assert!(result.is_none());
+        clear_primary_for_test();
+    }
+}

--- a/frontend/src-tauri/src/whisper_engine/commands.rs
+++ b/frontend/src-tauri/src/whisper_engine/commands.rs
@@ -394,8 +394,9 @@ pub async fn whisper_transcribe_audio(audio_data: Vec<f32>) -> Result<String, St
     if let Some(engine) = engine {
         // Get language preference
         let language = crate::get_language_preference_internal();
+        let initial_prompt = crate::current_meeting_domain_prompt();
         engine
-            .transcribe_audio(audio_data, language)
+            .transcribe_audio(audio_data, language, initial_prompt)
             .await
             .map_err(|e| format!("Transcription failed: {}", e))
     } else {

--- a/frontend/src-tauri/src/whisper_engine/parallel_processor.rs
+++ b/frontend/src-tauri/src/whisper_engine/parallel_processor.rs
@@ -342,9 +342,10 @@ impl ParallelProcessor {
 
         // Get language preference
         let language = crate::get_language_preference_internal();
+        let initial_prompt = crate::current_meeting_domain_prompt();
 
         // Transcribe with timeout to prevent hanging
-        let transcription_future = engine.transcribe_audio(chunk.data.clone(), language);
+        let transcription_future = engine.transcribe_audio(chunk.data.clone(), language, initial_prompt);
         let timeout_duration = tokio::time::Duration::from_secs(120); // 2 minute timeout per chunk
 
         let text = tokio::time::timeout(timeout_duration, transcription_future)

--- a/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
+++ b/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
@@ -513,7 +513,7 @@ impl WhisperEngine {
     }
     
     /// Transcribe audio with streaming support for partial results and adaptive quality
-    pub async fn transcribe_audio_with_confidence(&self, audio_data: Vec<f32>, language: Option<String>) -> Result<(String, f32, bool)> {
+    pub async fn transcribe_audio_with_confidence(&self, audio_data: Vec<f32>, language: Option<String>, initial_prompt: Option<String>) -> Result<(String, f32, bool)> {
         let ctx_lock = self.current_context.read().await;
         let ctx = ctx_lock.as_ref()
             .ok_or_else(|| anyhow!("No model loaded. Please load a model first."))?;
@@ -539,6 +539,12 @@ impl WhisperEngine {
         };
         params.set_language(language_code);
         params.set_translate(should_translate);
+
+        // Domain-specific vocabulary hint to bias decoding (e.g. proper nouns,
+        // client names). Skipped when None/empty so behavior is unchanged.
+        if let Some(prompt) = initial_prompt.as_deref().map(str::trim).filter(|p| !p.is_empty()) {
+            params.set_initial_prompt(prompt);
+        }
 
         // CRITICAL: Disable timestamp tokens to prevent whisper.cpp chunking heuristics
         // The "single timestamp ending - skip entire chunk" optimization incorrectly discards
@@ -630,7 +636,7 @@ impl WhisperEngine {
         Ok((cleaned_result, avg_confidence, is_partial))
     }
 
-    pub async fn transcribe_audio(&self, audio_data: Vec<f32>, language: Option<String>) -> Result<String> {
+    pub async fn transcribe_audio(&self, audio_data: Vec<f32>, language: Option<String>, initial_prompt: Option<String>) -> Result<String> {
         let ctx_lock = self.current_context.read().await;
         let ctx = ctx_lock.as_ref()
             .ok_or_else(|| anyhow!("No model loaded. Please load a model first."))?;
@@ -656,6 +662,10 @@ impl WhisperEngine {
         };
         params.set_language(language_code);
         params.set_translate(should_translate);
+
+        if let Some(prompt) = initial_prompt.as_deref().map(str::trim).filter(|p| !p.is_empty()) {
+            params.set_initial_prompt(prompt);
+        }
 
         // CRITICAL: Disable timestamp tokens to prevent whisper.cpp chunking heuristics
         // The "single timestamp ending - skip entire chunk" optimization incorrectly discards

--- a/frontend/src/app/_components/SettingsModal.tsx
+++ b/frontend/src/app/_components/SettingsModal.tsx
@@ -2,13 +2,14 @@ import { ModelConfig } from "@/components/ModelSettingsModal";
 import { PreferenceSettings } from "@/components/PreferenceSettings";
 import { DeviceSelection } from "@/components/DeviceSelection";
 import { LanguageSelection } from "@/components/LanguageSelection";
+import { MeetingDomainSettings } from "@/components/MeetingDomainSettings";
 import { TranscriptSettings } from "@/components/TranscriptSettings";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { toast } from "sonner";
 import { useConfig } from "@/contexts/ConfigContext";
 import { useRecordingState } from "@/contexts/RecordingStateContext";
 
-type modalType = "modelSettings" | "deviceSettings" | "languageSettings" | "modelSelector" | "errorAlert" | "chunkDropWarning";
+type modalType = "modelSettings" | "deviceSettings" | "languageSettings" | "meetingDomainSettings" | "modelSelector" | "errorAlert" | "chunkDropWarning";
 
 /**
  * SettingsModals Component
@@ -22,6 +23,7 @@ interface SettingsModalsProps {
     modelSettings: boolean;
     deviceSettings: boolean;
     languageSettings: boolean;
+    meetingDomainSettings: boolean;
     modelSelector: boolean;
     errorAlert: boolean;
     chunkDropWarning: boolean;
@@ -232,6 +234,36 @@ export function SettingsModals({
           <div className="mt-6 flex justify-end">
             <button
               onClick={() => onClose('languageSettings')}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      </div>
+    )}
+
+    {/* Meeting Domain Settings Modal */}
+    {modals.meetingDomainSettings && (
+      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+        <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4 shadow-xl">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="text-lg font-semibold text-gray-900">Meeting Domain</h3>
+            <button
+              onClick={() => onClose('meetingDomainSettings')}
+              className="text-gray-500 hover:text-gray-700"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <MeetingDomainSettings />
+
+          <div className="mt-6 flex justify-end">
+            <button
+              onClick={() => onClose('meetingDomainSettings')}
               className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
             >
               Done

--- a/frontend/src/app/_components/TranscriptPanel.tsx
+++ b/frontend/src/app/_components/TranscriptPanel.tsx
@@ -2,7 +2,7 @@ import { VirtualizedTranscriptView } from '@/components/VirtualizedTranscriptVie
 import { PermissionWarning } from '@/components/PermissionWarning';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
-import { Copy, GlobeIcon } from 'lucide-react';
+import { Copy, GlobeIcon, Tag } from 'lucide-react';
 import { useTranscripts } from '@/contexts/TranscriptContext';
 import { useConfig } from '@/contexts/ConfigContext';
 import { useRecordingState } from '@/contexts/RecordingStateContext';
@@ -80,6 +80,19 @@ export function TranscriptPanel({
                     <GlobeIcon />
                     <span className='hidden md:inline'>
                       Language
+                    </span>
+                  </Button>
+                }
+                {transcriptModelConfig.provider === "localWhisper" &&
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => showModal('meetingDomainSettings')}
+                    title="Meeting Domain — vocabulary hint for Whisper"
+                  >
+                    <Tag />
+                    <span className='hidden md:inline'>
+                      Domain
                     </span>
                   </Button>
                 }

--- a/frontend/src/components/MeetingDetails/RetranscribeDialog.tsx
+++ b/frontend/src/components/MeetingDetails/RetranscribeDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { RefreshCw, Globe, Loader2, AlertCircle, CheckCircle2, X, Cpu } from 'lucide-react';
+import { RefreshCw, Globe, Loader2, AlertCircle, CheckCircle2, X, Cpu, Tag } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -58,11 +58,13 @@ export function RetranscribeDialog({
   meetingFolderPath,
   onComplete,
 }: RetranscribeDialogProps) {
-  const { selectedLanguage, transcriptModelConfig } = useConfig();
+  const { selectedLanguage, selectedDomain, transcriptModelConfig } = useConfig();
   const [isProcessing, setIsProcessing] = useState(false);
   const [progress, setProgress] = useState<RetranscriptionProgress | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selectedLang, setSelectedLang] = useState(selectedLanguage || 'auto');
+  const [dialogDomain, setDialogDomain] = useState<string>(selectedDomain || '');
+  const [availableDomains, setAvailableDomains] = useState<string[]>([]);
 
   // Use centralized model fetching hook
   const {
@@ -112,11 +114,17 @@ export function RetranscribeDialog({
       setProgress(null);
       setError(null);
       setSelectedLang(selectedLanguage || 'auto');
+      setDialogDomain(selectedDomain || '');
 
       // Fetch available models using centralized hook
       fetchModels();
+
+      // Fetch available domain names so user can pick or change for this run.
+      invoke<string[]>('list_meeting_domains')
+        .then(setAvailableDomains)
+        .catch(err => console.error('Failed to list meeting domains:', err));
     }
-  }, [open, selectedLanguage, transcriptModelConfig, fetchModels]);
+  }, [open, selectedLanguage, selectedDomain, transcriptModelConfig, fetchModels]);
 
   // Listen for retranscription events
   useEffect(() => {
@@ -214,12 +222,16 @@ export function RetranscribeDialog({
         model_name: selectedModelDetails?.name || ''
       });
 
+      // Domain only applies to Whisper; Parakeet ignores initial_prompt.
+      const domainToSend = isParakeetModel ? null : (dialogDomain || null);
+
       await invoke('start_retranscription_command', {
         meetingId,
         meetingFolderPath,
         language: languageToSend,
         model: selectedModelDetails?.name || null,
         provider: selectedModelDetails?.provider || null,
+        meetingDomain: domainToSend,
       });
     } catch (err: any) {
       setIsProcessing(false);
@@ -356,6 +368,33 @@ export function RetranscribeDialog({
               </Select>
               <p className="text-xs text-muted-foreground">
                 Choose a transcription model
+              </p>
+            </div>
+          )}
+
+          {!isProcessing && !error && !isParakeetModel && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <Tag className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm font-medium">Meeting Domain</span>
+              </div>
+              <Select
+                value={dialogDomain || '__none__'}
+                onValueChange={(v) => setDialogDomain(v === '__none__' ? '' : v)}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="None" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__none__">None (no vocabulary hint)</SelectItem>
+                  {availableDomains.map((d) => (
+                    <SelectItem key={d} value={d}>{d}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                Biases Whisper toward custom vocabulary (proper nouns, jargon).
+                Defaults to your current setting.
               </p>
             </div>
           )}

--- a/frontend/src/components/MeetingDomainSettings.tsx
+++ b/frontend/src/components/MeetingDomainSettings.tsx
@@ -1,0 +1,306 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from './ui/select';
+import { Input } from './ui/input';
+import { Textarea } from './ui/textarea';
+import { Button } from './ui/button';
+import { Label } from './ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog';
+import { FolderOpen, Pencil, RefreshCw, Trash2 } from 'lucide-react';
+import { useConfig } from '@/contexts/ConfigContext';
+
+const NONE_VALUE = '__none__';
+
+type Mode = 'list' | 'edit';
+
+export function MeetingDomainSettings() {
+  const { selectedDomain, setSelectedDomain } = useConfig();
+  const [domains, setDomains] = useState<string[]>([]);
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<Mode>('list');
+  const [editingName, setEditingName] = useState('');
+  const [editingOriginal, setEditingOriginal] = useState<string | null>(null);
+  const [editingContent, setEditingContent] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const list = await invoke<string[]>('list_meeting_domains');
+      setDomains(list);
+    } catch (err) {
+      console.error('Failed to list meeting domains:', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleSelect = (value: string) => {
+    setSelectedDomain(value === NONE_VALUE ? '' : value);
+  };
+
+  const startCreate = () => {
+    setMode('edit');
+    setEditingOriginal(null);
+    setEditingName('');
+    setEditingContent('');
+    setError(null);
+  };
+
+  const startEdit = async (name: string) => {
+    setMode('edit');
+    setEditingOriginal(name);
+    setEditingName(name);
+    setError(null);
+    try {
+      const content = await invoke<string | null>('get_meeting_domain_content', { name });
+      setEditingContent(content ?? '');
+    } catch (err) {
+      setError(String(err));
+      setEditingContent('');
+    }
+  };
+
+  const handleDelete = async (name: string) => {
+    if (!confirm(`Delete meeting domain "${name}"?`)) return;
+    try {
+      await invoke('delete_meeting_domain', { name });
+      if (selectedDomain === name) {
+        setSelectedDomain('');
+      }
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const targetName = editingName.trim();
+      if (!targetName) {
+        setError('Name is required');
+        setSaving(false);
+        return;
+      }
+      await invoke('save_meeting_domain', {
+        name: targetName,
+        content: editingContent,
+      });
+      // If renaming an existing domain, remove the old file.
+      if (editingOriginal && editingOriginal !== targetName) {
+        await invoke('delete_meeting_domain', { name: editingOriginal });
+        if (selectedDomain === editingOriginal) {
+          setSelectedDomain(targetName);
+        }
+      }
+      await refresh();
+      setMode('list');
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleOpenFolder = async () => {
+    try {
+      await invoke('open_meeting_domains_folder');
+    } catch (err) {
+      console.error('Failed to open meeting domains folder:', err);
+    }
+  };
+
+  return (
+    <div>
+      <Label className="block text-sm font-medium text-gray-700 mb-1">
+        Meeting Domain
+      </Label>
+      <p className="text-xs text-gray-500 mb-2 mx-1">
+        Biases Whisper transcription toward a custom vocabulary file
+        (e.g. proper nouns, client names). Leave as "None" for default behavior.
+      </p>
+      <div className="flex space-x-2 mx-1">
+        <Select
+          value={selectedDomain ? selectedDomain : NONE_VALUE}
+          onValueChange={handleSelect}
+        >
+          <SelectTrigger className="focus:ring-1 focus:ring-blue-500 focus:border-blue-500">
+            <SelectValue placeholder="None" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={NONE_VALUE}>None (default)</SelectItem>
+            {domains.map((d) => (
+              <SelectItem key={d} value={d}>
+                {d}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={refresh}
+          title="Rescan domain folder"
+        >
+          <RefreshCw className="h-4 w-4" />
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => {
+            setMode('list');
+            setError(null);
+            setOpen(true);
+          }}
+        >
+          Manage…
+        </Button>
+      </div>
+
+      <Dialog
+        open={open}
+        onOpenChange={(o) => {
+          setOpen(o);
+          if (!o) {
+            setMode('list');
+            setError(null);
+          }
+        }}
+      >
+        <DialogContent className="max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Manage Meeting Domains</DialogTitle>
+            <DialogDescription>
+              Each domain is a plain-text vocabulary hint sent to Whisper as
+              <code className="mx-1">initial_prompt</code>. Keep it short — the
+              file is truncated at ~1000 characters.
+            </DialogDescription>
+          </DialogHeader>
+
+          {error && (
+            <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded p-2">
+              {error}
+            </div>
+          )}
+
+          {mode === 'list' ? (
+            <div className="space-y-3">
+              <div className="max-h-72 overflow-y-auto border rounded">
+                {domains.length === 0 ? (
+                  <div className="p-4 text-sm text-gray-500 text-center">
+                    No domains yet. Click "+ Add new" to create one.
+                  </div>
+                ) : (
+                  <ul>
+                    {domains.map((d) => (
+                      <li
+                        key={d}
+                        className="flex items-center justify-between p-2 border-b last:border-b-0 hover:bg-gray-50"
+                      >
+                        <span className="text-sm font-mono">{d}</span>
+                        <div className="flex space-x-1">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => startEdit(d)}
+                            title="Edit"
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleDelete(d)}
+                            title="Delete"
+                          >
+                            <Trash2 className="h-4 w-4 text-red-500" />
+                          </Button>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+              <div className="flex justify-between">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleOpenFolder}
+                >
+                  <FolderOpen className="h-4 w-4 mr-1" />
+                  Open folder
+                </Button>
+                <Button type="button" size="sm" onClick={startCreate}>
+                  + Add new
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <div>
+                <Label className="text-sm font-medium">Name</Label>
+                <Input
+                  value={editingName}
+                  onChange={(e) => setEditingName(e.target.value)}
+                  placeholder="e.g. tekni"
+                  className="mt-1"
+                />
+                <p className="text-xs text-gray-500 mt-1">
+                  Lowercase letters, digits, dashes, underscores. No spaces or slashes.
+                </p>
+              </div>
+              <div>
+                <Label className="text-sm font-medium">Prompt content</Label>
+                <Textarea
+                  value={editingContent}
+                  onChange={(e) => setEditingContent(e.target.value)}
+                  placeholder="Names, terms, acronyms separated by commas or periods…"
+                  rows={10}
+                  className="mt-1 font-mono text-sm"
+                />
+                <p className="text-xs text-gray-500 mt-1">
+                  {editingContent.length} / ~1000 chars (longer is truncated when sent to Whisper)
+                </p>
+              </div>
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setMode('list')}
+                  disabled={saving}
+                >
+                  Cancel
+                </Button>
+                <Button type="button" onClick={handleSave} disabled={saving}>
+                  {saving ? 'Saving…' : 'Save'}
+                </Button>
+              </DialogFooter>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/components/TranscriptSettings.tsx
+++ b/frontend/src/components/TranscriptSettings.tsx
@@ -7,6 +7,7 @@ import { Label } from './ui/label';
 import { Eye, EyeOff, Lock, Unlock } from 'lucide-react';
 import { ModelManager } from './WhisperModelManager';
 import { ParakeetModelManager } from './ParakeetModelManager';
+import { MeetingDomainSettings } from './MeetingDomainSettings';
 
 
 export interface TranscriptModelProps {
@@ -169,6 +170,12 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 onModelSelect={handleParakeetModelSelect}
                                 autoSave={true}
                             />
+                        </div>
+                    )}
+
+                    {uiProvider === 'localWhisper' && (
+                        <div className="mt-6">
+                            <MeetingDomainSettings />
                         </div>
                     )}
 

--- a/frontend/src/contexts/ConfigContext.tsx
+++ b/frontend/src/contexts/ConfigContext.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, ReactNode, useRef } from 'react';
-import { TranscriptModelProps } from '@/components/TranscriptSettings';
-import { SelectedDevices } from '@/components/DeviceSelection';
+import type { TranscriptModelProps } from '@/components/TranscriptSettings';
+import type { SelectedDevices } from '@/components/DeviceSelection';
 import { configService, ModelConfig } from '@/services/configService';
 import { invoke } from '@tauri-apps/api/core';
 import Analytics from '@/lib/analytics';
@@ -58,6 +58,10 @@ interface ConfigContextType {
   // Language preference
   selectedLanguage: string;
   setSelectedLanguage: (lang: string) => void;
+
+  // Meeting domain (whisper initial_prompt) preference
+  selectedDomain: string;
+  setSelectedDomain: (domain: string) => void;
 
   // UI preferences
   showConfidenceIndicator: boolean;
@@ -145,6 +149,14 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     return 'auto';
   });
 
+  // Meeting domain preference state (empty string = none selected)
+  const [selectedDomain, setSelectedDomain] = useState<string>(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('meetingDomain') || '';
+    }
+    return '';
+  });
+
   // UI preferences state
   const [showConfidenceIndicator, setShowConfidenceIndicator] = useState<boolean>(() => {
     if (typeof window !== 'undefined') {
@@ -222,7 +234,16 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
           console.error('[ConfigContext] Failed to sync language preference to Rust on startup:', err);
         });
     }
-  }, []); 
+  }, []);
+
+  // Sync meeting domain to Rust on mount so live transcription picks up the
+  // selection saved in a prior session.
+  useEffect(() => {
+    invoke('set_meeting_domain', { domain: selectedDomain })
+      .catch(err => {
+        console.error('[ConfigContext] Failed to sync meeting domain to Rust on startup:', err);
+      });
+  }, []);
 
   // Load model configuration on mount
   useEffect(() => {
@@ -482,6 +503,17 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     );
   }, []);
 
+  // Wrapper for setSelectedDomain that persists to localStorage and syncs to Rust
+  const handleSetSelectedDomain = useCallback((domain: string) => {
+    setSelectedDomain(domain);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('meetingDomain', domain);
+    }
+    invoke('set_meeting_domain', { domain }).catch(err =>
+      console.error('Failed to sync meeting domain to Rust:', err)
+    );
+  }, []);
+
   const value: ConfigContextType = useMemo(() => ({
     modelConfig,
     setModelConfig,
@@ -495,6 +527,8 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     setSelectedDevices,
     selectedLanguage,
     setSelectedLanguage: handleSetSelectedLanguage,
+    selectedDomain,
+    setSelectedDomain: handleSetSelectedDomain,
     showConfidenceIndicator,
     toggleConfidenceIndicator,
     betaFeatures,
@@ -517,6 +551,8 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     selectedDevices,
     selectedLanguage,
     handleSetSelectedLanguage,
+    selectedDomain,
+    handleSetSelectedDomain,
     showConfidenceIndicator,
     toggleConfidenceIndicator,
     betaFeatures,

--- a/frontend/src/hooks/useModalState.ts
+++ b/frontend/src/hooks/useModalState.ts
@@ -7,6 +7,7 @@ export type ModalType =
   | 'modelSettings'
   | 'deviceSettings'
   | 'languageSettings'
+  | 'meetingDomainSettings'
   | 'modelSelector'
   | 'errorAlert'
   | 'chunkDropWarning';
@@ -15,6 +16,7 @@ interface ModalState {
   modelSettings: boolean;
   deviceSettings: boolean;
   languageSettings: boolean;
+  meetingDomainSettings: boolean;
   modelSelector: boolean;
   errorAlert: boolean;
   chunkDropWarning: boolean;
@@ -49,6 +51,7 @@ export function useModalState(transcriptModelConfig?: TranscriptModelProps): Use
     modelSettings: false,
     deviceSettings: false,
     languageSettings: false,
+    meetingDomainSettings: false,
     modelSelector: false,
     errorAlert: false,
     chunkDropWarning: false,
@@ -87,6 +90,7 @@ export function useModalState(transcriptModelConfig?: TranscriptModelProps): Use
       modelSettings: false,
       deviceSettings: false,
       languageSettings: false,
+      meetingDomainSettings: false,
       modelSelector: false,
       errorAlert: false,
       chunkDropWarning: false,


### PR DESCRIPTION
## Description

Adds a "Meeting Domain" feature that lets users provide vocabulary hints (custom names, jargon, technical terms) to bias Whisper transcription via its `initial_prompt` parameter.

Domains are plain-text files in `~/Library/Application Support/com.meetily.ai/domains/` (falls back to `~/.meetily/domains/`). When a domain is active, its contents are forwarded as `initial_prompt` to whisper-rs at every transcription call site. No domain selected → unchanged behavior.

**UX surfaces:**
- New "Meeting Domain" section in Transcript Settings with a dropdown + a Manage… dialog (list / edit / delete / open folder / char counter)
- A "Domain" button in the transcript header next to the existing Language button, so users can switch mid-recording
- A "Meeting Domain" dropdown in the Retranscribe dialog with a "None" option, so users can A/B different hint files without changing their global setting
- All Domain UI is hidden when Parakeet is the active provider (Parakeet doesn't support `initial_prompt`)

**Implementation notes:**
- New module: `frontend/src-tauri/src/meeting_domain/mod.rs` (file CRUD, name validation, ~1000-char / ~224-token truncation matching whisper.cpp's hard limit)
- Global `MEETING_DOMAIN` state mirrors the existing `LANGUAGE_PREFERENCE` pattern; Tauri commands surface get/set/list/save/delete to the frontend
- `initial_prompt` is threaded through `transcribe_audio` / `transcribe_audio_with_confidence` so every whisper invocation receives the same hint (live worker, standalone command, parallel processor, audio import, retranscription)
- `ConfigContext` persists `selectedDomain` to localStorage and syncs to Rust on mount, mirroring `selectedLanguage`

## Related Issue

Fixes #474

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other

## Testing
- [x] Unit tests added (7 tests in `meeting_domain::tests` covering name validation, listing, save/delete round-trip, and truncation)
- [x] Manual testing performed on macOS with NB-Whisper-large (Norwegian) — confirmed proper nouns and domain jargon are recognized correctly when the matching domain file is active, and that unchecking the domain restores baseline behavior
- [x] `cargo test meeting_domain` — 7/7 pass
- [x] `cargo build` — clean (warnings are pre-existing in unrelated files)
- [x] `tsc --noEmit` — 0 errors

## Documentation
- [ ] Documentation updated
- [x] No documentation needed for initial review — happy to add a docs page once the design is accepted

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots

### Settings → Transcription → Meeting Domain (with Manage dialog)
<img src="https://raw.githubusercontent.com/Polsemaker/meetily/assets/meeting-domain-screenshots/docs/screenshots/01-settings-meeting-domain.png" width="800" alt="Meeting Domain section in Transcription settings">

### Transcript header — Domain button next to Language
<img src="https://raw.githubusercontent.com/Polsemaker/meetily/assets/meeting-domain-screenshots/docs/screenshots/02-transcript-domain-button.png" width="800" alt="Domain button in transcript header during recording">

### Retranscribe dialog — per-retranscription Meeting Domain override
<img src="https://raw.githubusercontent.com/Polsemaker/meetily/assets/meeting-domain-screenshots/docs/screenshots/03-retranscribe-domain.png" width="500" alt="Retranscribe dialog with Meeting Domain dropdown">

## Additional Notes

- ~224 token (~1000 char) cap on `initial_prompt` is enforced with a graceful truncation + log warning, matching whisper.cpp's hard limit.
- Domain UI is provider-aware: hidden for Parakeet to avoid suggesting a no-op control.
- Selected domain is read fresh at each transcription start, so editing a domain file mid-session takes effect on the next recording without a restart.
- Design intentionally orthogonal to #335 (VibeVoice-ASR) — this is a small biasing knob on the existing Whisper path, not a new engine.