### PR TITLE
feat: floating recording indicator with live mic waveform

### DIFF
--- a/frontend/public/floating-indicator.html
+++ b/frontend/public/floating-indicator.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Recording</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+      user-select: none;
+      -webkit-user-select: none;
+    }
+
+    html, body {
+      width: 100%;
+      height: 100%;
+      background: transparent;
+      overflow: hidden;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    .pill {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      padding: 0 6px 0 3px;
+      border-radius: 15px;
+      background: rgba(48, 50, 54, 0.95);
+      border: 1px solid rgba(255, 255, 255, 0.10);
+    }
+
+    /* Drag handle: six dots, grab cursor */
+    .grip {
+      display: grid;
+      grid-template-columns: repeat(2, 2px);
+      grid-template-rows: repeat(3, 2px);
+      gap: 2.5px;
+      padding: 6px 4px;
+      height: 100%;
+      align-content: center;
+      cursor: grab;
+      flex-shrink: 0;
+    }
+
+    .grip:active { cursor: grabbing; }
+
+    .grip .gd {
+      width: 2px;
+      height: 2px;
+      border-radius: 50%;
+      background: rgba(255, 255, 255, 0.40);
+    }
+
+    .grip:hover .gd { background: rgba(255, 255, 255, 0.62); }
+
+    .wave {
+      display: flex;
+      align-items: center;
+      gap: 1.5px;
+      height: 16px;
+      flex-shrink: 0;
+      cursor: grab;
+    }
+
+    .wave .bar {
+      width: 2px;
+      height: 2px;
+      border-radius: 1px;
+      background: rgba(209, 213, 219, 0.85);
+      transition: height 130ms ease-out;
+    }
+
+    .time {
+      font-size: 11px;
+      font-weight: 600;
+      font-variant-numeric: tabular-nums;
+      color: rgba(229, 231, 235, 0.92);
+      white-space: nowrap;
+      cursor: grab;
+      padding: 0 1px;
+    }
+
+    .stop {
+      position: relative;
+      z-index: 20;
+      width: 20px;
+      height: 20px;
+      border: none;
+      border-radius: 50%;
+      background: rgba(120, 124, 130, 0.95);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      flex-shrink: 0;
+      transition: background 120ms ease, transform 120ms ease;
+    }
+
+    .stop:hover { background: rgba(150, 154, 160, 0.95); transform: scale(1.08); }
+    .stop:active { transform: scale(0.94); }
+    .stop:disabled { background: rgba(80, 82, 86, 0.95); cursor: default; transform: none; }
+
+    .stop .square {
+      width: 7px;
+      height: 7px;
+      border-radius: 1.5px;
+      background: #f3f4f6;
+    }
+
+    /* Paused state */
+    body.paused .wave .bar { background: rgba(255, 255, 255, 0.22); }
+    body.paused .time { color: rgba(180, 184, 190, 0.95); }
+
+    /* Stopping state */
+    body.stopping .pill { opacity: 0.6; }
+  </style>
+</head>
+<body>
+  <div class="pill" id="pill">
+    <div class="grip" id="grip" title="Drag to move">
+      <div class="gd"></div><div class="gd"></div>
+      <div class="gd"></div><div class="gd"></div>
+      <div class="gd"></div><div class="gd"></div>
+    </div>
+    <div class="wave" id="wave"></div>
+    <div class="time" id="time">0:00</div>
+    <button class="stop" id="stop" title="Stop recording" aria-label="Stop recording">
+      <div class="square"></div>
+    </button>
+  </div>
+  <script src="floating-indicator.js"></script>
+</body>
+</html>

--- a/frontend/public/floating-indicator.js
+++ b/frontend/public/floating-indicator.js
@@ -1,0 +1,161 @@
+// Floating recording indicator pill.
+// Driven by "mic-level" events emitted by the Rust backend while recording.
+//
+// Uses the low-level __TAURI_INTERNALS__ IPC directly (always injected by Tauri)
+// instead of the withGlobalTauri wrapper, so the main window keeps its original
+// JS environment untouched.
+
+(function () {
+  const internals = window.__TAURI_INTERNALS__;
+  if (!internals || typeof internals.invoke !== 'function') {
+    console.error('[FloatingIndicator] __TAURI_INTERNALS__ not available');
+    return;
+  }
+
+  const WINDOW_LABEL = 'floating-indicator';
+
+  function invoke(cmd, args) {
+    return internals.invoke(cmd, args || {});
+  }
+
+  // Minimal event listener built on the core event plugin.
+  function listen(eventName, handler) {
+    const callbackId = internals.transformCallback((e) => handler(e));
+    return invoke('plugin:event|listen', {
+      event: eventName,
+      target: { kind: 'Any' },
+      handler: callbackId,
+    });
+  }
+
+  function startDragging() {
+    return invoke('plugin:window|start_dragging', { label: WINDOW_LABEL });
+  }
+
+  const BAR_COUNT = 10;
+  const MIN_BAR_PX = 2;
+  const MAX_BAR_PX = 15;
+
+  const pillEl = document.getElementById('pill');
+  const waveEl = document.getElementById('wave');
+  const timeEl = document.getElementById('time');
+  const stopBtn = document.getElementById('stop');
+
+  // Build waveform bars
+  const bars = [];
+  for (let i = 0; i < BAR_COUNT; i++) {
+    const bar = document.createElement('div');
+    bar.className = 'bar';
+    waveEl.appendChild(bar);
+    bars.push(bar);
+  }
+
+  // Scrolling level history: newest sample enters on the right
+  const levels = new Array(BAR_COUNT).fill(0);
+
+  function scaleLevel(rms) {
+    // Raw speech RMS is typically 0.005–0.15; sqrt gives a livelier wave
+    return Math.min(1, Math.sqrt(rms * 12));
+  }
+
+  function renderWave() {
+    for (let i = 0; i < BAR_COUNT; i++) {
+      const h = MIN_BAR_PX + levels[i] * (MAX_BAR_PX - MIN_BAR_PX);
+      bars[i].style.height = h.toFixed(1) + 'px';
+    }
+  }
+
+  function formatDuration(seconds) {
+    if (seconds == null || !isFinite(seconds)) return '0:00';
+    const total = Math.max(0, Math.floor(seconds));
+    const h = Math.floor(total / 3600);
+    const m = Math.floor((total % 3600) / 60);
+    const s = total % 60;
+    const ss = String(s).padStart(2, '0');
+    return h > 0 ? h + ':' + String(m).padStart(2, '0') + ':' + ss : m + ':' + ss;
+  }
+
+  let stopping = false;
+
+  listen('mic-level', (event) => {
+    if (stopping) return;
+    const { rms, is_paused: isPaused, duration } = event.payload;
+
+    levels.shift();
+    levels.push(isPaused ? 0 : scaleLevel(rms));
+    renderWave();
+
+    timeEl.textContent = isPaused ? 'Paused' : formatDuration(duration);
+    document.body.classList.toggle('paused', !!isPaused);
+  });
+
+  // Reset to a clean state when a new recording starts
+  listen('recording-started', () => {
+    stopping = false;
+    stopBtn.disabled = false;
+    document.body.classList.remove('stopping', 'paused');
+    levels.fill(0);
+    renderWave();
+    timeEl.textContent = '0:00';
+  });
+
+  // Drag handling.
+  //
+  // While dragging, macOS activates the app and focuses the main window, which
+  // would make the backend hide the pill mid-drag (it would then drag invisibly
+  // in the background). We tell the backend a drag is in progress so it keeps
+  // the pill visible. Exact end timing isn't critical: once the drag ends the
+  // main window is no longer focused, so the pill stays visible anyway.
+  let dragSafetyTimer = null;
+
+  function setDragging(active) {
+    invoke('set_indicator_dragging', { dragging: active }).catch(() => {});
+  }
+
+  function endDrag() {
+    if (dragSafetyTimer) { clearTimeout(dragSafetyTimer); dragSafetyTimer = null; }
+    setDragging(false);
+  }
+
+  function armSafety() {
+    if (dragSafetyTimer) clearTimeout(dragSafetyTimer);
+    // Fallback in case a mouseup is swallowed by the OS drag loop.
+    dragSafetyTimer = setTimeout(() => { setDragging(false); dragSafetyTimer = null; }, 1500);
+  }
+
+  pillEl.addEventListener('mousedown', (e) => {
+    if (e.button !== 0) return;
+    if (stopBtn.contains(e.target)) return;
+    // Prevent the default focus/activation so macOS doesn't raise the main window.
+    e.preventDefault();
+    setDragging(true);
+    armSafety();
+    startDragging()
+      .catch((err) => {
+        console.error('[FloatingIndicator] startDragging failed:', err);
+        endDrag();
+      });
+  });
+
+  // Clear the drag flag once the mouse is released or the window stops moving.
+  document.addEventListener('mouseup', endDrag);
+  listen('tauri://move', () => { if (dragSafetyTimer) armSafety(); });
+
+  stopBtn.addEventListener('click', async () => {
+    if (stopping) return;
+    stopping = true;
+    stopBtn.disabled = true;
+    document.body.classList.add('stopping');
+    timeEl.textContent = 'Stopping…';
+    try {
+      await invoke('stop_recording_from_indicator');
+    } catch (e) {
+      console.error('[FloatingIndicator] Failed to stop recording:', e);
+      stopping = false;
+      stopBtn.disabled = false;
+      document.body.classList.remove('stopping');
+    }
+  });
+
+  renderWave();
+})();

--- a/frontend/src-tauri/src/audio/mic_level.rs
+++ b/frontend/src-tauri/src/audio/mic_level.rs
@@ -1,0 +1,28 @@
+//! Lock-free storage for the live microphone level.
+//!
+//! The audio capture callback writes the latest RMS/peak here and the
+//! floating recording indicator reads it on a timer to drive its waveform.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+
+static MIC_RMS: AtomicU32 = AtomicU32::new(0);
+static MIC_PEAK: AtomicU32 = AtomicU32::new(0);
+
+/// Store the latest microphone level (called from the audio callback).
+pub fn update(rms: f32, peak: f32) {
+    MIC_RMS.store(rms.to_bits(), Ordering::Relaxed);
+    MIC_PEAK.store(peak.to_bits(), Ordering::Relaxed);
+}
+
+/// Read the latest microphone level as `(rms, peak)`.
+pub fn get() -> (f32, f32) {
+    (
+        f32::from_bits(MIC_RMS.load(Ordering::Relaxed)),
+        f32::from_bits(MIC_PEAK.load(Ordering::Relaxed)),
+    )
+}
+
+/// Reset levels to silence (called when recording stops).
+pub fn reset() {
+    update(0.0, 0.0);
+}

--- a/frontend/src-tauri/src/audio/mod.rs
+++ b/frontend/src-tauri/src/audio/mod.rs
@@ -26,6 +26,7 @@ pub mod recording_saver;
 pub mod incremental_saver;  // NEW: Incremental audio saving with checkpoints
 pub mod level_monitor;
 pub mod simple_level_monitor;
+pub mod mic_level; // Live mic level for the floating recording indicator
 pub mod buffer_pool;
 pub mod post_processor;
 pub mod hardware_detector;

--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -396,6 +396,13 @@ impl AudioCapture {
             data.to_vec()
         };
 
+        // Feed the live mic meter (raw level, pre-enhancement) for the floating indicator
+        if matches!(self.device_type, DeviceType::Microphone) && !mono_data.is_empty() {
+            let rms = (mono_data.iter().map(|&x| x * x).sum::<f32>() / mono_data.len() as f32).sqrt();
+            let peak = mono_data.iter().fold(0.0f32, |m, &x| m.max(x.abs()));
+            super::mic_level::update(rms, peak);
+        }
+
         // CRITICAL FIX: Resample to 48kHz if device uses different sample rate
         // This fixes Bluetooth devices (like Sony WH-1000XM4) that report 16kHz or 44.1kHz
         // Without this, audio is sped up 3x and VAD fails

--- a/frontend/src-tauri/src/floating_indicator.rs
+++ b/frontend/src-tauri/src/floating_indicator.rs
@@ -1,0 +1,287 @@
+//! Floating recording indicator.
+//!
+//! A small always-on-top, draggable pill window that appears while a
+//! recording is active and the main window is not focused. It shows a live
+//! microphone waveform, the elapsed time, and a stop button.
+//!
+//! Visibility and level updates are driven by a single background task so
+//! every start/stop path (UI, tray, errors) is handled uniformly.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use tauri::{AppHandle, Emitter, Manager, Runtime, WebviewUrl, WebviewWindowBuilder};
+
+pub const WINDOW_LABEL: &str = "floating-indicator";
+
+const PILL_WIDTH: f64 = 124.0;
+const PILL_HEIGHT: f64 = 30.0;
+const TICK_MS: u64 = 150;
+
+/// Preference store file and key, shared with the frontend settings UI.
+const PREFERENCES_STORE: &str = "preferences.json";
+const ENABLED_KEY: &str = "show_floating_indicator";
+
+/// Whether the floating indicator feature is enabled (user setting). Defaults to
+/// on; the persisted value is loaded at startup and updated live from settings.
+static ENABLED: AtomicBool = AtomicBool::new(true);
+
+/// Whether the main window currently has focus (updated from `on_window_event`).
+static MAIN_FOCUSED: AtomicBool = AtomicBool::new(true);
+
+/// Whether the pill is currently being dragged. While dragging, macOS briefly
+/// activates the app (focusing the main window), which would otherwise make the
+/// driver hide the pill mid-drag. This flag suppresses that hide.
+static DRAGGING: AtomicBool = AtomicBool::new(false);
+
+pub fn set_main_focused(focused: bool) {
+    MAIN_FOCUSED.store(focused, Ordering::SeqCst);
+}
+
+/// Set from the indicator UI while a window drag is in progress.
+#[tauri::command]
+pub fn set_indicator_dragging(dragging: bool) {
+    DRAGGING.store(dragging, Ordering::SeqCst);
+}
+
+/// Enable/disable the floating indicator live from the settings UI.
+#[tauri::command]
+pub fn set_floating_indicator_enabled(enabled: bool) {
+    ENABLED.store(enabled, Ordering::SeqCst);
+}
+
+/// Load the persisted enabled preference (defaults to true if unset/unreadable).
+fn load_enabled_preference<R: Runtime>(app: &AppHandle<R>) {
+    use tauri_plugin_store::StoreExt;
+    if let Ok(store) = app.store(PREFERENCES_STORE) {
+        if let Some(value) = store.get(ENABLED_KEY) {
+            if let Some(enabled) = value.as_bool() {
+                ENABLED.store(enabled, Ordering::SeqCst);
+            }
+        }
+    }
+}
+
+/// Decide whether the pill should be visible.
+///
+/// Visible only while recording and enabled. It stays up during a drag (macOS
+/// focuses the main window while the OS drag loop runs), and otherwise only when
+/// neither the main window nor the pill itself is focused.
+fn should_show_pill(
+    recording: bool,
+    enabled: bool,
+    dragging: bool,
+    main_focused: bool,
+    pill_focused: bool,
+) -> bool {
+    recording && enabled && (dragging || (!main_focused && !pill_focused))
+}
+
+/// Spawn the background task that drives the indicator window.
+pub fn init<R: Runtime>(app: &AppHandle<R>) {
+    load_enabled_preference(app);
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let mut visible = false;
+        let mut interval = tokio::time::interval(Duration::from_millis(TICK_MS));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            interval.tick().await;
+
+            let recording = crate::audio::recording_commands::is_recording().await;
+
+            if recording {
+                let state = crate::audio::recording_commands::get_recording_state().await;
+                let (rms, peak) = crate::audio::mic_level::get();
+                let payload = serde_json::json!({
+                    "rms": rms,
+                    "peak": peak,
+                    "is_paused": state["is_paused"].as_bool().unwrap_or(false),
+                    "duration": state["recording_duration"].as_f64(),
+                });
+                let _ = app.emit("mic-level", payload);
+            } else {
+                crate::audio::mic_level::reset();
+                DRAGGING.store(false, Ordering::SeqCst);
+            }
+
+            // Query the main window's focus directly each tick. This is more
+            // reliable than caching focus events, which don't always fire for a
+            // borderless accessory window on macOS.
+            let main_focused = app
+                .get_webview_window("main")
+                .and_then(|w| w.is_focused().ok())
+                .unwrap_or_else(|| MAIN_FOCUSED.load(Ordering::SeqCst));
+
+            // Keep the pill visible while the user is interacting with it.
+            let pill_focused = app
+                .get_webview_window(WINDOW_LABEL)
+                .and_then(|w| w.is_focused().ok())
+                .unwrap_or(false);
+
+            // Keep the pill visible throughout a drag, even though macOS focuses
+            // the main window while the OS drag loop is active.
+            let dragging = DRAGGING.load(Ordering::SeqCst);
+
+            let enabled = ENABLED.load(Ordering::SeqCst);
+
+            let should_show =
+                should_show_pill(recording, enabled, dragging, main_focused, pill_focused);
+            if should_show != visible {
+                if should_show {
+                    show_indicator(&app);
+                } else {
+                    hide_indicator(&app);
+                }
+                visible = should_show;
+            }
+        }
+    });
+}
+
+fn show_indicator<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = ensure_window(app) {
+        if let Err(e) = window.show() {
+            log::error!("Floating indicator: failed to show window: {}", e);
+        }
+        let _ = window.set_always_on_top(true);
+    }
+}
+
+fn hide_indicator<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window(WINDOW_LABEL) {
+        if let Err(e) = window.hide() {
+            log::error!("Floating indicator: failed to hide window: {}", e);
+        }
+    }
+}
+
+/// Get the indicator window, creating it (hidden) on first use.
+/// The window is reused across recordings so it keeps its dragged position.
+fn ensure_window<R: Runtime>(app: &AppHandle<R>) -> Option<tauri::WebviewWindow<R>> {
+    if let Some(window) = app.get_webview_window(WINDOW_LABEL) {
+        return Some(window);
+    }
+
+    let mut builder = WebviewWindowBuilder::new(
+        app,
+        WINDOW_LABEL,
+        WebviewUrl::App("floating-indicator.html".into()),
+    )
+    .title("Recording")
+    .inner_size(PILL_WIDTH, PILL_HEIGHT)
+    .resizable(false)
+    .maximizable(false)
+    .minimizable(false)
+    .decorations(false)
+    .transparent(true)
+    .shadow(false)
+    .always_on_top(true)
+    .visible_on_all_workspaces(true)
+    .skip_taskbar(true)
+    .accept_first_mouse(true)
+    // Non-focusable: clicking the pill must not activate the app and raise the
+    // main window. Combined with accept_first_mouse, the webview still receives
+    // the click so the stop button and window dragging keep working.
+    .focusable(false)
+    .focused(false)
+    .visible(false);
+
+    // Default position: top-right corner of the primary monitor
+    if let Ok(Some(monitor)) = app.primary_monitor() {
+        let scale = monitor.scale_factor();
+        let size = monitor.size().to_logical::<f64>(scale);
+        let pos = monitor.position().to_logical::<f64>(scale);
+        builder = builder.position(pos.x + size.width - PILL_WIDTH - 24.0, pos.y + 48.0);
+    }
+
+    match builder.build() {
+        Ok(window) => Some(window),
+        Err(e) => {
+            log::error!("Floating indicator: failed to create window: {}", e);
+            None
+        }
+    }
+}
+
+/// Stop the active recording from the floating indicator.
+/// Mirrors the tray stop flow: generates a save path, stops the recording and
+/// notifies the frontend so post-processing (DB save, navigation) runs there.
+#[tauri::command]
+pub async fn stop_recording_from_indicator<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
+    log::info!("Floating indicator: stop recording requested");
+
+    if !crate::audio::recording_commands::is_recording().await {
+        hide_indicator(&app);
+        return Ok(());
+    }
+
+    hide_indicator(&app);
+    crate::tray::set_tray_state(&app, crate::tray::RecordingState::Stopping);
+    crate::tray::focus_main_window(&app);
+
+    let data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+    let timestamp = chrono::Local::now().format("%Y-%m-%dT%H-%M-%S").to_string();
+    let save_path = data_dir.join(format!("recording-{}.wav", timestamp));
+
+    crate::audio::recording_commands::stop_recording(
+        app.clone(),
+        crate::audio::recording_commands::RecordingArgs {
+            save_path: save_path.to_string_lossy().to_string(),
+        },
+    )
+    .await?;
+
+    // Trigger frontend post-processing (SQLite save, navigation, analytics)
+    if let Err(e) = app.emit("recording-stop-complete", true) {
+        log::error!("Floating indicator: failed to emit recording-stop-complete: {}", e);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_show_pill;
+
+    #[test]
+    fn hidden_when_not_recording() {
+        // Nothing shows unless a recording is active, regardless of focus/drag.
+        assert!(!should_show_pill(false, true, false, false, false));
+        assert!(!should_show_pill(false, true, true, false, false));
+    }
+
+    #[test]
+    fn hidden_when_disabled() {
+        assert!(!should_show_pill(true, false, false, false, false));
+        assert!(!should_show_pill(true, false, true, false, false));
+    }
+
+    #[test]
+    fn shown_when_recording_and_main_unfocused() {
+        assert!(should_show_pill(true, true, false, false, false));
+    }
+
+    #[test]
+    fn hidden_when_main_window_focused() {
+        // Returning to the main window hides the pill.
+        assert!(!should_show_pill(true, true, false, true, false));
+    }
+
+    #[test]
+    fn hidden_when_pill_focused_but_not_dragging() {
+        assert!(!should_show_pill(true, true, false, false, true));
+    }
+
+    #[test]
+    fn stays_visible_while_dragging_even_if_main_focused() {
+        // macOS focuses the main window during the OS drag loop; the pill must
+        // stay visible throughout the drag.
+        assert!(should_show_pill(true, true, true, true, false));
+        assert!(should_show_pill(true, true, true, true, true));
+    }
+}

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub mod audio;
 pub mod config;
 pub mod console_utils;
 pub mod database;
+pub mod floating_indicator;
 pub mod notifications;
 pub mod ollama;
 pub mod onboarding;
@@ -425,6 +426,9 @@ pub fn run() {
                 log::error!("Failed to create system tray: {}", e);
             }
 
+            // Start the floating recording indicator driver
+            floating_indicator::init(_app.handle());
+
             // Initialize notification system with proper defaults
             log::info!("Initializing notification system...");
             let app_for_notif = _app.handle().clone();
@@ -522,10 +526,20 @@ pub fn run() {
                     }
                 }
             }
+
+            // Track main window focus to drive the floating recording indicator
+            if let tauri::WindowEvent::Focused(focused) = event {
+                if window.label() == "main" {
+                    floating_indicator::set_main_focused(*focused);
+                }
+            }
         })
         .invoke_handler(tauri::generate_handler![
             start_recording,
             stop_recording,
+            floating_indicator::stop_recording_from_indicator,
+            floating_indicator::set_indicator_dragging,
+            floating_indicator::set_floating_indicator_enabled,
             is_recording,
             get_transcription_status,
             read_audio_file,

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -74,6 +74,20 @@
                             ]
                         }
                     ]
+                },
+                {
+                    "identifier": "floating-indicator",
+                    "description": "Floating recording indicator pill window",
+                    "windows": [
+                        "floating-indicator"
+                    ],
+                    "permissions": [
+                        "core:event:default",
+                        "core:window:default",
+                        "core:window:allow-start-dragging",
+                        "core:webview:default",
+                        "core:app:default"
+                    ]
                 }
             ]
         }

--- a/frontend/src/components/RecordingSettings.tsx
+++ b/frontend/src/components/RecordingSettings.tsx
@@ -29,6 +29,7 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [showRecordingNotification, setShowRecordingNotification] = useState(true);
+  const [showFloatingIndicator, setShowFloatingIndicator] = useState(true);
 
   // Load recording preferences on component mount
   useEffect(() => {
@@ -66,6 +67,21 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
       }
     };
     loadNotificationPref();
+  }, []);
+
+  // Load floating recording indicator preference
+  useEffect(() => {
+    const loadFloatingIndicatorPref = async () => {
+      try {
+        const { Store } = await import('@tauri-apps/plugin-store');
+        const store = await Store.load('preferences.json');
+        const show = await store.get<boolean>('show_floating_indicator') ?? true;
+        setShowFloatingIndicator(show);
+      } catch (error) {
+        console.error('Failed to load floating indicator preference:', error);
+      }
+    };
+    loadFloatingIndicatorPref();
   }, []);
 
   const handleAutoSaveToggle = async (enabled: boolean) => {
@@ -117,6 +133,25 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
       });
     } catch (error) {
       console.error('Failed to save notification preference:', error);
+      toast.error('Failed to save preference');
+    }
+  };
+
+  const handleFloatingIndicatorToggle = async (enabled: boolean) => {
+    try {
+      setShowFloatingIndicator(enabled);
+      const { Store } = await import('@tauri-apps/plugin-store');
+      const store = await Store.load('preferences.json');
+      await store.set('show_floating_indicator', enabled);
+      await store.save();
+      // Apply immediately in the running backend driver
+      await invoke('set_floating_indicator_enabled', { enabled });
+      toast.success('Preference saved');
+      await Analytics.track('floating_indicator_preference_changed', {
+        enabled: enabled.toString()
+      });
+    } catch (error) {
+      console.error('Failed to save floating indicator preference:', error);
       toast.error('Failed to save preference');
     }
   };
@@ -224,6 +259,20 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
         <Switch
           checked={showRecordingNotification}
           onCheckedChange={handleNotificationToggle}
+        />
+      </div>
+
+      {/* Floating Recording Indicator Toggle */}
+      <div className="flex items-center justify-between p-4 border rounded-lg">
+        <div className="flex-1">
+          <div className="font-medium">Floating Recording Indicator</div>
+          <div className="text-sm text-gray-600">
+            Show a small draggable widget with a live mic waveform and stop button when you switch away from Meetily during a recording
+          </div>
+        </div>
+        <Switch
+          checked={showFloatingIndicator}
+          onCheckedChange={handleFloatingIndicatorToggle}
         />
       </div>
 


### PR DESCRIPTION
## Description
Adds a floating recording indicator: a small, always-on-top, draggable pill that appears while a recording is active and the main window is not focused. It shows a live microphone waveform, the elapsed time, and a stop button, and hides when you return to the main window. The feature can be toggled in Recording Settings (persisted, default on).

How it works:
- A separate borderless, transparent, always-on-top `WebviewWindow` (`floating-indicator`) renders a static page (`public/floating-indicator.html` and `.js`) driven via `__TAURI_INTERNALS__`, so the main window does not need `withGlobalTauri` and its CSP stays untouched.
- A backend driver (`floating_indicator.rs`) polls recording state and the main window's focus each tick to show or hide the pill, and emits a `mic-level` event with live RMS tapped from the capture pipeline (`audio/mic_level.rs`, fed in `audio/pipeline.rs`).
- Stopping from the pill (`stop_recording_from_indicator`) mirrors the tray stop flow and emits `recording-stop-complete`, so the existing post-processing (save and navigate) runs.
- macOS: the window is non-focusable with `accept_first_mouse`, so clicking or dragging it does not activate the app or raise the main window. Dragging uses `start_dragging` with a `DRAGGING` flag so the pill stays visible throughout a drag.
- The Settings toggle persists to `preferences.json` (`show_floating_indicator`); the backend reads it at startup and updates live via `set_floating_indicator_enabled`.

## Related Issue
Fixes #522

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] All tests pass

Unit tests cover the visibility decision (`should_show_pill`): hidden when not recording or disabled, shown when recording and the main window is unfocused, hidden when the main window or the pill is focused, and kept visible throughout a drag.

Manual testing on macOS (Apple Silicon): start recording, switch to another app and the pill appears; the waveform reacts to mic input; dragging via the grip keeps the pill visible and moves it; returning to Meetily hides it; Stop ends the recording, focuses the main window, and the meeting is saved and opened; turning the setting off hides the pill live and after a restart. `cargo check` is clean.

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)
The pill, left to right: a six-dot grip handle, the live mic waveform, the elapsed time, and a round stop button.
<img width="124" height="30" alt="meetily-pill" src="https://github.com/user-attachments/assets/53939d01-5715-4f67-902f-a5c5cc9bfdb1" />

## Additional Notes
- Uses cross-platform Tauri APIs and is tested on macOS. Linux and Windows should behave the same, but I have not verified the focus and drag behavior there.
- The branch is a single `feat` commit.
