### PR TITLE
Add Soniox transcription provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,6 +1508,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,6 +3679,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -7240,6 +7247,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7512,6 +7533,26 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "typeid"

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -100,6 +100,7 @@ nnnoiseless = "0.5"
 # NOTE: whisper-rs is declared in platform-specific sections below (macOS/Windows/Linux)
 # to ensure correct GPU features are enabled per platform
 futures-util = "0.3"
+tokio-tungstenite = { version = "0.21", features = ["native-tls"] }
 silero_rs = { git = "https://github.com/emotechlab/silero-rs", rev = "26a6460", package = "silero" }
 
 # Parakeet (ONNX-based fast transcription) dependencies

--- a/frontend/src-tauri/migrations/20251230000000_add_soniox_transcript_api_key.sql
+++ b/frontend/src-tauri/migrations/20251230000000_add_soniox_transcript_api_key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE transcript_settings ADD COLUMN sonioxApiKey TEXT;

--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -266,6 +266,7 @@ pub async fn start_import<R: Runtime>(
     IMPORT_CANCELLED.store(false, Ordering::SeqCst);
 
     let use_parakeet = provider.as_deref() == Some("parakeet");
+    let use_soniox = provider.as_deref() == Some(super::soniox::PROVIDER);
     let result = run_import(
         app.clone(),
         source_path,
@@ -277,7 +278,9 @@ pub async fn start_import<R: Runtime>(
     .await;
 
     // Unload the engine after the batch job (success, failure, or cancellation)
-    super::common::unload_engine_after_batch(use_parakeet).await;
+    if !use_soniox {
+        super::common::unload_engine_after_batch(use_parakeet).await;
+    }
 
     // Guard will automatically clear flag on drop
     // No need for manual: IMPORT_IN_PROGRESS.store(false, Ordering::SeqCst);
@@ -330,6 +333,7 @@ async fn run_import<R: Runtime>(
 
     // Determine which provider to use (default to whisper)
     let use_parakeet = provider.as_deref() == Some("parakeet");
+    let use_soniox = provider.as_deref() == Some(super::soniox::PROVIDER);
 
     emit_progress(&app, "copying", 5, "Creating meeting folder...");
 
@@ -368,6 +372,85 @@ async fn run_import<R: Runtime>(
         // Cleanup: remove the meeting folder
         let _ = std::fs::remove_dir_all(&meeting_folder);
         return Err(anyhow!("Import cancelled"));
+    }
+
+    if use_soniox {
+        emit_progress(&app, "transcribing", 15, "Preparing Soniox transcription...");
+        let duration_seconds = match extract_duration_from_metadata(&dest_path) {
+            Ok(duration) => duration,
+            Err(e) => {
+                warn!("Soniox import metadata duration failed: {}, decoding duration", e);
+                let decoded = tokio::task::spawn_blocking({
+                    let path = dest_path.clone();
+                    move || decode_audio_file(&path)
+                })
+                .await
+                .map_err(|e| anyhow!("Decode task join error: {}", e))??;
+                decoded.duration_seconds
+            }
+        };
+
+        let client = super::soniox::client_from_config(&app).await?;
+        let app_for_progress = app.clone();
+        let client_reference_id = format!("import:{}", title);
+        let transcript = client
+            .transcribe_file_with_progress(
+                &dest_path,
+                language.clone(),
+                &client_reference_id,
+                move |provider_progress, message| {
+                    let overall_progress = 15 + ((provider_progress as f32 * 0.70) as u32);
+                    emit_progress(&app_for_progress, "transcribing", overall_progress.min(85), message);
+                },
+                || IMPORT_CANCELLED.load(Ordering::SeqCst),
+            )
+            .await?;
+
+        if IMPORT_CANCELLED.load(Ordering::SeqCst) {
+            let _ = std::fs::remove_dir_all(&meeting_folder);
+            return Err(anyhow!("Import cancelled"));
+        }
+
+        emit_progress(&app, "saving", 85, "Creating meeting...");
+        let segments = super::soniox::transcript_to_segments(&transcript, duration_seconds);
+
+        let app_state = app
+            .try_state::<AppState>()
+            .ok_or_else(|| anyhow!("App state not available"))?;
+
+        let meeting_id = create_meeting_with_transcripts(
+            app_state.db_manager.pool(),
+            &title,
+            &segments,
+            meeting_folder.to_string_lossy().to_string(),
+        )
+        .await?;
+
+        emit_progress(&app, "saving", 90, "Writing transcript files...");
+
+        if let Err(e) = write_transcripts_json(&meeting_folder, &segments) {
+            warn!("Failed to write transcripts.json: {}", e);
+        }
+
+        if let Err(e) = write_import_metadata(
+            &meeting_folder,
+            &meeting_id,
+            &title,
+            duration_seconds,
+            &dest_filename,
+            "import",
+        ) {
+            warn!("Failed to write metadata.json: {}", e);
+        }
+
+        emit_progress(&app, "complete", 100, "Import complete");
+
+        return Ok(ImportResult {
+            meeting_id,
+            title,
+            segments_count: segments.len(),
+            duration_seconds,
+        });
     }
 
     emit_progress(&app, "decoding", 15, "Decoding audio file...");

--- a/frontend/src-tauri/src/audio/mod.rs
+++ b/frontend/src-tauri/src/audio/mod.rs
@@ -4,6 +4,7 @@ pub mod decoder;
 pub mod encode;
 pub mod ffmpeg;
 pub mod vad;
+pub mod soniox;
 
 // Modularized device management
 pub mod devices;
@@ -118,4 +119,3 @@ pub use decoder::{decode_audio_file, DecodedAudio};
 
 // Export audio constants
 pub use constants::AUDIO_EXTENSIONS;
-

--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -13,6 +13,12 @@ use super::recording_state::{AudioChunk, AudioError, RecordingState, DeviceType}
 use super::audio_processing::{audio_to_mono, LoudnessNormalizer, NoiseSuppressionProcessor, HighPassFilter};
 use super::vad::{ContinuousVadProcessor};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TranscriptionPipelineMode {
+    VadSpeechOnly,
+    ContinuousMixed,
+}
+
 /// Ring buffer for synchronized audio mixing
 /// Accumulates samples from mic and system streams until we have aligned windows
 struct AudioMixerRingBuffer {
@@ -694,6 +700,8 @@ pub struct AudioPipeline {
     mixer: ProfessionalAudioMixer,
     // Recording sender for pre-mixed audio
     recording_sender_for_mixed: Option<mpsc::UnboundedSender<AudioChunk>>,
+    transcription_mode: TranscriptionPipelineMode,
+    mixed_transcription_next_timestamp: Option<f64>,
 }
 
 impl AudioPipeline {
@@ -707,6 +715,7 @@ impl AudioPipeline {
         mic_device_kind: super::device_detection::InputDeviceKind,
         system_device_name: String,
         system_device_kind: super::device_detection::InputDeviceKind,
+        send_continuous_transcription: bool,
     ) -> Self {
         // Log device characteristics for adaptive buffering
         info!("🎛️ AudioPipeline initializing with device characteristics:");
@@ -760,6 +769,12 @@ impl AudioPipeline {
             ring_buffer,
             mixer,
             recording_sender_for_mixed: None,  // Will be set by manager
+            transcription_mode: if send_continuous_transcription {
+                TranscriptionPipelineMode::ContinuousMixed
+            } else {
+                TranscriptionPipelineMode::VadSpeechOnly
+            },
+            mixed_transcription_next_timestamp: None,
         }
     }
 
@@ -831,37 +846,61 @@ impl AudioPipeline {
                             // Previous 2x gain was causing excessive limiting/distortion
                             let mixed_with_gain = mixed_clean;
 
-                            // STEP 3: Send mixed audio for transcription (VAD + Whisper)
-                            match self.vad_processor.process_audio(&mixed_with_gain) {
-                                Ok(speech_segments) => {
-                                    for segment in speech_segments {
-                                        let duration_ms = segment.end_timestamp_ms - segment.start_timestamp_ms;
+                            // STEP 3: Send mixed audio for transcription.
+                            // Local engines still receive VAD speech segments, while Soniox
+                            // receives a continuous stream to keep realtime endpointing stable.
+                            if self.transcription_mode == TranscriptionPipelineMode::ContinuousMixed {
+                                let duration = mixed_with_gain.len() as f64 / self.sample_rate as f64;
+                                let timestamp = self
+                                    .mixed_transcription_next_timestamp
+                                    .unwrap_or(chunk.timestamp);
+                                self.mixed_transcription_next_timestamp = Some(timestamp + duration);
 
-                                        if segment.samples.len() >= 800 {  // Minimum 50ms at 16kHz - matches Parakeet capability
-                                            info!("📤 Sending VAD segment: {:.1}ms, {} samples",
-                                                  duration_ms, segment.samples.len());
+                                let transcription_chunk = AudioChunk {
+                                    data: mixed_with_gain.clone(),
+                                    sample_rate: self.sample_rate,
+                                    timestamp,
+                                    chunk_id: self.chunk_id_counter,
+                                    device_type: DeviceType::Microphone,
+                                };
 
-                                            let transcription_chunk = AudioChunk {
-                                                data: segment.samples,
-                                                sample_rate: 16000,
-                                                timestamp: segment.start_timestamp_ms / 1000.0,
-                                                chunk_id: self.chunk_id_counter,
-                                                device_type: DeviceType::Microphone,  // Mixed audio
-                                            };
+                                if let Err(e) = self.transcription_sender.send(transcription_chunk) {
+                                    warn!("Failed to send mixed Soniox transcription chunk: {}", e);
+                                } else {
+                                    self.chunk_id_counter += 1;
+                                }
+                            } else {
+                                match self.vad_processor.process_audio(&mixed_with_gain) {
+                                    Ok(speech_segments) => {
+                                        for segment in speech_segments {
+                                            let duration_ms = segment.end_timestamp_ms - segment.start_timestamp_ms;
 
-                                            if let Err(e) = self.transcription_sender.send(transcription_chunk) {
-                                                warn!("Failed to send VAD segment: {}", e);
+                                            if segment.samples.len() >= 800 {  // Minimum 50ms at 16kHz - matches Parakeet capability
+                                                info!("📤 Sending VAD segment: {:.1}ms, {} samples",
+                                                      duration_ms, segment.samples.len());
+
+                                                let transcription_chunk = AudioChunk {
+                                                    data: segment.samples,
+                                                    sample_rate: 16000,
+                                                    timestamp: segment.start_timestamp_ms / 1000.0,
+                                                    chunk_id: self.chunk_id_counter,
+                                                    device_type: DeviceType::Microphone,  // Mixed audio
+                                                };
+
+                                                if let Err(e) = self.transcription_sender.send(transcription_chunk) {
+                                                    warn!("Failed to send VAD segment: {}", e);
+                                                } else {
+                                                    self.chunk_id_counter += 1;
+                                                }
                                             } else {
-                                                self.chunk_id_counter += 1;
+                                                debug!("⏭️ Dropping short VAD segment: {:.1}ms ({} samples < 800)",
+                                                       duration_ms, segment.samples.len());
                                             }
-                                        } else {
-                                            debug!("⏭️ Dropping short VAD segment: {:.1}ms ({} samples < 800)",
-                                                   duration_ms, segment.samples.len());
                                         }
                                     }
-                                }
-                                Err(e) => {
-                                    warn!("⚠️ VAD error: {}", e);
+                                    Err(e) => {
+                                        warn!("⚠️ VAD error: {}", e);
+                                    }
                                 }
                             }
 
@@ -891,7 +930,9 @@ impl AudioPipeline {
         }
 
         // Flush any remaining VAD segments
-        self.flush_remaining_audio()?;
+        if self.transcription_mode == TranscriptionPipelineMode::VadSpeechOnly {
+            self.flush_remaining_audio()?;
+        }
 
         info!("VAD-driven audio pipeline ended");
         Ok(())
@@ -966,6 +1007,7 @@ impl AudioPipelineManager {
         mic_device_kind: super::device_detection::InputDeviceKind,
         system_device_name: String,
         system_device_kind: super::device_detection::InputDeviceKind,
+        send_continuous_transcription: bool,
     ) -> Result<()> {
         // Log device information for adaptive buffering
         info!("🎙️ Starting pipeline with device info:");
@@ -989,6 +1031,7 @@ impl AudioPipelineManager {
             mic_device_kind,
             system_device_name,
             system_device_kind,
+            send_continuous_transcription,
         );
 
         // CRITICAL FIX: Connect recording sender to receive pre-mixed audio

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -105,6 +105,7 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
         return Err(validation_error);
     }
     info!("✅ Transcription model validation passed");
+    let send_continuous_transcription = transcription::is_soniox_transcription_provider(&app).await;
 
     // Async-first approach - no more blocking operations!
     info!("🚀 Starting async recording initialization");
@@ -234,7 +235,12 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
 
     // Start recording with resolved devices (replaces start_recording_with_defaults_and_auto_save call)
     let transcription_receiver = manager
-        .start_recording(microphone_device, system_device, auto_save)
+        .start_recording(
+            microphone_device,
+            system_device,
+            auto_save,
+            send_continuous_transcription,
+        )
         .await
         .map_err(|e| format!("Failed to start recording: {}", e))?;
 
@@ -351,6 +357,7 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
         return Err(validation_error);
     }
     info!("✅ Transcription model validation passed");
+    let send_continuous_transcription = transcription::is_soniox_transcription_provider(&app).await;
 
     // Parse devices
     let mic_device = if let Some(ref name) = mic_device_name {
@@ -405,7 +412,12 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
 
     // Start recording with specified devices and auto_save setting
     let transcription_receiver = manager
-        .start_recording(mic_device, system_device, auto_save)
+        .start_recording(
+            mic_device,
+            system_device,
+            auto_save,
+            send_continuous_transcription,
+        )
         .await
         .map_err(|e| format!("Failed to start recording: {}", e))?;
 

--- a/frontend/src-tauri/src/audio/recording_manager.rs
+++ b/frontend/src-tauri/src/audio/recording_manager.rs
@@ -65,6 +65,7 @@ impl RecordingManager {
         microphone_device: Option<Arc<AudioDevice>>,
         system_device: Option<Arc<AudioDevice>>,
         auto_save: bool,
+        send_continuous_transcription: bool,
     ) -> Result<mpsc::UnboundedReceiver<AudioChunk>> {
         info!("Starting recording manager (auto_save: {})", auto_save);
 
@@ -116,6 +117,7 @@ impl RecordingManager {
             mic_kind,
             sys_name,
             sys_kind,
+            send_continuous_transcription,
         )?;
 
         // Give the pipeline a moment to fully initialize before starting streams
@@ -186,7 +188,7 @@ impl RecordingManager {
             }
 
             // Start recording with selected devices and auto_save setting
-            self.start_recording(microphone_device, system_device, auto_save).await
+            self.start_recording(microphone_device, system_device, auto_save, false).await
         }
 
         #[cfg(not(target_os = "macos"))]
@@ -221,7 +223,7 @@ impl RecordingManager {
                 return Err(anyhow::anyhow!("No microphone device available"));
             }
 
-            self.start_recording(microphone_device, system_device, auto_save).await
+            self.start_recording(microphone_device, system_device, auto_save, false).await
         }
     }
 

--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -102,10 +102,13 @@ pub async fn start_retranscription<R: Runtime>(
     RETRANSCRIPTION_CANCELLED.store(false, Ordering::SeqCst);
 
     let use_parakeet = provider.as_deref() == Some("parakeet");
+    let use_soniox = provider.as_deref() == Some(super::soniox::PROVIDER);
     let result = run_retranscription(app.clone(), meeting_id.clone(), meeting_folder_path, language, model, provider).await;
 
     // Unload the engine after the batch job (success, failure, or cancellation)
-    super::common::unload_engine_after_batch(use_parakeet).await;
+    if !use_soniox {
+        super::common::unload_engine_after_batch(use_parakeet).await;
+    }
 
     // Guard will automatically clear flag on drop
     // No need for manual: RETRANSCRIPTION_IN_PROGRESS.store(false, Ordering::SeqCst);
@@ -182,11 +185,125 @@ async fn run_retranscription<R: Runtime>(
 
     // Determine which provider to use (default to whisper)
     let use_parakeet = provider.as_deref() == Some("parakeet");
+    let use_soniox = provider.as_deref() == Some(super::soniox::PROVIDER);
 
     info!(
         "Starting retranscription for meeting {} with language {:?}, model {:?}, provider {:?}",
         meeting_id, language, model, provider
     );
+
+    if use_soniox {
+        emit_progress(&app, &meeting_id, "transcribing", 5, "Preparing Soniox transcription...");
+        let duration_seconds = match super::import::validate_audio_file(&audio_path) {
+            Ok(info) => info.duration_seconds,
+            Err(e) => {
+                warn!("Soniox retranscription metadata duration failed: {}, decoding duration", e);
+                let decoded = tokio::task::spawn_blocking({
+                    let path = audio_path.clone();
+                    move || decode_audio_file(&path)
+                })
+                .await
+                .map_err(|e| anyhow!("Decode task panicked: {}", e))??;
+                decoded.duration_seconds
+            }
+        };
+
+        let client = super::soniox::client_from_config(&app).await?;
+        let app_for_progress = app.clone();
+        let meeting_id_for_progress = meeting_id.clone();
+        let client_reference_id = format!("retranscription:{}", meeting_id);
+        let transcript = client
+            .transcribe_file_with_progress(
+                &audio_path,
+                language.clone(),
+                &client_reference_id,
+                move |provider_progress, message| {
+                    let overall_progress = 5 + ((provider_progress as f32 * 0.75) as u32);
+                    emit_progress(
+                        &app_for_progress,
+                        &meeting_id_for_progress,
+                        "transcribing",
+                        overall_progress.min(80),
+                        message,
+                    );
+                },
+                || RETRANSCRIPTION_CANCELLED.load(Ordering::SeqCst),
+            )
+            .await?;
+
+        if RETRANSCRIPTION_CANCELLED.load(Ordering::SeqCst) {
+            return Err(anyhow!("Retranscription cancelled"));
+        }
+
+        emit_progress(&app, &meeting_id, "saving", 80, "Saving transcripts...");
+        let segments = super::soniox::transcript_to_segments(&transcript, duration_seconds);
+
+        let app_state = app
+            .try_state::<AppState>()
+            .ok_or_else(|| anyhow!("App state not available"))?;
+
+        let pool = app_state.db_manager.pool();
+        let mut conn = pool.acquire().await.map_err(|e| anyhow!("DB error: {}", e))?;
+        let mut tx = sqlx::Connection::begin(&mut *conn)
+            .await
+            .map_err(|e| anyhow!("Failed to start transaction: {}", e))?;
+
+        sqlx::query("DELETE FROM transcripts WHERE meeting_id = ?")
+            .bind(&meeting_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| anyhow!("Failed to delete existing transcripts: {}", e))?;
+
+        for segment in &segments {
+            sqlx::query(
+                "INSERT INTO transcripts (id, meeting_id, transcript, timestamp, audio_start_time, audio_end_time, duration)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)"
+            )
+            .bind(&segment.id)
+            .bind(&meeting_id)
+            .bind(&segment.text)
+            .bind(&segment.timestamp)
+            .bind(segment.audio_start_time)
+            .bind(segment.audio_end_time)
+            .bind(segment.duration)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| anyhow!("Failed to insert transcript: {}", e))?;
+        }
+
+        tx.commit().await
+            .map_err(|e| anyhow!("Failed to commit transaction: {}", e))?;
+
+        emit_progress(&app, &meeting_id, "saving", 90, "Writing transcript files...");
+
+        if let Err(e) = write_transcripts_json(&folder_path, &segments) {
+            warn!("Failed to write transcripts.json: {}", e);
+        }
+
+        let audio_filename = audio_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("audio.mp4")
+            .to_string();
+
+        if let Err(e) = write_retranscription_metadata(
+            &folder_path,
+            &meeting_id,
+            duration_seconds,
+            &audio_filename,
+        ) {
+            warn!("Failed to update metadata.json: {}", e);
+        }
+
+        emit_progress(&app, &meeting_id, "complete", 100, "Retranscription complete");
+
+        return Ok(RetranscriptionResult {
+            meeting_id,
+            segments_count: segments.len(),
+            duration_seconds,
+            language,
+        });
+    }
 
     // Emit progress: decoding
     emit_progress(&app, &meeting_id, "decoding", 5, "Decoding audio file...");

--- a/frontend/src-tauri/src/audio/soniox.rs
+++ b/frontend/src-tauri/src/audio/soniox.rs
@@ -1,0 +1,975 @@
+use anyhow::{anyhow, Context, Result};
+use futures_util::{SinkExt, StreamExt};
+use log::{error, info, warn};
+use reqwest::multipart::{Form, Part};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, Ordering},
+    Arc,
+};
+use std::time::Duration;
+use tauri::{AppHandle, Emitter, Manager, Runtime};
+use tokio::sync::{mpsc, Mutex};
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{client::IntoClientRequest, http::HeaderValue, Message},
+};
+use tokio_util::codec::{BytesCodec, FramedRead};
+
+use crate::api::TranscriptSegment;
+use crate::database::repositories::setting::SettingsRepository;
+use crate::state::AppState;
+
+use super::recording_state::AudioChunk;
+use super::transcription::TranscriptUpdate;
+
+pub const PROVIDER: &str = "soniox";
+const FILES_URL: &str = "https://api.soniox.com/v1/files";
+const TRANSCRIPTIONS_URL: &str = "https://api.soniox.com/v1/transcriptions";
+const REALTIME_WS_URL: &str = "wss://stt-rt.soniox.com/transcribe-websocket";
+const PCM_SAMPLE_RATE: u32 = 16_000;
+const MAX_POLL_ATTEMPTS: usize = 3_600; // 2 hours at 2s intervals
+
+static REALTIME_SEQUENCE_COUNTER: AtomicU64 = AtomicU64::new(0);
+static REALTIME_SPEECH_DETECTED_EMITTED: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Clone)]
+pub struct SonioxClient {
+    api_key: String,
+    http: reqwest::Client,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SonioxToken {
+    #[serde(default)]
+    pub text: String,
+    #[serde(default)]
+    pub start_ms: Option<f64>,
+    #[serde(default)]
+    pub end_ms: Option<f64>,
+    #[serde(default)]
+    pub confidence: Option<f32>,
+    #[serde(default)]
+    pub speaker: Option<String>,
+    #[serde(default)]
+    pub is_final: Option<bool>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SonioxTranscript {
+    pub text: String,
+    pub tokens: Vec<SonioxToken>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UploadFileResponse {
+    #[serde(alias = "id")]
+    file_id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateTranscriptionRequest<'a> {
+    model: &'a str,
+    file_id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    language_hints: Option<Vec<String>>,
+    enable_language_identification: bool,
+    enable_speaker_diarization: bool,
+    client_reference_id: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateTranscriptionResponse {
+    #[serde(alias = "transcription_id")]
+    id: String,
+    #[serde(default)]
+    status: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TranscriptionStatusResponse {
+    status: String,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    error_message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TranscriptResponse {
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    tokens: Vec<SonioxToken>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RealtimeResponse {
+    #[serde(default)]
+    tokens: Vec<SonioxToken>,
+    #[serde(default)]
+    error_code: Option<String>,
+    #[serde(default)]
+    error_message: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AudioTimeMapEntry {
+    pub stream_start_ms: f64,
+    pub stream_end_ms: f64,
+    pub original_start_ms: f64,
+    pub original_end_ms: f64,
+}
+
+#[derive(Debug, Clone)]
+struct MappedRealtimeToken {
+    text: String,
+    start_ms: f64,
+    end_ms: f64,
+    confidence: Option<f32>,
+    speaker: Option<String>,
+}
+
+struct RealtimeSegmentBuffer<R: Runtime> {
+    app: AppHandle<R>,
+    tokens: Vec<MappedRealtimeToken>,
+}
+
+impl SonioxClient {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            api_key,
+            http: reqwest::Client::new(),
+        }
+    }
+
+    pub async fn transcribe_file_with_progress<F, C>(
+        &self,
+        path: &Path,
+        language: Option<String>,
+        client_reference_id: &str,
+        mut progress: F,
+        mut should_cancel: C,
+    ) -> Result<SonioxTranscript>
+    where
+        F: FnMut(u32, &str),
+        C: FnMut() -> bool,
+    {
+        ensure_not_cancelled(&mut should_cancel)?;
+        progress(5, "Uploading audio to Soniox...");
+        let file_id = self.upload_file(path).await?;
+
+        ensure_not_cancelled(&mut should_cancel)?;
+        progress(20, "Creating Soniox transcription...");
+        let transcription_id = self
+            .create_transcription(&file_id, language, client_reference_id)
+            .await?;
+
+        progress(30, "Waiting for Soniox transcription...");
+        self.poll_until_complete(&transcription_id, &mut progress, &mut should_cancel)
+            .await?;
+
+        ensure_not_cancelled(&mut should_cancel)?;
+        progress(90, "Fetching Soniox transcript...");
+        self.get_transcript(&transcription_id).await
+    }
+
+    async fn upload_file(&self, path: &Path) -> Result<String> {
+        let file = tokio::fs::File::open(path)
+            .await
+            .with_context(|| format!("Failed to open audio file: {}", path.display()))?;
+        let filename = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("audio")
+            .to_string();
+        let stream = FramedRead::new(file, BytesCodec::new());
+        let body = reqwest::Body::wrap_stream(stream);
+        let part = Part::stream(body)
+            .file_name(filename)
+            .mime_str("application/octet-stream")?;
+        let form = Form::new().part("file", part);
+
+        let response = self
+            .http
+            .post(FILES_URL)
+            .bearer_auth(&self.api_key)
+            .multipart(form)
+            .send()
+            .await
+            .context("Failed to upload audio to Soniox")?;
+
+        let response = ensure_success(response, "upload file").await?;
+        let payload: UploadFileResponse = response
+            .json()
+            .await
+            .context("Failed to parse Soniox upload response")?;
+
+        Ok(payload.file_id)
+    }
+
+    async fn create_transcription(
+        &self,
+        file_id: &str,
+        language: Option<String>,
+        client_reference_id: &str,
+    ) -> Result<String> {
+        let language_hints = language_hints(language);
+        let body = CreateTranscriptionRequest {
+            model: crate::config::DEFAULT_SONIOX_ASYNC_MODEL,
+            file_id,
+            language_hints: if language_hints.is_empty() {
+                None
+            } else {
+                Some(language_hints)
+            },
+            enable_language_identification: true,
+            enable_speaker_diarization: false,
+            client_reference_id,
+        };
+
+        let response = self
+            .http
+            .post(TRANSCRIPTIONS_URL)
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await
+            .context("Failed to create Soniox transcription")?;
+
+        let response = ensure_success(response, "create transcription").await?;
+        let payload: CreateTranscriptionResponse = response
+            .json()
+            .await
+            .context("Failed to parse Soniox create-transcription response")?;
+
+        if let Some(status) = payload.status.as_deref() {
+            info!(
+                "Soniox transcription {} created with status {}",
+                payload.id, status
+            );
+        }
+
+        Ok(payload.id)
+    }
+
+    async fn poll_until_complete<F, C>(
+        &self,
+        transcription_id: &str,
+        progress: &mut F,
+        should_cancel: &mut C,
+    ) -> Result<()>
+    where
+        F: FnMut(u32, &str),
+        C: FnMut() -> bool,
+    {
+        for attempt in 0..MAX_POLL_ATTEMPTS {
+            ensure_not_cancelled(should_cancel)?;
+
+            let response = self
+                .http
+                .get(format!("{}/{}", TRANSCRIPTIONS_URL, transcription_id))
+                .bearer_auth(&self.api_key)
+                .send()
+                .await
+                .context("Failed to poll Soniox transcription")?;
+            let response = ensure_success(response, "poll transcription").await?;
+            let status: TranscriptionStatusResponse = response
+                .json()
+                .await
+                .context("Failed to parse Soniox transcription status")?;
+
+            match status.status.as_str() {
+                "completed" => {
+                    progress(85, "Soniox transcription completed");
+                    return Ok(());
+                }
+                "error" | "failed" => {
+                    let message = status
+                        .error_message
+                        .or(status.error)
+                        .unwrap_or_else(|| "Unknown Soniox transcription error".to_string());
+                    return Err(anyhow!("Soniox transcription failed: {}", message));
+                }
+                "queued" | "processing" => {
+                    let poll_progress = 30 + ((attempt as f32 / 90.0).min(1.0) * 50.0) as u32;
+                    progress(poll_progress, "Soniox transcription is processing...");
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                }
+                other => {
+                    warn!("Unknown Soniox transcription status: {}", other);
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                }
+            }
+        }
+
+        Err(anyhow!("Timed out waiting for Soniox transcription"))
+    }
+
+    async fn get_transcript(&self, transcription_id: &str) -> Result<SonioxTranscript> {
+        let response = self
+            .http
+            .get(format!(
+                "{}/{}/transcript",
+                TRANSCRIPTIONS_URL, transcription_id
+            ))
+            .bearer_auth(&self.api_key)
+            .send()
+            .await
+            .context("Failed to fetch Soniox transcript")?;
+        let response = ensure_success(response, "fetch transcript").await?;
+        let payload: TranscriptResponse = response
+            .json()
+            .await
+            .context("Failed to parse Soniox transcript response")?;
+
+        let text = payload.text.unwrap_or_else(|| {
+            payload
+                .tokens
+                .iter()
+                .map(|token| token.text.as_str())
+                .collect()
+        });
+
+        Ok(SonioxTranscript {
+            text,
+            tokens: payload.tokens,
+        })
+    }
+}
+
+pub async fn configured_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<String> {
+    let app_state = app
+        .try_state::<AppState>()
+        .ok_or_else(|| anyhow!("App state not available"))?;
+
+    let stored_key =
+        SettingsRepository::get_transcript_api_key(app_state.db_manager.pool(), PROVIDER)
+            .await
+            .context("Failed to read Soniox API key from settings")?;
+
+    let key = stored_key
+        .filter(|key| !key.trim().is_empty())
+        .or_else(|| std::env::var("SONIOX_API_KEY").ok())
+        .unwrap_or_default();
+
+    if key.trim().is_empty() {
+        return Err(anyhow!(
+            "Soniox API key is not configured. Add it in Transcription settings or set SONIOX_API_KEY."
+        ));
+    }
+
+    Ok(key)
+}
+
+pub async fn validate_configured_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+    configured_api_key(app)
+        .await
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+pub async fn client_from_config<R: Runtime>(app: &AppHandle<R>) -> Result<SonioxClient> {
+    Ok(SonioxClient::new(configured_api_key(app).await?))
+}
+
+pub fn soniox_tokens_to_transcript_tuples(tokens: &[SonioxToken]) -> Vec<(String, f64, f64)> {
+    let mut segments = Vec::new();
+    let mut current_text = String::new();
+    let mut current_start_ms = 0.0;
+    let mut current_end_ms = 0.0;
+    let mut current_speaker: Option<String> = None;
+
+    for token in tokens {
+        if token.text.is_empty() {
+            continue;
+        }
+
+        let token_start_ms = token.start_ms.unwrap_or(current_end_ms);
+        let token_end_ms = token.end_ms.unwrap_or(token_start_ms).max(token_start_ms);
+        let speaker_changed = current_speaker.is_some() && token.speaker != current_speaker;
+        let long_gap = !current_text.is_empty() && token_start_ms - current_end_ms > 1500.0;
+        let long_segment =
+            token_start_ms - current_start_ms > 30_000.0 && ends_sentence(&current_text);
+
+        if !current_text.is_empty() && (speaker_changed || long_gap || long_segment) {
+            push_transcript_tuple(
+                &mut segments,
+                std::mem::take(&mut current_text),
+                current_start_ms,
+                current_end_ms,
+            );
+            current_speaker = None;
+        }
+
+        if current_text.is_empty() {
+            current_start_ms = token_start_ms;
+            current_speaker = token.speaker.clone();
+        }
+
+        current_text.push_str(&token.text);
+        current_end_ms = token_end_ms;
+    }
+
+    push_transcript_tuple(
+        &mut segments,
+        current_text,
+        current_start_ms,
+        current_end_ms,
+    );
+    segments
+}
+
+pub fn soniox_tokens_to_transcript_segments(tokens: &[SonioxToken]) -> Vec<TranscriptSegment> {
+    super::common::create_transcript_segments(&soniox_tokens_to_transcript_tuples(tokens))
+}
+
+pub fn transcript_to_segments(
+    transcript: &SonioxTranscript,
+    fallback_duration_seconds: f64,
+) -> Vec<TranscriptSegment> {
+    let mut segments = soniox_tokens_to_transcript_segments(&transcript.tokens);
+    if segments.is_empty() && !transcript.text.trim().is_empty() {
+        segments.push(TranscriptSegment {
+            id: format!("transcript-{}", uuid::Uuid::new_v4()),
+            text: transcript.text.trim().to_string(),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            audio_start_time: Some(0.0),
+            audio_end_time: Some(fallback_duration_seconds),
+            duration: Some(fallback_duration_seconds),
+        });
+    }
+    segments
+}
+
+pub fn map_stream_ms_to_original(entries: &[AudioTimeMapEntry], stream_ms: f64) -> f64 {
+    if entries.is_empty() {
+        return stream_ms;
+    }
+
+    if let Some(entry) = entries
+        .iter()
+        .find(|entry| stream_ms >= entry.stream_start_ms && stream_ms <= entry.stream_end_ms)
+    {
+        let stream_duration = (entry.stream_end_ms - entry.stream_start_ms).max(1.0);
+        let original_duration = (entry.original_end_ms - entry.original_start_ms).max(0.0);
+        let offset_ratio = ((stream_ms - entry.stream_start_ms) / stream_duration).clamp(0.0, 1.0);
+        return entry.original_start_ms + original_duration * offset_ratio;
+    }
+
+    if stream_ms < entries[0].stream_start_ms {
+        return entries[0].original_start_ms;
+    }
+
+    let last = entries.last().expect("entries is not empty");
+    last.original_end_ms + (stream_ms - last.stream_end_ms).max(0.0)
+}
+
+pub async fn run_realtime_transcription<R: Runtime>(
+    app: AppHandle<R>,
+    transcription_receiver: mpsc::UnboundedReceiver<AudioChunk>,
+) -> Result<(), String> {
+    REALTIME_SPEECH_DETECTED_EMITTED.store(false, Ordering::SeqCst);
+
+    let api_key = configured_api_key(&app).await.map_err(|e| e.to_string())?;
+    let language = crate::get_language_preference_internal();
+    let language_hints = language_hints(language);
+
+    let mut request = REALTIME_WS_URL
+        .into_client_request()
+        .map_err(|e| format!("Failed to build Soniox WebSocket request: {}", e))?;
+    let auth_header = HeaderValue::from_str(&format!("Bearer {}", api_key))
+        .map_err(|e| format!("Failed to build Soniox auth header: {}", e))?;
+    request.headers_mut().insert("Authorization", auth_header);
+
+    info!("Connecting to Soniox realtime transcription");
+    let (ws_stream, _) = connect_async(request)
+        .await
+        .map_err(|e| format!("Failed to connect to Soniox realtime API: {}", e))?;
+    let (mut write, mut read) = ws_stream.split();
+
+    let config = serde_json::json!({
+        "api_key": api_key,
+        "model": crate::config::DEFAULT_SONIOX_REALTIME_MODEL,
+        "audio_format": "pcm_s16le",
+        "sample_rate": PCM_SAMPLE_RATE,
+        "num_channels": 1,
+        "enable_language_identification": true,
+        "enable_endpoint_detection": true,
+        "language_hints": language_hints,
+    });
+
+    write
+        .send(Message::Text(config.to_string()))
+        .await
+        .map_err(|e| format!("Failed to send Soniox realtime config: {}", e))?;
+
+    let time_map = Arc::new(Mutex::new(Vec::<AudioTimeMapEntry>::new()));
+    let stream_cursor_ms = Arc::new(Mutex::new(0.0f64));
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    let writer_time_map = time_map.clone();
+    let writer_cursor = stream_cursor_ms.clone();
+    let writer_shutdown = shutdown.clone();
+    let writer_handle = tokio::spawn(async move {
+        let mut receiver = transcription_receiver;
+        let mut ping_interval = tokio::time::interval(Duration::from_secs(20));
+        let mut shutdown_interval = tokio::time::interval(Duration::from_millis(250));
+
+        loop {
+            tokio::select! {
+                _ = shutdown_interval.tick() => {
+                    if writer_shutdown.load(Ordering::SeqCst) {
+                        break;
+                    }
+                }
+                _ = ping_interval.tick() => {
+                    if let Err(e) = write.send(Message::Ping(Vec::new())).await {
+                        return Err(anyhow!("Failed to ping Soniox realtime API: {}", e));
+                    }
+                }
+                maybe_chunk = receiver.recv() => {
+                    let Some(chunk) = maybe_chunk else {
+                        break;
+                    };
+
+                    if chunk.data.is_empty() {
+                        continue;
+                    }
+
+                    let original_start_ms = chunk.timestamp * 1000.0;
+                    let original_duration_ms =
+                        chunk.data.len() as f64 / chunk.sample_rate as f64 * 1000.0;
+                    let original_end_ms = original_start_ms + original_duration_ms;
+
+                    let pcm_samples = if chunk.sample_rate != PCM_SAMPLE_RATE {
+                        super::audio_processing::resample_audio(&chunk.data, chunk.sample_rate, PCM_SAMPLE_RATE)
+                    } else {
+                        chunk.data
+                    };
+
+                    if pcm_samples.is_empty() {
+                        continue;
+                    }
+
+                    let duration_ms = pcm_samples.len() as f64 / PCM_SAMPLE_RATE as f64 * 1000.0;
+
+                    {
+                        let mut cursor = writer_cursor.lock().await;
+                        let entry = AudioTimeMapEntry {
+                            stream_start_ms: *cursor,
+                            stream_end_ms: *cursor + duration_ms,
+                            original_start_ms,
+                            original_end_ms,
+                        };
+                        *cursor += duration_ms;
+                        writer_time_map.lock().await.push(entry);
+                    }
+
+                    let bytes = f32_to_pcm16le(&pcm_samples);
+                    write
+                        .send(Message::Binary(bytes))
+                        .await
+                        .map_err(|e| anyhow!("Failed to send audio to Soniox realtime API: {}", e))?;
+                }
+            }
+        }
+
+        let _ = write.send(Message::Binary(Vec::new())).await;
+        Ok::<(), anyhow::Error>(())
+    });
+
+    let reader_time_map = time_map.clone();
+    let reader_shutdown = shutdown.clone();
+    let reader_app = app.clone();
+    let reader_handle = tokio::spawn(async move {
+        let mut buffer = RealtimeSegmentBuffer::new(reader_app);
+
+        while let Some(message) = read.next().await {
+            let message = match message {
+                Ok(message) => message,
+                Err(e) => {
+                    reader_shutdown.store(true, Ordering::SeqCst);
+                    return Err(anyhow!("Soniox realtime WebSocket error: {}", e));
+                }
+            };
+
+            match message {
+                Message::Text(text) => {
+                    let response: RealtimeResponse = match serde_json::from_str(&text) {
+                        Ok(response) => response,
+                        Err(e) => {
+                            warn!("Failed to parse Soniox realtime response: {} ({})", e, text);
+                            continue;
+                        }
+                    };
+
+                    if let Some(message) = response
+                        .error_message
+                        .or(response.error)
+                        .or(response.error_code)
+                    {
+                        reader_shutdown.store(true, Ordering::SeqCst);
+                        return Err(anyhow!("Soniox realtime error: {}", message));
+                    }
+
+                    let entries = reader_time_map.lock().await.clone();
+                    let final_tokens = response
+                        .tokens
+                        .into_iter()
+                        .filter(|token| token.is_final.unwrap_or(false))
+                        .map(|token| {
+                            let start_ms = map_stream_ms_to_original(
+                                &entries,
+                                token.start_ms.unwrap_or_default(),
+                            );
+                            let end_ms = map_stream_ms_to_original(
+                                &entries,
+                                token.end_ms.unwrap_or(token.start_ms.unwrap_or_default()),
+                            )
+                            .max(start_ms);
+                            MappedRealtimeToken {
+                                text: token.text,
+                                start_ms,
+                                end_ms,
+                                confidence: token.confidence,
+                                speaker: token.speaker,
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    buffer.ingest(final_tokens);
+                }
+                Message::Close(_) => break,
+                _ => {}
+            }
+        }
+
+        buffer.flush();
+        reader_shutdown.store(true, Ordering::SeqCst);
+        Ok::<(), anyhow::Error>(())
+    });
+
+    let writer_result = writer_handle
+        .await
+        .map_err(|e| format!("Soniox realtime writer task failed: {}", e))?;
+    if let Err(e) = writer_result {
+        shutdown.store(true, Ordering::SeqCst);
+        emit_transcription_error(&app, e.to_string());
+        return Err(e.to_string());
+    }
+
+    let mut reader_handle = reader_handle;
+    match tokio::time::timeout(Duration::from_secs(30), &mut reader_handle).await {
+        Ok(join_result) => {
+            let reader_result =
+                join_result.map_err(|e| format!("Soniox realtime reader task failed: {}", e))?;
+            if let Err(e) = reader_result {
+                emit_transcription_error(&app, e.to_string());
+                return Err(e.to_string());
+            }
+        }
+        Err(_) => {
+            reader_handle.abort();
+            warn!("Timed out waiting for Soniox realtime final response");
+        }
+    }
+
+    info!("Soniox realtime transcription task completed");
+    Ok(())
+}
+
+impl<R: Runtime> RealtimeSegmentBuffer<R> {
+    fn new(app: AppHandle<R>) -> Self {
+        Self {
+            app,
+            tokens: Vec::new(),
+        }
+    }
+
+    fn ingest(&mut self, tokens: Vec<MappedRealtimeToken>) {
+        for token in tokens {
+            if token.text.is_empty() {
+                continue;
+            }
+
+            let gap = self
+                .tokens
+                .last()
+                .map(|last| token.start_ms - last.end_ms > 1200.0)
+                .unwrap_or(false);
+            let speaker_changed = self
+                .tokens
+                .last()
+                .map(|last| last.speaker != token.speaker)
+                .unwrap_or(false);
+
+            if !self.tokens.is_empty() && (gap || speaker_changed) {
+                self.flush();
+            }
+
+            self.tokens.push(token);
+
+            if self
+                .tokens
+                .last()
+                .map(|last| ends_sentence(&last.text))
+                .unwrap_or(false)
+            {
+                self.flush();
+            }
+        }
+    }
+
+    fn flush(&mut self) {
+        if self.tokens.is_empty() {
+            return;
+        }
+
+        let text = self
+            .tokens
+            .iter()
+            .map(|token| token.text.as_str())
+            .collect::<String>()
+            .trim()
+            .to_string();
+        if text.is_empty() {
+            self.tokens.clear();
+            return;
+        }
+
+        emit_speech_detected(&self.app);
+
+        let start_ms = self
+            .tokens
+            .first()
+            .map(|token| token.start_ms)
+            .unwrap_or(0.0);
+        let end_ms = self
+            .tokens
+            .last()
+            .map(|token| token.end_ms)
+            .unwrap_or(start_ms);
+        let confidence =
+            average_confidence(self.tokens.iter().filter_map(|token| token.confidence));
+        emit_transcript_update(&self.app, text, start_ms, end_ms, confidence, false);
+        self.tokens.clear();
+    }
+}
+
+fn emit_speech_detected<R: Runtime>(app: &AppHandle<R>) {
+    if REALTIME_SPEECH_DETECTED_EMITTED
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        let _ = app.emit(
+            "speech-detected",
+            serde_json::json!({ "message": "Speech activity detected" }),
+        );
+    }
+}
+
+fn emit_transcript_update<R: Runtime>(
+    app: &AppHandle<R>,
+    text: String,
+    start_ms: f64,
+    end_ms: f64,
+    confidence: f32,
+    is_partial: bool,
+) {
+    let sequence_id = REALTIME_SEQUENCE_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let audio_start_time = start_ms / 1000.0;
+    let audio_end_time = end_ms.max(start_ms) / 1000.0;
+    let duration = (audio_end_time - audio_start_time).max(0.0);
+
+    let update = TranscriptUpdate {
+        text,
+        timestamp: chrono::Local::now().format("%H:%M:%S").to_string(),
+        source: "Audio".to_string(),
+        sequence_id,
+        chunk_start_time: audio_start_time,
+        is_partial,
+        confidence,
+        audio_start_time,
+        audio_end_time,
+        duration,
+    };
+
+    if let Err(e) = app.emit("transcript-update", &update) {
+        error!("Failed to emit Soniox transcript update: {}", e);
+    }
+}
+
+fn emit_transcription_error<R: Runtime>(app: &AppHandle<R>, error: String) {
+    let _ = app.emit(
+        "transcription-error",
+        serde_json::json!({
+            "error": error,
+            "userMessage": "Soniox transcription failed. Check your API key and network connection.",
+            "actionable": true
+        }),
+    );
+}
+
+fn language_hints(language: Option<String>) -> Vec<String> {
+    language
+        .into_iter()
+        .map(|language| language.trim().to_string())
+        .filter(|language| {
+            !language.is_empty()
+                && language != "auto"
+                && language != "auto-translate"
+                && language != "detect"
+        })
+        .collect()
+}
+
+fn f32_to_pcm16le(samples: &[f32]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(samples.len() * 2);
+    for sample in samples {
+        let clamped = sample.clamp(-1.0, 1.0);
+        let pcm = (clamped * i16::MAX as f32) as i16;
+        bytes.extend_from_slice(&pcm.to_le_bytes());
+    }
+    bytes
+}
+
+async fn ensure_success(response: reqwest::Response, action: &str) -> Result<reqwest::Response> {
+    if response.status().is_success() {
+        return Ok(response);
+    }
+
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    Err(anyhow!(
+        "Soniox {} failed (HTTP {}): {}",
+        action,
+        status,
+        truncate_for_error(&body)
+    ))
+}
+
+fn ensure_not_cancelled<C>(should_cancel: &mut C) -> Result<()>
+where
+    C: FnMut() -> bool,
+{
+    if should_cancel() {
+        Err(anyhow!("Operation cancelled"))
+    } else {
+        Ok(())
+    }
+}
+
+fn push_transcript_tuple(
+    segments: &mut Vec<(String, f64, f64)>,
+    text: String,
+    start_ms: f64,
+    end_ms: f64,
+) {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+
+    segments.push((trimmed.to_string(), start_ms, end_ms.max(start_ms)));
+}
+
+fn average_confidence(values: impl Iterator<Item = f32>) -> f32 {
+    let mut sum = 0.0;
+    let mut count = 0usize;
+    for value in values {
+        sum += value;
+        count += 1;
+    }
+
+    if count == 0 {
+        0.85
+    } else {
+        sum / count as f32
+    }
+}
+
+fn ends_sentence(text: &str) -> bool {
+    text.trim_end()
+        .chars()
+        .last()
+        .map(|c| matches!(c, '.' | '!' | '?' | '\n'))
+        .unwrap_or(false)
+}
+
+fn truncate_for_error(text: &str) -> String {
+    const MAX_LEN: usize = 500;
+    if text.len() <= MAX_LEN {
+        return text.to_string();
+    }
+
+    let mut end = MAX_LEN;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &text[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn groups_tokens_on_large_gaps() {
+        let tokens = vec![
+            SonioxToken {
+                text: "Hello".to_string(),
+                start_ms: Some(0.0),
+                end_ms: Some(400.0),
+                confidence: Some(0.9),
+                speaker: None,
+                is_final: Some(true),
+            },
+            SonioxToken {
+                text: " world.".to_string(),
+                start_ms: Some(450.0),
+                end_ms: Some(900.0),
+                confidence: Some(0.9),
+                speaker: None,
+                is_final: Some(true),
+            },
+            SonioxToken {
+                text: "Later".to_string(),
+                start_ms: Some(3000.0),
+                end_ms: Some(3400.0),
+                confidence: Some(0.8),
+                speaker: None,
+                is_final: Some(true),
+            },
+        ];
+
+        let segments = soniox_tokens_to_transcript_tuples(&tokens);
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0], ("Hello world.".to_string(), 0.0, 900.0));
+        assert_eq!(segments[1], ("Later".to_string(), 3000.0, 3400.0));
+    }
+
+    #[test]
+    fn maps_stream_time_to_original_chunk_time() {
+        let entries = vec![
+            AudioTimeMapEntry {
+                stream_start_ms: 0.0,
+                stream_end_ms: 1000.0,
+                original_start_ms: 5000.0,
+                original_end_ms: 6000.0,
+            },
+            AudioTimeMapEntry {
+                stream_start_ms: 1000.0,
+                stream_end_ms: 2000.0,
+                original_start_ms: 9000.0,
+                original_end_ms: 10_000.0,
+            },
+        ];
+
+        assert_eq!(map_stream_ms_to_original(&entries, 500.0), 5500.0);
+        assert_eq!(map_stream_ms_to_original(&entries, 1500.0), 9500.0);
+    }
+}

--- a/frontend/src-tauri/src/audio/transcription/engine.rs
+++ b/frontend/src-tauri/src/audio/transcription/engine.rs
@@ -135,10 +135,23 @@ pub async fn validate_transcription_model_ready<R: Runtime>(app: &AppHandle<R>) 
                 }
             }
         }
+        "soniox" => {
+            info!("🔍 Validating Soniox API key...");
+            match crate::audio::soniox::validate_configured_api_key(app).await {
+                Ok(()) => {
+                    info!("✅ Soniox API key is configured");
+                    Ok(())
+                }
+                Err(e) => {
+                    warn!("❌ Soniox validation failed: {}", e);
+                    Err(e)
+                }
+            }
+        }
         other => {
             warn!("❌ Unsupported transcription provider for local recording: {}", other);
             Err(format!(
-                "Provider '{}' is not supported for local transcription. Please select 'localWhisper' or 'parakeet'.",
+                "Provider '{}' is not supported for recording. Please select 'localWhisper', 'parakeet', or 'soniox'.",
                 other
             ))
         }
@@ -212,10 +225,24 @@ pub async fn get_or_init_transcription_engine<R: Runtime>(
                 }
             }
         }
+        "soniox" => {
+            Err("Soniox realtime transcription is handled by the Soniox streaming worker".to_string())
+        }
         "localWhisper" | _ => {
             info!("🎤 Initializing Whisper transcription engine");
             let whisper_engine = get_or_init_whisper(app).await?;
             Ok(TranscriptionEngine::Whisper(whisper_engine))
+        }
+    }
+}
+
+pub async fn is_soniox_transcription_provider<R: Runtime>(app: &AppHandle<R>) -> bool {
+    match crate::api::api::api_get_transcript_config(app.clone(), app.clone().state(), None).await {
+        Ok(Some(config)) => config.provider == crate::audio::soniox::PROVIDER,
+        Ok(None) => false,
+        Err(e) => {
+            warn!("⚠️ Failed to read transcript config while checking Soniox provider: {}", e);
+            false
         }
     }
 }

--- a/frontend/src-tauri/src/audio/transcription/mod.rs
+++ b/frontend/src-tauri/src/audio/transcription/mod.rs
@@ -16,7 +16,8 @@ pub use engine::{
     TranscriptionEngine,
     validate_transcription_model_ready,
     get_or_init_transcription_engine,
-    get_or_init_whisper
+    get_or_init_whisper,
+    is_soniox_transcription_provider
 };
 pub use worker::{
     start_transcription_task,

--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -49,6 +49,24 @@ pub fn start_transcription_task<R: Runtime>(
     tokio::spawn(async move {
         info!("🚀 Starting optimized parallel transcription task - guaranteeing zero chunk loss");
 
+        if super::engine::is_soniox_transcription_provider(&app).await {
+            info!("☁️ Starting Soniox realtime transcription task");
+            if let Err(e) = crate::audio::soniox::run_realtime_transcription(
+                app.clone(),
+                transcription_receiver,
+            )
+            .await
+            {
+                error!("Soniox realtime transcription failed: {}", e);
+                let _ = app.emit("transcription-error", serde_json::json!({
+                    "error": e,
+                    "userMessage": "Soniox transcription failed. Check your API key and network connection.",
+                    "actionable": true
+                }));
+            }
+            return;
+        }
+
         // Initialize transcription engine (Whisper or Parakeet based on config)
         let transcription_engine = match super::engine::get_or_init_transcription_engine(&app).await {
             Ok(engine) => engine,

--- a/frontend/src-tauri/src/config.rs
+++ b/frontend/src-tauri/src/config.rs
@@ -11,6 +11,12 @@ pub const DEFAULT_WHISPER_MODEL: &str = "large-v3-turbo";
 /// This is the quantized version optimized for speed.
 pub const DEFAULT_PARAKEET_MODEL: &str = "parakeet-tdt-0.6b-v3-int8";
 
+/// Default Soniox model for realtime cloud transcription.
+pub const DEFAULT_SONIOX_REALTIME_MODEL: &str = "stt-rt-v5";
+
+/// Default Soniox model for async cloud transcription of existing files.
+pub const DEFAULT_SONIOX_ASYNC_MODEL: &str = "stt-async-v5";
+
 /// Whisper model catalog with metadata for all supported models.
 /// Used by both WhisperEngine::discover_models() and discover_models_standalone().
 ///

--- a/frontend/src-tauri/src/database/models.rs
+++ b/frontend/src-tauri/src/database/models.rs
@@ -127,4 +127,7 @@ pub struct TranscriptSetting {
     #[sqlx(rename = "openaiApiKey")]
     #[serde(rename = "openaiApiKey")]
     pub openai_api_key: Option<String>,
+    #[sqlx(rename = "sonioxApiKey")]
+    #[serde(rename = "sonioxApiKey")]
+    pub soniox_api_key: Option<String>,
 }

--- a/frontend/src-tauri/src/database/repositories/setting.rs
+++ b/frontend/src-tauri/src/database/repositories/setting.rs
@@ -24,7 +24,7 @@ pub struct SaveTranscriptConfigRequest {
 
 pub struct SettingsRepository;
 
-// Transcript providers: localWhisper, deepgram, elevenLabs, groq, openai
+// Transcript providers: localWhisper, parakeet, soniox, deepgram, elevenLabs, groq, openai
 // Summary providers: openai, claude, ollama, groq, added openrouter
 // NOTE: Handle data exclusion in the higher layer as this is database abstraction layer(using SELECT *)
 
@@ -184,6 +184,7 @@ impl SettingsRepository {
             "elevenLabs" => "elevenLabsApiKey",
             "groq" => "groqApiKey",
             "openai" => "openaiApiKey",
+            "soniox" => "sonioxApiKey",
             _ => {
                 return Err(sqlx::Error::Protocol(
                     format!("Invalid provider: {}", provider).into(),
@@ -216,6 +217,7 @@ impl SettingsRepository {
             "elevenLabs" => "elevenLabsApiKey",
             "groq" => "groqApiKey",
             "openai" => "openaiApiKey",
+            "soniox" => "sonioxApiKey",
             _ => {
                 return Err(sqlx::Error::Protocol(
                     format!("Invalid provider: {}", provider).into(),

--- a/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
+++ b/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
@@ -395,7 +395,7 @@ export function ImportAudioDialog({
                                   key={`${model.provider}:${model.name}`}
                                   value={`${model.provider}:${model.name}`}
                                 >
-                                  {model.displayName} ({Math.round(model.size_mb)} MB)
+                                  {model.displayName}{model.size_mb > 0 ? ` (${Math.round(model.size_mb)} MB)` : ''}
                                 </SelectItem>
                               ))}
                             </SelectContent>

--- a/frontend/src/components/LanguageSelection.tsx
+++ b/frontend/src/components/LanguageSelection.tsx
@@ -118,7 +118,7 @@ interface LanguageSelectionProps {
   selectedLanguage: string;
   onLanguageChange: (language: string) => void;
   disabled?: boolean;
-  provider?: 'localWhisper' | 'parakeet' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
+  provider?: 'localWhisper' | 'parakeet' | 'soniox' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
 }
 
 export function LanguageSelection({

--- a/frontend/src/components/MeetingDetails/RetranscribeDialog.tsx
+++ b/frontend/src/components/MeetingDetails/RetranscribeDialog.tsx
@@ -349,7 +349,7 @@ export function RetranscribeDialog({
                 <SelectContent>
                   {availableModels.map((model) => (
                     <SelectItem key={`${model.provider}:${model.name}`} value={`${model.provider}:${model.name}`}>
-                      {model.displayName} ({Math.round(model.size_mb)} MB)
+                      {model.displayName}{model.size_mb > 0 ? ` (${Math.round(model.size_mb)} MB)` : ''}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/frontend/src/components/TranscriptSettings.tsx
+++ b/frontend/src/components/TranscriptSettings.tsx
@@ -7,10 +7,11 @@ import { Label } from './ui/label';
 import { Eye, EyeOff, Lock, Unlock } from 'lucide-react';
 import { ModelManager } from './WhisperModelManager';
 import { ParakeetModelManager } from './ParakeetModelManager';
+import { DEFAULT_SONIOX_REALTIME_MODEL } from '@/constants/modelDefaults';
 
 
 export interface TranscriptModelProps {
-    provider: 'localWhisper' | 'parakeet' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
+    provider: 'localWhisper' | 'parakeet' | 'soniox' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
     model: string;
     apiKey?: string | null;
 }
@@ -53,12 +54,25 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
     const modelOptions = {
         localWhisper: [], // Model selection handled by ModelManager component
         parakeet: [], // Model selection handled by ParakeetModelManager component
+        soniox: [DEFAULT_SONIOX_REALTIME_MODEL],
         deepgram: ['nova-2-phonecall'],
         elevenLabs: ['eleven_multilingual_v2'],
         groq: ['llama-3.3-70b-versatile'],
         openai: ['gpt-4o'],
     };
-    const requiresApiKey = transcriptModelConfig.provider === 'deepgram' || transcriptModelConfig.provider === 'elevenLabs' || transcriptModelConfig.provider === 'openai' || transcriptModelConfig.provider === 'groq';
+    const requiresApiKey = uiProvider === 'soniox' || uiProvider === 'deepgram' || uiProvider === 'elevenLabs' || uiProvider === 'openai' || uiProvider === 'groq';
+
+    const saveCloudConfig = async (provider: TranscriptModelProps['provider'], model: string, key: string | null) => {
+        try {
+            await invoke('api_save_transcript_config', {
+                provider,
+                model,
+                apiKey: key || null
+            });
+        } catch (error) {
+            console.error('Failed to save transcript provider:', error);
+        }
+    };
 
     const handleInputClick = () => {
         if (isApiKeyLocked) {
@@ -114,6 +128,10 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                     setUiProvider(provider);
                                     if (provider !== 'localWhisper' && provider !== 'parakeet') {
                                         fetchApiKey(provider);
+                                        const model = modelOptions[provider][0];
+                                        const nextConfig = { ...transcriptModelConfig, provider, model };
+                                        setTranscriptModelConfig(nextConfig);
+                                        saveCloudConfig(provider, model, apiKey);
                                     }
                                 }}
                             >
@@ -123,6 +141,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 <SelectContent>
                                     <SelectItem value="parakeet">⚡ Parakeet (Recommended - Real-time / Accurate)</SelectItem>
                                     <SelectItem value="localWhisper">🏠 Local Whisper (High Accuracy)</SelectItem>
+                                    <SelectItem value="soniox">☁️ Soniox (Cloud)</SelectItem>
                                     {/* <SelectItem value="deepgram">☁️ Deepgram (Backup)</SelectItem>
                                     <SelectItem value="elevenLabs">☁️ ElevenLabs</SelectItem>
                                     <SelectItem value="groq">☁️ Groq</SelectItem>
@@ -136,6 +155,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                     onValueChange={(value) => {
                                         const model = value as TranscriptModelProps['model'];
                                         setTranscriptModelConfig({ ...transcriptModelConfig, provider: uiProvider, model });
+                                        saveCloudConfig(uiProvider, model, apiKey);
                                     }}
                                 >
                                     <SelectTrigger className='focus:ring-1 focus:ring-blue-500 focus:border-blue-500'>
@@ -185,6 +205,18 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                         }`}
                                     value={apiKey || ''}
                                     onChange={(e) => setApiKey(e.target.value)}
+                                    onBlur={() => {
+                                        if (requiresApiKey) {
+                                            const model = transcriptModelConfig.model || modelOptions[uiProvider][0];
+                                            saveCloudConfig(uiProvider, model, apiKey);
+                                            setTranscriptModelConfig({
+                                                ...transcriptModelConfig,
+                                                provider: uiProvider,
+                                                model,
+                                                apiKey
+                                            });
+                                        }
+                                    }}
                                     disabled={isApiKeyLocked}
                                     onClick={handleInputClick}
                                     placeholder="Enter your API key"
@@ -224,7 +256,6 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
         </div >
     )
 }
-
 
 
 

--- a/frontend/src/constants/modelDefaults.ts
+++ b/frontend/src/constants/modelDefaults.ts
@@ -16,10 +16,21 @@ export const DEFAULT_WHISPER_MODEL = 'large-v3-turbo';
 export const DEFAULT_PARAKEET_MODEL = 'parakeet-tdt-0.6b-v3-int8';
 
 /**
+ * Default Soniox model for realtime cloud transcription.
+ */
+export const DEFAULT_SONIOX_REALTIME_MODEL = 'stt-rt-v5';
+
+/**
+ * Default Soniox model for imported audio and retranscription.
+ */
+export const DEFAULT_SONIOX_ASYNC_MODEL = 'stt-async-v5';
+
+/**
  * Model defaults by provider type
  */
 export const MODEL_DEFAULTS = {
   whisper: DEFAULT_WHISPER_MODEL,
   localWhisper: DEFAULT_WHISPER_MODEL,
   parakeet: DEFAULT_PARAKEET_MODEL,
+  soniox: DEFAULT_SONIOX_REALTIME_MODEL,
 } as const;

--- a/frontend/src/hooks/useTranscriptionModels.ts
+++ b/frontend/src/hooks/useTranscriptionModels.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { DEFAULT_SONIOX_ASYNC_MODEL } from '@/constants/modelDefaults';
 
 export interface RawModelInfo {
   name: string;
@@ -8,7 +9,7 @@ export interface RawModelInfo {
 }
 
 export interface ModelOption {
-  provider: 'whisper' | 'parakeet';
+  provider: 'whisper' | 'parakeet' | 'soniox';
   name: string;
   displayName: string;
   size_mb: number;
@@ -77,6 +78,13 @@ export function useTranscriptionModels(transcriptModelConfig: TranscriptModelCon
       console.error('Failed to fetch Parakeet models:', err);
     }
 
+    allModels.push({
+      provider: 'soniox',
+      name: DEFAULT_SONIOX_ASYNC_MODEL,
+      displayName: `☁️ Soniox: ${DEFAULT_SONIOX_ASYNC_MODEL}`,
+      size_mb: 0,
+    });
+
     setAvailableModels(allModels);
 
     // Set default model based on user's saved configuration
@@ -88,7 +96,8 @@ export function useTranscriptionModels(transcriptModelConfig: TranscriptModelCon
     const configuredMatch = allModels.find(
       (m) =>
         (configuredProvider === 'localWhisper' && m.provider === 'whisper' && m.name === configuredModel) ||
-        (configuredProvider === 'parakeet' && m.provider === 'parakeet' && m.name === configuredModel)
+        (configuredProvider === 'parakeet' && m.provider === 'parakeet' && m.name === configuredModel) ||
+        (configuredProvider === 'soniox' && m.provider === 'soniox')
     );
 
     // Only set default model if user hasn't manually selected one


### PR DESCRIPTION
## Summary
- add Soniox as a selectable transcription provider in settings
- support Soniox realtime transcription for live recording via WebSocket
- support Soniox async transcription for imported audio and retranscription
- persist Soniox API keys through transcript settings

## Verification
- cargo check
- cargo test soniox --lib
- pnpm --dir frontend build
- built macOS app + DMG successfully with updater artifacts disabled for local test packaging
- smoke-tested Soniox async REST and realtime WebSocket paths with a valid API key

## Notes
- API keys are not committed; Soniox can read from saved settings or SONIOX_API_KEY in the environment.
- The local test build was ad-hoc signed and not notarized.