### PR TITLE
fix(parakeet): show precise model

### DIFF
--- a/frontend/src-tauri/src/parakeet_engine/parakeet_engine.rs
+++ b/frontend/src-tauri/src/parakeet_engine/parakeet_engine.rs
@@ -174,6 +174,7 @@ impl ParakeetEngine {
         let model_configs = [
             ("parakeet-tdt-0.6b-v3-int8", 670, QuantizationType::Int8, "Ultra Fast (v3)", "Real time on M4 Max, latest version with int8 quantization"),
             ("parakeet-tdt-0.6b-v2-int8", 661, QuantizationType::Int8, "Fast (v2)", "Previous version with int8 quantization, good balance of speed and accuracy"),
+            ("parakeet-tdt-0.6b-v3-fp32", 2554, QuantizationType::FP32, "Fast (v3 FP32)", "Full precision v3 model with higher accuracy"),
         ];
 
         // Get active downloads to override status
@@ -199,6 +200,7 @@ impl ParakeetEngine {
                     ],
                     QuantizationType::FP32 => vec![
                         "encoder-model.onnx",
+                        "encoder-model.onnx.data",
                         "decoder_joint-model.onnx",
                         "nemo128.onnx",
                         "vocab.txt",
@@ -290,7 +292,8 @@ impl ParakeetEngine {
             ]
         } else {
             vec![
-                ("encoder-model.onnx", 2_200_000_000),        // ~2.44 GB, min 2.2 GB
+                ("encoder-model.onnx", 35_000_000),           // ~41.8 MB graph, min 35 MB
+                ("encoder-model.onnx.data", 2_200_000_000),   // ~2.44 GB weights, min 2.2 GB
                 ("decoder_joint-model.onnx", 65_000_000),     // ~72 MB, min 65 MB
                 ("nemo128.onnx", 100_000),                    // ~140 KB, min 100 KB
                 ("vocab.txt", 5_000),                         // ~94 KB, min 5 KB
@@ -608,6 +611,7 @@ impl ParakeetEngine {
             ],
             QuantizationType::FP32 => vec![
                 "encoder-model.onnx",
+                "encoder-model.onnx.data",
                 "decoder_joint-model.onnx",
                 "nemo128.onnx",
                 "vocab.txt",
@@ -666,12 +670,13 @@ impl ParakeetEngine {
                 }
             }
             QuantizationType::FP32 => {
-                // FP32 model sizes (encoder has .onnx + .onnx.data)
+                // FP32 model sizes (encoder has an ONNX graph plus external weights data)
                 [
-                    ("encoder-model.onnx", 41_800_000u64 + 2_440_000_000u64), // 41.8 MB + 2.44 GB
-                    ("decoder_joint-model.onnx", 72_500_000u64),               // 72.5 MB
-                    ("nemo128.onnx", 140_000u64),                              // 140 KB
-                    ("vocab.txt", 93_900u64),                                  // 93.9 KB
+                    ("encoder-model.onnx", 41_800_000u64),         // 41.8 MB
+                    ("encoder-model.onnx.data", 2_440_000_000u64), // 2.44 GB
+                    ("decoder_joint-model.onnx", 72_500_000u64),   // 72.5 MB
+                    ("nemo128.onnx", 140_000u64),                  // 140 KB
+                    ("vocab.txt", 93_900u64),                      // 93.9 KB
                 ].iter().cloned().collect()
             }
         };


### PR DESCRIPTION
## Description

Adds the missing FP32 Parakeet model to the backend model catalog so the existing frontend `Precise` display configuration can render in transcription settings and model pickers.

## Root Cause

`frontend/src/lib/parakeet.ts` already defined display metadata for `parakeet-tdt-0.6b-v3-fp32`, but `ParakeetEngine::discover_models()` only returned the two Int8 models. Because the UI renders models returned by `parakeet_get_available_models`, the `Precise` option never appeared.

While enabling the FP32 model, this also fixes the FP32 encoder file layout. The upstream ONNX repo stores the encoder as `encoder-model.onnx` plus external weights in `encoder-model.onnx.data`, so validation and download bookkeeping now track those files separately.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other

## Testing

- [x] Manual testing performed
- [x] `git diff --check`
- [x] `pnpm run build`
- [x] `pnpm tauri build --features coreml --no-bundle`

## Screenshots
<img width="1212" height="812" alt="image" src="https://github.com/user-attachments/assets/7e6b1391-1b36-4b4b-b5c7-23bf648bdf70" />
<img width="1212" height="812" alt="image" src="https://github.com/user-attachments/assets/60f19214-3678-44ae-9ab2-76e4df5a1b45" />

## Documentation

- [x] No documentation needed

## Checklist

- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [x] Updated README if needed
