### PR TITLE
Delete meeting recording folder when removing a meeting from the UI.

### DIFF
--- a/frontend/src-tauri/src/api/api.rs
+++ b/frontend/src-tauri/src/api/api.rs
@@ -742,7 +742,7 @@ pub async fn api_delete_api_key<R: Runtime>(
 
 #[tauri::command]
 pub async fn api_delete_meeting<R: Runtime>(
-    _app: AppHandle<R>,
+    app: AppHandle<R>,
     state: tauri::State<'_, AppState>,
     meeting_id: String,
     auth_token: Option<String>,
@@ -755,8 +755,35 @@ pub async fn api_delete_meeting<R: Runtime>(
 
     let pool = state.db_manager.pool();
 
+    let folder_path = MeetingsRepository::get_meeting_metadata(pool, &meeting_id)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|meeting| meeting.folder_path.filter(|path| !path.trim().is_empty()));
+
+    let save_folder = crate::audio::recording_preferences::load_recording_preferences(&app)
+        .await
+        .map(|preferences| preferences.save_folder)
+        .unwrap_or_else(|_| crate::audio::recording_preferences::get_default_recordings_folder());
+    let allowed_roots = crate::audio::meeting_folder::recordings_roots(save_folder);
+
     match MeetingsRepository::delete_meeting(pool, &meeting_id).await {
         Ok(true) => {
+            if let Some(path) = folder_path {
+                if let Err(error) =
+                    crate::audio::meeting_folder::delete_meeting_folder_if_allowed(
+                        &path,
+                        &allowed_roots,
+                    )
+                {
+                    log_warn!(
+                        "Meeting {} deleted from database but folder cleanup failed: {}",
+                        meeting_id,
+                        error
+                    );
+                }
+            }
+
             log_info!("Successfully deleted meeting {}", meeting_id);
             Ok(serde_json::json!({
                 "status": "success",

--- a/frontend/src-tauri/src/audio/meeting_folder.rs
+++ b/frontend/src-tauri/src/audio/meeting_folder.rs
@@ -1,0 +1,121 @@
+use log::{info, warn};
+use std::path::{Path, PathBuf};
+
+use super::recording_preferences::get_default_recordings_folder;
+
+/// Build the list of directories where meeting folders are allowed to live.
+pub fn recordings_roots(save_folder: PathBuf) -> Vec<PathBuf> {
+    let default_folder = get_default_recordings_folder();
+    if save_folder == default_folder {
+        vec![save_folder]
+    } else {
+        vec![save_folder, default_folder]
+    }
+}
+
+/// Delete a meeting folder if it exists and is inside an allowed recordings root.
+pub fn delete_meeting_folder_if_allowed(
+    folder_path: &str,
+    allowed_roots: &[PathBuf],
+) -> Result<(), String> {
+    let trimmed = folder_path.trim();
+    if trimmed.is_empty() {
+        return Ok(());
+    }
+
+    let path = Path::new(trimmed);
+    if !path.exists() {
+        info!("Meeting folder already absent, skipping delete: {}", trimmed);
+        return Ok(());
+    }
+
+    if !path.is_dir() {
+        warn!("Meeting folder path is not a directory: {}", trimmed);
+        return Ok(());
+    }
+
+    let canonical_folder = path
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve meeting folder '{}': {}", trimmed, e))?;
+
+    if !is_within_allowed_roots(&canonical_folder, allowed_roots) {
+        warn!(
+            "Refusing to delete meeting folder outside recordings directories: {}",
+            canonical_folder.display()
+        );
+        return Ok(());
+    }
+
+    std::fs::remove_dir_all(&canonical_folder)
+        .map_err(|e| format!("Failed to delete meeting folder '{}': {}", trimmed, e))?;
+
+    info!("Deleted meeting folder: {}", canonical_folder.display());
+    Ok(())
+}
+
+fn is_within_allowed_roots(folder: &Path, allowed_roots: &[PathBuf]) -> bool {
+    allowed_roots
+        .iter()
+        .any(|root| is_path_within_root(folder, root))
+}
+
+fn is_path_within_root(path: &Path, root: &Path) -> bool {
+    let root_path = canonicalize_if_exists(root);
+    path.starts_with(&root_path)
+}
+
+fn canonicalize_if_exists(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        std::env::temp_dir().join(format!("meetily-{name}-{nanos}"))
+    }
+
+    #[test]
+    fn deletes_folder_inside_allowed_root() {
+        let root = unique_temp_dir("delete-allowed");
+        let meeting = root.join("Meeting_2026-01-01_12-00");
+        fs::create_dir_all(&meeting).expect("create meeting dir");
+        fs::write(meeting.join("metadata.json"), "{}").expect("write metadata");
+
+        delete_meeting_folder_if_allowed(
+            meeting.to_string_lossy().as_ref(),
+            &[root.clone()],
+        )
+        .expect("delete should succeed");
+
+        assert!(!meeting.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn refuses_folder_outside_allowed_root() {
+        let allowed_root = unique_temp_dir("allowed-root");
+        let outside_root = unique_temp_dir("outside-root");
+        let meeting = outside_root.join("Meeting_outside");
+        fs::create_dir_all(&meeting).expect("create meeting dir");
+
+        delete_meeting_folder_if_allowed(
+            meeting.to_string_lossy().as_ref(),
+            &[allowed_root.clone()],
+        )
+        .expect("should not error when refusing");
+
+        assert!(meeting.exists());
+
+        let _ = fs::remove_dir_all(meeting);
+        let _ = fs::remove_dir_all(outside_root);
+        let _ = fs::remove_dir_all(allowed_root);
+    }
+}

--- a/frontend/src-tauri/src/audio/mod.rs
+++ b/frontend/src-tauri/src/audio/mod.rs
@@ -51,6 +51,9 @@ pub mod retranscription;
 // Import module (import external audio files as new meetings)
 pub mod import;
 
+// Meeting folder lifecycle helpers (create/delete on disk)
+pub mod meeting_folder;
+
 pub use devices::{
     default_input_device, default_output_device, get_device_and_config, list_audio_devices,
     parse_audio_device, trigger_audio_permission,

--- a/frontend/src/components/Sidebar/index.tsx
+++ b/frontend/src/components/Sidebar/index.tsx
@@ -338,7 +338,7 @@ const Sidebar: React.FC = () => {
 
       // Show success toast
       toast.success("Meeting deleted successfully", {
-        description: "All associated data has been removed"
+        description: "Meeting data and recording files have been removed"
       });
 
       // If deleting the active meeting, navigate to home


### PR DESCRIPTION
## Description

Deleting a meeting from the sidebar previously removed only SQLite data (transcripts, summaries, meeting row). The on-disk meeting folder (`audio.mp4`, `metadata.json`, `transcripts.json`, etc.) was left behind.

This PR deletes the meeting's recording folder after a successful database delete when:

- The meeting has a `folder_path` stored in the database
- The folder exists on disk
- The path resolves inside the configured recordings save folder or the platform default recordings directory

Paths outside those roots are refused as a safety measure. If folder deletion fails after the DB delete succeeds, the API still returns success and logs a warning (avoids leaving the UI out of sync with the database).

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] All tests pass (CI pending)

**Unit tests:**
- [x] `deletes_folder_inside_allowed_root`
- [x] `refuses_folder_outside_allowed_root`

**Manual testing suggested:**
- [x] Record a meeting with auto-save enabled
- [x] Delete the meeting from the sidebar
- [x] Confirm the meeting folder is removed from the recordings directory
- [x] Confirm the meeting no longer appears in the app

## Documentation

- [ ] Documentation updated
- [x] No documentation needed

## Checklist

- [x] Code follows project style
- [x] Self-reviewed the code
- [ ] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)

N/A (behavioral backend change; optional before/after of Finder folder)

## Additional Notes
- Legacy meetings without `folder_path` continue to behave as before (DB-only delete)