### PR TITLE
Allow changing the default recordings save location

### DIFF
--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 use super::audio_processing::create_meeting_folder;
 use super::common::{create_transcript_segments, split_segment_at_silence, write_transcripts_json};
 use super::constants::AUDIO_EXTENSIONS;
-use super::recording_preferences::get_default_recordings_folder;
+use super::recording_preferences::get_recordings_save_folder;
 
 /// Global flag to track if import is in progress
 static IMPORT_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
@@ -339,7 +339,7 @@ async fn run_import<R: Runtime>(
     }
 
     // Create meeting folder
-    let base_folder = get_default_recordings_folder();
+    let base_folder = get_recordings_save_folder(&app).await;
     let meeting_folder = create_meeting_folder(&base_folder, &title, false)?;
 
     // Copy audio file to meeting folder

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -112,17 +112,27 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
     // Create new recording manager
     let mut manager = RecordingManager::new();
 
-    // Load recording preferences to get auto_save AND device preferences
-    let (auto_save, preferred_mic_name, preferred_system_name) =
+    // Load recording preferences to get auto_save, save folder, and device preferences
+    let (auto_save, save_folder, preferred_mic_name, preferred_system_name) =
         match super::recording_preferences::load_recording_preferences(&app).await {
             Ok(prefs) => {
-                info!("📋 Loaded recording preferences: auto_save={}, preferred_mic={:?}, preferred_system={:?}",
-                      prefs.auto_save, prefs.preferred_mic_device, prefs.preferred_system_device);
-                (prefs.auto_save, prefs.preferred_mic_device, prefs.preferred_system_device)
+                info!("📋 Loaded recording preferences: auto_save={}, save_folder={:?}, preferred_mic={:?}, preferred_system={:?}",
+                      prefs.auto_save, prefs.save_folder, prefs.preferred_mic_device, prefs.preferred_system_device);
+                (
+                    prefs.auto_save,
+                    prefs.save_folder,
+                    prefs.preferred_mic_device,
+                    prefs.preferred_system_device,
+                )
             }
             Err(e) => {
                 warn!("Failed to load recording preferences, using defaults: {}", e);
-                (true, None, None)
+                (
+                    true,
+                    super::recording_preferences::get_default_recordings_folder(),
+                    None,
+                    None,
+                )
             }
         };
 
@@ -225,6 +235,7 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
         )
     });
     manager.set_meeting_name(Some(effective_meeting_name));
+    manager.set_save_folder(save_folder);
 
     // Set up error callback
     let app_for_error = app.clone();
@@ -375,17 +386,27 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
     // Create new recording manager
     let mut manager = RecordingManager::new();
 
-    // Load recording preferences to check auto_save setting
-    let auto_save = match super::recording_preferences::load_recording_preferences(&app).await {
-        Ok(prefs) => {
-            info!("📋 Loaded recording preferences: auto_save={}", prefs.auto_save);
-            prefs.auto_save
-        }
-        Err(e) => {
-            warn!("Failed to load recording preferences, defaulting to auto_save=true: {}", e);
-            true // Default to saving if preferences can't be loaded
-        }
-    };
+    // Load recording preferences to check auto_save setting and save folder
+    let (auto_save, save_folder) =
+        match super::recording_preferences::load_recording_preferences(&app).await {
+            Ok(prefs) => {
+                info!(
+                    "📋 Loaded recording preferences: auto_save={}, save_folder={:?}",
+                    prefs.auto_save, prefs.save_folder
+                );
+                (prefs.auto_save, prefs.save_folder)
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to load recording preferences, defaulting to auto_save=true: {}",
+                    e
+                );
+                (
+                    true,
+                    super::recording_preferences::get_default_recordings_folder(),
+                )
+            }
+        };
 
     // Always ensure a meeting name is set so incremental saver initializes
     let effective_meeting_name = meeting_name.clone().unwrap_or_else(|| {
@@ -396,6 +417,7 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
         )
     });
     manager.set_meeting_name(Some(effective_meeting_name));
+    manager.set_save_folder(save_folder);
 
     // Set up error callback
     let app_for_error = app.clone();

--- a/frontend/src-tauri/src/audio/recording_manager.rs
+++ b/frontend/src-tauri/src/audio/recording_manager.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::path::PathBuf;
 use tokio::sync::mpsc;
 use anyhow::Result;
 use log::{debug, error, info, warn};
@@ -432,6 +433,11 @@ impl RecordingManager {
     /// Set the meeting name for this recording session
     pub fn set_meeting_name(&mut self, name: Option<String>) {
         self.recording_saver.set_meeting_name(name);
+    }
+
+    /// Set the base folder where meeting recordings are stored.
+    pub fn set_save_folder(&mut self, folder: PathBuf) {
+        self.recording_saver.set_save_folder(folder);
     }
 
     /// Add a structured transcript segment to be saved later

--- a/frontend/src-tauri/src/audio/recording_preferences.rs
+++ b/frontend/src-tauri/src/audio/recording_preferences.rs
@@ -2,6 +2,7 @@ use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tauri::{AppHandle, Runtime};
+use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_store::StoreExt;
 
 use anyhow::Result;
@@ -259,13 +260,36 @@ pub async fn open_recordings_folder<R: Runtime>(app: AppHandle<R>) -> Result<(),
 
 #[tauri::command]
 pub async fn select_recording_folder<R: Runtime>(
-    _app: AppHandle<R>,
+    app: AppHandle<R>,
 ) -> Result<Option<String>, String> {
-    // Use Tauri's dialog to select folder
-    // For now, return None - this would need to be implemented with tauri-plugin-dialog
-    // when it's available in the Cargo.toml
-    warn!("Folder selection not yet implemented - using dialog plugin");
-    Ok(None)
+    let current_folder = load_recording_preferences(&app)
+        .await
+        .map(|prefs| prefs.save_folder)
+        .unwrap_or_else(|_| get_default_recordings_folder());
+
+    let app_clone = app.clone();
+    let folder_path = tokio::task::spawn_blocking(move || {
+        app_clone
+            .dialog()
+            .file()
+            .set_title("Select Recordings Folder")
+            .set_directory(&current_folder)
+            .blocking_pick_folder()
+    })
+    .await
+    .map_err(|e| format!("Folder dialog task failed: {}", e))?;
+
+    match folder_path {
+        Some(path) => {
+            let path_str = path.to_string();
+            info!("User selected recordings folder: {}", path_str);
+            Ok(Some(path_str))
+        }
+        None => {
+            info!("User cancelled folder selection");
+            Ok(None)
+        }
+    }
 }
 
 // Backend selection commands

--- a/frontend/src-tauri/src/audio/recording_preferences.rs
+++ b/frontend/src-tauri/src/audio/recording_preferences.rs
@@ -76,6 +76,20 @@ pub fn get_default_recordings_folder() -> PathBuf {
     }
 }
 
+/// Resolve the folder where recordings should be saved.
+pub async fn get_recordings_save_folder<R: Runtime>(app: &AppHandle<R>) -> PathBuf {
+    match load_recording_preferences(app).await {
+        Ok(prefs) => prefs.save_folder,
+        Err(e) => {
+            warn!(
+                "Failed to load recording preferences for save folder, using default: {}",
+                e
+            );
+            get_default_recordings_folder()
+        }
+    }
+}
+
 /// Ensure the recordings directory exists
 pub fn ensure_recordings_directory(path: &PathBuf) -> Result<()> {
     if !path.exists() {

--- a/frontend/src-tauri/src/audio/recording_saver.rs
+++ b/frontend/src-tauri/src/audio/recording_saver.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc;
 use serde::{Serialize, Deserialize};
 use std::path::PathBuf;
 
+use super::recording_preferences::get_default_recordings_folder;
 use super::recording_state::AudioChunk;
 use super::audio_processing::create_meeting_folder;
 use super::incremental_saver::IncrementalAudioSaver;
@@ -51,6 +52,7 @@ pub struct RecordingSaver {
     incremental_saver: Option<Arc<AsyncMutex<IncrementalAudioSaver>>>,
     meeting_folder: Option<PathBuf>,
     meeting_name: Option<String>,
+    base_save_folder: Option<PathBuf>,
     metadata: Option<MeetingMetadata>,
     transcript_segments: Arc<Mutex<Vec<TranscriptSegment>>>,
     chunk_receiver: Option<mpsc::UnboundedReceiver<AudioChunk>>,
@@ -63,11 +65,17 @@ impl RecordingSaver {
             incremental_saver: None,
             meeting_folder: None,
             meeting_name: None,
+            base_save_folder: None,
             metadata: None,
             transcript_segments: Arc::new(Mutex::new(Vec::new())),
             chunk_receiver: None,
             is_saving: Arc::new(Mutex::new(false)),
         }
+    }
+
+    /// Set the base folder where meeting recordings are stored.
+    pub fn set_save_folder(&mut self, folder: PathBuf) {
+        self.base_save_folder = Some(folder);
     }
 
     /// Set the meeting name for this recording session
@@ -228,8 +236,10 @@ impl RecordingSaver {
     /// * `meeting_name` - Name of the meeting
     /// * `create_checkpoints` - Whether to create .checkpoints/ directory and IncrementalAudioSaver
     fn initialize_meeting_folder(&mut self, meeting_name: &str, create_checkpoints: bool) -> Result<()> {
-        // Load preferences to get base recordings folder
-        let base_folder = super::recording_preferences::get_default_recordings_folder();
+        let base_folder = self
+            .base_save_folder
+            .clone()
+            .unwrap_or_else(get_default_recordings_folder);
 
         // Create meeting folder structure (with or without .checkpoints/ subdirectory)
         let meeting_folder = create_meeting_folder(&base_folder, meeting_name, create_checkpoints)?;

--- a/frontend/src/components/PreferenceSettings.tsx
+++ b/frontend/src/components/PreferenceSettings.tsx
@@ -14,6 +14,7 @@ export function PreferenceSettings() {
     storageLocations,
     isLoadingPreferences,
     loadPreferences,
+    refreshRecordingsStorageLocation,
     updateNotificationSettings
   } = useConfig();
 
@@ -25,9 +26,10 @@ export function PreferenceSettings() {
   // Lazy load preferences on mount (only loads if not already cached)
   useEffect(() => {
     loadPreferences();
+    refreshRecordingsStorageLocation();
     // Reset tracking ref on mount (every tab visit)
     hasTrackedViewRef.current = false;
-  }, [loadPreferences]);
+  }, [loadPreferences, refreshRecordingsStorageLocation]);
 
   // Track preferences viewed analytics on every tab visit (once per mount)
   useEffect(() => {

--- a/frontend/src/components/RecordingSettings.tsx
+++ b/frontend/src/components/RecordingSettings.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Switch } from '@/components/ui/switch';
-import { FolderOpen } from 'lucide-react';
+import { FolderOpen, FolderInput } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { DeviceSelection, SelectedDevices } from '@/components/DeviceSelection';
 import Analytics from '@/lib/analytics';
@@ -101,6 +101,32 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
       await invoke('open_recordings_folder');
     } catch (error) {
       console.error('Failed to open recordings folder:', error);
+      toast.error('Failed to open recordings folder');
+    }
+  };
+
+  const handleChangeFolder = async () => {
+    try {
+      const selectedPath = await invoke<string | null>('select_recording_folder');
+      if (!selectedPath) {
+        return;
+      }
+
+      const newPreferences = { ...preferences, save_folder: selectedPath };
+      setPreferences(newPreferences);
+      await savePreferences(newPreferences, {
+        title: 'Save location updated',
+        description: selectedPath,
+      });
+
+      await Analytics.track('recording_save_location_changed', {
+        path: selectedPath,
+      });
+    } catch (error) {
+      console.error('Failed to change recordings folder:', error);
+      toast.error('Failed to change save location', {
+        description: error instanceof Error ? error.message : String(error),
+      });
     }
   };
 
@@ -121,21 +147,30 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
     }
   };
 
-  const savePreferences = async (prefs: RecordingPreferences) => {
+  const savePreferences = async (
+    prefs: RecordingPreferences,
+    successMessage?: { title: string; description?: string }
+  ) => {
     setSaving(true);
     try {
       await invoke('set_recording_preferences', { preferences: prefs });
       onSave?.(prefs);
 
-      // Show success toast with device details
-      const micDevice = prefs.preferred_mic_device || 'Default';
-      const systemDevice = prefs.preferred_system_device || 'Default';
-      toast.success("Device preferences saved", {
-        description: `Microphone: ${micDevice}, System Audio: ${systemDevice}`
-      });
+      if (successMessage) {
+        toast.success(successMessage.title, {
+          description: successMessage.description,
+        });
+      } else {
+        // Show success toast with device details
+        const micDevice = prefs.preferred_mic_device || 'Default';
+        const systemDevice = prefs.preferred_system_device || 'Default';
+        toast.success("Device preferences saved", {
+          description: `Microphone: ${micDevice}, System Audio: ${systemDevice}`
+        });
+      }
     } catch (error) {
       console.error('Failed to save recording preferences:', error);
-      toast.error("Failed to save device preferences", {
+      toast.error("Failed to save recording preferences", {
         description: error instanceof Error ? error.message : String(error)
       });
     } finally {
@@ -184,13 +219,23 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
             <div className="text-sm text-gray-600 mb-3 break-all">
               {preferences.save_folder || 'Default folder'}
             </div>
-            <button
-              onClick={handleOpenFolder}
-              className="flex items-center gap-2 px-3 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
-            >
-              <FolderOpen className="w-4 h-4" />
-              Open Folder
-            </button>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={handleChangeFolder}
+                disabled={saving}
+                className="flex items-center gap-2 px-3 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-50 transition-colors disabled:opacity-50"
+              >
+                <FolderInput className="w-4 h-4" />
+                Change Location
+              </button>
+              <button
+                onClick={handleOpenFolder}
+                className="flex items-center gap-2 px-3 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+              >
+                <FolderOpen className="w-4 h-4" />
+                Open Folder
+              </button>
+            </div>
           </div>
 
           <div className="p-4 border rounded-lg bg-blue-50">

--- a/frontend/src/components/RecordingSettings.tsx
+++ b/frontend/src/components/RecordingSettings.tsx
@@ -5,6 +5,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { DeviceSelection, SelectedDevices } from '@/components/DeviceSelection';
 import Analytics from '@/lib/analytics';
 import { toast } from 'sonner';
+import { useConfig } from '@/contexts/ConfigContext';
 
 export interface RecordingPreferences {
   save_folder: string;
@@ -19,6 +20,7 @@ interface RecordingSettingsProps {
 }
 
 export function RecordingSettings({ onSave }: RecordingSettingsProps) {
+  const { refreshRecordingsStorageLocation } = useConfig();
   const [preferences, setPreferences] = useState<RecordingPreferences>({
     save_folder: '',
     auto_save: true,
@@ -154,6 +156,7 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
     setSaving(true);
     try {
       await invoke('set_recording_preferences', { preferences: prefs });
+      await refreshRecordingsStorageLocation();
       onSave?.(prefs);
 
       if (successMessage) {

--- a/frontend/src/contexts/ConfigContext.tsx
+++ b/frontend/src/contexts/ConfigContext.tsx
@@ -90,6 +90,7 @@ interface ConfigContextType {
   storageLocations: StorageLocations | null;
   isLoadingPreferences: boolean;
   loadPreferences: () => Promise<void>;
+  refreshRecordingsStorageLocation: () => Promise<void>;
   updateNotificationSettings: (settings: NotificationSettings) => Promise<void>;
 }
 
@@ -410,6 +411,23 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     setProviderApiKeys(prev => ({ ...prev, [provider]: apiKey }));
   }, []);
 
+  const fetchRecordingsFolder = useCallback(async (): Promise<string> => {
+    try {
+      const prefs = await invoke<{ save_folder: string }>('get_recording_preferences');
+      return prefs.save_folder;
+    } catch (error) {
+      console.error('[ConfigContext] Failed to load recording preferences, using default folder:', error);
+      return invoke<string>('get_default_recordings_folder_path');
+    }
+  }, []);
+
+  const refreshRecordingsStorageLocation = useCallback(async () => {
+    const recordings = await fetchRecordingsFolder();
+    setStorageLocations((prev) =>
+      prev ? { ...prev, recordings } : { database: '', models: '', recordings }
+    );
+  }, [fetchRecordingsFolder]);
+
   // Lazy load preference settings (only loads if not already cached)
   const loadPreferences = useCallback(async () => {
     // If already loaded, don't reload
@@ -436,11 +454,11 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
         setNotificationSettings(null);
       }
 
-      // Load storage locations
+      // Load storage locations (recordings uses saved preference, not platform default)
       const [dbDir, modelsDir, recordingsDir] = await Promise.all([
         invoke<string>('get_database_directory'),
         invoke<string>('whisper_get_models_directory'),
-        invoke<string>('get_default_recordings_folder_path')
+        fetchRecordingsFolder(),
       ]);
 
       setStorageLocations({
@@ -457,7 +475,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
       isLoadingRef.current = false;
       setIsLoadingPreferences(false);
     }
-  }, []);
+  }, [fetchRecordingsFolder]);
 
   // Update notification settings
   const updateNotificationSettings = useCallback(async (settings: NotificationSettings) => {
@@ -506,6 +524,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     storageLocations,
     isLoadingPreferences,
     loadPreferences,
+    refreshRecordingsStorageLocation,
     updateNotificationSettings,
   }), [
     modelConfig,
@@ -528,6 +547,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     storageLocations,
     isLoadingPreferences,
     loadPreferences,
+    refreshRecordingsStorageLocation,
     updateNotificationSettings,
   ]);
 


### PR DESCRIPTION
## Description
Meetily had a save_folder preference in storage, but users could not change it from the UI, and the recording pipeline ignored it and always used the hardcoded platform default (~/Movies/meetily-recordings on macOS). Open Folder in settings read the preference, but new recordings did not.

This PR wires up end-to-end custom recording save locations:

- **Settings → Recordings**: adds a **Change Location** button that opens a native folder picker (`select_recording_folder` via `tauri-plugin-dialog`) and persists the choice
- **Recording pipeline**: `RecordingSaver` and audio import use the saved `save_folder` from recording preferences instead of `get_default_recordings_folder()`
- **Settings → General → Data Storage Locations**: shows the configured recordings path (not the hardcoded default) and refreshes when preferences change

## Related Issue
Fixes https://github.com/Zackriya-Solutions/meetily/issues/481

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] All tests pass

Manual testing (macOS):
- [x] Settings → Recordings → Change Location opens folder picker and saves path
- [x] Open Folder opens the chosen location
- [x] New recording creates meeting folder under the custom path
- [x] Settings → General → Data Storage Locations shows the same path as Recordings
- [x] Production build (./build-gpu.sh) runs successfully

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [ ] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)


## Additional Notes
Commits (5, scoped):
1. Use saved recording folder preference when saving meetings
1. Use saved recording folder preference for audio imports
1. Implement select_recording_folder with native folder dialog
1. Add Change Location control to recording settings UI
1. Show configured recordings path in General storage settings