### PR TITLE
feat(export): export transcripts to .txt and .vtt (#441)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
         "@remirror/react": "^3.0.1",
         "@tanstack/react-virtual": "^3.13.13",
         "@tauri-apps/api": "^2.6.0",
+        "@tauri-apps/plugin-dialog": "~2.3.0",
         "@tauri-apps/plugin-fs": "^2.4.0",
         "@tauri-apps/plugin-notification": "~2.3.1",
         "@tauri-apps/plugin-os": "^2.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,7 +57,7 @@
         "@remirror/react": "^3.0.1",
         "@tanstack/react-virtual": "^3.13.13",
         "@tauri-apps/api": "^2.6.0",
-        "@tauri-apps/plugin-dialog": "~2.3.0",
+        "@tauri-apps/plugin-dialog": "^2.7.0",
         "@tauri-apps/plugin-fs": "^2.4.0",
         "@tauri-apps/plugin-notification": "~2.3.1",
         "@tauri-apps/plugin-os": "^2.3.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: ^2.6.0
         version: 2.11.0
       '@tauri-apps/plugin-dialog':
-        specifier: ~2.3.0
-        version: 2.3.3
+        specifier: ^2.7.0
+        version: 2.7.1
       '@tauri-apps/plugin-fs':
         specifier: ^2.4.0
         version: 2.5.1
@@ -1660,8 +1660,8 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@tauri-apps/plugin-dialog@2.3.3':
-    resolution: {integrity: sha512-cWXB9QJDbLIA0v7I5QY183awazBEQNPhp19iPvrMZoJRX8SbFkhWFx1/q7zy7xGpXXzxz29qtq6z21Ho7W5Iew==}
+  '@tauri-apps/plugin-dialog@2.7.1':
+    resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
 
   '@tauri-apps/plugin-fs@2.5.1':
     resolution: {integrity: sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ==}
@@ -5318,7 +5318,7 @@ snapshots:
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.1
       '@tauri-apps/cli-win32-x64-msvc': 2.11.1
 
-  '@tauri-apps/plugin-dialog@2.3.3':
+  '@tauri-apps/plugin-dialog@2.7.1':
     dependencies:
       '@tauri-apps/api': 2.11.0
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  prosemirror-model: 1.25.3
+  prosemirror-state: 1.4.3
+  prosemirror-view: 1.41.3
+  prosemirror-transform: 1.10.4
+  prosemirror-tables: 1.8.1
+
 importers:
 
   .:
@@ -95,6 +102,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.6.0
         version: 2.11.0
+      '@tauri-apps/plugin-dialog':
+        specifier: ~2.3.0
+        version: 2.3.3
       '@tauri-apps/plugin-fs':
         specifier: ^2.4.0
         version: 2.5.1
@@ -1650,6 +1660,9 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
+  '@tauri-apps/plugin-dialog@2.3.3':
+    resolution: {integrity: sha512-cWXB9QJDbLIA0v7I5QY183awazBEQNPhp19iPvrMZoJRX8SbFkhWFx1/q7zy7xGpXXzxz29qtq6z21Ho7W5Iew==}
+
   '@tauri-apps/plugin-fs@2.5.1':
     resolution: {integrity: sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ==}
 
@@ -2930,10 +2943,10 @@ packages:
       '@types/hast': ^3.0.0
       highlight.js: ^11.9.0
       lowlight: ^3.1.0
-      prosemirror-model: ^1.19.3
-      prosemirror-state: ^1.4.3
-      prosemirror-transform: ^1.8.0
-      prosemirror-view: ^1.32.4
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.3
       refractor: ^5.0.0
       sugar-high: ^0.6.1 || ^0.7.0 || ^0.8.0 || ^0.9.0
     peerDependenciesMeta:
@@ -2979,9 +2992,9 @@ packages:
   prosemirror-paste-rules@3.0.0:
     resolution: {integrity: sha512-p2ayp2xtSTtDPZutoxZyK6UKJhJk0hEpIfdfVYfd3DSENE1Lyrcg96pju+ClgwXlTjPUykXx5DrsfRbHCY+gGQ==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-schema-basic@1.2.4:
     resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
@@ -2995,9 +3008,9 @@ packages:
   prosemirror-suggest@3.0.0:
     resolution: {integrity: sha512-cEYnJHOAnQ+ET7PKY1tY8SMSpyR2rQAuYfPEmVtet0V9exgHAeiaSEzyBcCSeLesxXJRIv8b9cofyqoqyMjlEw==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-tables@1.8.1:
     resolution: {integrity: sha512-DAgDoUYHCcc6tOGpLVPSU1k84kCUWTWnfWX3UDy2Delv4ryH0KqTD6RBI6k4yi9j9I8gl3j8MkPpRD/vWPZbug==}
@@ -3005,9 +3018,9 @@ packages:
   prosemirror-trailing-node@3.0.0:
     resolution: {integrity: sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-transform@1.10.4:
     resolution: {integrity: sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==}
@@ -3448,9 +3461,9 @@ packages:
     resolution: {integrity: sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     peerDependencies:
-      prosemirror-model: ^1.7.1
-      prosemirror-state: ^1.2.3
-      prosemirror-view: ^1.9.10
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
       y-protocols: ^1.0.1
       yjs: ^13.5.38
 
@@ -5304,6 +5317,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.1
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.1
       '@tauri-apps/cli-win32-x64-msvc': 2.11.1
+
+  '@tauri-apps/plugin-dialog@2.3.3':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-fs@2.5.1':
     dependencies:

--- a/frontend/src-tauri/src/api/export.rs
+++ b/frontend/src-tauri/src/api/export.rs
@@ -5,6 +5,11 @@
 //! `String`, so they're trivially unit-testable with no DB.
 
 use crate::database::models::Transcript;
+use crate::database::repositories::meeting::MeetingsRepository;
+use crate::state::AppState;
+use serde::Serialize;
+use std::path::PathBuf;
+use tauri::{AppHandle, Runtime};
 
 /// Format transcripts as plain text, one segment per line.
 ///
@@ -138,6 +143,56 @@ pub fn sanitize_filename_stem(title: &str, meeting_id: &str) -> String {
     } else {
         truncated
     }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExportResult {
+    pub bytes_written: u64,
+    pub segments_written: usize,
+    pub segments_skipped: usize,
+    pub output_path: String,
+}
+
+/// Read all transcripts for a meeting, format them according to `format`
+/// ("txt" or "vtt"), and write them to `output_path`. Returns counts so
+/// the frontend can surface a useful toast (especially the skipped-segment
+/// count for VTT when some rows had no timing).
+#[tauri::command]
+pub async fn api_export_transcript<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    meeting_id: String,
+    format: String,
+    output_path: String,
+) -> Result<ExportResult, String> {
+    let pool = state.db_manager.pool();
+    let segments = MeetingsRepository::get_all_transcripts_for_meeting(pool, &meeting_id)
+        .await
+        .map_err(|e| format!("Failed to read transcripts: {}", e))?;
+
+    if segments.is_empty() {
+        return Err(format!("No transcripts for meeting {}", meeting_id));
+    }
+
+    let (content, skipped) = match format.as_str() {
+        "txt" => (format_txt(&segments), 0usize),
+        "vtt" => format_vtt(&segments),
+        other => return Err(format!("Unsupported format: {}", other)),
+    };
+
+    let path = PathBuf::from(&output_path);
+    std::fs::write(&path, &content)
+        .map_err(|e| format!("Failed to write {}: {}", path.display(), e))?;
+
+    let bytes_written = content.as_bytes().len() as u64;
+    let segments_written = segments.len() - skipped;
+
+    Ok(ExportResult {
+        bytes_written,
+        segments_written,
+        segments_skipped: skipped,
+        output_path,
+    })
 }
 
 #[cfg(test)]

--- a/frontend/src-tauri/src/api/export.rs
+++ b/frontend/src-tauri/src/api/export.rs
@@ -1,0 +1,49 @@
+//! Export transcripts to .txt / .vtt files for issue #441.
+//!
+//! Pure formatters live alongside the Tauri command so the test surface
+//! stays in one place. The formatters take owned data and return owned
+//! `String`, so they're trivially unit-testable with no DB.
+
+use crate::database::models::Transcript;
+
+/// Format transcripts as plain text, one segment per line.
+///
+/// Line shape: `[HH:MM:SS] text` when `audio_start_time` is present,
+/// else just `text`. Internal newlines in `transcript` are collapsed
+/// to a single space. The output ends with a trailing newline.
+pub fn format_txt(segments: &[Transcript]) -> String {
+    let _ = segments; // wired in next task
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seg(
+        text: &str,
+        audio_start_time: Option<f64>,
+        audio_end_time: Option<f64>,
+        duration: Option<f64>,
+    ) -> Transcript {
+        Transcript {
+            id: "t-test".into(),
+            meeting_id: "m-test".into(),
+            transcript: text.into(),
+            timestamp: "2026-05-26T00:00:00Z".into(),
+            summary: None,
+            action_items: None,
+            key_points: None,
+            audio_start_time,
+            audio_end_time,
+            duration,
+        }
+    }
+
+    #[test]
+    fn format_txt_compiles() {
+        // placeholder; real tests land in Task 2.
+        let _ = format_txt(&[]);
+        let _ = seg("", None, None, None);
+    }
+}

--- a/frontend/src-tauri/src/api/export.rs
+++ b/frontend/src-tauri/src/api/export.rs
@@ -100,6 +100,46 @@ fn escape_vtt(text: &str) -> String {
         .replace('>', "&gt;")
 }
 
+/// Build a safe filename stem from a meeting title.
+///
+/// Strips path separators and other characters that are problematic on
+/// Windows or macOS, collapses internal whitespace, trims surrounding
+/// whitespace and dots, truncates to 80 characters, and falls back to
+/// `meeting-<first 8 chars of id>` if the result is empty.
+pub fn sanitize_filename_stem(title: &str, meeting_id: &str) -> String {
+    const BANNED: &[char] = &['/', '\\', ':', '*', '?', '"', '<', '>', '|'];
+
+    let cleaned: String = title
+        .chars()
+        .filter(|c| !BANNED.contains(c) && !c.is_control())
+        .collect();
+
+    let mut collapsed = String::with_capacity(cleaned.len());
+    let mut prev_ws = false;
+    for c in cleaned.chars() {
+        if c.is_whitespace() {
+            if !prev_ws {
+                collapsed.push(' ');
+            }
+            prev_ws = true;
+        } else {
+            collapsed.push(c);
+            prev_ws = false;
+        }
+    }
+    let trimmed = collapsed.trim_matches(|c: char| c.is_whitespace() || c == '.');
+
+    let truncated: String = trimmed.chars().take(80).collect();
+
+    if truncated.is_empty() {
+        let id = meeting_id.strip_prefix("meeting-").unwrap_or(meeting_id);
+        let prefix: String = id.chars().take(8).collect();
+        format!("meeting-{}", prefix)
+    } else {
+        truncated
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -267,5 +307,39 @@ mod tests {
         let (out, skipped) = format_vtt(&[]);
         assert_eq!(out, "WEBVTT\n\n");
         assert_eq!(skipped, 0);
+    }
+
+    // ----- sanitize_filename_stem -----
+
+    #[test]
+    fn sanitize_strips_path_separators_and_control_chars() {
+        let out = sanitize_filename_stem("Q3/Strategy: layoffs\\plan?", "m-abc12345");
+        assert_eq!(out, "Q3Strategy layoffsplan");
+    }
+
+    #[test]
+    fn sanitize_collapses_whitespace_and_trims() {
+        let out = sanitize_filename_stem("   hello   world   ", "m-abc12345");
+        assert_eq!(out, "hello world");
+    }
+
+    #[test]
+    fn sanitize_empty_title_falls_back_to_meeting_id_prefix() {
+        let out = sanitize_filename_stem("", "meeting-abc12345xyz");
+        assert_eq!(out, "meeting-abc12345");
+    }
+
+    #[test]
+    fn sanitize_whitespace_only_title_falls_back() {
+        let out = sanitize_filename_stem("   ", "meeting-abc12345xyz");
+        assert_eq!(out, "meeting-abc12345");
+    }
+
+    #[test]
+    fn sanitize_truncates_to_80_chars() {
+        let long = "a".repeat(200);
+        let out = sanitize_filename_stem(&long, "m-abc12345");
+        assert_eq!(out.len(), 80);
+        assert!(out.chars().all(|c| c == 'a'));
     }
 }

--- a/frontend/src-tauri/src/api/export.rs
+++ b/frontend/src-tauri/src/api/export.rs
@@ -12,8 +12,35 @@ use crate::database::models::Transcript;
 /// else just `text`. Internal newlines in `transcript` are collapsed
 /// to a single space. The output ends with a trailing newline.
 pub fn format_txt(segments: &[Transcript]) -> String {
-    let _ = segments; // wired in next task
-    String::new()
+    let mut sorted: Vec<&Transcript> = segments.iter().collect();
+    sorted.sort_by(|a, b| {
+        a.audio_start_time
+            .partial_cmp(&b.audio_start_time)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let mut out = String::new();
+    for seg in sorted {
+        let line_text = seg.transcript.replace(['\n', '\r'], " ");
+        match seg.audio_start_time {
+            Some(t) => {
+                out.push_str(&format!("[{}] {}\n", format_hms(t), line_text));
+            }
+            None => {
+                out.push_str(&line_text);
+                out.push('\n');
+            }
+        }
+    }
+    out
+}
+
+fn format_hms(seconds: f64) -> String {
+    let total = seconds.max(0.0) as u64;
+    let hours = total / 3600;
+    let minutes = (total % 3600) / 60;
+    let secs = total % 60;
+    format!("{:02}:{:02}:{:02}", hours, minutes, secs)
 }
 
 #[cfg(test)]
@@ -41,9 +68,67 @@ mod tests {
     }
 
     #[test]
-    fn format_txt_compiles() {
-        // placeholder; real tests land in Task 2.
-        let _ = format_txt(&[]);
-        let _ = seg("", None, None, None);
+    fn format_txt_happy_path() {
+        let segments = vec![
+            seg("We should ship the feature.", Some(83.0), Some(88.0), Some(5.0)),
+            seg("Agreed.", Some(90.0), Some(92.0), Some(2.0)),
+        ];
+        let out = format_txt(&segments);
+        assert_eq!(
+            out,
+            "[00:01:23] We should ship the feature.\n[00:01:30] Agreed.\n"
+        );
+    }
+
+    #[test]
+    fn format_txt_null_timestamp_omits_bracket() {
+        let segments = vec![seg("Imported audio.", None, None, None)];
+        let out = format_txt(&segments);
+        assert_eq!(out, "Imported audio.\n");
+    }
+
+    #[test]
+    fn format_txt_collapses_internal_newlines() {
+        let segments = vec![seg(
+            "line one\nline two\rline three",
+            Some(0.0),
+            Some(1.0),
+            Some(1.0),
+        )];
+        let out = format_txt(&segments);
+        assert_eq!(out, "[00:00:00] line one line two line three\n");
+    }
+
+    #[test]
+    fn format_txt_sorts_by_audio_start_time() {
+        let segments = vec![
+            seg("third", Some(3.0), Some(4.0), Some(1.0)),
+            seg("first", Some(1.0), Some(2.0), Some(1.0)),
+            seg("second", Some(2.0), Some(3.0), Some(1.0)),
+        ];
+        let out = format_txt(&segments);
+        assert!(out.starts_with("[00:00:01] first\n"));
+        assert!(out.contains("[00:00:02] second\n"));
+        assert!(out.ends_with("[00:00:03] third\n"));
+    }
+
+    #[test]
+    fn format_txt_handles_hour_rollover() {
+        let segments = vec![seg("late", Some(3725.0), Some(3730.0), Some(5.0))];
+        let out = format_txt(&segments);
+        assert_eq!(out, "[01:02:05] late\n");
+    }
+
+    #[test]
+    fn format_txt_empty_input_returns_empty_string() {
+        let out = format_txt(&[]);
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn format_txt_ends_with_trailing_newline_when_non_empty() {
+        let segments = vec![seg("hi", Some(0.0), Some(1.0), Some(1.0))];
+        let out = format_txt(&segments);
+        assert!(out.ends_with('\n'));
     }
 }

--- a/frontend/src-tauri/src/api/export.rs
+++ b/frontend/src-tauri/src/api/export.rs
@@ -43,6 +43,63 @@ fn format_hms(seconds: f64) -> String {
     format!("{:02}:{:02}:{:02}", hours, minutes, secs)
 }
 
+/// Format transcripts as WebVTT v1. Returns `(content, segments_skipped)`.
+/// Segments with `audio_start_time = None` cannot form a valid cue and are
+/// reported in the second tuple field so the caller can warn the user.
+pub fn format_vtt(segments: &[Transcript]) -> (String, usize) {
+    let mut sorted: Vec<&Transcript> = segments.iter().collect();
+    sorted.sort_by(|a, b| {
+        a.audio_start_time
+            .partial_cmp(&b.audio_start_time)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let mut out = String::from("WEBVTT\n\n");
+    let mut skipped: usize = 0;
+
+    for seg in sorted {
+        let start = match seg.audio_start_time {
+            Some(t) => t,
+            None => {
+                skipped += 1;
+                continue;
+            }
+        };
+        let end = seg
+            .audio_end_time
+            .or_else(|| seg.duration.map(|d| start + d))
+            .unwrap_or(start + 5.0);
+
+        let cue_text = escape_vtt(&seg.transcript.replace(['\n', '\r'], " "));
+        out.push_str(&format!(
+            "{} --> {}\n{}\n\n",
+            format_vtt_timestamp(start),
+            format_vtt_timestamp(end),
+            cue_text
+        ));
+    }
+
+    (out, skipped)
+}
+
+fn format_vtt_timestamp(seconds: f64) -> String {
+    let secs = seconds.max(0.0);
+    let hours = (secs / 3600.0).floor() as u64;
+    let minutes = ((secs % 3600.0) / 60.0).floor() as u64;
+    let whole_seconds = (secs % 60.0).floor() as u64;
+    let millis = ((secs - secs.floor()) * 1000.0).round() as u64;
+    format!(
+        "{:02}:{:02}:{:02}.{:03}",
+        hours, minutes, whole_seconds, millis
+    )
+}
+
+fn escape_vtt(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -130,5 +187,85 @@ mod tests {
         let segments = vec![seg("hi", Some(0.0), Some(1.0), Some(1.0))];
         let out = format_txt(&segments);
         assert!(out.ends_with('\n'));
+    }
+
+    // ----- format_vtt -----
+
+    #[test]
+    fn format_vtt_happy_path() {
+        let segments = vec![
+            seg("We should ship the feature.", Some(0.0), Some(8.5), Some(8.5)),
+            seg("Agreed.", Some(8.5), Some(12.3), Some(3.8)),
+        ];
+        let (out, skipped) = format_vtt(&segments);
+        assert_eq!(skipped, 0);
+        assert_eq!(
+            out,
+            "WEBVTT\n\n\
+             00:00:00.000 --> 00:00:08.500\n\
+             We should ship the feature.\n\n\
+             00:00:08.500 --> 00:00:12.300\n\
+             Agreed.\n\n"
+        );
+    }
+
+    #[test]
+    fn format_vtt_uses_duration_when_end_missing() {
+        let segments = vec![seg("only duration", Some(10.0), None, Some(2.5))];
+        let (out, _) = format_vtt(&segments);
+        assert!(out.contains("00:00:10.000 --> 00:00:12.500"));
+    }
+
+    #[test]
+    fn format_vtt_uses_5s_fallback_when_end_and_duration_missing() {
+        let segments = vec![seg("naked start", Some(20.0), None, None)];
+        let (out, _) = format_vtt(&segments);
+        assert!(out.contains("00:00:20.000 --> 00:00:25.000"));
+    }
+
+    #[test]
+    fn format_vtt_skips_segments_without_start_time() {
+        let segments = vec![
+            seg("good", Some(0.0), Some(1.0), Some(1.0)),
+            seg("orphan", None, None, None),
+            seg("good 2", Some(2.0), Some(3.0), Some(1.0)),
+        ];
+        let (out, skipped) = format_vtt(&segments);
+        assert_eq!(skipped, 1);
+        assert!(out.contains("good"));
+        assert!(out.contains("good 2"));
+        assert!(!out.contains("orphan"));
+    }
+
+    #[test]
+    fn format_vtt_escapes_special_characters() {
+        let segments = vec![seg("3 < 5 & 7 > 6", Some(0.0), Some(1.0), Some(1.0))];
+        let (out, _) = format_vtt(&segments);
+        assert!(out.contains("3 &lt; 5 &amp; 7 &gt; 6"));
+    }
+
+    #[test]
+    fn format_vtt_keeps_overlapping_segments_as_distinct_cues() {
+        let segments = vec![
+            seg("mic talks", Some(0.0), Some(5.0), Some(5.0)),
+            seg("system talks", Some(2.0), Some(6.0), Some(4.0)),
+        ];
+        let (out, _) = format_vtt(&segments);
+        assert!(out.contains("00:00:00.000 --> 00:00:05.000\nmic talks"));
+        assert!(out.contains("00:00:02.000 --> 00:00:06.000\nsystem talks"));
+    }
+
+    #[test]
+    fn format_vtt_timestamp_at_hour_boundary() {
+        let segments = vec![seg("late", Some(3725.5), Some(3730.5), Some(5.0))];
+        let (out, _) = format_vtt(&segments);
+        assert!(out.contains("01:02:05.500 --> 01:02:10.500"));
+    }
+
+    #[test]
+    fn format_vtt_empty_input_returns_header_only() {
+        let (out, skipped) = format_vtt(&[]);
+        assert_eq!(out, "WEBVTT\n\n");
+        assert_eq!(skipped, 0);
     }
 }

--- a/frontend/src-tauri/src/api/mod.rs
+++ b/frontend/src-tauri/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod commands;
+pub mod export;
 
 pub use api::*;
 // Don't re-export commands to avoid conflicts - lib.rs will import directly

--- a/frontend/src-tauri/src/database/repositories/meeting.rs
+++ b/frontend/src-tauri/src/database/repositories/meeting.rs
@@ -165,6 +165,31 @@ impl MeetingsRepository {
         Ok((transcripts, total.0))
     }
 
+    /// Returns every transcript row for a meeting in `audio_start_time`
+    /// ascending order, with rows lacking a start time sorted last.
+    /// Used by the export command; do not call from hot paths.
+    pub async fn get_all_transcripts_for_meeting(
+        pool: &SqlitePool,
+        meeting_id: &str,
+    ) -> Result<Vec<Transcript>, SqlxError> {
+        if meeting_id.trim().is_empty() {
+            return Err(SqlxError::Protocol(
+                "meeting_id cannot be empty".to_string(),
+            ));
+        }
+
+        let transcripts = sqlx::query_as::<_, Transcript>(
+            "SELECT * FROM transcripts
+             WHERE meeting_id = ?
+             ORDER BY (audio_start_time IS NULL), audio_start_time ASC",
+        )
+        .bind(meeting_id)
+        .fetch_all(pool)
+        .await?;
+
+        Ok(transcripts)
+    }
+
     pub async fn update_meeting_title(
         pool: &SqlitePool,
         meeting_id: &str,

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -647,6 +647,7 @@ pub fn run() {
             api::api_get_meeting,
             api::api_get_meeting_metadata,
             api::api_get_meeting_transcripts,
+            api::export::api_export_transcript,
             api::api_save_meeting_title,
             api::api_save_transcript,
             api::open_meeting_folder,

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -52,6 +52,7 @@
                         "fs:allow-download-write",
                         "fs:allow-download-read",
                         "fs:scope-download",
+                        "dialog:allow-save",
                         "core:path:default",
                         "core:event:default",
                         "core:window:default",

--- a/frontend/src/app/meeting-details/page-content.tsx
+++ b/frontend/src/app/meeting-details/page-content.tsx
@@ -191,6 +191,9 @@ export default function PageContent({
           meetingId={meeting.id}
           meetingFolderPath={meeting.folder_path}
           onRefetchTranscripts={onRefetchTranscripts}
+          // Export props (#441)
+          meetingTitle={meeting.title}
+          meetingCreatedAt={meeting.created_at}
         />
         <SummaryPanel
           meeting={meeting}

--- a/frontend/src/components/MeetingDetails/TranscriptButtonGroup.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptButtonGroup.tsx
@@ -1,41 +1,135 @@
 "use client";
 
 import { useState, useCallback } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { save } from '@tauri-apps/plugin-dialog';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
-import { Copy, FolderOpen, RefreshCw } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Copy, Download, FolderOpen, RefreshCw } from 'lucide-react';
 import Analytics from '@/lib/analytics';
 import { RetranscribeDialog } from './RetranscribeDialog';
 import { useConfig } from '@/contexts/ConfigContext';
 
+type ExportFormat = 'txt' | 'vtt';
+
+interface ExportResult {
+  bytes_written: number;
+  segments_written: number;
+  segments_skipped: number;
+  output_path: string;
+}
 
 interface TranscriptButtonGroupProps {
   transcriptCount: number;
   onCopyTranscript: () => void;
   onOpenMeetingFolder: () => Promise<void>;
   meetingId?: string;
+  meetingTitle?: string;
+  meetingCreatedAt?: string;
+  isRecording?: boolean;
   meetingFolderPath?: string | null;
   onRefetchTranscripts?: () => Promise<void>;
 }
 
+function buildDefaultFilename(
+  title: string | undefined,
+  createdAt: string | undefined,
+  ext: ExportFormat,
+): string {
+  const safeTitle = (title ?? '')
+    .replace(/[\\/:*?"<>|\x00-\x1F]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const stem = safeTitle.length > 0 ? safeTitle.slice(0, 80) : 'transcript';
+  const date = createdAt ? new Date(createdAt) : new Date();
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${stem} - ${yyyy}-${mm}-${dd}.${ext}`;
+}
 
 export function TranscriptButtonGroup({
   transcriptCount,
   onCopyTranscript,
   onOpenMeetingFolder,
   meetingId,
+  meetingTitle,
+  meetingCreatedAt,
+  isRecording = false,
   meetingFolderPath,
   onRefetchTranscripts,
 }: TranscriptButtonGroupProps) {
   const { betaFeatures } = useConfig();
   const [showRetranscribeDialog, setShowRetranscribeDialog] = useState(false);
+  const [exporting, setExporting] = useState(false);
 
   const handleRetranscribeComplete = useCallback(async () => {
-    // Refetch transcripts to show the updated data
     if (onRefetchTranscripts) {
       await onRefetchTranscripts();
     }
   }, [onRefetchTranscripts]);
+
+  const handleExport = useCallback(
+    async (format: ExportFormat) => {
+      if (!meetingId || transcriptCount === 0 || isRecording || exporting) return;
+
+      try {
+        setExporting(true);
+        const defaultPath = buildDefaultFilename(meetingTitle, meetingCreatedAt, format);
+        const filterName = format === 'txt' ? 'Plain text' : 'WebVTT subtitles';
+
+        const chosenPath = await save({
+          defaultPath,
+          filters: [{ name: filterName, extensions: [format] }],
+        });
+
+        if (!chosenPath) {
+          // user cancelled — silent no-op
+          return;
+        }
+
+        Analytics.trackButtonClick(`export_transcript_${format}`, 'meeting_details');
+
+        const result = await invoke<ExportResult>('api_export_transcript', {
+          meetingId,
+          format,
+          outputPath: chosenPath,
+        });
+
+        const summary = `${result.segments_written} segment${result.segments_written === 1 ? '' : 's'} → ${format.toUpperCase()}`;
+        if (result.segments_skipped > 0) {
+          toast.warning(`Exported ${summary} (${result.segments_skipped} skipped: missing timing)`, {
+            description: result.output_path,
+          });
+        } else {
+          toast.success(`Exported ${summary}`, {
+            description: result.output_path,
+          });
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        toast.error('Export failed', { description: message });
+      } finally {
+        setExporting(false);
+      }
+    },
+    [meetingId, transcriptCount, isRecording, exporting, meetingTitle, meetingCreatedAt],
+  );
+
+  const exportDisabled = transcriptCount === 0 || isRecording || exporting || !meetingId;
+  const exportTitle =
+    transcriptCount === 0
+      ? 'No transcript to export'
+      : isRecording
+        ? 'Stop recording before exporting'
+        : 'Export transcript';
 
   return (
     <div className="flex items-center justify-center w-full gap-2">
@@ -67,6 +161,29 @@ export function TranscriptButtonGroup({
           <FolderOpen className="xl:mr-2" size={18} />
           <span className="hidden lg:inline">Recording</span>
         </Button>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              size="sm"
+              variant="outline"
+              className="xl:px-4"
+              disabled={exportDisabled}
+              title={exportTitle}
+            >
+              <Download className="xl:mr-2" size={18} />
+              <span className="hidden lg:inline">Export</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => handleExport('txt')}>
+              Plain text (.txt)
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => handleExport('vtt')}>
+              WebVTT (.vtt)
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
 
         {betaFeatures.importAndRetranscribe && meetingId && meetingFolderPath && (
           <Button

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -28,6 +28,10 @@ interface TranscriptPanelProps {
   meetingId?: string;
   meetingFolderPath?: string | null;
   onRefetchTranscripts?: () => Promise<void>;
+
+  // Export props (#441)
+  meetingTitle?: string;
+  meetingCreatedAt?: string;
 }
 
 export function TranscriptPanel({
@@ -48,6 +52,8 @@ export function TranscriptPanel({
   meetingId,
   meetingFolderPath,
   onRefetchTranscripts,
+  meetingTitle,
+  meetingCreatedAt,
 }: TranscriptPanelProps) {
   // Convert transcripts to segments if pagination is not used but we want virtualization
   const convertedSegments = useMemo(() => {
@@ -73,6 +79,9 @@ export function TranscriptPanel({
           onCopyTranscript={onCopyTranscript}
           onOpenMeetingFolder={onOpenMeetingFolder}
           meetingId={meetingId}
+          meetingTitle={meetingTitle}
+          meetingCreatedAt={meetingCreatedAt}
+          isRecording={isRecording}
           meetingFolderPath={meetingFolderPath}
           onRefetchTranscripts={onRefetchTranscripts}
         />


### PR DESCRIPTION
## Description

Adds an **Export** dropdown to the meeting transcript toolbar with two options: plain text (`.txt`) and WebVTT (`.vtt`). Both formats are built in Rust (unit-tested) and written to a user-chosen path via the existing `tauri-plugin-dialog` save dialog. Disabled while recording or when no transcripts exist.

### .txt format
```
[00:01:23] We should ship the feature.
[00:01:30] Agreed.
```
One line per segment, sorted by `audio_start_time`. Timestamp bracket omitted when the segment has no timing (e.g. imported audio). Internal newlines collapsed.

### .vtt format
Standard WebVTT v1 with `&`, `<`, `>` escaping. End-time fallback chain: `audio_end_time` → `audio_start_time + duration` → `audio_start_time + 5.0`. Segments without a start time are skipped and the count is surfaced in a sonner warning toast. Overlapping mic/system audio segments are kept as distinct cues.

### Default filename
`<sanitized meeting title> - <YYYY-MM-DD>.{txt|vtt}` (date from `meeting.created_at`).

## Related Issue

Fixes #441

## Type of Change

- [x] New feature

## Testing

- [x] **20 Rust unit tests** added in `frontend/src-tauri/src/api/export.rs`:
  - `format_txt` (7): happy path, NULL timestamp, newline collapse, ordering, hour rollover, empty input, trailing newline invariant
  - `format_vtt` (8): happy path, duration fallback, 5s fallback, NULL-start skipping, character escaping, overlapping cues, hour-boundary formatting, empty input
  - `sanitize_filename_stem` (5): banned characters, whitespace collapse, empty fallback, whitespace-only fallback, 80-char truncation
- [x] `pnpm run build` passes (TypeScript + Next.js static generation)
- [x] **Fork CI green on macOS + Linux 22.04 + Linux 24.04** (see notes on Windows below)
- [ ] **Manual VLC verification not performed by contributor** — my dev environment lacks a full local Tauri build setup; would appreciate a maintainer with a configured macOS dev env loading an exported `.vtt` into VLC against a real recording to confirm timing sync.

## Documentation

- [x] No user-facing docs change needed (button is self-explanatory)

## Notes for reviewers

**Windows CI failure is pre-existing and unrelated.** The Windows job fails inside `llama-cpp-sys-2 v0.1.146`'s build script when CMake tries to build the bundled `vulkan-shaders-gen` tool (`Not a file: cmake_install.cmake`). This is in the `llama-helper` sidecar's dependency chain — a path my changes don't touch. Evidence:
- The same failure occurred on this PR's first CI run *before any of my Rust changes had even been compiled* (at a step that runs before the Tauri build).
- Open PR #460 ("upgrade whisper-rs to 0.16.0 and fix Windows build") is the upstream effort to address Windows build chain issues. Happy to rebase once that lands.

**Speaker labels were intentionally excluded from v1.** The `transcripts.speaker` column exists from migration `20251110000001_add_speaker_field.sql`, but no writer in the live code populates it. Emitting `<v Speaker>` cues today would only ever produce blanks. Deferred to a follow-up paired with whoever wires diarization end-to-end.

**`pnpm-lock.yaml` diff includes a small overrides reconciliation.** `pnpm install --frozen-lockfile` was already failing against the pre-existing lockfile on `devtest` (overrides-config mismatch). The non-frozen install fixed that drift in the same hunk as the new `@tauri-apps/plugin-dialog` dep. Happy to split into a separate `chore(deps)` commit if you'd prefer.

**`dialog:allow-save` is the only new capability.** The Rust `tauri-plugin-dialog` was already in `Cargo.toml` (`2.7.1` per `Cargo.lock`) and registered in `lib.rs:411`. The JS package was pinned to match (`^2.7.0`) — see commit `fix(export): bump @tauri-apps/plugin-dialog to ^2.7.0` for the version-mismatch fix discovered in CI.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Branch targets `devtest`
- [x] No unrelated changes (lockfile reconciliation noted above)
