### PR TITLE
fix(audio): filter raw ALSA PCM names from Linux device pickers (#437)

### DIFF
--- a/frontend/src-tauri/src/audio/devices/discovery.rs
+++ b/frontend/src-tauri/src/audio/devices/discovery.rs
@@ -27,10 +27,18 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
         }
     };
 
-    // Add any additional devices from the default host
+    // Add any additional devices from the default host.
+    // On Linux, filter raw ALSA PCM permutations the same way configure_linux_audio
+    // does for inputs — otherwise the noise re-enters the list here as fake outputs (#437).
     if let Ok(other_devices) = host.devices() {
         for device in other_devices {
             if let Ok(name) = device.name() {
+                #[cfg(target_os = "linux")]
+                {
+                    if !platform::linux::is_meaningful_alsa_pcm(&name) {
+                        continue;
+                    }
+                }
                 if !devices.iter().any(|d| d.name == name) {
                     devices.push(AudioDevice::new(name, DeviceType::Output));
                 }

--- a/frontend/src-tauri/src/audio/devices/platform/linux.rs
+++ b/frontend/src-tauri/src/audio/devices/platform/linux.rs
@@ -3,14 +3,41 @@ use cpal::traits::{DeviceTrait, HostTrait};
 
 use crate::audio::devices::configuration::{AudioDevice, DeviceType};
 
+/// Returns `false` for ALSA PCM device names that are raw permutations
+/// users don't care about (front/surround/iec958/hw/dmix/dsnoop/etc.).
+/// Logical endpoints (`default`, `pipewire`, `pulse`, `sysdefault`) and
+/// friendly device names pass through unchanged.
+///
+/// Issue: #437 — Linux device pickers showed every ALSA profile per card.
+pub fn is_meaningful_alsa_pcm(name: &str) -> bool {
+    const BANNED_PREFIXES: &[&str] = &[
+        "front:",
+        "rear:",
+        "center_lfe:",
+        "side:",
+        "surround",      // surround21/40/41/50/51/71:CARD=...
+        "iec958:",
+        "spdif:",
+        "hw:",
+        "plughw:",
+        "dmix:",
+        "dsnoop:",
+        "usbstream:",
+        "sysdefault:",   // per-card sysdefault (top-level "sysdefault" passes)
+    ];
+    !BANNED_PREFIXES.iter().any(|p| name.starts_with(p))
+}
+
 /// Configure Linux audio devices using ALSA/PulseAudio
 pub fn configure_linux_audio(host: &cpal::Host) -> Result<Vec<AudioDevice>> {
     let mut devices = Vec::new();
 
-    // Add input devices
+    // Add input devices, skipping raw ALSA PCM permutations (#437).
     for device in host.input_devices()? {
         if let Ok(name) = device.name() {
-            devices.push(AudioDevice::new(name, DeviceType::Input));
+            if is_meaningful_alsa_pcm(&name) {
+                devices.push(AudioDevice::new(name, DeviceType::Input));
+            }
         }
     }
 
@@ -18,11 +45,14 @@ pub fn configure_linux_audio(host: &cpal::Host) -> Result<Vec<AudioDevice>> {
     if let Ok(pulse_host) = cpal::host_from_id(cpal::HostId::Alsa) {
         for device in pulse_host.input_devices()? {
             if let Ok(name) = device.name() {
-                // Check if it's a monitor source
+                // Monitor sources contain "monitor" in their name and don't
+                // start with any of the banned PCM prefixes, so they pass
+                // is_meaningful_alsa_pcm naturally — but we still gate on the
+                // "monitor" substring to label them as system-audio outputs.
                 if name.contains("monitor") {
                     devices.push(AudioDevice::new(
                         format!("{} (System Audio)", name),
-                        DeviceType::Output
+                        DeviceType::Output,
                     ));
                 }
             }
@@ -30,4 +60,118 @@ pub fn configure_linux_audio(host: &cpal::Host) -> Result<Vec<AudioDevice>> {
     }
 
     Ok(devices)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- KEEP cases --
+
+    #[test]
+    fn keeps_default_endpoint() {
+        assert!(is_meaningful_alsa_pcm("default"));
+    }
+
+    #[test]
+    fn keeps_pipewire_endpoint() {
+        assert!(is_meaningful_alsa_pcm("pipewire"));
+    }
+
+    #[test]
+    fn keeps_pulse_endpoint() {
+        assert!(is_meaningful_alsa_pcm("pulse"));
+    }
+
+    #[test]
+    fn keeps_toplevel_sysdefault() {
+        assert!(is_meaningful_alsa_pcm("sysdefault"));
+    }
+
+    #[test]
+    fn keeps_friendly_usb_mic_name() {
+        assert!(is_meaningful_alsa_pcm("Yeti X"));
+        assert!(is_meaningful_alsa_pcm("AT2020USB+ Mono"));
+    }
+
+    #[test]
+    fn keeps_pipewire_node_name() {
+        assert!(is_meaningful_alsa_pcm(
+            "alsa_input.usb-Blue_Microphones_Yeti_X-00.analog-stereo"
+        ));
+        assert!(is_meaningful_alsa_pcm(
+            "alsa_output.pci-0000_00_1f.3.analog-stereo.monitor"
+        ));
+    }
+
+    #[test]
+    fn keeps_builtin_audio_name() {
+        assert!(is_meaningful_alsa_pcm("HDA Intel PCH"));
+        assert!(is_meaningful_alsa_pcm("Built-in Audio Analog Stereo"));
+    }
+
+    #[test]
+    fn keeps_empty_string() {
+        assert!(is_meaningful_alsa_pcm(""));
+    }
+
+    // -- FILTER cases (every example from the issue) --
+
+    #[test]
+    fn filters_per_card_sysdefault() {
+        assert!(!is_meaningful_alsa_pcm("sysdefault:CARD=NTUSB"));
+        assert!(!is_meaningful_alsa_pcm("sysdefault:CARD=Generic"));
+    }
+
+    #[test]
+    fn filters_front_stereo_pcm() {
+        assert!(!is_meaningful_alsa_pcm("front:CARD=NTUSB,DEV=0"));
+        assert!(!is_meaningful_alsa_pcm("front:CARD=Generic,DEV=0"));
+    }
+
+    #[test]
+    fn filters_surround_variants() {
+        for variant in [
+            "surround21", "surround40", "surround41", "surround50", "surround51", "surround71",
+        ] {
+            assert!(
+                !is_meaningful_alsa_pcm(&format!("{variant}:CARD=Generic,DEV=0")),
+                "expected {variant} variant to be filtered"
+            );
+        }
+    }
+
+    #[test]
+    fn filters_iec958_and_spdif() {
+        assert!(!is_meaningful_alsa_pcm("iec958:CARD=NTUSB,DEV=0"));
+        assert!(!is_meaningful_alsa_pcm("spdif:CARD=Generic,DEV=1"));
+    }
+
+    #[test]
+    fn filters_raw_hardware_handles() {
+        assert!(!is_meaningful_alsa_pcm("hw:0,0"));
+        assert!(!is_meaningful_alsa_pcm("hw:CARD=NTUSB,DEV=0"));
+        assert!(!is_meaningful_alsa_pcm("plughw:0,0"));
+    }
+
+    #[test]
+    fn filters_software_mixing_nodes() {
+        assert!(!is_meaningful_alsa_pcm("dmix:CARD=NTUSB,DEV=0"));
+        assert!(!is_meaningful_alsa_pcm("dsnoop:CARD=NTUSB,DEV=0"));
+    }
+
+    #[test]
+    fn filters_rear_center_side_pcms() {
+        assert!(!is_meaningful_alsa_pcm("rear:CARD=Generic,DEV=0"));
+        assert!(!is_meaningful_alsa_pcm("center_lfe:CARD=Generic,DEV=0"));
+        assert!(!is_meaningful_alsa_pcm("side:CARD=Generic,DEV=0"));
+    }
+
+    #[test]
+    fn does_not_falsely_filter_lookalike_names() {
+        // Filter uses case-sensitive startsWith, so capital-S "Surrounded"
+        // doesn't match "surround", and "iec958_helper" doesn't match "iec958:".
+        assert!(is_meaningful_alsa_pcm("Surrounded by USB Mics"));
+        assert!(is_meaningful_alsa_pcm("iec958_helper"));
+    }
 }


### PR DESCRIPTION
## Description

Linux device pickers (microphone + speaker) were populated with every ALSA profile permutation per audio card — `sysdefault:CARD=X`, `front:CARD=X,DEV=0`, `surround40:CARD=X,DEV=0`, `surround51:CARD=X,DEV=0`, `surround71:CARD=X,DEV=0`, `iec958:CARD=X,DEV=0`, `hw:`, `plughw:`, `dmix:`, `dsnoop:`, etc. — making them effectively unusable.

Adds `is_meaningful_alsa_pcm(name)` in `audio/devices/platform/linux.rs` with a banned-prefix list for these ALSA noise patterns. **Logical endpoints** (`default`, `pipewire`, `pulse`, top-level `sysdefault`) and **friendly device names** (USB mics, `alsa_input.usb-…` PipeWire nodes, `HDA Intel PCH`, `Built-in Audio Analog Stereo`, etc.) pass through unchanged.

### Before

```
Default Microphone  (✓)
sysdefault
pipewire
default
sysdefault:CARD=NTUSB
front:CARD=NTUSB,DEV=0
surround40:CARD=NTUSB,DEV=0
iec958:CARD=NTUSB,DEV=0
sysdefault:CARD=Generic
front:CARD=Generic,DEV=0
surround40:CARD=Generic,DEV=0
surround51:CARD=Generic,DEV=0
surround71:CARD=Generic,DEV=0
…
```

### After

```
Default Microphone  (✓)
default
pipewire
pulse
sysdefault
<friendly device names per card>
```

## Related Issue

Fixes #437

## Type of Change

- [x] Bug fix

## Applied at two call sites

1. `audio/devices/platform/linux.rs::configure_linux_audio` — filter the inputs loop.
2. `audio/devices/discovery.rs::list_audio_devices` — filter the post-pass over `host.devices()` (`#[cfg(target_os = "linux")]`-gated). Without filtering here, ALSA noise would re-enter the list as fake Output devices.

PulseAudio monitor sources (system audio) still flow through because their names (`alsa_output.…monitor`) don't start with any banned prefix.

## Testing

- [x] **16 Rust unit tests** in `linux.rs`:
  - **KEEP cases** (8): `default`, `pipewire`, `pulse`, top-level `sysdefault`, USB mic names (`Yeti X`, `AT2020USB+`), PipeWire node names (`alsa_input.usb-…`, `alsa_output.…monitor`), built-in audio names (`HDA Intel PCH`, `Built-in Audio Analog Stereo`), empty string, lookalike non-matches (`Surrounded by USB Mics`, `iec958_helper`)
  - **FILTER cases** (8): every ALSA noise example from the issue — per-card `sysdefault:`, `front:`, all `surround*:` variants (21/40/41/50/51/71), `iec958:`, `spdif:`, raw `hw:` and `plughw:`, `dmix:`, `dsnoop:`, `rear:`, `center_lfe:`, `side:`
- [x] **Fork CI passes on macOS + Linux 22.04 + Linux 24.04** (Linux is the platform this fix targets)
- [ ] **Real ALSA enumeration not verified by contributor** — I don't have a Linux machine to verify against actual device enumeration. The filter logic is fully unit-tested against the noise patterns the issue reporter documented. Would appreciate a maintainer or the issue reporter (@Hankanman, with PipeWire + the NTUSB / Generic cards) confirming the picker is now clean in a release build.

## Notes for reviewers

**Filter is case-sensitive prefix-match**, so it won't falsely filter friendly names that happen to start with similar letters (e.g. `Surrounded by USB Mics` is kept because the prefix is lowercase `surround`).

**`sysdefault:` (per-card) is filtered but top-level `sysdefault` is kept.** The per-card variant is redundant with the top-level entry; users only need one.

**Windows CI failure is pre-existing and unrelated.** Same `llama-cpp-sys-2 v0.1.146` / `vulkan-shaders-gen` CMake build issue documented in #441. Not introduced by this PR.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Branch targets `devtest`
- [x] No unrelated changes
