### PR TITLE
fix: re-export __tauri_command_name_* alongside __cmd__ in summary mod.rs (Tauri 2.6 generate_handler! resolution)

### DIFF
--- a/frontend/src-tauri/src/summary/mod.rs
+++ b/frontend/src-tauri/src/summary/mod.rs
@@ -38,16 +38,25 @@ pub mod summary_engine;
 pub mod template_commands;
 pub mod templates;
 
-// Re-export Tauri commands (with their generated __cmd__ variants)
+// Re-export Tauri commands (with their generated __cmd__ AND __tauri_command_name_* variants).
+// The __cmd__ form is the legacy Tauri 1.x macro output; __tauri_command_name_* is what
+// Tauri 2.6+ generate_handler! looks up at the path used in the handler list. Both names
+// are emitted by #[tauri::command] in Tauri 2.x; re-export both so handler resolution works
+// regardless of which form the call site uses.
 pub use commands::{
     __cmd__api_cancel_summary, __cmd__api_get_summary, __cmd__api_process_transcript,
-    __cmd__api_save_meeting_summary, api_cancel_summary, api_get_summary,
+    __cmd__api_save_meeting_summary,
+    __tauri_command_name_api_cancel_summary, __tauri_command_name_api_get_summary,
+    __tauri_command_name_api_process_transcript, __tauri_command_name_api_save_meeting_summary,
+    api_cancel_summary, api_get_summary,
     api_process_transcript, api_save_meeting_summary,
 };
 
 // Re-export template commands
 pub use template_commands::{
     __cmd__api_get_template_details, __cmd__api_list_templates, __cmd__api_validate_template,
+    __tauri_command_name_api_get_template_details, __tauri_command_name_api_list_templates,
+    __tauri_command_name_api_validate_template,
     api_get_template_details, api_list_templates, api_validate_template,
 };
 

--- a/frontend/src-tauri/src/summary/summary_engine/mod.rs
+++ b/frontend/src-tauri/src/summary/summary_engine/mod.rs
@@ -13,7 +13,15 @@ pub use commands::{
     __cmd__builtin_ai_cancel_download, __cmd__builtin_ai_delete_model,
     __cmd__builtin_ai_download_model, __cmd__builtin_ai_get_available_summary_model,
     __cmd__builtin_ai_get_model_info, __cmd__builtin_ai_get_recommended_model, __cmd__builtin_ai_is_model_ready,
-    __cmd__builtin_ai_list_models, builtin_ai_cancel_download, builtin_ai_delete_model, builtin_ai_download_model,
+    __cmd__builtin_ai_list_models,
+    // Tauri 2.6+ generate_handler! looks up __tauri_command_name_<fn> at the path used
+    // in the handler list; re-export those alongside the legacy __cmd__* form so lookup
+    // succeeds from src/lib.rs at `summary_engine::builtin_ai_*`.
+    __tauri_command_name_builtin_ai_cancel_download, __tauri_command_name_builtin_ai_delete_model,
+    __tauri_command_name_builtin_ai_download_model, __tauri_command_name_builtin_ai_get_available_summary_model,
+    __tauri_command_name_builtin_ai_get_model_info, __tauri_command_name_builtin_ai_get_recommended_model,
+    __tauri_command_name_builtin_ai_is_model_ready, __tauri_command_name_builtin_ai_list_models,
+    builtin_ai_cancel_download, builtin_ai_delete_model, builtin_ai_download_model,
     builtin_ai_get_available_summary_model, builtin_ai_get_model_info, builtin_ai_get_recommended_model, builtin_ai_is_model_ready,
     builtin_ai_list_models, init_model_manager, ModelManagerState,
 };


### PR DESCRIPTION
## Summary

- Adds `__tauri_command_name_<fn>` to the existing `pub use commands::{...}` and `pub use template_commands::{...}` re-exports in `src-tauri/src/summary/mod.rs` + `src-tauri/src/summary/summary_engine/mod.rs`
- 20 insertions / 3 deletions across 2 files; purely additive — no behaviour change
- Fixes the 15× `E0433 cannot find __tauri_command_name_<fn> in <module>` build errors seen when running `./build-gpu.sh` on a fresh clone of `91b0c09` (current `main` HEAD / `v0.3.0` tag)

## The bug

Tauri 2.6's `#[tauri::command]` proc-macro emits **two** sibling constants per command function:

- `__cmd__<fn_name>` — legacy Tauri 1.x compat name (per `tauri-macros-2.6.2/src/command/mod.rs:15`)
- `__tauri_command_name_<fn_name>` — what `generate_handler!` looks up in Tauri 2.x (per `tauri-macros-2.6.2/src/command/handler.rs:166` and `command/wrapper.rs:299`)

The existing `pub use commands::{__cmd__api_*, api_*, ...}` re-exports in `summary/mod.rs` only re-export the legacy `__cmd__*` form. The `__tauri_command_name_*` constants stay private to the `commands` submodule.

`src-tauri/src/lib.rs` then calls `tauri::generate_handler![summary::api_process_transcript, summary_engine::builtin_ai_list_models, ...]`, which expands to lookups like `summary::__tauri_command_name_api_process_transcript` — names that don't exist at that path because they were never re-exported.

Result: 15 compile errors on a fresh build, blocking everyone from building the project from current `main`.

## Reproducer

```bash
git clone https://github.com/Zackriya-Solutions/meetily
cd meetily/frontend
pnpm install
./build-gpu.sh
# → 15× error[E0433]: cannot find `__tauri_command_name_<fn>` in `<module>`
# → error: could not compile `meetily` (lib) due to 15 previous errors
```

## The fix

In `summary/mod.rs` and `summary/summary_engine/mod.rs`, extend the existing `pub use commands::{...}` and `pub use template_commands::{...}` lists to include the `__tauri_command_name_<fn>` variant of every re-exported Tauri command.

Diff is mechanical — for each `__cmd__<fn>` already re-exported, add `__tauri_command_name_<fn>` alongside it.

The functions themselves are still annotated `#[tauri::command]` and the proc-macro already emits both constants — this PR only widens the visibility of the new-form constants so `generate_handler!` (which expects them at the same path it uses for the function name) can resolve them.

## Verification

After the fix, `./build-gpu.sh` completes cleanly and produces:
- `target/release/meetily` (77 MB ELF)
- `target/release/bundle/deb/meetily_0.3.0_amd64.deb`
- `target/release/bundle/appimage/meetily_0.3.0_amd64.AppImage`

Tested on:
- `rustc 1.95.0` / `cargo 1.95.0`
- Ubuntu 24.04 LTS x86_64
- `tauri 2.6.2` + `tauri-macros 2.6.2` (resolved from current `Cargo.toml`)

## Test plan

- [x] Fresh clone + `pnpm install` + `./build-gpu.sh` produces binary + bundles without errors
- [x] No behaviour change at runtime (re-exports are purely additive; same constants the proc-macro already emits)
- [ ] Reviewer: confirm fix resolves the 15× E0433 build error on their machine

## Notes

The legacy `__cmd__*` re-exports are kept in place for backward compatibility with any external consumers — this PR is additive, not a rename.

If a wholesale `pub use commands::*;` is preferred over the explicit name list, happy to revise. The explicit form was chosen to match the existing style of these mod.rs files.