### PR TITLE
feat: local HTTP control API for external recording start/stop

### DIFF
--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -111,6 +111,9 @@ tokio = { version = "1.32.0", features = ["full", "tracing"] }
 tokio-util = "0.7"  # Utilities for tokio including CancellationToken
 async-trait = "0.1"  # Trait abstraction for async methods
 
+# Local HTTP control API (127.0.0.1 start/stop endpoints)
+axum = "0.8"
+
 reqwest = { version = "0.11", features = ["blocking", "multipart", "json", "stream"] }
 
 # crossbeam

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -890,6 +890,35 @@ pub async fn stop_recording<R: Runtime>(
     Ok(())
 }
 
+/// Stop recording from a Rust-initiated trigger (tray menu, local API) and notify
+/// the frontend to run post-stop processing (transcription wait, SQLite save, navigation).
+pub async fn stop_recording_and_notify<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
+    // Generate save path (same as RecordingControls.tsx)
+    let data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+
+    let timestamp = chrono::Local::now().format("%Y-%m-%dT%H-%M-%S").to_string();
+    let save_path = data_dir.join(format!("recording-{}.wav", timestamp));
+
+    stop_recording(
+        app.clone(),
+        RecordingArgs {
+            save_path: save_path.to_string_lossy().to_string(),
+        },
+    )
+    .await?;
+
+    // Trigger frontend post-processing via event (works from any page)
+    // (SQLite save, navigation, analytics)
+    if let Err(e) = app.emit("recording-stop-complete", true) {
+        error!("Failed to emit recording-stop-complete event: {}", e);
+    }
+
+    Ok(())
+}
+
 /// Check if recording is active
 pub async fn is_recording() -> bool {
     IS_RECORDING.load(Ordering::SeqCst)

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub mod audio;
 pub mod config;
 pub mod console_utils;
 pub mod database;
+pub mod local_api;
 pub mod notifications;
 pub mod ollama;
 pub mod onboarding;
@@ -409,6 +410,12 @@ pub fn run() {
             if let Err(e) = tray::create_tray(_app.handle()) {
                 log::error!("Failed to create system tray: {}", e);
             }
+
+            // Start local HTTP control API (127.0.0.1 only) for external start/stop
+            let app_for_local_api = _app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                local_api::serve(app_for_local_api).await;
+            });
 
             // Initialize notification system with proper defaults
             log::info!("Initializing notification system...");

--- a/frontend/src-tauri/src/local_api.rs
+++ b/frontend/src-tauri/src/local_api.rs
@@ -1,0 +1,162 @@
+//! Local HTTP control API.
+//!
+//! Lets other local processes start/stop recordings and check recording status.
+//! Bound to 127.0.0.1 only — same trust level as the system tray, which uses the
+//! identical start/stop mechanisms (sessionStorage auto-start flag for start,
+//! `stop_recording_and_notify` for stop).
+//!
+//! Endpoints:
+//! - `GET  /status` → `{"recording": bool}`
+//! - `POST /start`  → body `{"title"?: string, "metadata"?: string}`; metadata is
+//!   injected by the frontend as the first transcript segment of the meeting
+//! - `POST /stop`   → `{"status": "stopped"}`; meeting save runs asynchronously
+//!   in the frontend exactly like a tray-initiated stop
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tauri::{AppHandle, Manager, Wry};
+
+use crate::audio::recording_commands;
+use crate::tray::{set_tray_state, update_tray_menu, RecordingState};
+
+const LOCAL_API_ADDR: &str = "127.0.0.1:5172";
+
+/// How long `/start` waits for the frontend to actually begin recording before
+/// reporting a timeout (model checks and device setup can take a few seconds).
+const START_TIMEOUT_MS: u64 = 15_000;
+const START_POLL_INTERVAL_MS: u64 = 250;
+
+#[derive(Debug, Default, Deserialize)]
+struct StartRequest {
+    /// Optional meeting title (replaces the auto-generated "Meeting DD_MM_YY..." name).
+    title: Option<String>,
+    /// Optional free-form text dropped at the top of the transcript.
+    metadata: Option<String>,
+}
+
+/// Run the local API server. Never returns under normal operation; logs and
+/// exits if the port cannot be bound so the app itself is unaffected.
+pub async fn serve(app: AppHandle<Wry>) {
+    let router = Router::new()
+        .route("/status", get(status_handler))
+        .route("/start", post(start_handler))
+        .route("/stop", post(stop_handler))
+        .with_state(app);
+
+    let listener = match tokio::net::TcpListener::bind(LOCAL_API_ADDR).await {
+        Ok(listener) => listener,
+        Err(e) => {
+            log::error!("Local API: failed to bind {}: {}", LOCAL_API_ADDR, e);
+            return;
+        }
+    };
+
+    log::info!("Local API listening on http://{}", LOCAL_API_ADDR);
+
+    if let Err(e) = axum::serve(listener, router).await {
+        log::error!("Local API server error: {}", e);
+    }
+}
+
+async fn status_handler(State(_app): State<AppHandle<Wry>>) -> Json<Value> {
+    Json(json!({ "recording": recording_commands::is_recording().await }))
+}
+
+async fn start_handler(
+    State(app): State<AppHandle<Wry>>,
+    body: Option<Json<StartRequest>>,
+) -> (StatusCode, Json<Value>) {
+    let request = body.map(|Json(r)| r).unwrap_or_default();
+
+    if recording_commands::is_recording().await {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({ "error": "already recording" })),
+        );
+    }
+
+    let Some(window) = app.get_webview_window("main") else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": "main window not available" })),
+        );
+    };
+
+    set_tray_state(&app, RecordingState::Starting);
+
+    // Stage start parameters for the frontend auto-start flow (same mechanism as
+    // the tray). serde_json::to_string produces a safe JS string literal for the
+    // arbitrary user-provided values.
+    if let Some(title) = &request.title {
+        let _ = window.eval(&format!(
+            "sessionStorage.setItem('externalMeetingTitle', {})",
+            serde_json::to_string(title).expect("string serialization cannot fail")
+        ));
+    }
+    if let Some(metadata) = &request.metadata {
+        let _ = window.eval(&format!(
+            "sessionStorage.setItem('externalMeetingMetadata', {})",
+            serde_json::to_string(metadata).expect("string serialization cannot fail")
+        ));
+    }
+    let _ = window.eval("sessionStorage.setItem('autoStartRecording', 'true')");
+    let _ = window.eval("window.location.assign('/')");
+
+    // Wait for the frontend to actually start recording (it performs model
+    // readiness checks and may legitimately refuse, e.g. no model downloaded).
+    let mut waited_ms = 0;
+    while waited_ms < START_TIMEOUT_MS {
+        tokio::time::sleep(std::time::Duration::from_millis(START_POLL_INTERVAL_MS)).await;
+        waited_ms += START_POLL_INTERVAL_MS;
+
+        if recording_commands::is_recording().await {
+            return (
+                StatusCode::OK,
+                Json(json!({ "status": "recording", "title": request.title })),
+            );
+        }
+    }
+
+    // Resync tray menu since we optimistically set it to "Starting"
+    update_tray_menu(&app);
+
+    (
+        StatusCode::GATEWAY_TIMEOUT,
+        Json(json!({
+            "error": "recording did not start within 15s (transcription model may be missing or downloading)"
+        })),
+    )
+}
+
+async fn stop_handler(State(app): State<AppHandle<Wry>>) -> (StatusCode, Json<Value>) {
+    if !recording_commands::is_recording().await {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({ "error": "not recording" })),
+        );
+    }
+
+    set_tray_state(&app, RecordingState::Stopping);
+
+    match recording_commands::stop_recording_and_notify(app.clone()).await {
+        Ok(_) => {
+            log::info!("Local API: recording stopped successfully");
+            (StatusCode::OK, Json(json!({ "status": "stopped" })))
+        }
+        Err(e) => {
+            log::error!("Local API: failed to stop recording: {}", e);
+            // Revert tray state on error
+            update_tray_menu(&app);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e })),
+            )
+        }
+    }
+}

--- a/frontend/src-tauri/src/summary/mod.rs
+++ b/frontend/src-tauri/src/summary/mod.rs
@@ -38,17 +38,21 @@ pub mod summary_engine;
 pub mod template_commands;
 pub mod templates;
 
-// Re-export Tauri commands (with their generated __cmd__ variants)
+// Re-export Tauri commands (with their generated __cmd__ and __tauri_command_name_ variants)
 pub use commands::{
     __cmd__api_cancel_summary, __cmd__api_get_summary, __cmd__api_process_transcript,
-    __cmd__api_save_meeting_summary, api_cancel_summary, api_get_summary,
+    __cmd__api_save_meeting_summary, __tauri_command_name_api_cancel_summary,
+    __tauri_command_name_api_get_summary, __tauri_command_name_api_process_transcript,
+    __tauri_command_name_api_save_meeting_summary, api_cancel_summary, api_get_summary,
     api_process_transcript, api_save_meeting_summary,
 };
 
 // Re-export template commands
 pub use template_commands::{
     __cmd__api_get_template_details, __cmd__api_list_templates, __cmd__api_validate_template,
-    api_get_template_details, api_list_templates, api_validate_template,
+    __tauri_command_name_api_get_template_details, __tauri_command_name_api_list_templates,
+    __tauri_command_name_api_validate_template, api_get_template_details, api_list_templates,
+    api_validate_template,
 };
 
 // Re-export commonly used items

--- a/frontend/src-tauri/src/summary/summary_engine/mod.rs
+++ b/frontend/src-tauri/src/summary/summary_engine/mod.rs
@@ -13,7 +13,12 @@ pub use commands::{
     __cmd__builtin_ai_cancel_download, __cmd__builtin_ai_delete_model,
     __cmd__builtin_ai_download_model, __cmd__builtin_ai_get_available_summary_model,
     __cmd__builtin_ai_get_model_info, __cmd__builtin_ai_get_recommended_model, __cmd__builtin_ai_is_model_ready,
-    __cmd__builtin_ai_list_models, builtin_ai_cancel_download, builtin_ai_delete_model, builtin_ai_download_model,
+    __cmd__builtin_ai_list_models, __tauri_command_name_builtin_ai_cancel_download,
+    __tauri_command_name_builtin_ai_delete_model, __tauri_command_name_builtin_ai_download_model,
+    __tauri_command_name_builtin_ai_get_available_summary_model, __tauri_command_name_builtin_ai_get_model_info,
+    __tauri_command_name_builtin_ai_get_recommended_model, __tauri_command_name_builtin_ai_is_model_ready,
+    __tauri_command_name_builtin_ai_list_models,
+    builtin_ai_cancel_download, builtin_ai_delete_model, builtin_ai_download_model,
     builtin_ai_get_available_summary_model, builtin_ai_get_model_info, builtin_ai_get_recommended_model, builtin_ai_is_model_ready,
     builtin_ai_list_models, init_model_manager, ModelManagerState,
 };

--- a/frontend/src-tauri/src/tray.rs
+++ b/frontend/src-tauri/src/tray.rs
@@ -1,5 +1,4 @@
 use tauri::{
-    Emitter,
     menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem},
     tray::TrayIconBuilder,
     AppHandle, Manager, Runtime,
@@ -62,38 +61,12 @@ fn toggle_recording_handler<R: Runtime>(app: &AppHandle<R>) {
 
             log::info!("Tray toggle: Stopping recording...");
 
-            // Generate save path (same as RecordingControls.tsx)
-            let data_dir = match app_clone.path().app_data_dir() {
-                Ok(dir) => dir,
-                Err(e) => {
-                    log::error!("Failed to get app data dir: {}", e);
-                    update_tray_menu_async(&app_clone).await;
-                    return;
-                }
-            };
-
-            let timestamp = chrono::Local::now().format("%Y-%m-%dT%H-%M-%S").to_string();
-            let save_path = data_dir.join(format!("recording-{}.wav", timestamp));
-
-            // Call Rust stop_recording command (like pause/resume pattern)
-            let stop_result = crate::audio::recording_commands::stop_recording(
-                app_clone.clone(),
-                crate::audio::recording_commands::RecordingArgs {
-                    save_path: save_path.to_string_lossy().to_string(),
-                },
-            )
-            .await;
-
-            // Handle result
-            match stop_result {
+            // Stop recording and trigger frontend post-processing (shared with local API)
+            match crate::audio::recording_commands::stop_recording_and_notify(app_clone.clone())
+                .await
+            {
                 Ok(_) => {
                     log::info!("Tray toggle: Recording stopped successfully");
-
-                    // Trigger frontend post-processing via event (works from any page)
-                    // (SQLite save, navigation, analytics)
-                    if let Err(e) = app_clone.emit("recording-stop-complete", true) {
-                        log::error!("Tray toggle: Failed to emit recording-stop-complete event: {}", e);
-                    }
                 }
                 Err(e) => {
                     log::error!("Tray toggle: Failed to stop recording: {}", e);
@@ -158,38 +131,10 @@ fn stop_recording_handler<R: Runtime>(app: &AppHandle<R>) {
     tauri::async_runtime::spawn(async move {
         log::info!("Tray: Stopping recording...");
 
-        // Generate save path (same as RecordingControls.tsx)
-        let data_dir = match app_clone.path().app_data_dir() {
-            Ok(dir) => dir,
-            Err(e) => {
-                log::error!("Failed to get app data dir: {}", e);
-                update_tray_menu_async(&app_clone).await;
-                return;
-            }
-        };
-
-        let timestamp = chrono::Local::now().format("%Y-%m-%dT%H-%M-%S").to_string();
-        let save_path = data_dir.join(format!("recording-{}.wav", timestamp));
-
-        // Call Rust stop_recording command (like pause/resume pattern)
-        let stop_result = crate::audio::recording_commands::stop_recording(
-            app_clone.clone(),
-            crate::audio::recording_commands::RecordingArgs {
-                save_path: save_path.to_string_lossy().to_string(),
-            },
-        )
-        .await;
-
-        // Handle result
-        match stop_result {
+        // Stop recording and trigger frontend post-processing (shared with local API)
+        match crate::audio::recording_commands::stop_recording_and_notify(app_clone.clone()).await {
             Ok(_) => {
                 log::info!("Tray: Recording stopped successfully");
-
-                // Trigger frontend post-processing via event (works from any page)
-                // (SQLite save, navigation, analytics)
-                if let Err(e) = app_clone.emit("recording-stop-complete", true) {
-                    log::error!("Tray: Failed to emit recording-stop-complete event: {}", e);
-                }
             }
             Err(e) => {
                 log::error!("Tray: Failed to stop recording: {}", e);

--- a/frontend/src/contexts/TranscriptContext.tsx
+++ b/frontend/src/contexts/TranscriptContext.tsx
@@ -385,7 +385,12 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
             duration: segment.duration,
           }));
 
-          setTranscripts(formattedTranscripts);
+          setTranscripts(prev => {
+            // Preserve synthetic segments (negative sequence_id, e.g. external
+            // metadata injected by the local API) - backend history doesn't contain them
+            const synthetic = prev.filter(t => (t.sequence_id ?? 0) < 0);
+            return [...synthetic, ...formattedTranscripts];
+          });
           console.log('[Reload Sync] ✅ Transcript history synced successfully');
 
           // Fetch meeting name from backend

--- a/frontend/src/hooks/useRecordingStart.ts
+++ b/frontend/src/hooks/useRecordingStart.ts
@@ -32,7 +32,7 @@ export function useRecordingStart(
 ): UseRecordingStartReturn {
   const [isAutoStarting, setIsAutoStarting] = useState(false);
 
-  const { clearTranscripts, setMeetingTitle } = useTranscripts();
+  const { clearTranscripts, setMeetingTitle, addTranscript } = useTranscripts();
   const { setIsMeetingActive } = useSidebar();
   const { selectedDevices } = useConfig();
   const { setStatus } = useRecordingState();
@@ -108,6 +108,9 @@ export function useRecordingStart(
 
       console.log('Parakeet ready - setting up meeting title and state');
 
+      // Manual start: clear any stale external metadata from a failed API start
+      sessionStorage.removeItem('activeMeetingMetadata');
+
       const randomTitle = generateMeetingTitle();
       setMeetingTitle(randomTitle);
 
@@ -153,6 +156,19 @@ export function useRecordingStart(
           setIsAutoStarting(true);
           sessionStorage.removeItem('autoStartRecording'); // Clear the flag
 
+          // External start parameters staged by the local API (see src-tauri/src/local_api.rs)
+          const externalTitle = sessionStorage.getItem('externalMeetingTitle');
+          const externalMetadata = sessionStorage.getItem('externalMeetingMetadata');
+          sessionStorage.removeItem('externalMeetingTitle');
+          sessionStorage.removeItem('externalMeetingMetadata');
+          // Keep metadata under a stable key until save time so it survives page
+          // reloads mid-recording (useRecordingStop prepends it if it's missing)
+          if (externalMetadata) {
+            sessionStorage.setItem('activeMeetingMetadata', externalMetadata);
+          } else {
+            sessionStorage.removeItem('activeMeetingMetadata');
+          }
+
           // Check if Parakeet transcription model is ready before starting
           const parakeetReady = await checkParakeetReady();
           if (!parakeetReady) {
@@ -178,8 +194,8 @@ export function useRecordingStart(
 
           // Start the actual backend recording
           try {
-            // Generate meeting title
-            const generatedMeetingTitle = generateMeetingTitle();
+            // Use externally provided title (local API) or generate one
+            const generatedMeetingTitle = externalTitle || generateMeetingTitle();
 
             // Set STARTING status before initiating backend recording
             setStatus(RecordingStatus.STARTING, 'Initializing recording...');
@@ -197,6 +213,27 @@ export function useRecordingStart(
             setMeetingTitle(generatedMeetingTitle);
             setIsRecording(true);
             clearTranscripts();
+
+            // Drop externally provided metadata at the top of the transcript as a
+            // synthetic segment. It renders first, is saved with the meeting, and is
+            // included in summarization.
+            if (externalMetadata) {
+              addTranscript({
+                text: externalMetadata,
+                timestamp: new Date().toLocaleTimeString(),
+                source: 'metadata',
+                // -1 cannot collide with real segments: Rust sequence_ids start at 0
+                // and TranscriptContext dedupes incoming segments by sequence_id
+                sequence_id: -1,
+                chunk_start_time: -1, // sorts before all real segments
+                is_partial: false,
+                confidence: 1,
+                audio_start_time: 0,
+                audio_end_time: 0,
+                duration: 0,
+              });
+            }
+
             setIsMeetingActive(true);
             Analytics.trackButtonClick('start_recording', 'sidebar_auto');
 
@@ -223,6 +260,7 @@ export function useRecordingStart(
     setMeetingTitle,
     setIsRecording,
     clearTranscripts,
+    addTranscript,
     setIsMeetingActive,
     checkParakeetReady,
     checkIfModelDownloading,
@@ -265,6 +303,9 @@ export function useRecordingStart(
       }
 
       try {
+        // Sidebar start: clear any stale external metadata from a failed API start
+        sessionStorage.removeItem('activeMeetingMetadata');
+
         // Generate meeting title
         const generatedMeetingTitle = generateMeetingTitle();
 

--- a/frontend/src/hooks/useRecordingStop.ts
+++ b/frontend/src/hooks/useRecordingStop.ts
@@ -236,6 +236,24 @@ export function useRecordingStop(
         // Get fresh transcript state (ALL transcripts including late ones)
         const freshTranscripts = [...transcriptsRef.current];
 
+        // Ensure externally provided metadata (local API start) is the first saved
+        // segment, even if the live injected segment was lost to a state resync
+        const externalMetadata = sessionStorage.getItem('activeMeetingMetadata');
+        if (externalMetadata && freshTranscripts[0]?.sequence_id !== -1) {
+          freshTranscripts.unshift({
+            id: 'external-metadata',
+            text: externalMetadata,
+            timestamp: new Date().toLocaleTimeString('en-GB', { hour12: false }),
+            sequence_id: -1,
+            chunk_start_time: -1,
+            is_partial: false,
+            confidence: 1,
+            audio_start_time: 0,
+            audio_end_time: 0,
+            duration: 0,
+          });
+        }
+
         // Get folder_path and meeting_name from recording-stopped event
         const folderPath = sessionStorage.getItem('last_recording_folder_path');
         const savedMeetingName = sessionStorage.getItem('last_recording_meeting_name');
@@ -271,6 +289,7 @@ export function useRecordingStop(
           // Clean up session storage
           sessionStorage.removeItem('last_recording_folder_path');
           sessionStorage.removeItem('last_recording_meeting_name');
+          sessionStorage.removeItem('activeMeetingMetadata');
           // Clean up IndexedDB meeting ID (redundant with markMeetingAsSaved cleanup, but ensures cleanup)
           sessionStorage.removeItem('indexeddb_current_meeting_id');
 

--- a/frontend/src/services/recordingService.ts
+++ b/frontend/src/services/recordingService.ts
@@ -71,10 +71,13 @@ export class RecordingService {
     systemDeviceName: string | null,
     meetingName: string
   ): Promise<void> {
+    // NOTE: Tauri v2 expects camelCase argument keys for snake_case Rust params.
+    // Snake_case keys were silently deserialized as None, dropping the selected
+    // devices and meeting name on every recording start.
     return invoke('start_recording_with_devices_and_meeting', {
-      mic_device_name: micDeviceName,
-      system_device_name: systemDeviceName,
-      meeting_name: meetingName
+      micDeviceName,
+      systemDeviceName,
+      meetingName
     });
   }
 


### PR DESCRIPTION
## What

Adds a **localhost-only HTTP control API** (`127.0.0.1:5172`) inside the Tauri app so other local processes (scripts, Raycast, window managers, automations) can control recordings:

| Endpoint | Description |
|---|---|
| `GET /status` | `{"recording": bool}` |
| `POST /start` | Body `{"title"?: string, "metadata"?: string}` — starts a recording. Optional custom meeting title; optional free-form metadata block that is saved as the **first transcript segment** (top of the meeting, included in summarization). Returns `200` once recording actually starts, `409` if already recording, `504` if the frontend refuses (e.g. no transcription model). |
| `POST /stop` | Stops the recording and runs the normal save flow (transcription flush → SQLite save → navigation). `409` if not recording. |

Example:

```bash
curl -X POST http://127.0.0.1:5172/start \
  -H 'content-type: application/json' \
  -d '{"title": "Standup", "metadata": "Attendees: Ryan, Alice\nTicket: ENG-123"}'

curl -X POST http://127.0.0.1:5172/stop
```

## How

The API deliberately reuses the existing tray mechanisms rather than inventing a new path:

- **Start** stages parameters in `sessionStorage` and triggers the same auto-start flow the tray uses (`useRecordingStart`), so model checks, device selection, meeting state, and save flow behave exactly like a button click.
- **Stop** uses a new shared `recording_commands::stop_recording_and_notify()` helper — both tray handlers were duplicating ~30 lines of this logic and now call the same helper.
- Metadata is injected as a synthetic transcript segment (`sequence_id: -1`, sorts before all real segments) both live and at save time, so it survives mid-recording page reloads and state resyncs.
- Server is `axum` on the existing tokio runtime, bound to `127.0.0.1` only (same trust level as the tray). Bind failure logs and degrades gracefully.

## Pre-existing bugs fixed along the way

1. **Selected devices and meeting name were silently dropped on every recording start**: `recordingService.startRecordingWithDevices` passed snake_case arg keys (`mic_device_name`, `meeting_name`) to a Tauri v2 command expecting camelCase, so Rust always received `None` (log: `Mic: None, System: None, Meeting: None`) and every meeting got the default `Meeting YYYY-MM-DD…` title regardless of the UI-generated one.
2. **Clean builds of `main` fail with the committed Cargo.lock** (tauri 2.11.2): `generate_handler!` requires the generated `__tauri_command_name_*` macros, but `summary/mod.rs` and `summary_engine/mod.rs` re-exported only the old `__cmd__*` ones → 15 × `E0433`. Added the missing re-exports.

## Testing

Verified end-to-end on macOS (Apple Silicon, dev build):

- `GET /status` → `{"recording":false}` / `{"recording":true}` ✅
- `POST /start` with title + metadata → app navigates home, recording starts, `200 {"status":"recording","title":"API Test Round 2"}`; Rust log confirms `Meeting: Some("API Test Round 2")` ✅
- `POST /start` while recording → `409` ✅ ; `POST /stop` while idle → `409` ✅
- Spoke during recording, then `POST /stop` → normal save flow; SQLite shows the meeting titled `API Test Round 2` with the metadata block as the first segment (`audio_start_time = 0`) followed by the real transcribed speech ✅
- `cargo check` and `tsc --noEmit` clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)