### PR TITLE
ui: clarify ScreenCaptureKit as coming soon instead of silently disabled

### DIFF
--- a/frontend/src/components/AudioBackendSelector.tsx
+++ b/frontend/src/components/AudioBackendSelector.tsx
@@ -129,7 +129,8 @@ export function AudioBackendSelector({
 
       <div className="space-y-2">
         {backends.map((backend) => {
-          const isDisabled = disabled;
+          const isComingSoon = backend.id === 'screencapturekit';
+          const isDisabled = disabled || isComingSoon;
 
           return (
             <label
@@ -157,6 +158,11 @@ export function AudioBackendSelector({
                   {currentBackend === backend.id && (
                     <span className="text-xs font-medium text-blue-600 bg-blue-100 px-2 py-0.5 rounded">
                       Active
+                    </span>
+                  )}
+                  {isComingSoon && (
+                    <span title="This backend is under development and will be available in a future release." className="text-xs font-medium text-amber-600 bg-amber-50 border border-amber-200 px-2 py-0.5 rounded cursor-help">
+                      Coming soon
                     </span>
                   )}
                 </div>

--- a/frontend/src/components/AudioBackendSelector.tsx
+++ b/frontend/src/components/AudioBackendSelector.tsx
@@ -129,9 +129,7 @@ export function AudioBackendSelector({
 
       <div className="space-y-2">
         {backends.map((backend) => {
-          // Disable Core Audio option
-          const isCoreAudio = backend.id === 'screencapturekit';
-          const isDisabled = disabled || isCoreAudio;
+          const isDisabled = disabled;
 
           return (
             <label
@@ -159,11 +157,6 @@ export function AudioBackendSelector({
                   {currentBackend === backend.id && (
                     <span className="text-xs font-medium text-blue-600 bg-blue-100 px-2 py-0.5 rounded">
                       Active
-                    </span>
-                  )}
-                  {isCoreAudio && (
-                    <span className="text-xs font-medium text-gray-500 bg-gray-100 px-2 py-0.5 rounded">
-                      Disabled
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
## Summary

- Replaces the silent `Disabled` badge on ScreenCaptureKit with a `Coming soon` badge in amber
- Adds a tooltip explaining the option is under development and not yet available
- No functional change — ScreenCaptureKit remains disabled until the backend is fully implemented

This follows feedback from @sujithatzackriya confirming that ScreenCaptureKit is intentionally disabled due to instability and incomplete backend implementation.

## Test plan

- [ ] Open Settings → Audio Devices → System Audio Backend
- [ ] Verify ScreenCaptureKit shows a "Coming soon" badge instead of "Disabled"
- [ ] Verify hovering the badge shows the tooltip: "This backend is under development and will be available in a future release."
- [ ] Verify Core Audio remains selectable and active by default

Fixes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)