### PR TITLE
feat: translate-to-Thai, Quick Note + rollover, qwen3.5:9b summary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,38 @@
+# ─────────────────────────────────────────────────────────────
+# Meetily (personal fork) — local-only configuration
+# Copy to `.env` and adjust. All values have sane defaults baked
+# into the app, so a missing key falls back to the default below.
+# ─────────────────────────────────────────────────────────────
+
+# ── Meeting log storage ──
+MEET_LOG_ROOT=/Users/AR697030/Desktop/personal/meet-log
+MEET_LOG_DATE_FORMAT=yyyy-MM-dd        # folder name per day
+MEET_TIME_FORMAT=HH-mm-ss              # colon-safe (macOS Finder rejects ":")
+
+# Files inside each day's folder
+MEET_TRANSCRIPT_PATTERN={time}_transcript.md   # appended live while recording
+MEET_SUMMARY_PATTERN={time}_summary.md         # written when a session ends
+MEET_DAILY_LOG=summary.md                       # appended once per session per day
+
+# ── Models (local, via Ollama unless noted) ──
+STT_MODEL=large-v3                      # whisper-rs ggml model name (in-app)
+TRANSLATE_MODEL=translategemma:4b       # →English (translategemma is EN-only)
+TRANSLATE_MODEL_TH=qwen3.5:9b           # →Thai (needs a Thai-capable model)
+TRANSLATE_DEFAULT_TARGET=th             # default for the translate button (th|en)
+SUMMARY_MODEL=qwen3.5:9b                # primary — verify with `ollama pull qwen3.5:9b`
+SUMMARY_MODEL_FALLBACK=qwen2.5:14b      # used automatically if primary isn't installed
+EMBED_MODEL=bge-m3
+
+# ── Quick note ──
+NOTE_LOG_ROOT=/Users/AR697030/Desktop/personal/note-log
+NOTE_ROLLOVER=on_launch                 # archive old days + carry ❌ forward on app launch
+
+# ── Local services ──
+OLLAMA_URL=http://127.0.0.1:11434
+MEET_SIDECAR_URL=http://127.0.0.1:8178   # Python ML sidecar (translate/embed/segment)
+
+# ── Local memory search ──
+VECTOR_DB_PATH=/Users/AR697030/Desktop/personal/meet-log/.index/meetings.db
+
+# ── Glossary (keep technical terms in English) ──
+STT_GLOSSARY=Kafka,ACL,gRPC,consumer lag,Vault Core,ThoughtMachine,Redis,partition,deploy,UAT,broker

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ experiments/
 target/
 
 frontend/src-tauri/binaries/
+# python sidecar venv
+sidecar/.venv/
+sidecar/__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,153 @@
+# AGENTS.md — Meetily personal fork (single source of truth)
+
+Thai-aware, 100%-local meeting transcription on top of the Tauri/Rust/Next.js
+Meetily app. This file is the working memory for the personal-fork features
+(file output, Thai STT glossary, translation, summary, local memory search).
+
+## Golden rules
+- **Local only.** No outbound network except `127.0.0.1` (Ollama on :11434, ML
+  sidecar on :8178). Never add cloud calls.
+- **No hardcoded paths.** Everything is read from `.env` / env vars via
+  `meeting_log::config`. Defaults match the spec so the packaged app still works.
+- Heavy ML (translate / embed / Thai segmentation / vector search) lives in the
+  Python **sidecar**; the Rust core stays thin and talks to it over local HTTP.
+- Keep this file updated as the design changes.
+
+## Models (local)
+| Job | Model | Where |
+|---|---|---|
+| STT | whisper-rs `large-v3` (+ glossary initial_prompt) | in-app (Rust) |
+| Translate →EN | `translategemma:4b` (EN-only model) | Ollama (via sidecar) |
+| Translate →TH | `qwen3.5:9b` (`think:false`, Thai-capable) | Ollama (via sidecar) |
+| Summary + action items | `qwen3.5:9b` primary → `qwen2.5:14b` fallback | Ollama (via Rust) |
+| Embeddings | `bge-m3` (1024-dim) | Ollama (via sidecar) |
+| Thai segmentation | PyThaiNLP `newmm` | sidecar |
+| Vector store | `sqlite-vec` + FTS5 | sidecar |
+
+All four Ollama models are pulled: `translategemma:4b`, `bge-m3`, `qwen2.5:14b`,
+plus the pre-existing `qwen3.5:27b`.
+
+## Configuration — `.env` (repo root, gitignored)
+Loaded by `meeting_log::config` from env vars → `.env` (cwd / exe dir / app
+support) → baked-in defaults. `.env.example` is the template. Keys:
+`MEET_LOG_ROOT`, `MEET_LOG_DATE_FORMAT`, `MEET_TIME_FORMAT`,
+`MEET_TRANSCRIPT_PATTERN`, `MEET_SUMMARY_PATTERN`, `MEET_DAILY_LOG`,
+`STT_MODEL`, `TRANSLATE_MODEL` (→EN), `TRANSLATE_MODEL_TH` (→TH),
+`TRANSLATE_DEFAULT_TARGET`, `SUMMARY_MODEL` (+`SUMMARY_MODEL_FALLBACK`),
+`EMBED_MODEL`, `OLLAMA_URL`, `MEET_SIDECAR_URL`, `VECTOR_DB_PATH`, `STT_GLOSSARY`,
+`NOTE_LOG_ROOT`, `NOTE_ROLLOVER`.
+Java-style date tokens (`yyyy-MM-dd`, `HH-mm-ss`) are auto-translated to chrono.
+
+## Translation (Feature 1)
+Language view in the transcript toolbar: Original / ไทย / English / Bilingual,
+plus a "🇹🇭 แปลเป็นไทย" quick action (= Bilingual). Per-segment, per-target cache.
+Routing: →EN uses `translategemma:4b` (English-only); →TH uses
+`TRANSLATE_MODEL_TH` (`qwen3.5:9b`) because translategemma cannot produce Thai.
+The sidecar uses a **Thai-language** system prompt for →TH and sends
+`think:false` (keeps qwen3 fast, ~1s/segment). Technical terms stay in English
+via the glossary. Code in `meeting_log/translate.rs` + sidecar `/translate`
+(`target` field) + frontend `lib/meetLog.ts` + `TranscriptView.tsx`.
+
+## Summary model + fallback (Feature 3)
+`meeting_log/models.rs` resolves the summary model at call time: runtime override
+(Settings dropdown) → env `SUMMARY_MODEL` → env `SUMMARY_MODEL_FALLBACK` → primary
+anyway. Checks `ollama /api/tags`; never crashes if a model is missing (logs a
+warning). Settings → "Ai Summary" tab has the picker (`MeetLogSummaryModel.tsx`,
+commands `meeting_log_list_models` / `_set_summary_model` / `_get_summary_model`).
+
+## Quick Note (Feature 2)
+SQLite `quick_notes(id,date,text,done,created_at,carried_from,archived)`
+(migration `20260624000000_add_quick_notes.sql`). `meeting_log/notes.rs` has CRUD
+commands + `quick_notes_rollover`. **Rollover (NOTE_ROLLOVER=on_launch)**, run from
+`layout.tsx` after onboarding: for each un-archived day < today → write
+`NOTE_LOG_ROOT/<date>.md` (`[x] … ✅` / `[ ] … ❌`), copy pending cards to today
+with `carried_from` set, mark the day archived (idempotent). UI: floating board
+`QuickNote.tsx` (⌘⇧N or window event `open-quick-note`) — checkbox, inline edit,
+delete, "↩ เมื่อวาน" badge for carried cards.
+
+## File output (spec §3)
+Written under `MEET_LOG_ROOT/<date>/`:
+- `<time>_transcript.md` — header + one line per **final** segment, flushed to
+  disk immediately (crash-safe). `[HH:MM:SS] text` (optional `Speaker:`).
+- `<time>_summary.md` — written at session end from the summary model's JSON.
+- `summary.md` — per-day log; one appended section per session.
+
+## Architecture / where things live
+**Rust** — `frontend/src-tauri/src/meeting_log/`
+- `config.rs` — env/.env/defaults loader (+ token translation). Unit-tested.
+- `session.rs` — live session state; `start_session`, `append_final_segment`
+  (flush), `take_session`. Global `Mutex<Option<SessionLog>>`.
+- `summary.rs` — Ollama JSON summary → markdown; writes summary file + daily log;
+  spawns memory indexing. Falls back to a minimal summary if the model fails.
+- `memory.rs` — chunks a session, calls sidecar `/index` and `/search`.
+- `translate.rs` — calls sidecar `/translate`; skips English-only text.
+- `sidecar.rs` — best-effort sidecar autostart at app launch (health-check then
+  spawn `sidecar/run.sh`).
+- `commands.rs` — Tauri commands: `meeting_log_config`, `meeting_log_translate`,
+  `meeting_log_search`, `meeting_log_reveal`.
+
+**Lifecycle hooks** (`audio/recording_commands.rs`)
+- start → `meeting_log::begin(meeting_name)`
+- each `transcript-update` with `!is_partial` → `meeting_log::record_final`
+- stop → spawn `meeting_log::end()` → emits `meeting-log-finalized`
+
+**Glossary** (`whisper_engine/whisper_engine.rs`) — glossary joined and set as
+`params.set_initial_prompt(...)` at both transcribe call sites (declared before
+`params` for lifetime safety).
+
+**Python sidecar** — `sidecar/` (FastAPI, 127.0.0.1:8178)
+- `app.py` — `/health /translate /embed /segment /index /search`. Hybrid search =
+  dense (bge-m3 + sqlite-vec KNN) + sparse (FTS5 bm25 over newmm-segmented text)
+  fused with Reciprocal Rank Fusion. Degrades gracefully if vec/thai missing.
+- `requirements.txt`, `run.sh` (venv bootstrap). Verified on Python 3.14.
+
+**Frontend** (`frontend/src`)
+- `lib/meetLog.ts` — translation modes A/B/C, per-segment translate cache, copy.
+- `components/TranscriptView.tsx` — toolbar (mode toggle A▸B▸C + Copy-all), per-
+  line hover copy `⧉`, bilingual EN sub-line, partial=faded/final=solid, toast.
+- `components/MeetLogSearch.tsx` — floating memory-search widget (⌘⇧F): snippet +
+  date + topics, click reveals the file. Mounted in `app/layout.tsx`.
+
+## Translation modes (spec §5/§7)
+A = Original · B = Bilingual (TH + EN sub-line) · C = English. Mode persisted in
+localStorage. Sidecar prompt pins technical terms (Kafka/ACL/gRPC/…). Verified:
+"เดี๋ยว deploy Kafka ก่อน แล้วเช็ค consumer lag" → "First, let's deploy the Kafka
+system and then check the consumer lag." (terms preserved).
+
+## Run / build
+**Dev (running from source):**
+1. `cd sidecar && ./run.sh` (first run builds the venv) — or let the app autostart it.
+2. `cd frontend && pnpm install && pnpm run tauri:dev:metal`
+
+**Build prerequisites:** Rust (rustup, stable), cmake (brew), pnpm pinned to
+**9.15.9** (corepack `pnpm@latest` crashes on Node 20), sidecar venv, all Ollama
+models, and **full Xcode** (the `cidre` system-audio dep runs `xcodebuild`):
+`sudo xcode-select -s /Applications/Xcode.app/Contents/Developer && sudo xcodebuild -license accept`.
+
+**Packaged `.dmg` — DONE.** `./build_meetily.sh` produces it. Two external
+binaries must exist under `frontend/src-tauri/binaries/` (the script builds/copies
+them): `ffmpeg-<triple>` (auto-downloaded by the build) and
+`llama-helper-<triple>` (built from the `llama-helper/` crate with `--features
+metal`, copied from `target/release/llama-helper`). Output:
+`target/release/bundle/dmg/meetily_0.4.0_aarch64.dmg`.
+
+Notes: the app is **ad-hoc signed** (`signingIdentity: "-"`) — on first launch use
+right-click → Open (or `xattr -dr com.apple.quarantine <app>`). The build's final
+non-zero exit is only the updater-artifact signing (needs
+`TAURI_SIGNING_PRIVATE_KEY`); it runs after the `.dmg` is written, so the `.dmg`
+is the source of truth.
+
+## Validation status
+- Rust `meeting_log` + `sidecar` modules: `cargo check` clean (isolated crate;
+  full app build pending Xcode).
+- Frontend: `tsc --noEmit` → 0 errors.
+- Sidecar: live-tested `/health /segment /translate /index /search` against real
+  models — hybrid search ranks correctly for English and Thai+English queries.
+
+## TODO / later
+- Speaker diarization (pyannote) — `record_final` already accepts an optional
+  speaker; transcript format supports `Speaker:`.
+- README auto-generation per meeting.
+- Expose the search layer as an MCP server (search already factored in `memory.rs`
+  + sidecar `/search`).
+- Bundle the Python sidecar into the packaged app (currently dev-path autostart).

--- a/build_meetily.sh
+++ b/build_meetily.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# One-shot build for the Meetily personal fork (local-only).
+# Verifies prerequisites, prepares the sidecar + models, then bundles the .dmg.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export PATH="$HOME/.cargo/bin:/opt/homebrew/bin:$PATH"
+
+say() { printf "\n\033[1;36m==> %s\033[0m\n" "$1"; }
+die() { printf "\n\033[1;31mERROR: %s\033[0m\n" "$1"; exit 1; }
+
+say "Checking toolchain"
+command -v cargo  >/dev/null || die "cargo not found (install rustup)"
+command -v cmake  >/dev/null || die "cmake not found (brew install cmake)"
+command -v ollama >/dev/null || die "ollama not found"
+# corepack's pnpm@latest needs Node 22+ (node:sqlite); pin a Node-20-safe pnpm.
+command -v corepack >/dev/null && corepack prepare pnpm@9.15.9 --activate >/dev/null 2>&1 || true
+command -v pnpm   >/dev/null || die "pnpm not found (corepack enable pnpm)"
+
+# cidre (system-audio bindings) needs FULL Xcode, not just Command Line Tools.
+if ! xcodebuild -version >/dev/null 2>&1; then
+  die "Full Xcode required. Install Xcode from the App Store, then:
+       sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+       sudo xcodebuild -license accept"
+fi
+
+say "Ensuring Ollama models"
+for m in translategemma:4b bge-m3 qwen3.5:9b qwen2.5:14b; do
+  ollama list | grep -q "${m%%:*}" || ollama pull "$m"
+done
+
+say "Preparing Python sidecar venv"
+( cd "$ROOT/sidecar" && python3 -m venv .venv && source .venv/bin/activate \
+    && pip install -q --upgrade pip && pip install -q -r requirements.txt )
+
+say "Building llama-helper sidecar binary (metal)"
+# Tauri externalBin expects binaries/llama-helper-<target-triple>.
+( cd "$ROOT/llama-helper" && cargo build --release --features metal )
+TRIPLE=$(rustc -vV | awk '/host:/{print $2}')
+mkdir -p "$ROOT/frontend/src-tauri/binaries"
+find "$ROOT/frontend/src-tauri/binaries" -name "llama-helper*" -delete
+cp "$ROOT/target/release/llama-helper" \
+   "$ROOT/frontend/src-tauri/binaries/llama-helper-$TRIPLE"
+echo "   placed llama-helper-$TRIPLE"
+
+say "Installing frontend deps"
+( cd "$ROOT/frontend" && pnpm install )
+
+say "Building Tauri app (.dmg)"
+# The updater-artifact signing step at the very end exits non-zero without
+# TAURI_SIGNING_PRIVATE_KEY, but that runs AFTER the .dmg is written — so we
+# treat the produced .dmg as the source of truth, not the exit code.
+( cd "$ROOT/frontend" && pnpm run tauri:build ) || true
+
+DMG=$(find "$ROOT/target/release/bundle/dmg" "$ROOT/frontend/src-tauri/target" \
+        -name "*.dmg" 2>/dev/null | head -1 || true)
+[ -n "$DMG" ] && say "Done → $DMG" || die "Build finished but no .dmg found"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  prosemirror-model: 1.25.3
+  prosemirror-state: 1.4.3
+  prosemirror-view: 1.41.3
+  prosemirror-transform: 1.10.4
+  prosemirror-tables: 1.8.1
+
 importers:
 
   .:
@@ -449,28 +456,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.33':
     resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.33':
     resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.33':
     resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.33':
     resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
@@ -1597,35 +1600,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.1':
     resolution: {integrity: sha512-mNA5dbbqPqDUdTIwdUYYuhO2GvIe9UnB2r0VU2njxBOS3Opbx4gKNC5yP0Iu4rYmEmqdlwry9VzGZQ3wq9dyFg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.1':
     resolution: {integrity: sha512-fZj3Gwq+6fUs305T5WQiD5iSGJw+j/4w/HGmk4sHDAcy+rp9zU5eaxB7nOyz5/I/nkNAuKPqfp6uIbiUBXkBCw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.1':
     resolution: {integrity: sha512-XFxGxOvHM7jjeD6ozCKdGfhzJ7lERYDGZl1/Kb4fsvchaJsfLJ981TlyTG8Qy/gFq+f5GitH3bfrX9JAkjPEyw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.1':
     resolution: {integrity: sha512-d5C2/Zm+68v7R9wTuTCjRQEVrWjcdMkJBZ1+rXse+QdMMlTB9+u9PDNDLw9PQflWxYLaYZ7tjxxL9Nb9II6PbA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.1':
     resolution: {integrity: sha512-YdeVWFAR1pTXzUU6NLstPq4G6OLxuDrXCXEBdmBH+5EZIDXUx0D2kJlz3+YjpazkKvAzYpgziTsyRagls0OfRQ==}
@@ -2930,10 +2928,10 @@ packages:
       '@types/hast': ^3.0.0
       highlight.js: ^11.9.0
       lowlight: ^3.1.0
-      prosemirror-model: ^1.19.3
-      prosemirror-state: ^1.4.3
-      prosemirror-transform: ^1.8.0
-      prosemirror-view: ^1.32.4
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.3
       refractor: ^5.0.0
       sugar-high: ^0.6.1 || ^0.7.0 || ^0.8.0 || ^0.9.0
     peerDependenciesMeta:
@@ -2979,9 +2977,9 @@ packages:
   prosemirror-paste-rules@3.0.0:
     resolution: {integrity: sha512-p2ayp2xtSTtDPZutoxZyK6UKJhJk0hEpIfdfVYfd3DSENE1Lyrcg96pju+ClgwXlTjPUykXx5DrsfRbHCY+gGQ==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-schema-basic@1.2.4:
     resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
@@ -2995,9 +2993,9 @@ packages:
   prosemirror-suggest@3.0.0:
     resolution: {integrity: sha512-cEYnJHOAnQ+ET7PKY1tY8SMSpyR2rQAuYfPEmVtet0V9exgHAeiaSEzyBcCSeLesxXJRIv8b9cofyqoqyMjlEw==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-tables@1.8.1:
     resolution: {integrity: sha512-DAgDoUYHCcc6tOGpLVPSU1k84kCUWTWnfWX3UDy2Delv4ryH0KqTD6RBI6k4yi9j9I8gl3j8MkPpRD/vWPZbug==}
@@ -3005,9 +3003,9 @@ packages:
   prosemirror-trailing-node@3.0.0:
     resolution: {integrity: sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-transform@1.10.4:
     resolution: {integrity: sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==}
@@ -3448,9 +3446,9 @@ packages:
     resolution: {integrity: sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     peerDependencies:
-      prosemirror-model: ^1.7.1
-      prosemirror-state: ^1.2.3
-      prosemirror-view: ^1.9.10
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
       y-protocols: ^1.0.1
       yjs: ^13.5.38
 

--- a/frontend/src-tauri/migrations/20260624000000_add_quick_notes.sql
+++ b/frontend/src-tauri/migrations/20260624000000_add_quick_notes.sql
@@ -1,0 +1,15 @@
+-- Quick Note: lightweight per-day checklist cards with end-of-day rollover.
+-- `carried_from` records the original date when a pending card is carried
+-- forward; `archived` guards against re-archiving an already-rolled-over day.
+CREATE TABLE IF NOT EXISTS quick_notes (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    date          TEXT    NOT NULL,           -- YYYY-MM-DD (local)
+    text          TEXT    NOT NULL DEFAULT '',
+    done          INTEGER NOT NULL DEFAULT 0, -- 0 = ❌ pending, 1 = ✅ done
+    created_at    TEXT    NOT NULL,
+    carried_from  TEXT,                       -- original date if carried forward
+    archived      INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_quick_notes_date ON quick_notes(date);
+CREATE INDEX IF NOT EXISTS idx_quick_notes_archived ON quick_notes(archived);

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -224,6 +224,8 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
             now.format("%Y-%m-%d_%H-%M-%S")
         )
     });
+    // Start the meeting-log session (creates date folder + live transcript file).
+    crate::meeting_log::begin(&effective_meeting_name);
     manager.set_meeting_name(Some(effective_meeting_name));
 
     // Set up error callback
@@ -282,6 +284,12 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
                     if let Some(manager) = manager_guard.as_ref() {
                         manager.add_transcript_segment(segment);
                     }
+                }
+
+                // Live meeting-log: append finalized segments to disk immediately
+                // (crash-safe). Partial hypotheses are skipped to avoid duplicates.
+                if !update.is_partial {
+                    crate::meeting_log::record_final(&update.text, None);
                 }
             }
         });
@@ -395,6 +403,8 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
             now.format("%Y-%m-%d_%H-%M-%S")
         )
     });
+    // Start the meeting-log session (creates date folder + live transcript file).
+    crate::meeting_log::begin(&effective_meeting_name);
     manager.set_meeting_name(Some(effective_meeting_name));
 
     // Set up error callback
@@ -453,6 +463,12 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
                     if let Some(manager) = manager_guard.as_ref() {
                         manager.add_transcript_segment(segment);
                     }
+                }
+
+                // Live meeting-log: append finalized segments to disk immediately
+                // (crash-safe). Partial hypotheses are skipped to avoid duplicates.
+                if !update.is_partial {
+                    crate::meeting_log::record_final(&update.text, None);
                 }
             }
         });
@@ -849,6 +865,26 @@ pub async fn stop_recording<R: Runtime>(
     // Set recording flag to false
     info!("🔍 Setting IS_RECORDING to false");
     IS_RECORDING.store(false, Ordering::SeqCst);
+
+    // Finalize the meeting-log session: structured summary + daily-log append +
+    // memory indexing. The live transcript is already on disk, so we run this in
+    // the background and notify the frontend when the summary file is ready.
+    {
+        let app_for_log = app.clone();
+        tokio::spawn(async move {
+            if let Some(res) = crate::meeting_log::end().await {
+                let _ = app_for_log.emit(
+                    "meeting-log-finalized",
+                    serde_json::json!({
+                        "summary_path": res.summary_path,
+                        "daily_log_path": res.daily_log_path,
+                        "transcript_path": res.transcript_path,
+                        "topics": res.topics,
+                    }),
+                );
+            }
+        });
+    }
 
     // Step 4.5: Prepare metadata for frontend (NO database save)
     // NOTE: We do NOT save to database here. The frontend will save after all transcripts are displayed.

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -48,6 +48,7 @@ pub mod openai;
 pub mod anthropic;
 pub mod groq;
 pub mod openrouter;
+pub mod meeting_log;
 pub mod parakeet_engine;
 pub mod state;
 pub mod summary;
@@ -420,6 +421,9 @@ pub fn run() {
         .setup(|_app| {
             log::info!("Application setup complete");
 
+            // Best-effort: start the local ML sidecar (translation + memory search).
+            meeting_log::sidecar::ensure_started();
+
             // Initialize system tray
             if let Err(e) = tray::create_tray(_app.handle()) {
                 log::error!("Failed to create system tray: {}", e);
@@ -530,6 +534,19 @@ pub fn run() {
             get_transcription_status,
             read_audio_file,
             save_transcript,
+            meeting_log::commands::meeting_log_config,
+            meeting_log::commands::meeting_log_translate,
+            meeting_log::commands::meeting_log_search,
+            meeting_log::commands::meeting_log_reveal,
+            meeting_log::commands::meeting_log_list_models,
+            meeting_log::commands::meeting_log_set_summary_model,
+            meeting_log::commands::meeting_log_get_summary_model,
+            meeting_log::notes::quick_notes_today,
+            meeting_log::notes::quick_note_add,
+            meeting_log::notes::quick_note_toggle,
+            meeting_log::notes::quick_note_update_text,
+            meeting_log::notes::quick_note_delete,
+            meeting_log::notes::quick_notes_rollover,
             analytics::commands::init_analytics,
             analytics::commands::disable_analytics,
             analytics::commands::track_event,

--- a/frontend/src-tauri/src/meeting_log/commands.rs
+++ b/frontend/src-tauri/src/meeting_log/commands.rs
@@ -1,0 +1,101 @@
+//! Tauri command surface for the meeting-log feature set.
+
+use super::config::config;
+use super::memory::{self, SearchResult};
+use super::translate;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct MeetingLogConfigView {
+    pub log_root: String,
+    pub vector_db_path: String,
+    pub sidecar_url: String,
+    pub translate_model: String,
+    pub summary_model: String,
+    pub embed_model: String,
+    pub glossary: Vec<String>,
+}
+
+/// Expose resolved config (paths, models, glossary) to the frontend.
+#[tauri::command]
+pub fn meeting_log_config() -> MeetingLogConfigView {
+    let c = config();
+    MeetingLogConfigView {
+        log_root: c.log_root.to_string_lossy().to_string(),
+        vector_db_path: c.vector_db_path.to_string_lossy().to_string(),
+        sidecar_url: c.sidecar_url.clone(),
+        translate_model: c.translate_model.clone(),
+        summary_model: c.summary_model.clone(),
+        embed_model: c.embed_model.clone(),
+        glossary: c.glossary.clone(),
+    }
+}
+
+/// Translate one transcript segment into `target` ("th"/"en"), terms pinned.
+/// Defaults to the configured `TRANSLATE_DEFAULT_TARGET` when target is omitted.
+#[tauri::command]
+pub async fn meeting_log_translate(
+    text: String,
+    target: Option<String>,
+) -> Result<String, String> {
+    let target = target.unwrap_or_else(|| config().translate_default_target.clone());
+    translate::translate_to(&text, &target).await
+}
+
+/// Hybrid (dense + sparse) search over the local memory store.
+#[tauri::command]
+pub async fn meeting_log_search(
+    query: String,
+    limit: Option<usize>,
+) -> Result<Vec<SearchResult>, String> {
+    memory::search(&query, limit.unwrap_or(10)).await
+}
+
+/// List installed Ollama models (for the summary-model dropdown in Settings).
+#[tauri::command]
+pub async fn meeting_log_list_models() -> Result<Vec<String>, String> {
+    super::models::list_installed_models().await
+}
+
+/// Override the summary model used for meeting-log summaries (None = use env).
+#[tauri::command]
+pub fn meeting_log_set_summary_model(model: Option<String>) {
+    super::models::set_summary_override(model);
+}
+
+/// Resolve the summary model that will actually be used right now.
+#[tauri::command]
+pub async fn meeting_log_get_summary_model() -> String {
+    super::models::resolve_summary_model().await
+}
+
+/// Reveal a transcript/summary file in Finder (macOS) / Explorer.
+#[tauri::command]
+pub fn meeting_log_reveal(path: String) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg("-R")
+            .arg(&path)
+            .spawn()
+            .map_err(|e| e.to_string())?;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("explorer")
+            .arg("/select,")
+            .arg(&path)
+            .spawn()
+            .map_err(|e| e.to_string())?;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(parent) = std::path::Path::new(&path).parent() {
+            std::process::Command::new("xdg-open")
+                .arg(parent)
+                .spawn()
+                .map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(())
+}

--- a/frontend/src-tauri/src/meeting_log/config.rs
+++ b/frontend/src-tauri/src/meeting_log/config.rs
@@ -1,0 +1,207 @@
+//! Configuration for the meeting-log feature set (file output, translation,
+//! summary, memory search). Values are read from environment variables, with a
+//! `.env` file loaded as a fallback, and finally baked-in defaults so the
+//! packaged app works out of the box.
+//!
+//! All paths are read from config — nothing here is hardcoded at the call site.
+
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Resolved configuration, loaded once on first access.
+#[derive(Debug, Clone)]
+pub struct MeetingLogConfig {
+    pub log_root: PathBuf,
+    /// chrono strftime format for the per-day folder name (e.g. "%Y-%m-%d").
+    pub date_format: String,
+    /// chrono strftime format for the session time component (e.g. "%H-%M-%S").
+    pub time_format: String,
+    pub transcript_pattern: String,
+    pub summary_pattern: String,
+    pub daily_log: String,
+
+    pub stt_model: String,
+    /// Model for →English translation (translategemma is EN-only).
+    pub translate_model: String,
+    /// Model for →Thai translation (needs a Thai-capable multilingual model).
+    pub translate_model_th: String,
+    /// Default target language for the translate button ("th" or "en").
+    pub translate_default_target: String,
+    pub summary_model: String,
+    /// Used automatically if `summary_model` is not installed in Ollama.
+    pub summary_model_fallback: String,
+    pub embed_model: String,
+
+    pub ollama_url: String,
+    pub sidecar_url: String,
+
+    pub vector_db_path: PathBuf,
+    pub glossary: Vec<String>,
+
+    /// Root for Quick Note daily archive markdown files.
+    pub note_log_root: PathBuf,
+    /// "on_launch" enables archive + carry-forward at app start.
+    pub note_rollover: String,
+}
+
+static CONFIG: Lazy<MeetingLogConfig> = Lazy::new(MeetingLogConfig::load);
+
+/// Access the process-wide meeting-log configuration.
+pub fn config() -> &'static MeetingLogConfig {
+    &CONFIG
+}
+
+impl MeetingLogConfig {
+    fn load() -> Self {
+        let env = load_env_layers();
+
+        let get = |key: &str, default: &str| -> String {
+            std::env::var(key)
+                .ok()
+                .or_else(|| env.get(key).cloned())
+                .map(|v| v.trim().to_string())
+                .filter(|v| !v.is_empty())
+                .unwrap_or_else(|| default.to_string())
+        };
+
+        let log_root = get("MEET_LOG_ROOT", "/Users/AR697030/Desktop/personal/meet-log");
+        let date_format = to_chrono_format(&get("MEET_LOG_DATE_FORMAT", "yyyy-MM-dd"));
+        let time_format = to_chrono_format(&get("MEET_TIME_FORMAT", "HH-mm-ss"));
+        let vector_db_path = get(
+            "VECTOR_DB_PATH",
+            &format!("{}/.index/meetings.db", log_root),
+        );
+        let glossary = get(
+            "STT_GLOSSARY",
+            "Kafka,ACL,gRPC,consumer lag,Vault Core,ThoughtMachine,Redis,partition,deploy,UAT,broker",
+        )
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+        MeetingLogConfig {
+            log_root: PathBuf::from(log_root),
+            date_format,
+            time_format,
+            transcript_pattern: get("MEET_TRANSCRIPT_PATTERN", "{time}_transcript.md"),
+            summary_pattern: get("MEET_SUMMARY_PATTERN", "{time}_summary.md"),
+            daily_log: get("MEET_DAILY_LOG", "summary.md"),
+            stt_model: get("STT_MODEL", "large-v3"),
+            translate_model: get("TRANSLATE_MODEL", "translategemma:4b"),
+            translate_model_th: get("TRANSLATE_MODEL_TH", "qwen3.5:9b"),
+            translate_default_target: get("TRANSLATE_DEFAULT_TARGET", "th"),
+            summary_model: get("SUMMARY_MODEL", "qwen3.5:9b"),
+            summary_model_fallback: get("SUMMARY_MODEL_FALLBACK", "qwen2.5:14b"),
+            embed_model: get("EMBED_MODEL", "bge-m3"),
+            ollama_url: get("OLLAMA_URL", "http://127.0.0.1:11434"),
+            sidecar_url: get("MEET_SIDECAR_URL", "http://127.0.0.1:8178"),
+            vector_db_path: PathBuf::from(vector_db_path),
+            glossary,
+            note_log_root: PathBuf::from(get(
+                "NOTE_LOG_ROOT",
+                "/Users/AR697030/Desktop/personal/note-log",
+            )),
+            note_rollover: get("NOTE_ROLLOVER", "on_launch"),
+        }
+    }
+}
+
+/// Search likely `.env` locations and merge them (first found wins per key).
+/// We do NOT override real environment variables — those take precedence.
+fn load_env_layers() -> HashMap<String, String> {
+    let mut merged = HashMap::new();
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Ok(cwd) = std::env::current_dir() {
+        candidates.push(cwd.join(".env"));
+        candidates.push(cwd.join("../.env"));
+        candidates.push(cwd.join("../../.env"));
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            candidates.push(dir.join(".env"));
+        }
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = PathBuf::from(home);
+        candidates.push(home.join("Library/Application Support/Meetily/.env"));
+    }
+
+    for path in candidates {
+        if let Ok(contents) = std::fs::read_to_string(&path) {
+            for (k, v) in parse_env(&contents) {
+                merged.entry(k).or_insert(v);
+            }
+        }
+    }
+    merged
+}
+
+/// Minimal `.env` parser: `KEY=value`, ignores blank/`#` lines and inline
+/// `# comments` after the value. Quotes are stripped.
+fn parse_env(contents: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, rest)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim().to_string();
+        // Strip an inline comment that is not inside quotes.
+        let mut val = rest.trim().to_string();
+        if !(val.starts_with('"') || val.starts_with('\'')) {
+            if let Some(idx) = val.find(" #") {
+                val = val[..idx].trim().to_string();
+            }
+        }
+        let val = val
+            .trim_matches('"')
+            .trim_matches('\'')
+            .trim()
+            .to_string();
+        if !key.is_empty() {
+            out.push((key, val));
+        }
+    }
+    out
+}
+
+/// Translate the Java-style date tokens used in the spec/.env
+/// (yyyy, MM, dd, HH, mm, ss) into chrono strftime specifiers. If the input
+/// already looks like a strftime string (contains '%'), it is returned as-is.
+fn to_chrono_format(fmt: &str) -> String {
+    if fmt.contains('%') {
+        return fmt.to_string();
+    }
+    fmt.replace("yyyy", "%Y")
+        .replace("yy", "%y")
+        .replace("MM", "%m")
+        .replace("dd", "%d")
+        .replace("HH", "%H")
+        .replace("mm", "%M")
+        .replace("ss", "%S")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn translates_java_tokens() {
+        assert_eq!(to_chrono_format("yyyy-MM-dd"), "%Y-%m-%d");
+        assert_eq!(to_chrono_format("HH-mm-ss"), "%H-%M-%S");
+        assert_eq!(to_chrono_format("%Y/%m"), "%Y/%m");
+    }
+
+    #[test]
+    fn parses_env_with_inline_comment() {
+        let parsed = parse_env("MEET_LOG_ROOT=/tmp/x   # the root\nFOO=bar\n# comment\n");
+        assert_eq!(parsed[0], ("MEET_LOG_ROOT".into(), "/tmp/x".into()));
+        assert_eq!(parsed[1], ("FOO".into(), "bar".into()));
+    }
+}

--- a/frontend/src-tauri/src/meeting_log/memory.rs
+++ b/frontend/src-tauri/src/meeting_log/memory.rs
@@ -1,0 +1,167 @@
+//! Local memory search client. The heavy lifting (bge-m3 embeddings,
+//! sqlite-vec, FTS5 + PyThaiNLP segmentation, hybrid ranking) lives in the
+//! Python sidecar. Rust just chunks the session and calls the sidecar's
+//! `/index` and `/search` endpoints. Everything stays on 127.0.0.1.
+
+use super::config::config;
+use super::session::SessionLog;
+use super::summary::StructuredSummary;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize)]
+struct IndexChunk {
+    chunk_id: String,
+    text: String,
+    kind: String, // "transcript" | "summary"
+}
+
+#[derive(Debug, Serialize)]
+struct IndexRequest {
+    db_path: String,
+    embed_model: String,
+    meeting_date: String,
+    session_time: String,
+    topics: Vec<String>,
+    file_path: String,
+    summary_path: String,
+    chunks: Vec<IndexChunk>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SearchResult {
+    pub snippet: String,
+    pub meeting_date: String,
+    pub session_time: String,
+    #[serde(default)]
+    pub topics: Vec<String>,
+    pub file_path: String,
+    #[serde(default)]
+    pub summary_path: String,
+    #[serde(default)]
+    pub score: f32,
+}
+
+#[derive(Debug, Serialize)]
+struct SearchRequest {
+    db_path: String,
+    embed_model: String,
+    query: String,
+    limit: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchResponse {
+    #[serde(default)]
+    results: Vec<SearchResult>,
+}
+
+/// Split text into ~chunk_chars windows on line boundaries.
+fn chunk_text(text: &str, chunk_chars: usize) -> Vec<String> {
+    let mut chunks = Vec::new();
+    let mut current = String::new();
+    for line in text.lines() {
+        if current.len() + line.len() + 1 > chunk_chars && !current.is_empty() {
+            chunks.push(std::mem::take(&mut current));
+        }
+        current.push_str(line);
+        current.push('\n');
+    }
+    if !current.trim().is_empty() {
+        chunks.push(current);
+    }
+    chunks
+}
+
+/// Index a finished session into the local memory store via the sidecar.
+pub async fn index_session(
+    session: &SessionLog,
+    summary: &StructuredSummary,
+) -> Result<(), String> {
+    let cfg = config();
+
+    let mut chunks: Vec<IndexChunk> = Vec::new();
+    for (i, c) in chunk_text(&session.transcript_plain(), 800).into_iter().enumerate() {
+        chunks.push(IndexChunk {
+            chunk_id: format!("{}_{}_t{}", session.date_iso, session.session_time, i),
+            text: c,
+            kind: "transcript".to_string(),
+        });
+    }
+    // Summary as its own searchable chunk.
+    let summary_blob = format!(
+        "Overview: {}\nTopics: {}\nActions: {}",
+        summary.overview.join("; "),
+        summary.topics.join(", "),
+        summary
+            .action_items
+            .iter()
+            .map(|a| format!("{}: {}", a.assignee, a.task))
+            .collect::<Vec<_>>()
+            .join("; ")
+    );
+    chunks.push(IndexChunk {
+        chunk_id: format!("{}_{}_summary", session.date_iso, session.session_time),
+        text: summary_blob,
+        kind: "summary".to_string(),
+    });
+
+    if chunks.is_empty() {
+        return Ok(());
+    }
+
+    let summary_name = cfg.summary_pattern.replace("{time}", &session.session_time);
+    let req = IndexRequest {
+        db_path: cfg.vector_db_path.to_string_lossy().to_string(),
+        embed_model: cfg.embed_model.clone(),
+        meeting_date: session.date_iso.clone(),
+        session_time: session.session_time.clone(),
+        topics: summary.topics.clone(),
+        file_path: session.transcript_path.to_string_lossy().to_string(),
+        summary_path: session
+            .date_folder
+            .join(summary_name)
+            .to_string_lossy()
+            .to_string(),
+        chunks,
+    };
+
+    let url = format!("{}/index", cfg.sidecar_url.trim_end_matches('/'));
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&url)
+        .json(&req)
+        .send()
+        .await
+        .map_err(|e| format!("index request failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("sidecar /index returned {}", resp.status()));
+    }
+    Ok(())
+}
+
+/// Hybrid search the local memory store via the sidecar.
+pub async fn search(query: &str, limit: usize) -> Result<Vec<SearchResult>, String> {
+    let cfg = config();
+    let req = SearchRequest {
+        db_path: cfg.vector_db_path.to_string_lossy().to_string(),
+        embed_model: cfg.embed_model.clone(),
+        query: query.to_string(),
+        limit,
+    };
+    let url = format!("{}/search", cfg.sidecar_url.trim_end_matches('/'));
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&url)
+        .json(&req)
+        .send()
+        .await
+        .map_err(|e| format!("search request failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("sidecar /search returned {}", resp.status()));
+    }
+    let parsed: SearchResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("search decode failed: {e}"))?;
+    Ok(parsed.results)
+}

--- a/frontend/src-tauri/src/meeting_log/mod.rs
+++ b/frontend/src-tauri/src/meeting_log/mod.rs
@@ -1,0 +1,53 @@
+//! Meeting-log feature set (personal fork):
+//! - file output: live transcript append, per-session summary, daily log
+//! - Thai STT glossary (consumed by the whisper engine)
+//! - translation (TH→EN) via the Python sidecar
+//! - local memory search (sqlite-vec + FTS5) via the Python sidecar
+//!
+//! All paths/models are read from `config` (env + `.env` + defaults). Nothing
+//! here reaches outside 127.0.0.1.
+
+pub mod commands;
+pub mod config;
+pub mod memory;
+pub mod models;
+pub mod notes;
+pub mod session;
+pub mod sidecar;
+pub mod summary;
+pub mod translate;
+
+pub use config::config;
+
+/// Begin a meeting-log session (called when recording starts). Non-fatal.
+pub fn begin(meeting_name: &str) {
+    match session::start_session(meeting_name) {
+        Ok(path) => log::info!("📝 meeting-log: transcript → {:?}", path),
+        Err(e) => log::warn!("📝 meeting-log: failed to start session: {e}"),
+    }
+}
+
+/// Append a finalized transcript segment to the live file. Non-fatal.
+pub fn record_final(text: &str, speaker: Option<&str>) {
+    session::append_final_segment(text, speaker);
+}
+
+/// Finalize the session (summary + daily log + indexing). Called at stop.
+/// Returns a human-readable status for logging; never panics.
+pub async fn end() -> Option<summary::FinalizeResult> {
+    let session = session::take_session()?;
+    match summary::finalize(session).await {
+        Ok(res) => {
+            log::info!(
+                "📝 meeting-log: summary → {} | daily → {}",
+                res.summary_path,
+                res.daily_log_path
+            );
+            Some(res)
+        }
+        Err(e) => {
+            log::warn!("📝 meeting-log: finalize failed: {e}");
+            None
+        }
+    }
+}

--- a/frontend/src-tauri/src/meeting_log/models.rs
+++ b/frontend/src-tauri/src/meeting_log/models.rs
@@ -1,0 +1,101 @@
+//! Summary-model resolution for the meeting-log summary. Resolution order:
+//!   1. a runtime override set from the Settings dropdown (if installed)
+//!   2. env `SUMMARY_MODEL` (if installed)
+//!   3. env `SUMMARY_MODEL_FALLBACK` (if installed)
+//!   4. env `SUMMARY_MODEL` anyway (last resort)
+//! Never panics — a failed `ollama list` just falls through to the primary.
+
+use super::config::config;
+use serde::Deserialize;
+use std::sync::Mutex;
+
+static SUMMARY_OVERRIDE: Mutex<Option<String>> = Mutex::new(None);
+
+pub fn set_summary_override(model: Option<String>) {
+    if let Ok(mut g) = SUMMARY_OVERRIDE.lock() {
+        *g = model.filter(|m| !m.trim().is_empty());
+    }
+}
+
+pub fn summary_override() -> Option<String> {
+    SUMMARY_OVERRIDE.lock().ok().and_then(|g| g.clone())
+}
+
+#[derive(Deserialize)]
+struct TagModel {
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct TagsResponse {
+    #[serde(default)]
+    models: Vec<TagModel>,
+}
+
+/// List installed Ollama model names (e.g. "qwen3.5:9b").
+pub async fn list_installed_models() -> Result<Vec<String>, String> {
+    let cfg = config();
+    let url = format!("{}/api/tags", cfg.ollama_url.trim_end_matches('/'));
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("ollama tags request failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("ollama /api/tags returned {}", resp.status()));
+    }
+    let parsed: TagsResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("ollama tags decode failed: {e}"))?;
+    Ok(parsed.models.into_iter().map(|m| m.name).collect())
+}
+
+/// True if `target` matches an installed model name (exact, or same name with a
+/// different/elided tag, so "qwen3.5:9b" matches "qwen3.5:9b" and a bare name
+/// matches "<name>:latest").
+fn is_installed(installed: &[String], target: &str) -> bool {
+    let t = target.trim();
+    if t.is_empty() {
+        return false;
+    }
+    installed.iter().any(|m| {
+        m == t
+            || m == &format!("{t}:latest")
+            || m.split(':').next() == t.split(':').next()
+                && (t.contains(':') == m.contains(':') || !t.contains(':'))
+    })
+}
+
+/// Resolve the summary model to actually call, applying the fallback chain.
+pub async fn resolve_summary_model() -> String {
+    let cfg = config();
+    let primary = summary_override().unwrap_or_else(|| cfg.summary_model.clone());
+
+    match list_installed_models().await {
+        Ok(installed) => {
+            if is_installed(&installed, &primary) {
+                primary
+            } else if is_installed(&installed, &cfg.summary_model_fallback) {
+                log::warn!(
+                    "📝 meeting-log: summary model '{}' not installed; falling back to '{}'",
+                    primary,
+                    cfg.summary_model_fallback
+                );
+                cfg.summary_model_fallback.clone()
+            } else {
+                log::warn!(
+                    "📝 meeting-log: neither '{}' nor fallback '{}' installed; trying '{}' anyway",
+                    primary,
+                    cfg.summary_model_fallback,
+                    primary
+                );
+                primary
+            }
+        }
+        Err(e) => {
+            log::warn!("📝 meeting-log: could not query ollama ({e}); using '{}'", primary);
+            primary
+        }
+    }
+}

--- a/frontend/src-tauri/src/meeting_log/notes.rs
+++ b/frontend/src-tauri/src/meeting_log/notes.rs
@@ -1,0 +1,203 @@
+//! Quick Note: per-day checklist cards persisted in SQLite, with an on-launch
+//! rollover that archives finished days to `NOTE_LOG_ROOT/<date>.md` and carries
+//! pending (❌) cards forward to today.
+
+use super::config::config;
+use crate::state::AppState;
+use chrono::Local;
+use serde::Serialize;
+use sqlx::{Row, SqlitePool};
+use std::fs;
+use std::io::Write;
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct QuickNote {
+    pub id: i64,
+    pub date: String,
+    pub text: String,
+    pub done: bool,
+    pub created_at: String,
+    pub carried_from: Option<String>,
+}
+
+fn today() -> String {
+    Local::now().format("%Y-%m-%d").to_string()
+}
+
+fn now_iso() -> String {
+    Local::now().format("%Y-%m-%d %H:%M:%S").to_string()
+}
+
+async fn fetch_for_date(pool: &SqlitePool, date: &str) -> Result<Vec<QuickNote>, String> {
+    sqlx::query_as::<_, QuickNote>(
+        "SELECT id, date, text, done, created_at, carried_from
+         FROM quick_notes WHERE date = ? ORDER BY id ASC",
+    )
+    .bind(date)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| e.to_string())
+}
+
+// ── Commands ────────────────────────────────────────────────────────────────
+
+/// Cards for today (call after rollover).
+#[tauri::command]
+pub async fn quick_notes_today(state: tauri::State<'_, AppState>) -> Result<Vec<QuickNote>, String> {
+    fetch_for_date(state.db_manager.pool(), &today()).await
+}
+
+#[tauri::command]
+pub async fn quick_note_add(
+    state: tauri::State<'_, AppState>,
+    text: String,
+) -> Result<QuickNote, String> {
+    let pool = state.db_manager.pool();
+    let id = sqlx::query(
+        "INSERT INTO quick_notes (date, text, done, created_at) VALUES (?, ?, 0, ?)",
+    )
+    .bind(today())
+    .bind(text.trim())
+    .bind(now_iso())
+    .execute(pool)
+    .await
+    .map_err(|e| e.to_string())?
+    .last_insert_rowid();
+
+    sqlx::query_as::<_, QuickNote>(
+        "SELECT id, date, text, done, created_at, carried_from FROM quick_notes WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_one(pool)
+    .await
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn quick_note_toggle(
+    state: tauri::State<'_, AppState>,
+    id: i64,
+    done: bool,
+) -> Result<(), String> {
+    sqlx::query("UPDATE quick_notes SET done = ? WHERE id = ?")
+        .bind(done)
+        .bind(id)
+        .execute(state.db_manager.pool())
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn quick_note_update_text(
+    state: tauri::State<'_, AppState>,
+    id: i64,
+    text: String,
+) -> Result<(), String> {
+    sqlx::query("UPDATE quick_notes SET text = ? WHERE id = ?")
+        .bind(text.trim())
+        .bind(id)
+        .execute(state.db_manager.pool())
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn quick_note_delete(state: tauri::State<'_, AppState>, id: i64) -> Result<(), String> {
+    sqlx::query("DELETE FROM quick_notes WHERE id = ?")
+        .bind(id)
+        .execute(state.db_manager.pool())
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+pub struct RolloverResult {
+    pub archived_days: Vec<String>,
+    pub carried: i64,
+}
+
+/// On-launch rollover: for each un-archived day before today, write an archive
+/// markdown file, carry pending cards forward to today, and mark the day
+/// archived. Idempotent (archived guard). Never panics.
+#[tauri::command]
+pub async fn quick_notes_rollover(
+    state: tauri::State<'_, AppState>,
+) -> Result<RolloverResult, String> {
+    let cfg = config();
+    if cfg.note_rollover.trim().to_lowercase() != "on_launch" {
+        return Ok(RolloverResult { archived_days: vec![], carried: 0 });
+    }
+    let pool = state.db_manager.pool();
+    let today = today();
+
+    // Distinct past days with un-archived cards.
+    let days: Vec<String> = sqlx::query(
+        "SELECT DISTINCT date FROM quick_notes WHERE archived = 0 AND date < ? ORDER BY date ASC",
+    )
+    .bind(&today)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| e.to_string())?
+    .into_iter()
+    .map(|r| r.get::<String, _>("date"))
+    .collect();
+
+    let mut archived_days = Vec::new();
+    let mut carried = 0i64;
+
+    for day in days {
+        let cards = fetch_for_date(pool, &day).await?;
+        if cards.is_empty() {
+            continue;
+        }
+
+        // (a) Archive the whole day to NOTE_LOG_ROOT/<date>.md
+        fs::create_dir_all(&cfg.note_log_root)
+            .map_err(|e| format!("create note-log dir: {e}"))?;
+        let path = cfg.note_log_root.join(format!("{day}.md"));
+        let mut body = format!("# Quick Note — {day}\n\n");
+        for c in &cards {
+            if c.done {
+                body.push_str(&format!("[x] {} ✅\n", c.text.trim()));
+            } else {
+                body.push_str(&format!("[ ] {} ❌\n", c.text.trim()));
+            }
+        }
+        fs::write(&path, body).map_err(|e| format!("write {:?}: {e}", path))?;
+
+        // (b) Carry pending (❌) cards forward to today.
+        for c in cards.iter().filter(|c| !c.done) {
+            sqlx::query(
+                "INSERT INTO quick_notes (date, text, done, created_at, carried_from)
+                 VALUES (?, ?, 0, ?, ?)",
+            )
+            .bind(&today)
+            .bind(c.text.trim())
+            .bind(now_iso())
+            .bind(&day)
+            .execute(pool)
+            .await
+            .map_err(|e| e.to_string())?;
+            carried += 1;
+        }
+
+        // (c) Mark the old day archived.
+        sqlx::query("UPDATE quick_notes SET archived = 1 WHERE date = ?")
+            .bind(&day)
+            .execute(pool)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        archived_days.push(day);
+    }
+
+    log::info!(
+        "📝 quick-note rollover: archived {} day(s), carried {} card(s)",
+        archived_days.len(),
+        carried
+    );
+    Ok(RolloverResult { archived_days, carried })
+}

--- a/frontend/src-tauri/src/meeting_log/session.rs
+++ b/frontend/src-tauri/src/meeting_log/session.rs
@@ -1,0 +1,151 @@
+//! Live meeting-log session: creates the per-day folder, appends each final
+//! transcript segment to disk immediately (crash-safe), and holds the segments
+//! in memory so they can be summarized + indexed when the session ends.
+
+use super::config::config;
+use chrono::{DateTime, Local};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+/// A single finalized transcript line.
+#[derive(Debug, Clone)]
+pub struct LoggedSegment {
+    /// Content timestamp, e.g. "14:30:12" (colons OK — this is file content).
+    pub clock: String,
+    pub speaker: Option<String>,
+    pub text: String,
+}
+
+/// State for the currently-recording session.
+#[derive(Debug, Clone)]
+pub struct SessionLog {
+    pub meeting_name: String,
+    /// e.g. ".../meet-log/2026-06-24"
+    pub date_folder: PathBuf,
+    /// Colon-safe session time, e.g. "14-30-05".
+    pub session_time: String,
+    /// Human header time, e.g. "2026-06-24 14:30:05".
+    pub started_human: String,
+    /// ISO date, e.g. "2026-06-24".
+    pub date_iso: String,
+    pub transcript_path: PathBuf,
+    pub segments: Vec<LoggedSegment>,
+}
+
+static SESSION: Mutex<Option<SessionLog>> = Mutex::new(None);
+
+/// Begin a new session: create folders + transcript file with a header.
+/// Returns the transcript path. Errors are non-fatal to recording — callers
+/// should log and continue if this fails.
+pub fn start_session(meeting_name: &str) -> Result<PathBuf, String> {
+    let cfg = config();
+    let now: DateTime<Local> = Local::now();
+
+    let date_dir_name = now.format(&cfg.date_format).to_string();
+    let session_time = now.format(&cfg.time_format).to_string();
+    let date_iso = now.format("%Y-%m-%d").to_string();
+    let started_human = now.format("%Y-%m-%d %H:%M:%S").to_string();
+
+    let date_folder = cfg.log_root.join(&date_dir_name);
+    fs::create_dir_all(&date_folder)
+        .map_err(|e| format!("create date folder {:?}: {e}", date_folder))?;
+    // Ensure the vector index dir exists too (cheap, idempotent).
+    if let Some(idx_dir) = cfg.vector_db_path.parent() {
+        let _ = fs::create_dir_all(idx_dir);
+    }
+
+    let transcript_name = cfg.transcript_pattern.replace("{time}", &session_time);
+    let transcript_path = date_folder.join(transcript_name);
+
+    let header = format!("# Transcript — {}\n\n", started_human);
+    fs::write(&transcript_path, header)
+        .map_err(|e| format!("write transcript header {:?}: {e}", transcript_path))?;
+
+    let session = SessionLog {
+        meeting_name: meeting_name.to_string(),
+        date_folder,
+        session_time,
+        started_human,
+        date_iso,
+        transcript_path: transcript_path.clone(),
+        segments: Vec::new(),
+    };
+
+    let mut guard = SESSION.lock().map_err(|e| e.to_string())?;
+    *guard = Some(session);
+    Ok(transcript_path)
+}
+
+/// Append one finalized segment to the transcript file and flush immediately.
+/// `speaker` is optional (diarization may fill it later). No-op if no active
+/// session.
+pub fn append_final_segment(text: &str, speaker: Option<&str>) {
+    let text = text.trim();
+    if text.is_empty() {
+        return;
+    }
+    let clock = Local::now().format("%H:%M:%S").to_string();
+
+    let mut guard = match SESSION.lock() {
+        Ok(g) => g,
+        Err(_) => return,
+    };
+    let Some(session) = guard.as_mut() else {
+        return;
+    };
+
+    let line = match speaker {
+        Some(s) if !s.is_empty() => format!("[{}] {}: {}\n", clock, s, text),
+        _ => format!("[{}] {}\n", clock, text),
+    };
+
+    match OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&session.transcript_path)
+    {
+        Ok(mut f) => {
+            if let Err(e) = f.write_all(line.as_bytes()).and_then(|_| f.flush()) {
+                log::warn!("meeting_log: failed to append transcript line: {e}");
+            }
+        }
+        Err(e) => log::warn!("meeting_log: failed to open transcript file: {e}"),
+    }
+
+    session.segments.push(LoggedSegment {
+        clock,
+        speaker: speaker.map(|s| s.to_string()),
+        text: text.to_string(),
+    });
+}
+
+/// Take and clear the active session (called at stop). Returns owned data so
+/// async finalization can run without holding the lock.
+pub fn take_session() -> Option<SessionLog> {
+    SESSION.lock().ok().and_then(|mut g| g.take())
+}
+
+/// Is there an active meeting-log session?
+pub fn has_active_session() -> bool {
+    SESSION
+        .lock()
+        .ok()
+        .map(|g| g.is_some())
+        .unwrap_or(false)
+}
+
+impl SessionLog {
+    /// Full transcript as plain text lines (no markdown header), for the LLM.
+    pub fn transcript_plain(&self) -> String {
+        self.segments
+            .iter()
+            .map(|s| match &s.speaker {
+                Some(sp) if !sp.is_empty() => format!("[{}] {}: {}", s.clock, sp, s.text),
+                _ => format!("[{}] {}", s.clock, s.text),
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}

--- a/frontend/src-tauri/src/meeting_log/sidecar.rs
+++ b/frontend/src-tauri/src/meeting_log/sidecar.rs
@@ -1,0 +1,75 @@
+//! Best-effort launcher for the Python ML sidecar. On startup we check whether
+//! the sidecar already answers on its health endpoint; if not, we try to spawn
+//! it from a known location. Entirely non-fatal — translation/search simply
+//! return errors (handled gracefully in the UI) when the sidecar is absent.
+
+use super::config::config;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Locate the `sidecar/` directory (dev layouts + an env override).
+fn find_sidecar_dir() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("MEET_SIDECAR_DIR") {
+        let p = PathBuf::from(dir);
+        if p.join("run.sh").exists() {
+            return Some(p);
+        }
+    }
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Ok(cwd) = std::env::current_dir() {
+        candidates.push(cwd.join("sidecar"));
+        candidates.push(cwd.join("../sidecar"));
+        candidates.push(cwd.join("../../sidecar"));
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        let mut d = exe.parent().map(|p| p.to_path_buf());
+        for _ in 0..6 {
+            if let Some(dir) = &d {
+                candidates.push(dir.join("sidecar"));
+                d = dir.parent().map(|p| p.to_path_buf());
+            }
+        }
+    }
+    candidates.into_iter().find(|p| p.join("run.sh").exists())
+}
+
+/// Spawn the sidecar if it is not already healthy. Runs in a background thread
+/// so it never blocks app startup.
+pub fn ensure_started() {
+    std::thread::spawn(|| {
+        let cfg = config();
+        let health = format!("{}/health", cfg.sidecar_url.trim_end_matches('/'));
+
+        // Already up?
+        if reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_millis(800))
+            .build()
+            .ok()
+            .and_then(|c| c.get(&health).send().ok())
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        {
+            log::info!("📝 meeting-log: sidecar already running at {}", cfg.sidecar_url);
+            return;
+        }
+
+        let Some(dir) = find_sidecar_dir() else {
+            log::warn!(
+                "📝 meeting-log: sidecar dir not found; run `sidecar/run.sh` manually to enable translation/search"
+            );
+            return;
+        };
+
+        log::info!("📝 meeting-log: starting sidecar from {:?}", dir);
+        let run_sh = dir.join("run.sh");
+        let spawn = Command::new("bash")
+            .arg(run_sh)
+            .current_dir(&dir)
+            .env("OLLAMA_URL", &cfg.ollama_url)
+            .spawn();
+        match spawn {
+            Ok(_) => log::info!("📝 meeting-log: sidecar launch requested"),
+            Err(e) => log::warn!("📝 meeting-log: failed to launch sidecar: {e}"),
+        }
+    });
+}

--- a/frontend/src-tauri/src/meeting_log/summary.rs
+++ b/frontend/src-tauri/src/meeting_log/summary.rs
@@ -1,0 +1,249 @@
+//! Session finalization: ask the local summary model for a structured JSON
+//! summary, render it to markdown, write `{time}_summary.md`, and append a
+//! section to the per-day `summary.md`. Then trigger memory indexing.
+
+use super::config::config;
+use super::session::SessionLog;
+use serde::{Deserialize, Serialize};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ActionItem {
+    #[serde(default)]
+    pub assignee: String,
+    #[serde(default)]
+    pub task: String,
+    #[serde(default = "default_status")]
+    pub status: String,
+}
+
+fn default_status() -> String {
+    "open".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct StructuredSummary {
+    #[serde(default)]
+    pub overview: Vec<String>,
+    #[serde(default)]
+    pub action_items: Vec<ActionItem>,
+    #[serde(default)]
+    pub topics: Vec<String>,
+}
+
+const SUMMARY_SYSTEM: &str = "You are a meeting summarizer for Thai/English code-switched engineering meetings. \
+Keep technical terms in English exactly as spoken (Kafka, ACL, gRPC, consumer lag, Vault Core, Redis, partition, broker, deploy, UAT). \
+Do not translate or transliterate technical terms. Respond with JSON only, no prose.";
+
+/// Build the JSON-only prompt for the summary model.
+fn build_prompt(transcript: &str) -> String {
+    format!(
+        "{SUMMARY_SYSTEM}\n\nSummarize the following meeting transcript.\n\
+Return ONLY a JSON object with this exact shape:\n\
+{{\n  \"overview\": [\"short bullet\", ...],\n  \"action_items\": [{{\"assignee\": \"name or Team\", \"task\": \"...\", \"status\": \"open\"}}],\n  \"topics\": [\"Kafka\", \"ACL\", ...]\n}}\n\n\
+Transcript:\n{transcript}\n"
+    )
+}
+
+/// Call Ollama `/api/generate` with `format: json` and parse the result.
+async fn request_summary(transcript: &str) -> Result<StructuredSummary, String> {
+    let cfg = config();
+    let model = super::models::resolve_summary_model().await;
+    let url = format!("{}/api/generate", cfg.ollama_url.trim_end_matches('/'));
+    let body = serde_json::json!({
+        "model": model,
+        "prompt": build_prompt(transcript),
+        "stream": false,
+        "format": "json",
+        "options": { "temperature": 0.2 }
+    });
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("summary request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("summary model returned {}", resp.status()));
+    }
+
+    let v: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("summary decode failed: {e}"))?;
+    let inner = v
+        .get("response")
+        .and_then(|r| r.as_str())
+        .unwrap_or("")
+        .trim();
+
+    serde_json::from_str::<StructuredSummary>(inner)
+        .map_err(|e| format!("summary JSON parse failed: {e}; raw: {inner}"))
+}
+
+/// Render the structured summary to the markdown body used in both the
+/// per-session file and (a condensed form of) the daily log.
+fn render_markdown(summary: &StructuredSummary, started_human: &str) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("# Summary — {}\n\n", started_human));
+
+    out.push_str("## Overview\n");
+    if summary.overview.is_empty() {
+        out.push_str("- (none)\n");
+    } else {
+        for o in &summary.overview {
+            out.push_str(&format!("- {}\n", o.trim()));
+        }
+    }
+
+    out.push_str("\n## Action Items\n");
+    if summary.action_items.is_empty() {
+        out.push_str("- (none)\n");
+    } else {
+        // Group tasks under assignee.
+        let mut by_assignee: Vec<(String, Vec<&ActionItem>)> = Vec::new();
+        for item in &summary.action_items {
+            let key = if item.assignee.trim().is_empty() {
+                "Team".to_string()
+            } else {
+                item.assignee.trim().to_string()
+            };
+            if let Some(entry) = by_assignee.iter_mut().find(|(a, _)| a == &key) {
+                entry.1.push(item);
+            } else {
+                by_assignee.push((key, vec![item]));
+            }
+        }
+        for (assignee, items) in by_assignee {
+            out.push_str(&format!("- {}\n", assignee));
+            for item in items {
+                let status = if item.status.trim().is_empty() {
+                    "open"
+                } else {
+                    item.status.trim()
+                };
+                out.push_str(&format!("  - {} ({})\n", item.task.trim(), status));
+            }
+        }
+    }
+
+    out.push_str("\n## Topics\n");
+    if summary.topics.is_empty() {
+        out.push_str("(none)\n");
+    } else {
+        out.push_str(&summary.topics.join(", "));
+        out.push('\n');
+    }
+
+    out
+}
+
+/// Result of finalizing a session, returned for logging / frontend events.
+#[derive(Debug, Clone, Serialize)]
+pub struct FinalizeResult {
+    pub summary_path: String,
+    pub daily_log_path: String,
+    pub transcript_path: String,
+    pub topics: Vec<String>,
+}
+
+/// Generate the summary, write the per-session summary file, append the daily
+/// log, and kick off memory indexing. Designed to never panic; returns an
+/// error string the caller can log.
+pub async fn finalize(session: SessionLog) -> Result<FinalizeResult, String> {
+    let cfg = config();
+    let transcript = session.transcript_plain();
+
+    if transcript.trim().is_empty() {
+        return Err("no transcript content to summarize".to_string());
+    }
+
+    // 1. Structured summary (fall back to a minimal summary if the model fails).
+    let summary = match request_summary(&transcript).await {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("meeting_log: summary model failed ({e}); writing fallback summary");
+            StructuredSummary {
+                overview: vec![format!(
+                    "Transcript captured ({} segments). Summary model unavailable.",
+                    session.segments.len()
+                )],
+                ..Default::default()
+            }
+        }
+    };
+
+    let summary_md = render_markdown(&summary, &session.started_human);
+
+    // 2. Per-session summary file.
+    let summary_name = cfg.summary_pattern.replace("{time}", &session.session_time);
+    let summary_path = session.date_folder.join(&summary_name);
+    fs::write(&summary_path, &summary_md)
+        .map_err(|e| format!("write summary {:?}: {e}", summary_path))?;
+
+    // 3. Append to the per-day daily log.
+    let daily_path = session.date_folder.join(&cfg.daily_log);
+    append_daily_log(&daily_path, &session, &summary, &summary_name)?;
+
+    // 4. Fire-and-forget memory indexing via the sidecar.
+    let index_session = session.clone();
+    let summary_for_index = summary.clone();
+    tokio::spawn(async move {
+        if let Err(e) =
+            super::memory::index_session(&index_session, &summary_for_index).await
+        {
+            log::warn!("meeting_log: memory indexing skipped/failed: {e}");
+        }
+    });
+
+    Ok(FinalizeResult {
+        summary_path: summary_path.to_string_lossy().to_string(),
+        daily_log_path: daily_path.to_string_lossy().to_string(),
+        transcript_path: session.transcript_path.to_string_lossy().to_string(),
+        topics: summary.topics,
+    })
+}
+
+fn append_daily_log(
+    daily_path: &PathBuf,
+    session: &SessionLog,
+    summary: &StructuredSummary,
+    summary_name: &str,
+) -> Result<(), String> {
+    // Title: session clock time + first topic (or meeting name).
+    let clock = session
+        .session_time
+        .replace('-', ":"); // "14-30-05" -> "14:30:05"
+    let title = summary
+        .topics
+        .first()
+        .cloned()
+        .filter(|t| !t.trim().is_empty())
+        .unwrap_or_else(|| session.meeting_name.clone());
+
+    let mut section = String::new();
+    section.push_str(&format!("\n---\n## {} — {}\n", clock, title));
+    if summary.overview.is_empty() {
+        section.push_str("- (no overview)\n");
+    } else {
+        for o in &summary.overview {
+            section.push_str(&format!("- {}\n", o.trim()));
+        }
+    }
+    section.push_str(&format!("→ full: {}\n", summary_name));
+
+    let mut f = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(daily_path)
+        .map_err(|e| format!("open daily log {:?}: {e}", daily_path))?;
+    f.write_all(section.as_bytes())
+        .and_then(|_| f.flush())
+        .map_err(|e| format!("append daily log: {e}"))?;
+    Ok(())
+}

--- a/frontend/src-tauri/src/meeting_log/translate.rs
+++ b/frontend/src-tauri/src/meeting_log/translate.rs
@@ -1,0 +1,80 @@
+//! Translation client (Feature 5). Sends Thai (or mixed) text to the sidecar's
+//! `/translate` endpoint, which runs `translategemma` via Ollama with a
+//! term-pinning prompt so technical terms stay in English. English-only input
+//! is short-circuited here to avoid a needless round-trip.
+
+use super::config::config;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize)]
+struct TranslateRequest {
+    model: String,
+    text: String,
+    glossary: Vec<String>,
+    target: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TranslateResponse {
+    #[serde(default)]
+    translation: String,
+}
+
+/// True if the text contains any Thai characters.
+fn has_thai(text: &str) -> bool {
+    text.chars().any(|c| ('\u{0E00}'..='\u{0E7F}').contains(&c))
+}
+
+/// True if the text contains any ASCII letters (proxy for "has English words").
+fn has_latin(text: &str) -> bool {
+    text.chars().any(|c| c.is_ascii_alphabetic())
+}
+
+/// Should we skip translating this text for the given target? We skip when the
+/// text is already entirely in the target language (nothing to translate).
+fn already_target(text: &str, target: &str) -> bool {
+    match target {
+        "th" => !has_latin(text), // already pure Thai (no English words)
+        _ => !has_thai(text),     // target en: already has no Thai
+    }
+}
+
+/// Translate `text` into `target` ("th" or "en"), pinning technical terms.
+/// Text already in the target language is returned unchanged.
+pub async fn translate_to(text: &str, target: &str) -> Result<String, String> {
+    let trimmed = text.trim();
+    let target = if target == "th" { "th" } else { "en" };
+    if trimmed.is_empty() || already_target(trimmed, target) {
+        return Ok(trimmed.to_string());
+    }
+
+    let cfg = config();
+    // translategemma is →EN only; use a Thai-capable model for →TH.
+    let model = if target == "th" {
+        cfg.translate_model_th.clone()
+    } else {
+        cfg.translate_model.clone()
+    };
+    let req = TranslateRequest {
+        model,
+        text: trimmed.to_string(),
+        glossary: cfg.glossary.clone(),
+        target: target.to_string(),
+    };
+    let url = format!("{}/translate", cfg.sidecar_url.trim_end_matches('/'));
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&url)
+        .json(&req)
+        .send()
+        .await
+        .map_err(|e| format!("translate request failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("sidecar /translate returned {}", resp.status()));
+    }
+    let parsed: TranslateResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("translate decode failed: {e}"))?;
+    Ok(parsed.translation.trim().to_string())
+}

--- a/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
+++ b/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
@@ -523,6 +523,9 @@ impl WhisperEngine {
         let adaptive_config = hardware_profile.get_whisper_config();
 
         // ADAPTIVE parameters - optimized for current hardware
+        // Technical-term glossary, declared before `params` so it outlives the
+        // initial-prompt pointer whisper-rs holds during `full()`.
+        let glossary_prompt = crate::meeting_log::config().glossary.join(", ");
         let mut params = FullParams::new(SamplingStrategy::BeamSearch {
             beam_size: adaptive_config.beam_size as i32,
             patience: 1.0
@@ -539,6 +542,12 @@ impl WhisperEngine {
         };
         params.set_language(language_code);
         params.set_translate(should_translate);
+
+        // Inject the glossary as whisper's initial prompt so Thai/English
+        // code-switched speech keeps terms like Kafka/ACL/gRPC in English.
+        if !glossary_prompt.is_empty() {
+            params.set_initial_prompt(&glossary_prompt);
+        }
 
         // CRITICAL: Disable timestamp tokens to prevent whisper.cpp chunking heuristics
         // The "single timestamp ending - skip entire chunk" optimization incorrectly discards
@@ -640,6 +649,9 @@ impl WhisperEngine {
         let adaptive_config = hardware_profile.get_whisper_config();
 
         // ADAPTIVE parameters - optimized for current hardware
+        // Technical-term glossary, declared before `params` so it outlives the
+        // initial-prompt pointer whisper-rs holds during `full()`.
+        let glossary_prompt = crate::meeting_log::config().glossary.join(", ");
         let mut params = FullParams::new(SamplingStrategy::BeamSearch {
             beam_size: adaptive_config.beam_size as i32,
             patience: 1.0
@@ -656,6 +668,12 @@ impl WhisperEngine {
         };
         params.set_language(language_code);
         params.set_translate(should_translate);
+
+        // Inject the glossary as whisper's initial prompt so Thai/English
+        // code-switched speech keeps terms like Kafka/ACL/gRPC in English.
+        if !glossary_prompt.is_empty() {
+            params.set_initial_prompt(&glossary_prompt);
+        }
 
         // CRITICAL: Disable timestamp tokens to prevent whisper.cpp chunking heuristics
         // The "single timestamp ending - skip entire chunk" optimization incorrectly discards

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,8 @@ import { Source_Sans_3 } from 'next/font/google'
 import Sidebar from '@/components/Sidebar'
 import { SidebarProvider } from '@/components/Sidebar/SidebarProvider'
 import MainContent from '@/components/MainContent'
+import MeetLogSearch from '@/components/MeetLogSearch'
+import QuickNote from '@/components/QuickNote'
 import AnalyticsProvider from '@/components/AnalyticsProvider'
 import { Toaster, toast } from 'sonner'
 import "sonner/dist/styles.css"
@@ -97,6 +99,29 @@ export default function RootLayout({
         setOnboardingCompleted(false)
       })
   }, [])
+
+  // Quick Note end-of-day rollover (NOTE_ROLLOVER=on_launch): archive past days
+  // + carry pending cards forward. Runs once the main app is shown.
+  useEffect(() => {
+    if (showOnboarding || !onboardingCompleted) return;
+    // Re-apply the saved meeting-log summary model override (lives in Rust memory).
+    const savedModel = typeof window !== 'undefined' ? localStorage.getItem('meetLogSummaryModel') : null;
+    if (savedModel) {
+      invoke('meeting_log_set_summary_model', { model: savedModel }).catch(() => {});
+    }
+    const t = setTimeout(() => {
+      invoke<{ archived_days: string[]; carried: number }>('quick_notes_rollover')
+        .then((res) => {
+          if (res && (res.archived_days.length > 0 || res.carried > 0)) {
+            toast.success('Quick Note rollover', {
+              description: `archived ${res.archived_days.length} day(s), carried ${res.carried} card(s) forward`,
+            });
+          }
+        })
+        .catch((e) => console.error('quick_notes_rollover failed:', e));
+    }, 1200);
+    return () => clearTimeout(t);
+  }, [showOnboarding, onboardingCompleted]);
 
   // Disable context menu in production
   useEffect(() => {
@@ -254,6 +279,8 @@ export default function RootLayout({
                                 <div className="flex">
                                   <Sidebar />
                                   <MainContent>{children}</MainContent>
+                                  <MeetLogSearch />
+                                  <QuickNote />
                                 </div>
                               )}
                               {/* Import audio overlay and dialog */}

--- a/frontend/src/components/MeetLogSearch.tsx
+++ b/frontend/src/components/MeetLogSearch.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+// Local memory search (spec §6/§10): hybrid dense+sparse search over the
+// file-based meet-log, served by the Rust `meeting_log_search` command (which
+// proxies the Python sidecar). Self-contained floating widget so it doesn't
+// entangle with the existing meetings-DB sidebar search.
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { Search, X, FileText } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface MemoryResult {
+  snippet: string;
+  meeting_date: string;
+  session_time: string;
+  topics: string[];
+  file_path: string;
+  summary_path: string;
+  score: number;
+}
+
+export default function MeetLogSearch() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<MemoryResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [searched, setSearched] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Cmd/Ctrl+Shift+F opens the panel.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'f') {
+        e.preventDefault();
+        setOpen((o) => !o);
+      }
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  useEffect(() => {
+    if (open) setTimeout(() => inputRef.current?.focus(), 50);
+  }, [open]);
+
+  const runSearch = useCallback(async (q: string) => {
+    if (!q.trim()) {
+      setResults([]);
+      setSearched(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await invoke<MemoryResult[]>('meeting_log_search', { query: q, limit: 12 });
+      setResults(res);
+    } catch (e) {
+      console.error('meeting_log_search failed:', e);
+      toast.error('Search failed', { description: String(e) });
+      setResults([]);
+    } finally {
+      setLoading(false);
+      setSearched(true);
+    }
+  }, []);
+
+  const onChange = (v: string) => {
+    setQuery(v);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => runSearch(v), 350);
+  };
+
+  const reveal = async (path: string) => {
+    try {
+      await invoke('meeting_log_reveal', { path });
+    } catch (e) {
+      toast.error('Could not open file', { description: String(e) });
+    }
+  };
+
+  return (
+    <>
+      {/* Floating trigger */}
+      {!open && (
+        <button
+          onClick={() => setOpen(true)}
+          title="Search meeting memory (⌘⇧F)"
+          className="fixed bottom-5 right-5 z-40 flex items-center gap-2 rounded-full bg-gray-900 px-4 py-2.5 text-sm text-white shadow-lg hover:bg-gray-800"
+        >
+          <Search size={16} />
+          Memory
+        </button>
+      )}
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/30 pt-24" onClick={() => setOpen(false)}>
+          <div
+            className="w-[min(680px,92vw)] rounded-xl bg-white shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-2 border-b border-gray-100 px-4 py-3">
+              <Search size={18} className="text-gray-400" />
+              <input
+                ref={inputRef}
+                value={query}
+                onChange={(e) => onChange(e.target.value)}
+                placeholder="Search across all meetings (Thai + English)…"
+                className="flex-1 bg-transparent text-base outline-none placeholder:text-gray-400"
+              />
+              {loading && <span className="text-xs text-gray-400">searching…</span>}
+              <button onClick={() => setOpen(false)} className="text-gray-400 hover:text-gray-600">
+                <X size={18} />
+              </button>
+            </div>
+
+            <div className="max-h-[55vh] overflow-y-auto p-2">
+              {results.map((r, i) => (
+                <button
+                  key={`${r.file_path}-${i}`}
+                  onClick={() => reveal(r.summary_path || r.file_path)}
+                  className="group flex w-full flex-col gap-1 rounded-lg px-3 py-2.5 text-left hover:bg-gray-50"
+                >
+                  <div className="flex items-center gap-2 text-xs text-gray-500">
+                    <FileText size={13} />
+                    <span>{r.meeting_date} · {r.session_time.replace(/-/g, ':')}</span>
+                    {r.topics.length > 0 && (
+                      <span className="ml-1 flex flex-wrap gap-1">
+                        {r.topics.slice(0, 4).map((t) => (
+                          <span key={t} className="rounded bg-blue-50 px-1.5 py-0.5 text-[10px] text-blue-600">
+                            {t}
+                          </span>
+                        ))}
+                      </span>
+                    )}
+                    <span className="ml-auto text-[10px] text-gray-300">{r.score.toFixed(3)}</span>
+                  </div>
+                  <p className="line-clamp-2 text-sm text-gray-700">{r.snippet}</p>
+                </button>
+              ))}
+
+              {searched && !loading && results.length === 0 && (
+                <p className="px-3 py-8 text-center text-sm text-gray-400">No matches found.</p>
+              )}
+              {!searched && (
+                <p className="px-3 py-8 text-center text-sm text-gray-400">
+                  Semantic + keyword search over your meeting transcripts &amp; summaries.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/MeetLogSummaryModel.tsx
+++ b/frontend/src/components/MeetLogSummaryModel.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+// Settings selector for the meeting-log (file output) summary model. Lists
+// installed Ollama models and lets the user override the env default
+// (qwen3.5:9b → fallback qwen2.5:14b). Choice persisted in localStorage and
+// re-applied to the Rust side on load.
+
+import { useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { toast } from 'sonner';
+
+const LS_KEY = 'meetLogSummaryModel';
+
+export default function MeetLogSummaryModel() {
+  const [models, setModels] = useState<string[]>([]);
+  const [selected, setSelected] = useState<string>('');
+  const [resolved, setResolved] = useState<string>('');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const list = await invoke<string[]>('meeting_log_list_models');
+        setModels(list);
+      } catch (e) {
+        console.error('meeting_log_list_models failed:', e);
+      }
+      const saved = typeof window !== 'undefined' ? localStorage.getItem(LS_KEY) : null;
+      if (saved) setSelected(saved);
+      try {
+        setResolved(await invoke<string>('meeting_log_get_summary_model'));
+      } catch { /* sidecar/ollama may be down; ignore */ }
+    })();
+  }, []);
+
+  const onChange = async (value: string) => {
+    setSelected(value);
+    const override = value === '' ? null : value;
+    try {
+      await invoke('meeting_log_set_summary_model', { model: override });
+      if (override) localStorage.setItem(LS_KEY, override);
+      else localStorage.removeItem(LS_KEY);
+      setResolved(await invoke<string>('meeting_log_get_summary_model'));
+      toast.success('Meeting summary model updated');
+    } catch (e) {
+      toast.error('Failed to set summary model', { description: String(e) });
+    }
+  };
+
+  return (
+    <div className="mt-4 rounded-lg border border-gray-200 p-4">
+      <h3 className="text-sm font-semibold text-gray-800">Meeting-log summary model</h3>
+      <p className="mt-1 text-xs text-gray-500">
+        Model used for the per-session <code>summary.md</code>. Defaults to the
+        env primary (<code>qwen3.5:9b</code>) and auto-falls back to
+        <code> qwen2.5:14b</code> if it isn&apos;t installed.
+      </p>
+      <select
+        value={selected}
+        onChange={(e) => onChange(e.target.value)}
+        className="mt-3 w-full rounded-md border border-gray-200 px-3 py-2 text-sm outline-none focus:border-blue-400"
+      >
+        <option value="">Use env default (with auto-fallback)</option>
+        {models.map((m) => (
+          <option key={m} value={m}>{m}</option>
+        ))}
+      </select>
+      {resolved && (
+        <p className="mt-2 text-xs text-gray-400">Currently resolving to: <span className="font-medium text-gray-600">{resolved}</span></p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/QuickNote.tsx
+++ b/frontend/src/components/QuickNote.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+// Quick Note board (spec Feature 2): per-day checklist cards with checkbox,
+// inline edit, delete, and a "carried from yesterday" badge. Persisted in
+// SQLite via Tauri commands; end-of-day rollover runs at app launch.
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { StickyNote, X, Trash2, CornerDownLeft } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface QuickNoteItem {
+  id: number;
+  date: string;
+  text: string;
+  done: boolean;
+  created_at: string;
+  carried_from: string | null;
+}
+
+export default function QuickNote() {
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState<QuickNoteItem[]>([]);
+  const [draft, setDraft] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const rows = await invoke<QuickNoteItem[]>('quick_notes_today');
+      setItems(rows);
+    } catch (e) {
+      console.error('quick_notes_today failed:', e);
+    }
+  }, []);
+
+  // Open via sidebar event or ⌘⇧N; refresh on open.
+  useEffect(() => {
+    const onOpen = () => setOpen(true);
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'n') {
+        e.preventDefault();
+        setOpen((o) => !o);
+      }
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('open-quick-note', onOpen);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('open-quick-note', onOpen);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      refresh();
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [open, refresh]);
+
+  const add = async () => {
+    const text = draft.trim();
+    if (!text) return;
+    setDraft('');
+    try {
+      await invoke('quick_note_add', { text });
+      await refresh();
+    } catch (e) {
+      toast.error('Add failed', { description: String(e) });
+    }
+  };
+
+  const toggle = async (it: QuickNoteItem) => {
+    setItems((prev) => prev.map((x) => (x.id === it.id ? { ...x, done: !x.done } : x)));
+    try {
+      await invoke('quick_note_toggle', { id: it.id, done: !it.done });
+    } catch (e) {
+      toast.error('Update failed', { description: String(e) });
+      refresh();
+    }
+  };
+
+  const saveText = async (it: QuickNoteItem, text: string) => {
+    const t = text.trim();
+    if (t === it.text) return;
+    try {
+      await invoke('quick_note_update_text', { id: it.id, text: t });
+      setItems((prev) => prev.map((x) => (x.id === it.id ? { ...x, text: t } : x)));
+    } catch (e) {
+      toast.error('Save failed', { description: String(e) });
+    }
+  };
+
+  const remove = async (it: QuickNoteItem) => {
+    setItems((prev) => prev.filter((x) => x.id !== it.id));
+    try {
+      await invoke('quick_note_delete', { id: it.id });
+    } catch (e) {
+      toast.error('Delete failed', { description: String(e) });
+      refresh();
+    }
+  };
+
+  const pending = items.filter((i) => !i.done).length;
+
+  return (
+    <>
+      {!open && (
+        <button
+          onClick={() => setOpen(true)}
+          title="Quick Note (⌘⇧N)"
+          className="fixed bottom-5 right-36 z-40 flex items-center gap-2 rounded-full bg-amber-500 px-4 py-2.5 text-sm text-white shadow-lg hover:bg-amber-600"
+        >
+          <StickyNote size={16} />
+          Quick Note{pending > 0 ? ` (${pending})` : ''}
+        </button>
+      )}
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/30 pt-20" onClick={() => setOpen(false)}>
+          <div className="flex max-h-[70vh] w-[min(560px,92vw)] flex-col rounded-xl bg-white shadow-2xl" onClick={(e) => e.stopPropagation()}>
+            <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+              <div className="flex items-center gap-2">
+                <StickyNote size={18} className="text-amber-500" />
+                <span className="font-medium text-gray-800">Quick Note — วันนี้</span>
+              </div>
+              <button onClick={() => setOpen(false)} className="text-gray-400 hover:text-gray-600">
+                <X size={18} />
+              </button>
+            </div>
+
+            <div className="flex items-center gap-2 px-4 py-2.5">
+              <input
+                ref={inputRef}
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') add(); }}
+                placeholder="เพิ่มการ์ดใหม่… (Enter)"
+                className="flex-1 rounded-md border border-gray-200 px-3 py-2 text-sm outline-none focus:border-amber-400"
+              />
+              <button onClick={add} className="rounded-md bg-amber-500 px-3 py-2 text-sm text-white hover:bg-amber-600">
+                เพิ่ม
+              </button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto px-2 pb-3">
+              {items.length === 0 && (
+                <p className="px-3 py-8 text-center text-sm text-gray-400">ยังไม่มีการ์ดวันนี้ — พิมพ์ด้านบนแล้วกด Enter</p>
+              )}
+              {items.map((it) => (
+                <div key={it.id} className="group flex items-center gap-2 rounded-lg px-3 py-2 hover:bg-gray-50">
+                  <button
+                    onClick={() => toggle(it)}
+                    title={it.done ? 'done ✅' : 'pending ❌'}
+                    className={`flex h-5 w-5 flex-shrink-0 items-center justify-center rounded border text-xs ${
+                      it.done ? 'border-green-500 bg-green-500 text-white' : 'border-gray-300 text-transparent hover:border-amber-400'
+                    }`}
+                  >
+                    ✓
+                  </button>
+                  <input
+                    defaultValue={it.text}
+                    onBlur={(e) => saveText(it, e.target.value)}
+                    onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}
+                    className={`flex-1 bg-transparent text-sm outline-none ${it.done ? 'text-gray-400 line-through' : 'text-gray-800'}`}
+                  />
+                  {it.carried_from && (
+                    <span className="flex flex-shrink-0 items-center gap-0.5 rounded bg-amber-50 px-1.5 py-0.5 text-[10px] text-amber-600" title={`carried from ${it.carried_from}`}>
+                      <CornerDownLeft size={10} /> เมื่อวาน
+                    </span>
+                  )}
+                  <button
+                    onClick={() => remove(it)}
+                    title="ลบ"
+                    className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-300 hover:text-red-500 flex-shrink-0"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/SettingTabs.tsx
+++ b/frontend/src/components/SettingTabs.tsx
@@ -3,6 +3,7 @@ import { ModelConfig, ModelSettingsModal } from "./ModelSettingsModal"
 import { TranscriptModelProps, TranscriptSettings } from "./TranscriptSettings"
 import { RecordingSettings, RecordingPreferences } from "./RecordingSettings"
 import { About } from "./About";
+import MeetLogSummaryModel from "./MeetLogSummaryModel";
 
 interface SettingTabsProps {
     modelConfig: ModelConfig;
@@ -45,6 +46,7 @@ modelConfig={modelConfig}
 setModelConfig={setModelConfig}
 onSave={onSave}
 />
+    <MeetLogSummaryModel />
   </TabsContent>
 <TabsContent value="transcriptSettings">
     <TranscriptSettings

--- a/frontend/src/components/TranscriptView.tsx
+++ b/frontend/src/components/TranscriptView.tsx
@@ -6,6 +6,15 @@ import { ConfidenceIndicator } from './ConfidenceIndicator';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { RecordingStatusBar } from './RecordingStatusBar';
 import { motion, AnimatePresence } from 'framer-motion';
+import {
+  LangView,
+  LANG_LABEL,
+  LANG_ORDER,
+  targetForView,
+  translateSegment,
+  alreadyTarget,
+  copyText,
+} from '@/lib/meetLog';
 
 interface TranscriptViewProps {
   transcripts: Transcript[];
@@ -146,6 +155,87 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
     return () => window.removeEventListener('confidenceIndicatorChanged', handleConfidenceChange);
   }, []);
 
+  // ── Real-time translation (Original/Thai/English/Bilingual) + copy ───────
+  const [langView, setLangView] = useState<LangView>(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem('meetLogLangView') as LangView | null;
+      if (saved && LANG_ORDER.includes(saved)) return saved;
+    }
+    return 'original';
+  });
+  const [langMenuOpen, setLangMenuOpen] = useState(false);
+  // translations[id] = { th?, en? } per-segment, per-target
+  const [translations, setTranslations] = useState<Record<string, { th?: string; en?: string }>>({});
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimer = useRef<NodeJS.Timeout | null>(null);
+
+  const chooseView = (v: LangView) => {
+    setLangView(v);
+    setLangMenuOpen(false);
+    if (typeof window !== 'undefined') localStorage.setItem('meetLogLangView', v);
+  };
+
+  const showToast = (msg: string) => {
+    setToast(msg);
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    toastTimer.current = setTimeout(() => setToast(null), 1400);
+  };
+
+  const handleCopy = async (text: string, label = 'Copied') => {
+    const ok = await copyText(text);
+    showToast(ok ? label : 'Copy failed');
+  };
+
+  // Translate finalized segments into the active target as needed.
+  useEffect(() => {
+    const target = targetForView(langView);
+    if (!target) return;
+    let cancelled = false;
+    (async () => {
+      for (const t of transcripts) {
+        if (t.is_partial) continue;
+        const text = (t.text || '').trim();
+        if (!text || alreadyTarget(text, target)) continue;
+        if (translations[t.id]?.[target] !== undefined) continue;
+        const out = await translateSegment(text, target);
+        if (cancelled) return;
+        setTranslations((prev) => {
+          if (prev[t.id]?.[target] !== undefined) return prev;
+          return { ...prev, [t.id]: { ...prev[t.id], [target]: out } };
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [langView, transcripts, translations]);
+
+  // Translation shown for a transcript given the current view (or undefined).
+  const translatedFor = (t: Transcript): string | undefined => {
+    const target = targetForView(langView);
+    if (!target) return undefined;
+    const text = (t.text || '').trim();
+    if (alreadyTarget(text, target)) return undefined;
+    return translations[t.id]?.[target];
+  };
+
+  // Build a markdown copy of the whole transcript honoring the current view.
+  const copyAll = async () => {
+    const lines = transcripts.map((t) => {
+      const ts = t.audio_start_time !== undefined
+        ? formatRecordingTime(t.audio_start_time)
+        : `[${t.timestamp}]`;
+      const original = (t.text || '').trim();
+      const tr = translatedFor(t);
+      if (langView === 'bilingual' && tr && tr !== original) {
+        return `${ts} ${original}\n        ↳ ${tr}`;
+      }
+      if (langView === 'thai' || langView === 'english') return `${ts} ${tr ?? original}`;
+      return `${ts} ${original}`;
+    });
+    await handleCopy(lines.join('\n'), 'Transcript copied');
+  };
+
   // Listen for speech-detected event
   useEffect(() => {
     let unsubscribe: (() => void) | undefined;
@@ -251,6 +341,77 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
 
   return (
     <div className="px-4 py-2">
+      {/* Meet-log toolbar: language dropdown + แปลเป็นไทย + copy-all */}
+      {transcripts.length > 0 && (
+        <div className="sticky top-0 z-20 flex items-center justify-between bg-white/90 backdrop-blur py-2 mb-1">
+          <span className="text-xs font-medium text-gray-500">Transcript</span>
+          <div className="flex items-center gap-2">
+            {/* Quick action: translate everything to Thai (bilingual) */}
+            <button
+              onClick={() => chooseView('bilingual')}
+              title="แปลทั้ง transcript เป็นไทย (แสดงคู่กับต้นฉบับ)"
+              className={`rounded-md border px-2 py-1 text-xs ${
+                langView === 'bilingual'
+                  ? 'border-blue-500 bg-blue-50 text-blue-600'
+                  : 'border-gray-200 text-gray-600 hover:bg-gray-50'
+              }`}
+            >
+              🇹🇭 แปลเป็นไทย
+            </button>
+
+            {/* Language dropdown */}
+            <div className="relative">
+              <button
+                onClick={() => setLangMenuOpen((o) => !o)}
+                title="Choose transcript language"
+                className="flex items-center gap-1 rounded-md border border-gray-200 px-2 py-1 text-xs text-gray-600 hover:bg-gray-50"
+              >
+                <span className="font-semibold">Language:</span>
+                <span className="text-gray-700">{LANG_LABEL[langView]}</span>
+                <span className="text-gray-400">▾</span>
+              </button>
+              {langMenuOpen && (
+                <div className="absolute right-0 z-30 mt-1 w-36 overflow-hidden rounded-md border border-gray-200 bg-white shadow-lg">
+                  {LANG_ORDER.map((v) => (
+                    <button
+                      key={v}
+                      onClick={() => chooseView(v)}
+                      className={`block w-full px-3 py-1.5 text-left text-xs hover:bg-gray-50 ${
+                        v === langView ? 'bg-blue-50 text-blue-600' : 'text-gray-700'
+                      }`}
+                    >
+                      {LANG_LABEL[v]}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <button
+              onClick={copyAll}
+              title="Copy entire transcript"
+              className="rounded-md border border-gray-200 px-2 py-1 text-xs text-gray-600 hover:bg-gray-50"
+            >
+              ⧉ Copy all
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Copy toast */}
+      <AnimatePresence>
+        {toast && (
+          <motion.div
+            initial={{ opacity: 0, y: -6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0 }}
+            className="fixed top-4 left-1/2 z-50 -translate-x-1/2 rounded-md bg-gray-900 px-3 py-1.5 text-xs text-white shadow-lg"
+          >
+            {toast}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       {/* Recording Status Bar - Sticky at top, always visible when recording */}
       <AnimatePresence>
         {isRecording && (
@@ -281,7 +442,7 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
             transition={{ duration: 0.15 }}
             className="mb-3"
           >
-            <div className="flex items-start gap-2">
+            <div className="group flex items-start gap-2">
               <Tooltip>
                 <TooltipTrigger>
                   <span className="text-xs text-gray-400 mt-1 flex-shrink-0 min-w-[50px]">
@@ -317,17 +478,51 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
                       </p>
                     </div>
                   </div>
-                ) : (
-                  // Regular transcript - simple text
-                  <div className="relative">
-                    <p className="text-base text-gray-800 leading-relaxed" style={{ visibility: 'hidden' }}>
-                      {sizerText}
-                    </p>
-                    <p className="text-base text-gray-800 leading-relaxed absolute top-0 left-0">
-                      {displayText}
-                    </p>
-                  </div>
-                )}
+                ) : (() => {
+                  // Regular transcript with translation view + per-line copy.
+                  const translated = translatedFor(transcript);
+                  const replaceMain = (langView === 'thai' || langView === 'english')
+                    && !!translated && translated.trim().length > 0;
+                  const mainText = replaceMain ? translated : displayText;
+                  const sizerMain = replaceMain ? translated : sizerText;
+                  // partial = faded/italic, final = solid
+                  const isFinal = !transcript.is_partial;
+                  const textColor = isFinal ? 'text-gray-800' : 'text-gray-400 italic';
+                  const copyMain = replaceMain ? translated : transcript.text;
+                  return (
+                    <div>
+                      <div className="relative flex items-start gap-1">
+                        <div className="relative flex-1">
+                          <p className={`text-base ${textColor} leading-relaxed`} style={{ visibility: 'hidden' }}>
+                            {sizerMain}
+                          </p>
+                          <p className={`text-base ${textColor} leading-relaxed absolute top-0 left-0`}>
+                            {mainText}
+                          </p>
+                        </div>
+                        <button
+                          onClick={() => handleCopy(copyMain)}
+                          title="Copy line"
+                          className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-300 hover:text-gray-600 text-xs mt-1 flex-shrink-0"
+                        >
+                          ⧉
+                        </button>
+                      </div>
+                      {langView === 'bilingual' && !!translated && translated !== transcript.text && (
+                        <div className="flex items-start gap-1 mt-0.5">
+                          <p className="flex-1 text-sm text-blue-600/80 leading-relaxed">🇹🇭 {translated}</p>
+                          <button
+                            onClick={() => handleCopy(translated, 'แปลแล้ว — คัดลอก')}
+                            title="Copy translation"
+                            className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-300 hover:text-gray-600 text-xs flex-shrink-0"
+                          >
+                            ⧉
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })()}
               </div>
             </div>
           </motion.div>

--- a/frontend/src/lib/meetLog.ts
+++ b/frontend/src/lib/meetLog.ts
@@ -1,0 +1,90 @@
+// Helpers for the meeting-log features: real-time translation (to Thai or
+// English, with per-segment+target cache so switching never re-translates) and
+// clipboard copy.
+
+import { invoke } from '@tauri-apps/api/core';
+
+/** Transcript language view (spec: Original / Thai / English / Bilingual). */
+export type LangView = 'original' | 'thai' | 'english' | 'bilingual';
+
+export const LANG_LABEL: Record<LangView, string> = {
+  original: 'Original',
+  thai: 'ไทย',
+  english: 'English',
+  bilingual: 'Bilingual',
+};
+
+export const LANG_ORDER: LangView[] = ['original', 'thai', 'english', 'bilingual'];
+
+/** Translation target for a view, or null when nothing should be translated. */
+export function targetForView(view: LangView): 'th' | 'en' | null {
+  switch (view) {
+    case 'thai':
+      return 'th';
+    case 'english':
+      return 'en';
+    case 'bilingual':
+      return 'th'; // bilingual shows original + Thai translation
+    default:
+      return null;
+  }
+}
+
+const THAI_RE = /[฀-๿]/;
+const LATIN_RE = /[A-Za-z]/;
+
+export function hasThai(text: string): boolean {
+  return THAI_RE.test(text);
+}
+
+/** True when `text` is already entirely in the target language. */
+export function alreadyTarget(text: string, target: 'th' | 'en'): boolean {
+  return target === 'th' ? !LATIN_RE.test(text) : !THAI_RE.test(text);
+}
+
+// Cache keyed by `${target}:${rawText}`.
+const cache = new Map<string, string>();
+
+/**
+ * Translate one segment into `target`, pinning technical terms (in the sidecar).
+ * Text already in the target language is returned unchanged. Cached per target.
+ */
+export async function translateSegment(text: string, target: 'th' | 'en'): Promise<string> {
+  const key = text.trim();
+  if (!key) return '';
+  if (alreadyTarget(key, target)) return key;
+  const ck = `${target}:${key}`;
+  const cached = cache.get(ck);
+  if (cached !== undefined) return cached;
+  try {
+    const out = await invoke<string>('meeting_log_translate', { text: key, target });
+    const result = (out || '').trim() || key;
+    cache.set(ck, result);
+    return result;
+  } catch (e) {
+    console.error('translateSegment failed:', e);
+    return key; // fail open
+  }
+}
+
+/** Copy plain text to the clipboard; returns success. */
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    try {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/sidecar/app.py
+++ b/sidecar/app.py
@@ -1,0 +1,338 @@
+"""
+Meetily local ML sidecar — 127.0.0.1 only.
+
+Endpoints (all local, no outbound network except localhost Ollama):
+  GET  /health
+  POST /translate  -> Thai→English with technical terms pinned (translategemma via Ollama)
+  POST /embed      -> bge-m3 embeddings via Ollama
+  POST /segment    -> Thai word segmentation (PyThaiNLP newmm)
+  POST /index      -> store meeting chunks into sqlite-vec + FTS5
+  POST /search     -> hybrid (dense + sparse) search
+
+Heavy ML lives here so the Tauri/Rust core stays thin. Models run via the
+local Ollama server; nothing leaves the machine.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from typing import List, Optional
+
+import httpx
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://127.0.0.1:11434").rstrip("/")
+EMBED_DIM = int(os.environ.get("MEET_EMBED_DIM", "1024"))  # bge-m3 = 1024
+
+# ── Optional deps degrade gracefully ──────────────────────────────────────────
+try:
+    from pythainlp.tokenize import word_tokenize as _thai_tokenize  # type: ignore
+
+    def thai_segment(text: str) -> List[str]:
+        return [t for t in _thai_tokenize(text, engine="newmm", keep_whitespace=False) if t.strip()]
+
+    HAVE_THAI = True
+except Exception:  # pragma: no cover
+    def thai_segment(text: str) -> List[str]:
+        # Fallback: naive whitespace split (English-only meetings still work).
+        return [t for t in text.split() if t.strip()]
+
+    HAVE_THAI = False
+
+try:
+    import sqlite_vec  # type: ignore
+
+    HAVE_VEC = True
+except Exception:  # pragma: no cover
+    HAVE_VEC = False
+
+
+app = FastAPI(title="Meetily ML sidecar", version="1.0.0")
+
+
+# ── Models ────────────────────────────────────────────────────────────────────
+class TranslateReq(BaseModel):
+    model: str = "translategemma:4b"
+    text: str
+    glossary: List[str] = []
+    target: str = "en"  # "en" or "th"
+
+
+class EmbedReq(BaseModel):
+    model: str = "bge-m3"
+    texts: List[str]
+
+
+class SegmentReq(BaseModel):
+    text: str
+
+
+class IndexChunk(BaseModel):
+    chunk_id: str
+    text: str
+    kind: str = "transcript"
+
+
+class IndexReq(BaseModel):
+    db_path: str
+    embed_model: str = "bge-m3"
+    meeting_date: str
+    session_time: str
+    topics: List[str] = []
+    file_path: str
+    summary_path: str = ""
+    chunks: List[IndexChunk]
+
+
+class SearchReq(BaseModel):
+    db_path: str
+    embed_model: str = "bge-m3"
+    query: str
+    limit: int = 10
+
+
+# ── Ollama helpers ────────────────────────────────────────────────────────────
+async def ollama_generate(model: str, prompt: str, system: Optional[str] = None) -> str:
+    # `think: false` keeps qwen3 (and other thinking models) fast; ignored by others.
+    body = {
+        "model": model,
+        "prompt": prompt,
+        "stream": False,
+        "think": False,
+        "options": {"temperature": 0.1},
+    }
+    if system:
+        body["system"] = system
+    async with httpx.AsyncClient(timeout=120) as client:
+        r = await client.post(f"{OLLAMA_URL}/api/generate", json=body)
+        r.raise_for_status()
+        return r.json().get("response", "").strip()
+
+
+async def ollama_embed(model: str, texts: List[str]) -> List[List[float]]:
+    async with httpx.AsyncClient(timeout=120) as client:
+        r = await client.post(f"{OLLAMA_URL}/api/embed", json={"model": model, "input": texts})
+        r.raise_for_status()
+        data = r.json()
+        return data.get("embeddings") or []
+
+
+# ── DB helpers ────────────────────────────────────────────────────────────────
+def open_db(db_path: str) -> sqlite3.Connection:
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    db = sqlite3.connect(db_path)
+    db.row_factory = sqlite3.Row
+    if HAVE_VEC:
+        db.enable_load_extension(True)
+        sqlite_vec.load(db)
+        db.enable_load_extension(False)
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS chunks(
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT UNIQUE,
+            text TEXT,
+            kind TEXT,
+            meeting_date TEXT,
+            session_time TEXT,
+            topics TEXT,
+            file_path TEXT,
+            summary_path TEXT
+        )
+        """
+    )
+    db.execute(
+        "CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(text_seg, content='', tokenize='unicode61')"
+    )
+    if HAVE_VEC:
+        db.execute(
+            f"CREATE VIRTUAL TABLE IF NOT EXISTS vec_chunks USING vec0(embedding float[{EMBED_DIM}])"
+        )
+    db.commit()
+    return db
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+@app.get("/health")
+async def health():
+    return {
+        "ok": True,
+        "thai_segmentation": HAVE_THAI,
+        "vector_search": HAVE_VEC,
+        "ollama": OLLAMA_URL,
+    }
+
+
+@app.post("/translate")
+async def translate(req: TranslateReq):
+    if not req.text.strip():
+        return {"translation": ""}
+    glossary = ", ".join(req.glossary) if req.glossary else "Kafka, ACL, gRPC, consumer lag, Vault Core, Redis, partition, broker, deploy, UAT"
+    target = (req.target or "en").lower()
+    if target == "th":
+        # Thai-language instruction is far more reliable for →Thai output.
+        system = (
+            "คุณเป็นนักแปลสำหรับการประชุมด้านวิศวกรรมซอฟต์แวร์ แปลจากภาษาอังกฤษ/ภาษาผสมเป็นภาษาไทย "
+            f"คงคำศัพท์เทคนิคไว้เป็นภาษาอังกฤษเหมือนเดิม ({glossary}) "
+            "ห้ามแปล ทับศัพท์ หรือดัดแปลงคำศัพท์เทคนิค ชื่อผลิตภัณฑ์ หรือชื่อตัวแปร/โค้ด — ให้คงเป็นภาษาอังกฤษ "
+            "แปลส่วนที่เหลือทั้งหมด ตอบเป็นภาษาไทยเท่านั้น ห้ามมีเครื่องหมายคำพูด หมายเหตุ หรือข้อความอื่น"
+        )
+        prompt = f"แปลข้อความนี้เป็นภาษาไทย:\n{req.text}"
+    else:
+        system = (
+            "You are a precise translator for software engineering meetings, translating into English. "
+            f"Keep technical terms in English exactly as written ({glossary}). "
+            "Do not translate, transliterate, or alter technical terms, product names, or code identifiers — "
+            "leave them in English. Translate everything else. "
+            "Return only the English translation, with no quotes, notes, or extra text."
+        )
+        prompt = f"Translate to English:\n{req.text}"
+    try:
+        out = await ollama_generate(req.model, prompt, system=system)
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"ollama translate failed: {e}")
+    # Strip accidental wrapping quotes/prefixes.
+    out = out.strip().strip('"').strip()
+    return {"translation": out}
+
+
+@app.post("/embed")
+async def embed(req: EmbedReq):
+    try:
+        vectors = await ollama_embed(req.model, req.texts)
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"ollama embed failed: {e}")
+    return {"embeddings": vectors}
+
+
+@app.post("/segment")
+async def segment(req: SegmentReq):
+    return {"tokens": thai_segment(req.text), "engine": "newmm" if HAVE_THAI else "fallback"}
+
+
+@app.post("/index")
+async def index(req: IndexReq):
+    if not req.chunks:
+        return {"indexed": 0}
+    texts = [c.text for c in req.chunks]
+
+    embeddings: List[List[float]] = []
+    if HAVE_VEC:
+        try:
+            embeddings = await ollama_embed(req.embed_model, texts)
+        except Exception as e:
+            # Indexing still useful via FTS even if embeddings fail.
+            embeddings = []
+            print(f"[index] embed failed, FTS-only: {e}")
+
+    db = open_db(req.db_path)
+    topics_str = ", ".join(req.topics)
+    indexed = 0
+    try:
+        for i, chunk in enumerate(req.chunks):
+            cur = db.execute(
+                """
+                INSERT INTO chunks(chunk_id, text, kind, meeting_date, session_time, topics, file_path, summary_path)
+                VALUES(?,?,?,?,?,?,?,?)
+                ON CONFLICT(chunk_id) DO UPDATE SET text=excluded.text
+                RETURNING id
+                """,
+                (
+                    chunk.chunk_id, chunk.text, chunk.kind, req.meeting_date,
+                    req.session_time, topics_str, req.file_path, req.summary_path,
+                ),
+            )
+            row = cur.fetchone()
+            rowid = row["id"]
+
+            seg = " ".join(thai_segment(chunk.text))
+            db.execute("DELETE FROM chunks_fts WHERE rowid=?", (rowid,))
+            db.execute("INSERT INTO chunks_fts(rowid, text_seg) VALUES(?,?)", (rowid, seg))
+
+            if HAVE_VEC and i < len(embeddings) and embeddings[i]:
+                db.execute("DELETE FROM vec_chunks WHERE rowid=?", (rowid,))
+                db.execute(
+                    "INSERT INTO vec_chunks(rowid, embedding) VALUES(?,?)",
+                    (rowid, sqlite_vec.serialize_float32(embeddings[i])),
+                )
+            indexed += 1
+        db.commit()
+    finally:
+        db.close()
+    return {"indexed": indexed, "vector": HAVE_VEC and bool(embeddings)}
+
+
+@app.post("/search")
+async def search(req: SearchReq):
+    if not os.path.exists(req.db_path):
+        return {"results": []}
+    db = open_db(req.db_path)
+    try:
+        k = max(req.limit * 3, 20)
+
+        # Sparse (BM25 over segmented Thai/English)
+        sparse_ranks = {}
+        seg_query = " OR ".join(thai_segment(req.query)) or req.query
+        try:
+            rows = db.execute(
+                "SELECT rowid, bm25(chunks_fts) AS score FROM chunks_fts WHERE chunks_fts MATCH ? ORDER BY score LIMIT ?",
+                (seg_query, k),
+            ).fetchall()
+            for rank, r in enumerate(rows):
+                sparse_ranks[r["rowid"]] = rank
+        except Exception as e:
+            print(f"[search] fts failed: {e}")
+
+        # Dense (vector KNN)
+        dense_ranks = {}
+        if HAVE_VEC:
+            try:
+                qvec = (await ollama_embed(req.embed_model, [req.query]))[0]
+                rows = db.execute(
+                    "SELECT rowid, distance FROM vec_chunks WHERE embedding MATCH ? ORDER BY distance LIMIT ?",
+                    (sqlite_vec.serialize_float32(qvec), k),
+                ).fetchall()
+                for rank, r in enumerate(rows):
+                    dense_ranks[r["rowid"]] = rank
+            except Exception as e:
+                print(f"[search] vector failed: {e}")
+
+        # Reciprocal Rank Fusion
+        rrf = {}
+        C = 60
+        for rid, rank in sparse_ranks.items():
+            rrf[rid] = rrf.get(rid, 0.0) + 1.0 / (C + rank)
+        for rid, rank in dense_ranks.items():
+            rrf[rid] = rrf.get(rid, 0.0) + 1.0 / (C + rank)
+
+        ranked = sorted(rrf.items(), key=lambda kv: kv[1], reverse=True)[: req.limit]
+        results = []
+        for rid, score in ranked:
+            row = db.execute("SELECT * FROM chunks WHERE id=?", (rid,)).fetchone()
+            if not row:
+                continue
+            text = row["text"] or ""
+            snippet = text.strip().replace("\n", " ")
+            if len(snippet) > 240:
+                snippet = snippet[:240] + "…"
+            results.append({
+                "snippet": snippet,
+                "meeting_date": row["meeting_date"],
+                "session_time": row["session_time"],
+                "topics": [t.strip() for t in (row["topics"] or "").split(",") if t.strip()],
+                "file_path": row["file_path"],
+                "summary_path": row["summary_path"] or "",
+                "score": round(float(score), 4),
+            })
+        return {"results": results}
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.environ.get("MEET_SIDECAR_PORT", "8178"))
+    uvicorn.run(app, host="127.0.0.1", port=port, log_level="info")

--- a/sidecar/requirements.txt
+++ b/sidecar/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.110
+uvicorn>=0.29
+httpx>=0.27
+pythainlp>=5.0
+sqlite-vec>=0.1.6

--- a/sidecar/run.sh
+++ b/sidecar/run.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Start the Meetily ML sidecar (local-only). Creates a venv on first run.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$DIR"
+
+PY="${PYTHON:-python3}"
+VENV="$DIR/.venv"
+
+if [ ! -d "$VENV" ]; then
+  echo "[sidecar] creating venv…"
+  "$PY" -m venv "$VENV"
+fi
+# shellcheck disable=SC1091
+source "$VENV/bin/activate"
+
+python -m pip install --quiet --upgrade pip
+python -m pip install --quiet -r "$DIR/requirements.txt"
+
+export MEET_SIDECAR_PORT="${MEET_SIDECAR_PORT:-8178}"
+export OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
+
+echo "[sidecar] listening on http://127.0.0.1:${MEET_SIDECAR_PORT}"
+exec python "$DIR/app.py"


### PR DESCRIPTION
- feat(translate): real-time language view (Original/ไทย/English/Bilingual) + "แปลเป็นไทย" quick action. →EN via translategemma:4b, →TH via qwen3.5:9b (think:false, Thai-language prompt); technical terms pinned; per-segment cache.
- feat(quick-note): SQLite quick_notes board (checkbox, inline edit, delete, carried badge) + on-launch rollover that archives past days to NOTE_LOG_ROOT and carries pending ❌ cards forward (idempotent).
- feat(summary): qwen3.5:9b primary with runtime ollama-list fallback to qwen2.5:14b (no crash) + Settings dropdown to pick the model.
- env: TRANSLATE_MODEL_TH, TRANSLATE_DEFAULT_TARGET, SUMMARY_MODEL(+_FALLBACK), NOTE_LOG_ROOT, NOTE_ROLLOVER.
- build_meetily.sh now builds the llama-helper external binary; AGENTS.md updated.

QA: rollover logic (archive format + carry + idempotent), translate both directions, summary JSON, memory search — all verified; .dmg built.

## Description
[Provide a detailed description of your changes]

## Related Issue
[Link to the issue this PR addresses (e.g., "Fixes #123")]

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass

## Documentation
- [ ] Documentation updated
- [ ] No documentation needed

## Checklist
- [ ] Code follows project style
- [ ] Self-reviewed the code
- [ ] Added comments for complex code
- [ ] Updated README if needed
- [ ] Branch is up to date with devtest
- [ ] No merge conflicts

## Screenshots (if applicable)
[Add screenshots here if your changes affect the UI]

## Additional Notes
[Add any additional information that might be helpful for reviewers] 