### PR TITLE
fix(tauri): prevent multiple desktop app instances [skip ci]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3666,6 +3666,7 @@ dependencies = [
  "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "tempfile",
@@ -6835,6 +6836,21 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acba6b5ca527a96cdfcc96ae09b09ccb91ddff5e33978ca6873b96ea16bb404c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -155,6 +155,10 @@ tauri-plugin-notification = "2.3.1"
 tauri-plugin-updater = "2.3.0"
 tauri-plugin-process = "2.3.0"
 
+# Desktop-only single instance guard
+[target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
+tauri-plugin-single-instance = "=2.3.7"
+
 # macOS-specific dependencies with Metal GPU acceleration
 [target.'cfg(target_os = "macos")'.dependencies]
 tauri = { version = "2.6.2", features = ["protocol-asset", "macos-private-api", "tray-icon"] }

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -390,7 +390,32 @@ pub fn get_language_preference_internal() -> Option<String> {
 pub fn run() {
     log::set_max_level(log::LevelFilter::Info);
 
-    tauri::Builder::default()
+    let mut builder = tauri::Builder::default();
+
+    #[cfg(any(target_os = "macos", windows, target_os = "linux"))]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, cwd| {
+            log_info!(
+                "Second app instance requested with args: {:?}, cwd: {:?}",
+                args,
+                cwd
+            );
+
+            if let Some(window) = app.get_webview_window("main") {
+                if let Err(e) = window.show() {
+                    log_error!("Failed to show main window for second instance: {}", e);
+                }
+
+                if let Err(e) = window.set_focus() {
+                    log_error!("Failed to focus main window for second instance: {}", e);
+                }
+            } else {
+                log_error!("Main window not found while handling second instance");
+            }
+        }));
+    }
+
+    builder
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_dialog::init())

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -401,17 +401,7 @@ pub fn run() {
                 cwd
             );
 
-            if let Some(window) = app.get_webview_window("main") {
-                if let Err(e) = window.show() {
-                    log_error!("Failed to show main window for second instance: {}", e);
-                }
-
-                if let Err(e) = window.set_focus() {
-                    log_error!("Failed to focus main window for second instance: {}", e);
-                }
-            } else {
-                log_error!("Main window not found while handling second instance");
-            }
+            tray::focus_main_window(app);
         }));
     }
 

--- a/frontend/src-tauri/src/tray.rs
+++ b/frontend/src-tauri/src/tray.rs
@@ -391,12 +391,23 @@ fn build_menu<R: Runtime>(
         .build()
 }
 
-fn focus_main_window<R: Runtime>(app: &AppHandle<R>) {
+pub(crate) fn focus_main_window<R: Runtime>(app: &AppHandle<R>) {
     if let Some(window) = app.get_webview_window("main") {
-        let _ = window.unminimize();
-        let _ = window.show();
-        let _ = window.set_focus();
-        let _ = window.eval("window.focus()");
+        if let Err(e) = window.unminimize() {
+            log::error!("Failed to unminimize main window: {}", e);
+        }
+
+        if let Err(e) = window.show() {
+            log::error!("Failed to show main window: {}", e);
+        }
+
+        if let Err(e) = window.set_focus() {
+            log::error!("Failed to focus main window: {}", e);
+        }
+
+        if let Err(e) = window.eval("window.focus()") {
+            log::error!("Failed to focus main webview: {}", e);
+        }
     } else {
         log::warn!("Could not find main window");
     }


### PR DESCRIPTION
## Description
Adds Tauri’s official single-instance plugin for desktop platforms so launching Meetily while it is already running no longer creates a second app instance.

When a second launch is attempted, the existing app process receives the event, logs the attempted launch arguments/current directory, restores the `main` window if it was hidden to tray, and focuses it. The handler logs window errors instead of panicking, so focus/show failures do not crash the existing instance.

## Related Issue
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [x] All tests pass

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [ ] Added comments for complex code
- [x] Updated README if needed
- [ ] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)
N/A

## Additional Notes
