### PR TITLE
feat(transcript): export meeting transcript as TXT and WebVTT

### DIFF
--- a/frontend/src-tauri/src/api/api.rs
+++ b/frontend/src-tauri/src/api/api.rs
@@ -1074,6 +1074,66 @@ pub async fn open_meeting_folder<R: Runtime>(
     }
 }
 
+/// Open a native "Save As" dialog and write the provided text to the chosen file.
+///
+/// Used to export meeting transcripts as plain text (.txt) or WebVTT (.vtt).
+/// The transcript content is formatted on the frontend and passed in here so the
+/// formatting logic stays shared with the existing "Copy transcript" feature.
+///
+/// Returns the saved file path, or `None` if the user cancelled the dialog.
+#[tauri::command]
+pub async fn export_transcript_file<R: Runtime>(
+    app: AppHandle<R>,
+    default_file_name: String,
+    content: String,
+    extension: String,
+) -> Result<Option<String>, String> {
+    use tauri_plugin_dialog::DialogExt;
+
+    log_info!(
+        "export_transcript_file called (name: {}, ext: {}, {} bytes)",
+        default_file_name,
+        extension,
+        content.len()
+    );
+
+    let (filter_name, ext) = match extension.as_str() {
+        "vtt" => ("WebVTT Subtitles", "vtt"),
+        _ => ("Text File", "txt"),
+    };
+
+    // Show the dialog on a blocking thread to avoid stalling the async runtime.
+    let app_clone = app.clone();
+    let default_name = default_file_name.clone();
+    let file_path = tokio::task::spawn_blocking(move || {
+        app_clone
+            .dialog()
+            .file()
+            .add_filter(filter_name, &[ext])
+            .set_file_name(&default_name)
+            .blocking_save_file()
+    })
+    .await
+    .map_err(|e| format!("File dialog task failed: {}", e))?;
+
+    match file_path {
+        Some(path) => {
+            let path_buf = path
+                .into_path()
+                .map_err(|e| format!("Invalid save path: {}", e))?;
+            std::fs::write(&path_buf, content)
+                .map_err(|e| format!("Failed to write transcript file: {}", e))?;
+            let path_str = path_buf.to_string_lossy().to_string();
+            log_info!("Transcript exported to: {}", path_str);
+            Ok(Some(path_str))
+        }
+        None => {
+            log_info!("User cancelled transcript export");
+            Ok(None)
+        }
+    }
+}
+
 // Simple test command to check backend connectivity
 #[tauri::command]
 pub async fn test_backend_connection<R: Runtime>(

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -650,6 +650,7 @@ pub fn run() {
             api::api_save_meeting_title,
             api::api_save_transcript,
             api::open_meeting_folder,
+            api::export_transcript_file,
             api::test_backend_connection,
             api::debug_backend_connection,
             api::open_external_url,

--- a/frontend/src/app/meeting-details/page-content.tsx
+++ b/frontend/src/app/meeting-details/page-content.tsx
@@ -176,6 +176,7 @@ export default function PageContent({
           customPrompt={customPrompt}
           onPromptChange={setCustomPrompt}
           onCopyTranscript={copyOperations.handleCopyTranscript}
+          onExportTranscript={copyOperations.handleExportTranscript}
           onOpenMeetingFolder={meetingOperations.handleOpenMeetingFolder}
           isRecording={isRecording}
           disableAutoScroll={true}

--- a/frontend/src/components/MeetingDetails/TranscriptButtonGroup.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptButtonGroup.tsx
@@ -3,15 +3,23 @@
 import { useState, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
-import { Copy, FolderOpen, RefreshCw } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Copy, FolderOpen, RefreshCw, Download } from 'lucide-react';
 import Analytics from '@/lib/analytics';
 import { RetranscribeDialog } from './RetranscribeDialog';
 import { useConfig } from '@/contexts/ConfigContext';
+import { TranscriptExportFormat } from '@/lib/transcriptExport';
 
 
 interface TranscriptButtonGroupProps {
   transcriptCount: number;
   onCopyTranscript: () => void;
+  onExportTranscript: (format: TranscriptExportFormat) => void;
   onOpenMeetingFolder: () => Promise<void>;
   meetingId?: string;
   meetingFolderPath?: string | null;
@@ -22,6 +30,7 @@ interface TranscriptButtonGroupProps {
 export function TranscriptButtonGroup({
   transcriptCount,
   onCopyTranscript,
+  onExportTranscript,
   onOpenMeetingFolder,
   meetingId,
   meetingFolderPath,
@@ -53,6 +62,28 @@ export function TranscriptButtonGroup({
           <Copy />
           <span className="hidden lg:inline">Copy</span>
         </Button>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={transcriptCount === 0}
+              title={transcriptCount === 0 ? 'No transcript available' : 'Export Transcript'}
+            >
+              <Download />
+              <span className="hidden lg:inline">Export</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            <DropdownMenuItem onClick={() => onExportTranscript('txt')}>
+              Plain text (.txt)
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onExportTranscript('vtt')}>
+              Subtitles with timestamps (.vtt)
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
 
         <Button
           size="sm"

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -4,6 +4,7 @@ import { Transcript, TranscriptSegmentData } from '@/types';
 import { TranscriptView } from '@/components/TranscriptView';
 import { VirtualizedTranscriptView } from '@/components/VirtualizedTranscriptView';
 import { TranscriptButtonGroup } from './TranscriptButtonGroup';
+import { TranscriptExportFormat } from '@/lib/transcriptExport';
 import { useMemo } from 'react';
 
 interface TranscriptPanelProps {
@@ -11,6 +12,7 @@ interface TranscriptPanelProps {
   customPrompt: string;
   onPromptChange: (value: string) => void;
   onCopyTranscript: () => void;
+  onExportTranscript: (format: TranscriptExportFormat) => void;
   onOpenMeetingFolder: () => Promise<void>;
   isRecording: boolean;
   disableAutoScroll?: boolean;
@@ -35,6 +37,7 @@ export function TranscriptPanel({
   customPrompt,
   onPromptChange,
   onCopyTranscript,
+  onExportTranscript,
   onOpenMeetingFolder,
   isRecording,
   disableAutoScroll = false,
@@ -71,6 +74,7 @@ export function TranscriptPanel({
         <TranscriptButtonGroup
           transcriptCount={usePagination ? (totalCount ?? convertedSegments.length) : (transcripts?.length || 0)}
           onCopyTranscript={onCopyTranscript}
+          onExportTranscript={onExportTranscript}
           onOpenMeetingFolder={onOpenMeetingFolder}
           meetingId={meetingId}
           meetingFolderPath={meetingFolderPath}

--- a/frontend/src/hooks/meeting-details/useCopyOperations.ts
+++ b/frontend/src/hooks/meeting-details/useCopyOperations.ts
@@ -4,6 +4,12 @@ import { BlockNoteSummaryViewRef } from '@/components/AISummary/BlockNoteSummary
 import { toast } from 'sonner';
 import Analytics from '@/lib/analytics';
 import { invoke as invokeTauri } from '@tauri-apps/api/core';
+import {
+  TranscriptExportFormat,
+  formatTranscriptTxt,
+  formatTranscriptVtt,
+  buildExportFileName,
+} from '@/lib/transcriptExport';
 
 interface UseCopyOperationsProps {
   meeting: any;
@@ -104,6 +110,52 @@ export function useCopyOperations({
     });
   }, [meeting, meetingTitle, fetchAllTranscripts]);
 
+  // Export transcript to a file (.txt or .vtt) via a native "Save As" dialog
+  const handleExportTranscript = useCallback(async (format: TranscriptExportFormat) => {
+    const allTranscripts = await fetchAllTranscripts(meeting.id);
+
+    if (!allTranscripts.length) {
+      toast.error('No transcripts available to export');
+      return;
+    }
+
+    const title = meetingTitle ?? meeting.title ?? 'Transcript';
+    const content =
+      format === 'vtt'
+        ? formatTranscriptVtt(allTranscripts)
+        : formatTranscriptTxt(allTranscripts, title, meeting.created_at);
+
+    try {
+      const savedPath = await invokeTauri<string | null>('export_transcript_file', {
+        defaultFileName: `${buildExportFileName(title)}.${format}`,
+        content,
+        extension: format,
+      });
+
+      if (!savedPath) {
+        // User cancelled the save dialog
+        return;
+      }
+
+      toast.success(`Transcript exported as ${format.toUpperCase()}`);
+
+      const wordCount = allTranscripts
+        .map(t => t.text.split(/\s+/).length)
+        .reduce((a, b) => a + b, 0);
+
+      await Analytics.trackButtonClick(`export_transcript_${format}`, 'meeting_details');
+      await Analytics.trackCopy('transcript', {
+        meeting_id: meeting.id,
+        transcript_length: allTranscripts.length.toString(),
+        word_count: wordCount.toString(),
+        export_format: format,
+      });
+    } catch (error) {
+      console.error('❌ Failed to export transcript:', error);
+      toast.error('Failed to export transcript');
+    }
+  }, [meeting, meetingTitle, fetchAllTranscripts]);
+
   // Copy summary to clipboard
   const handleCopySummary = useCallback(async () => {
     try {
@@ -191,6 +243,7 @@ export function useCopyOperations({
 
   return {
     handleCopyTranscript,
+    handleExportTranscript,
     handleCopySummary,
   };
 }

--- a/frontend/src/lib/transcriptExport.ts
+++ b/frontend/src/lib/transcriptExport.ts
@@ -1,0 +1,106 @@
+import { Transcript } from '@/types';
+
+export type TranscriptExportFormat = 'txt' | 'vtt';
+
+/**
+ * Format a recording-relative offset (in seconds) as `MM:SS`, used for the
+ * plain-text export. Mirrors the timestamp style of the "Copy transcript" feature.
+ */
+function formatClockTime(seconds: number): string {
+  const totalSecs = Math.max(0, Math.floor(seconds));
+  const mins = Math.floor(totalSecs / 60);
+  const secs = totalSecs % 60;
+  return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Format a recording-relative offset (in seconds) as a WebVTT timestamp
+ * (`HH:MM:SS.mmm`).
+ */
+function formatVttTime(seconds: number): string {
+  const safe = Math.max(0, seconds);
+  const totalMs = Math.round(safe * 1000);
+  const ms = totalMs % 1000;
+  const totalSecs = Math.floor(totalMs / 1000);
+  const secs = totalSecs % 60;
+  const mins = Math.floor(totalSecs / 60) % 60;
+  const hrs = Math.floor(totalSecs / 3600);
+  return (
+    `${hrs.toString().padStart(2, '0')}:` +
+    `${mins.toString().padStart(2, '0')}:` +
+    `${secs.toString().padStart(2, '0')}.` +
+    `${ms.toString().padStart(3, '0')}`
+  );
+}
+
+/**
+ * Plain-text export: a readable transcript with a title header and
+ * recording-relative `[MM:SS]` timestamps when available.
+ */
+export function formatTranscriptTxt(
+  transcripts: Transcript[],
+  meetingTitle: string,
+  createdAt?: string,
+): string {
+  const header = `Transcript: ${meetingTitle}`;
+  const dateLine = createdAt
+    ? `Date: ${new Date(createdAt).toLocaleString()}`
+    : '';
+  const divider = '='.repeat(Math.max(header.length, 12));
+
+  const body = transcripts
+    .map((t) => {
+      const stamp =
+        t.audio_start_time !== undefined
+          ? `[${formatClockTime(t.audio_start_time)}] `
+          : t.timestamp
+            ? `[${t.timestamp}] `
+            : '';
+      return `${stamp}${t.text.trim()}`;
+    })
+    .join('\n');
+
+  return [header, dateLine, divider, '', body, ''].filter((l) => l !== null).join('\n');
+}
+
+/**
+ * WebVTT export: timed cues suitable for use as subtitles/captions.
+ *
+ * Cue boundaries use the recording-relative `audio_start_time` /
+ * `audio_end_time`. When an end time is missing we fall back to the next
+ * segment's start; legacy segments without any offset are placed sequentially
+ * so the file stays valid.
+ */
+export function formatTranscriptVtt(transcripts: Transcript[]): string {
+  const lines: string[] = ['WEBVTT', ''];
+  let cursor = 0; // fallback running clock for legacy segments
+
+  transcripts.forEach((t, i) => {
+    const start = t.audio_start_time ?? cursor;
+    const next = transcripts[i + 1];
+    let end = t.audio_end_time ?? next?.audio_start_time ?? start + 2;
+    // A cue must have a strictly positive duration.
+    if (end <= start) {
+      end = start + 2;
+    }
+    cursor = end;
+
+    lines.push(`${formatVttTime(start)} --> ${formatVttTime(end)}`);
+    lines.push(t.text.trim());
+    lines.push('');
+  });
+
+  return lines.join('\n');
+}
+
+/**
+ * Build a filesystem-safe default filename (without extension) from the meeting title.
+ */
+export function buildExportFileName(meetingTitle: string): string {
+  const base = (meetingTitle || 'transcript')
+    .trim()
+    .replace(/[^a-z0-9\-_ ]/gi, '')
+    .replace(/\s+/g, '_')
+    .slice(0, 80);
+  return base || 'transcript';
+}


### PR DESCRIPTION
## Description

Adds an **Export** option to the meeting transcript panel, letting users save a
meeting's full transcript to disk without first generating a summary.

Two formats are supported:
- **Plain text (`.txt`)** — readable transcript with a title header and
  recording-relative `[MM:SS]` timestamps.
- **WebVTT (`.vtt`)** — timed subtitle cues (`HH:MM:SS.mmm`) suitable for use as
  captions, built from each segment's `audio_start_time` / `audio_end_time`.

The Export button sits next to the existing Copy button and opens a native
"Save As" dialog. Transcript text is fetched with the same
fetch-all-transcripts logic used by "Copy transcript", formatted on the
frontend, and written to the chosen path by a new Tauri command.

### Implementation notes
- New Tauri command `export_transcript_file` (`api.rs`) opens the save dialog
  (via `tauri-plugin-dialog`) and writes the file; returns the saved path, or
  `None` if the user cancels.
- Formatting lives in `lib/transcriptExport.ts` as pure functions, keeping the
  logic shared and easy to reason about.
- Legacy segments without `audio_start_time` fall back gracefully so the `.vtt`
  output stays valid.

## Related Issue

Fixes #441

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] Manual testing — exported a meeting transcript to `.txt` and verified
      header + `[MM:SS]` timestamps.
- [x] Manual testing — exported to `.vtt` and confirmed it loads as valid
      captions with correctly ordered cues.
- [x] Verified the "Save As" cancel path produces no file and no error toast.

> No unit tests added: the frontend has no test runner/existing test suite, so
> this matches the current project setup and relies on manual testing.

## Documentation

- [x] N/A — no user-facing docs/README changes required.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code where needed, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (N/A)
