### PR TITLE
docs(transcription): document RemoteProvider contract + sample worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ pnpm install
 
 ### 🎯 Local Transcription
 
-Transcribe meetings entirely on your device using **Whisper** or **Parakeet** models. No cloud required.
+Transcribe meetings entirely on your device using **Whisper** or **Parakeet** models. No cloud required. Configure your provider in Settings → Transcription. See [Transcription Providers](docs/transcription-providers.md) for details on `localWhisper`, `parakeet`, and the new **Remote HTTPS** option.
 
 <p align="center">
     <img src="docs/home.png" width="650" style="border-radius: 10px;" alt="Meetily Demo" />

--- a/docs/sample-remote-worker/README.md
+++ b/docs/sample-remote-worker/README.md
@@ -1,0 +1,15 @@
+# Sample Remote ASR Worker
+
+A minimal, vendor-neutral HTTP worker implementing the RemoteProvider JSON contract.
+
+## Run
+
+```bash
+# Terminal 1: start the worker
+python handler.py 8080
+
+# Terminal 2: run smoke test
+python smoke_test.py 8080
+```
+
+The worker listens on `POST /transcribe` and returns `{"segments": [{"start", "end", "text", "speaker"?}]}`.

--- a/docs/sample-remote-worker/handler.py
+++ b/docs/sample-remote-worker/handler.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Minimal HTTPS ASR worker implementing RemoteProvider JSON contract."""
+import json, base64, wave, io, argparse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', 0))
+        body = json.loads(self.rfile.read(length))
+        audio_b64 = body.get('audio_base64', '')
+        audio_bytes = base64.b64decode(audio_b64) if audio_b64 else b''
+        # Detect duration from WAV data (or use fallback)
+        duration = 5.0
+        if audio_bytes:
+            with wave.open(io.BytesIO(audio_bytes), 'rb') as wf:
+                n_frames = wf.getnframes()
+                rate = wf.getframerate()
+                duration = max(0.1, n_frames / rate)
+        response = {"segments": [{"start": 0.0, "end": duration, "text": f"Received {duration:.1f}s audio", "speaker": None}]}
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps(response).encode())
+
+    def log_message(self, *args): pass
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('port', type=int, default=8080)
+    args = parser.parse_args()
+    HTTPServer(('localhost', args.port), Handler).serve_forever()

--- a/docs/sample-remote-worker/smoke_test.py
+++ b/docs/sample-remote-worker/smoke_test.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Smoke test: POST 5s synthetic WAV to worker, assert valid response."""
+import json, base64, wave, io, struct, sys, urllib.request
+
+def make_wav(duration_sec=5, sample_rate=16000):
+    frames = int(duration_sec * sample_rate)
+    buf = io.BytesIO()
+    with wave.open(buf, 'wb') as wf:
+        wf.setnchannels(1); wf.setsampwidth(2); wf.setframerate(sample_rate)
+        data = struct.pack('<' + 'h' * frames, *[(i % 100) - 50 for i in range(frames)])
+        wf.writeframes(data)
+    return buf.getvalue()
+
+def main(port):
+    wav_b64 = base64.b64encode(make_wav()).decode()
+    payload = json.dumps({"audio_base64": wav_b64, "model": "test", "language": "en", "min_speakers": 1, "max_speakers": 2}).encode()
+    req = urllib.request.Request(f'http://localhost:{port}/transcribe', data=payload, headers={'Content-Type': 'application/json'})
+    with urllib.request.urlopen(req) as resp:
+        assert resp.status == 200, f"Expected 200, got {resp.status}"
+        result = json.loads(resp.read())
+    assert 'segments' in result and len(result['segments']) >= 1, "Missing segments"
+    seg = result['segments'][0]
+    assert 'start' in seg and 'end' in seg and 'text' in seg, "Missing segment fields"
+    print(f"OK: {seg['text']} (duration: {seg['end'] - seg['start']}s)")
+
+if __name__ == '__main__':
+    main(int(sys.argv[1]) if len(sys.argv) > 1 else 8080)

--- a/docs/transcription-providers.md
+++ b/docs/transcription-providers.md
@@ -1,0 +1,87 @@
+# Transcription Providers
+
+Meetily supports multiple transcription providers. Choose the one that best fits your hardware, privacy requirements, and feature needs.
+
+## Existing Providers
+
+### localWhisper
+
+Runs Whisper models locally using `whisper.cpp`. Works on CPU or GPU (CUDA/Vulkan). No audio leaves your machine. Model selection is available at Settings → Transcription.
+
+**GPU acceleration:** Automatic when building with CUDA/Vulkan support.
+
+**Default:** Yes (`large-v3` multilingual model).
+
+### parakeet
+
+NVIDIA's Parakeet model via ONNX runtime. Fast transcription on CPU/GPU, optimized for English. Language selection is not supported. Model selection available at Settings → Transcription.
+
+## Remote HTTPS (new)
+
+Posts audio to a user-configured HTTPS endpoint. Use this to integrate with any WhisperX-compatible backend (self-hosted, cloud GPU, or custom inference server).
+
+### Configuration
+
+| Field | Description |
+|-------|-------------|
+| `endpoint_url` | HTTPS URL that accepts the contract below (required) |
+| `bearer_token` | Token sent as `Authorization: Bearer <token>` (optional) |
+| `model` | Model identifier forwarded to the worker (optional) |
+| `default_lang` | Language hint, e.g. `en`, `ar` (optional) |
+| `min_speakers` | Minimum speakers for diarization (optional) |
+| `max_speakers` | Maximum speakers for diarization (optional) |
+
+Configure via Settings → Transcription → "Remote HTTPS ASR" after setting up provider/UI in PR 2.
+
+## Request/Response Contract
+
+The Remote HTTPS provider speaks a simple JSON wire format compatible with WhisperX-style workers.
+
+### Request
+
+```json
+{
+  "audio_base64": "<base64-encoded WAV bytes>",
+  "model": "whisperx-large-v2",
+  "language": "en",
+  "min_speakers": 1,
+  "max_speakers": 5
+}
+```
+
+- `audio_base64`: Required. 16kHz mono 16-bit PCM WAV.
+- `model`: Required. Model identifier your backend recognizes.
+- `language`: Optional. ISO language code.
+- `min_speakers`, `max_speakers`: Optional. Passed to diarization models.
+
+### Response
+
+```json
+{
+  "segments": [
+    {"start": 0.0, "end": 1.5, "text": "hello world", "speaker": "SPEAKER_00"},
+    {"start": 1.5, "end": 3.0, "text": "how are you", "speaker": "SPEAKER_01"}
+  ],
+  "error": null
+}
+```
+
+- `segments`: Array of transcribed segments. Each has `start`, `end`, `text`. Speaker diarization is indicated by the optional `speaker` field.
+- `error`: If present with HTTP 200, treated as a worker error.
+
+### Speaker Diarization Convention
+
+Segments with a `speaker` field are rendered as `SPEAKER_XX: text`. Segments without `speaker` are rendered as plain lines. Empty text fields in segments are ignored.
+
+## Privacy
+
+The Remote HTTPS provider **uploads your entire meeting audio** to the configured endpoint. If privacy is a concern, use `localWhisper` or `parakeet` instead, or ensure your endpoint runs on infrastructure you control.
+
+## Errors
+
+| Condition | Result |
+|-----------|--------|
+| HTTP 4xx/5xx | `TranscriptionError::EngineFailed` with status code |
+| `{"error": "..."}` (HTTP 200) | `TranscriptionError::EngineFailed` with error message |
+| JSON parse failure | `TranscriptionError::EngineFailed` with parse error |
+| Missing `endpoint_url` | `TranscriptionError::EngineFailed` immediately, no request sent |


### PR DESCRIPTION
## Description

Adds `docs/transcription-providers.md` covering the existing localWhisper
and parakeet providers plus the new Remote HTTPS option (PR #528 + #532).
Includes the exact JSON request/response contract so anyone can implement
their own worker, plus privacy warning and error semantics.

`docs/sample-remote-worker/` ships a minimal stdlib-only Python worker
(`handler.py` + `smoke_test.py` + `README.md`) that demonstrates the
contract end-to-end. Smoke test passes locally: POSTs a 5s synthetic WAV
to the worker, asserts 200 + segments response shape.

README.md updated with a link to the new docs page.

## Related Issue
Follows PR #528 (RemoteProvider) and PR #532 (UI). Closes documentation
side of #335.

## Type of Change
- [x] Documentation update

## Testing
- [x] Smoke test passes locally
- [x] Sample worker reaches +200 with valid segments response
- [ ] Manual testing performed (docs and sample worker only)

## Documentation
- [x] Documentation update

## Checklist
- [x] Vendor-neutral wording (no RunPod/AWS/Replicate branding)
- [x] No code changes outside docs/ + README
- [x] Sample worker uses stdlib only (no third-party deps)