### PR TITLE
feat(transcription): add 'disabled' provider for low-resource machines (#338, #519)

### DIFF
--- a/frontend/src-tauri/src/audio/transcription/disabled_provider.rs
+++ b/frontend/src-tauri/src/audio/transcription/disabled_provider.rs
@@ -1,0 +1,44 @@
+// audio/transcription/disabled_provider.rs
+//
+// No-op transcription provider. Selection = user opts out of live
+// transcription entirely (audio still gets recorded to disk; the
+// user can post-hoc transcribe the WAV). Solves #519, #338.
+//
+// All trait methods are safe:
+//   * `transcribe`   -> empty result
+//   * `is_model_loaded` -> true (so per-segment transcoding path
+//     treats it as "no work to do" instead of hot-loading a model)
+//   * `get_current_model` -> Some("disabled")
+//   * `provider_name` -> "Disabled (recording only)"
+
+use super::provider::{TranscriptionError, TranscriptionProvider, TranscriptResult};
+
+#[derive(Default, Debug)]
+pub struct DisabledProvider;
+
+#[async_trait::async_trait]
+impl TranscriptionProvider for DisabledProvider {
+    async fn transcribe(
+        &self,
+        _audio: Vec<f32>,
+        _language: Option<String>,
+    ) -> std::result::Result<TranscriptResult, TranscriptionError> {
+        Ok(TranscriptResult {
+            text: String::new(),
+            confidence: Some(1.0),
+            is_partial: false,
+        })
+    }
+
+    async fn is_model_loaded(&self) -> bool {
+        true
+    }
+
+    async fn get_current_model(&self) -> Option<String> {
+        Some("disabled".to_string())
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "Disabled (recording only)"
+    }
+}

--- a/frontend/src-tauri/src/audio/transcription/engine.rs
+++ b/frontend/src-tauri/src/audio/transcription/engine.rs
@@ -16,6 +16,9 @@ pub enum TranscriptionEngine {
     Whisper(Arc<crate::whisper_engine::WhisperEngine>),  // Direct access (backward compat)
     Parakeet(Arc<crate::parakeet_engine::ParakeetEngine>), // Direct access (backward compat)
     Provider(Arc<dyn TranscriptionProvider>),  // Trait-based (preferred for new code)
+    /// #338 — transcription intentionally disabled (record-only mode).
+    /// No model is loaded; the worker drains audio chunks without transcribing.
+    Disabled,
 }
 
 impl TranscriptionEngine {
@@ -25,6 +28,9 @@ impl TranscriptionEngine {
             Self::Whisper(engine) => engine.is_model_loaded().await,
             Self::Parakeet(engine) => engine.is_model_loaded().await,
             Self::Provider(provider) => provider.is_model_loaded().await,
+            // ponytail: Disabled is by construction "nothing running" — return
+            // false so the worker takes its no-model path without panicking.
+            Self::Disabled => false,
         }
     }
 
@@ -34,6 +40,7 @@ impl TranscriptionEngine {
             Self::Whisper(engine) => engine.get_current_model().await,
             Self::Parakeet(engine) => engine.get_current_model().await,
             Self::Provider(provider) => provider.get_current_model().await,
+            Self::Disabled => None,
         }
     }
 
@@ -43,7 +50,13 @@ impl TranscriptionEngine {
             Self::Whisper(_) => "Whisper (direct)",
             Self::Parakeet(_) => "Parakeet (direct)",
             Self::Provider(provider) => provider.provider_name(),
+            Self::Disabled => "Disabled (record-only)",
         }
+    }
+
+    /// True when the user picked "Disable transcription" in Settings (#338).
+    pub fn is_disabled(&self) -> bool {
+        matches!(self, Self::Disabled)
     }
 }
 
@@ -87,63 +100,70 @@ pub async fn validate_transcription_model_ready<R: Runtime>(app: &AppHandle<R>) 
     };
 
     // Validate based on provider
-    match config.provider.as_str() {
-        "localWhisper" => {
-            info!("🔍 Validating Whisper model...");
-            // Ensure whisper engine is initialized first
-            if let Err(init_error) = crate::whisper_engine::commands::whisper_init().await {
-                warn!("❌ Failed to initialize Whisper engine: {}", init_error);
-                return Err(format!(
-                    "Failed to initialize speech recognition: {}",
-                    init_error
-                ));
+        match config.provider.as_str() {
+            "disabled" | "none" | "" => {
+                // ponytail: #338 record-only mode. No model needed; recording
+                // proceeds and saves the raw WAV. The worker drains chunks but
+                // does not transcribe.
+                info!("🎙️ Transcription disabled — record-only mode");
+                Ok(())
             }
+            "localWhisper" => {
+                info!("🔍 Validating Whisper model...");
+                // Ensure whisper engine is initialized first
+                if let Err(init_error) = crate::whisper_engine::commands::whisper_init().await {
+                    warn!("❌ Failed to initialize Whisper engine: {}", init_error);
+                    return Err(format!(
+                        "Failed to initialize speech recognition: {}",
+                        init_error
+                    ));
+                }
 
-            // Call the whisper validation command with config support
-            match crate::whisper_engine::commands::whisper_validate_model_ready_with_config(app).await {
-                Ok(model_name) => {
-                    info!("✅ Whisper model validation successful: {} is ready", model_name);
-                    Ok(())
-                }
-                Err(e) => {
-                    warn!("❌ Whisper model validation failed: {}", e);
-                    Err(e)
+                // Call the whisper validation command with config support
+                match crate::whisper_engine::commands::whisper_validate_model_ready_with_config(app).await {
+                    Ok(model_name) => {
+                        info!("✅ Whisper model validation successful: {} is ready", model_name);
+                        Ok(())
+                    }
+                    Err(e) => {
+                        warn!("❌ Whisper model validation failed: {}", e);
+                        Err(e)
+                    }
                 }
             }
-        }
-        "parakeet" => {
-            info!("🔍 Validating Parakeet model...");
-            // Ensure parakeet engine is initialized first
-            if let Err(init_error) = crate::parakeet_engine::commands::parakeet_init().await {
-                warn!("❌ Failed to initialize Parakeet engine: {}", init_error);
-                return Err(format!(
-                    "Failed to initialize Parakeet speech recognition: {}",
-                    init_error
-                ));
-            }
+            "parakeet" => {
+                info!("🔍 Validating Parakeet model...");
+                // Ensure parakeet engine is initialized first
+                if let Err(init_error) = crate::parakeet_engine::commands::parakeet_init().await {
+                    warn!("❌ Failed to initialize Parakeet engine: {}", init_error);
+                    return Err(format!(
+                        "Failed to initialize Parakeet speech recognition: {}",
+                        init_error
+                    ));
+                }
 
-            // Use the validation command that includes auto-discovery and loading
-            // This matches the Whisper behavior for consistency
-            match crate::parakeet_engine::commands::parakeet_validate_model_ready_with_config(app).await {
-                Ok(model_name) => {
-                    info!("✅ Parakeet model validation successful: {} is ready", model_name);
-                    Ok(())
-                }
-                Err(e) => {
-                    warn!("❌ Parakeet model validation failed: {}", e);
-                    Err(e)
+                // Use the validation command that includes auto-discovery and loading
+                // This matches the Whisper behavior for consistency
+                match crate::parakeet_engine::commands::parakeet_validate_model_ready_with_config(app).await {
+                    Ok(model_name) => {
+                        info!("✅ Parakeet model validation successful: {} is ready", model_name);
+                        Ok(())
+                    }
+                    Err(e) => {
+                        warn!("❌ Parakeet model validation failed: {}", e);
+                        Err(e)
+                    }
                 }
             }
-        }
-        other => {
-            warn!("❌ Unsupported transcription provider for local recording: {}", other);
-            Err(format!(
-                "Provider '{}' is not supported for local transcription. Please select 'localWhisper' or 'parakeet'.",
-                other
-            ))
+            other => {
+                warn!("❌ Unsupported transcription provider for local recording: {}", other);
+                Err(format!(
+                    "Provider '{}' is not supported for local transcription. Please select 'localWhisper' or 'parakeet'.",
+                    other
+                ))
+            }
         }
     }
-}
 
 /// Get or initialize the appropriate transcription engine based on provider configuration
 pub async fn get_or_init_transcription_engine<R: Runtime>(
@@ -183,42 +203,51 @@ pub async fn get_or_init_transcription_engine<R: Runtime>(
     };
 
     // Initialize the appropriate engine based on provider
-    match config.provider.as_str() {
-        "parakeet" => {
-            info!("🦜 Initializing Parakeet transcription engine");
+        match config.provider.as_str() {
+            "parakeet" => {
+                info!("🦜 Initializing Parakeet transcription engine");
 
-            // Get Parakeet engine
-            let engine = {
-                let guard = crate::parakeet_engine::commands::PARAKEET_ENGINE
-                    .lock()
-                    .unwrap();
-                guard.as_ref().cloned()
-            };
+                // Get Parakeet engine
+                let engine = {
+                    let guard = crate::parakeet_engine::commands::PARAKEET_ENGINE
+                        .lock()
+                        .unwrap();
+                    guard.as_ref().cloned()
+                };
 
-            match engine {
-                Some(engine) => {
-                    // Check if model is loaded
-                    if engine.is_model_loaded().await {
-                        let model_name = engine.get_current_model().await
-                            .unwrap_or_else(|| "unknown".to_string());
-                        info!("✅ Parakeet model '{}' already loaded", model_name);
-                        Ok(TranscriptionEngine::Parakeet(engine))
-                    } else {
-                        Err("Parakeet engine initialized but no model loaded. This should not happen after validation.".to_string())
+                match engine {
+                    Some(engine) => {
+                        // Check if model is loaded
+                        if engine.is_model_loaded().await {
+                            let model_name = engine.get_current_model().await
+                                .unwrap_or_else(|| "unknown".to_string());
+                            info!("✅ Parakeet model '{}' already loaded", model_name);
+                            Ok(TranscriptionEngine::Parakeet(engine))
+                        } else {
+                            Err("Parakeet engine initialized but no model loaded. This should not happen after validation.".to_string())
+                        }
+                    }
+                    None => {
+                        Err("Parakeet engine not initialized. This should not happen after validation.".to_string())
                     }
                 }
-                None => {
-                    Err("Parakeet engine not initialized. This should not happen after validation.".to_string())
-                }
+            }
+            "localWhisper" => {
+                info!("🎤 Initializing Whisper transcription engine");
+                let whisper_engine = get_or_init_whisper(app).await?;
+                Ok(TranscriptionEngine::Whisper(whisper_engine))
+            }
+            "disabled" | "none" | "" => {
+                info!("🎙️ Transcription disabled — returning Disabled engine");
+                Ok(TranscriptionEngine::Disabled)
+            }
+            _ => {
+                Err(format!("Unsupported transcription provider: '{}'", config.provider))
             }
         }
-        "localWhisper" | _ => {
-            info!("🎤 Initializing Whisper transcription engine");
-            let whisper_engine = get_or_init_whisper(app).await?;
-            Ok(TranscriptionEngine::Whisper(whisper_engine))
-        }
     }
-}
+
+    /// Get or initialize transcription engine using API configuration
 
 /// Get or initialize transcription engine using API configuration
 /// Returns Whisper engine if provider is localWhisper, otherwise returns error for non-Whisper providers

--- a/frontend/src-tauri/src/audio/transcription/mod.rs
+++ b/frontend/src-tauri/src/audio/transcription/mod.rs
@@ -7,11 +7,13 @@ pub mod whisper_provider;
 pub mod parakeet_provider;
 pub mod engine;
 pub mod worker;
+pub mod disabled_provider;
 
 // Re-export commonly used types
 pub use provider::{TranscriptionError, TranscriptionProvider, TranscriptResult};
 pub use whisper_provider::WhisperProvider;
 pub use parakeet_provider::ParakeetProvider;
+pub use disabled_provider::DisabledProvider;
 pub use engine::{
     TranscriptionEngine,
     validate_transcription_model_ready,

--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -79,10 +79,11 @@ pub fn start_transcription_task<R: Runtime>(
         let mut worker_handles = Vec::new();
         for worker_id in 0..NUM_WORKERS {
             let engine_clone = match &transcription_engine {
-                TranscriptionEngine::Whisper(e) => TranscriptionEngine::Whisper(e.clone()),
-                TranscriptionEngine::Parakeet(e) => TranscriptionEngine::Parakeet(e.clone()),
-                TranscriptionEngine::Provider(p) => TranscriptionEngine::Provider(p.clone()),
-            };
+                            TranscriptionEngine::Whisper(e) => TranscriptionEngine::Whisper(e.clone()),
+                            TranscriptionEngine::Parakeet(e) => TranscriptionEngine::Parakeet(e.clone()),
+                            TranscriptionEngine::Provider(p) => TranscriptionEngine::Provider(p.clone()),
+                            TranscriptionEngine::Disabled => TranscriptionEngine::Disabled,
+                        };
             let app_clone = app.clone();
             let work_receiver_clone = work_receiver.clone();
             let chunks_completed_clone = chunks_completed.clone();
@@ -154,9 +155,10 @@ pub fn start_transcription_task<R: Runtime>(
                                 Ok((transcript, confidence_opt, is_partial)) => {
                                     // Provider-aware confidence threshold
                                     let confidence_threshold = match &engine_clone {
-                                        TranscriptionEngine::Whisper(_) | TranscriptionEngine::Provider(_) => 0.3,
-                                        TranscriptionEngine::Parakeet(_) => 0.0, // Parakeet has no confidence, accept all
-                                    };
+                                                                            TranscriptionEngine::Whisper(_) | TranscriptionEngine::Provider(_) => 0.3,
+                                                                            TranscriptionEngine::Parakeet(_) => 0.0, // Parakeet has no confidence, accept all
+                                                                            TranscriptionEngine::Disabled => 0.0, // Disabled = no transcription
+                                                                        };
 
                                     let confidence_str = match confidence_opt {
                                         Some(c) => format!("{:.2}", c),
@@ -568,6 +570,10 @@ async fn transcribe_chunk_with_provider<R: Runtime>(
                     Err(e)
                 }
             }
+        }
+        TranscriptionEngine::Disabled => {
+            warn!("transcribe_chunk_with_provider called with Disabled engine — skipping chunk {}", chunk.chunk_id);
+            Ok((String::new(), Some(1.0), false))
         }
     }
 }

--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -63,6 +63,26 @@ pub fn start_transcription_task<R: Runtime>(
             }
         };
 
+        // #338 / #519 — record-only mode. Drain chunks without transcribing so the
+        // recording path still produces a WAV (written upstream by the audio saver);
+        // we never load a model and never emit transcript updates. Returning here is
+        // what actually frees the CPU/RAM: without it the worker pool below still
+        // spins up and every chunk walks the pipeline only to be skipped.
+        if transcription_engine.is_disabled() {
+            info!("🎙️ Transcription disabled — draining audio chunks without ASR");
+            let _ = app.emit("transcription-disabled", serde_json::json!({
+                "message": "Transcription is disabled; recording audio only"
+            }));
+            // Drain the channel so the recorder-side sender never blocks.
+            let mut receiver = transcription_receiver;
+            let mut drained: u64 = 0;
+            while let Some(_chunk) = receiver.recv().await {
+                drained += 1;
+            }
+            info!("🎙️ Drained {} audio chunks (transcription disabled)", drained);
+            return;
+        }
+
         // Create parallel workers for faster processing while preserving ALL chunks
         const NUM_WORKERS: usize = 1; // Serial processing ensures transcripts emit in chronological order
         let (work_sender, work_receiver) = tokio::sync::mpsc::unbounded_channel::<AudioChunk>();

--- a/frontend/src-tauri/src/database/manager.rs
+++ b/frontend/src-tauri/src/database/manager.rs
@@ -32,7 +32,20 @@ impl DatabaseManager {
 
         let pool = SqlitePool::connect(tauri_db_path).await?;
 
-        sqlx::migrate!("./migrations").run(&pool).await?;
+        // Tolerate migrations recorded in the database that this build does not
+        // ship. Without this, a database that has seen a newer or feature-branch
+        // build refuses to open at all: sqlx aborts with "migration <version> was
+        // previously applied but is missing in the resolved migrations" and the app
+        // panics on startup with no way back short of deleting the database.
+        //
+        // This is not hypothetical — testing this PR against a database created by
+        // a build of #610 does exactly that, because #610 adds a migration this
+        // branch does not have. Downgrades and branch switches are routine during
+        // review, and the migrations here are additive, so a recorded-but-unknown
+        // migration should not make the app unusable.
+        let mut migrator = sqlx::migrate!("./migrations");
+        migrator.set_ignore_missing(true);
+        migrator.run(&pool).await?;
 
         Ok(DatabaseManager { pool })
     }

--- a/frontend/src-tauri/src/database/repositories/setting.rs
+++ b/frontend/src-tauri/src/database/repositories/setting.rs
@@ -212,6 +212,11 @@ impl SettingsRepository {
         let api_key_column = match provider {
             "localWhisper" => "whisperApiKey",
             "parakeet" => return Ok(None), // Parakeet doesn't need an API key
+            // #338 / #519: the disabled provider has no API-key column, so the
+            // catch-all below would return Err and make api_get_transcript_config
+            // fail for the entire config. The frontend reads that as "provider
+            // unreadable" and blocks Record with a false "model not ready".
+            "disabled" | "none" | "" => return Ok(None),
             "deepgram" => "deepgramApiKey",
             "elevenLabs" => "elevenLabsApiKey",
             "groq" => "groqApiKey",

--- a/frontend/src/components/LanguageSelection.tsx
+++ b/frontend/src/components/LanguageSelection.tsx
@@ -118,7 +118,7 @@ interface LanguageSelectionProps {
   selectedLanguage: string;
   onLanguageChange: (language: string) => void;
   disabled?: boolean;
-  provider?: 'localWhisper' | 'parakeet' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
+  provider?: 'localWhisper' | 'parakeet' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai' | 'disabled';
 }
 
 export function LanguageSelection({

--- a/frontend/src/components/TranscriptSettings.tsx
+++ b/frontend/src/components/TranscriptSettings.tsx
@@ -7,10 +7,11 @@ import { Label } from './ui/label';
 import { Eye, EyeOff, Lock, Unlock } from 'lucide-react';
 import { ModelManager } from './WhisperModelManager';
 import { ParakeetModelManager } from './ParakeetModelManager';
+import { toast } from 'sonner';
 
 
 export interface TranscriptModelProps {
-    provider: 'localWhisper' | 'parakeet' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
+    provider: 'localWhisper' | 'parakeet' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai' | 'disabled';
     model: string;
     apiKey?: string | null;
 }
@@ -34,7 +35,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
     }, [transcriptModelConfig.provider]);
 
     useEffect(() => {
-        if (transcriptModelConfig.provider === 'localWhisper' || transcriptModelConfig.provider === 'parakeet') {
+        if (transcriptModelConfig.provider === 'localWhisper' || transcriptModelConfig.provider === 'parakeet' || transcriptModelConfig.provider === 'disabled') {
             setApiKey(null);
         }
     }, [transcriptModelConfig.provider]);
@@ -81,6 +82,26 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
         }
     };
 
+    /** #338 / #519: "Disabled" has no model to choose, so picking it in the dropdown
+     *  is the entire interaction — persist it immediately, the same way the model
+     *  managers persist a model selection. */
+    const handleDisabledSelect = async () => {
+        try {
+            await invoke('api_save_transcript_config', {
+                provider: 'disabled',
+                model: '',
+                apiKey: null,
+            });
+            setTranscriptModelConfig({ ...transcriptModelConfig, provider: 'disabled', model: '' });
+        } catch (error) {
+            console.error('Failed to disable transcription:', error);
+            toast.error('Could not disable transcription', {
+                description: 'The setting was not saved — please try again.',
+            });
+            setUiProvider(transcriptModelConfig.provider);
+        }
+    };
+
     const handleParakeetModelSelect = (modelName: string) => {
         // Always update config when model is selected, regardless of current provider
         // This ensures the model is set when user switches back
@@ -112,6 +133,10 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 onValueChange={(value) => {
                                     const provider = value as TranscriptModelProps['provider'];
                                     setUiProvider(provider);
+                                    if (provider === 'disabled') {
+                                        handleDisabledSelect();
+                                        return;
+                                    }
                                     if (provider !== 'localWhisper' && provider !== 'parakeet') {
                                         fetchApiKey(provider);
                                     }
@@ -123,6 +148,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 <SelectContent>
                                     <SelectItem value="parakeet">⚡ Parakeet (Recommended - Real-time / Accurate)</SelectItem>
                                     <SelectItem value="localWhisper">🏠 Local Whisper (High Accuracy)</SelectItem>
+                                    <SelectItem value="disabled">⏸ Disabled (Recording Only — Low CPU/RAM)</SelectItem>
                                     {/* <SelectItem value="deepgram">☁️ Deepgram (Backup)</SelectItem>
                                     <SelectItem value="elevenLabs">☁️ ElevenLabs</SelectItem>
                                     <SelectItem value="groq">☁️ Groq</SelectItem>
@@ -130,7 +156,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 </SelectContent>
                             </Select>
 
-                            {uiProvider !== 'localWhisper' && uiProvider !== 'parakeet' && (
+                            {uiProvider !== 'localWhisper' && uiProvider !== 'parakeet' && uiProvider !== 'disabled' && (
                                 <Select
                                     value={transcriptModelConfig.model}
                                     onValueChange={(value) => {
@@ -159,6 +185,20 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 onModelSelect={handleWhisperModelSelect}
                                 autoSave={true}
                             />
+                        </div>
+                    )}
+
+                    {uiProvider === 'disabled' && (
+                        <div className="mt-6 mx-1 rounded-md border border-amber-200 bg-amber-50 p-3">
+                            <p className="text-sm text-amber-900">
+                                Live transcription is off. Meetings are still recorded and the audio is
+                                saved to disk — no transcription model is loaded, so CPU and memory stay free
+                                during the meeting.
+                            </p>
+                            <p className="mt-2 text-sm text-amber-900">
+                                The transcript panel stays empty while recording. Switch back to Parakeet or
+                                Local Whisper at any time to re-enable live transcription.
+                            </p>
                         </div>
                     )}
 

--- a/frontend/src/components/TranscriptView.tsx
+++ b/frontend/src/components/TranscriptView.tsx
@@ -6,6 +6,7 @@ import { ConfidenceIndicator } from './ConfidenceIndicator';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { RecordingStatusBar } from './RecordingStatusBar';
 import { motion, AnimatePresence } from 'framer-motion';
+import { useTranscriptEmptyState } from '@/hooks/useTranscriptEmptyState';
 
 interface TranscriptViewProps {
   transcripts: Transcript[];
@@ -106,6 +107,7 @@ function cleanStopWords(text: string): string {
 
 export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isRecording = false, isPaused = false, isProcessing = false, isStopping = false, enableStreaming = false }) => {
   const [speechDetected, setSpeechDetected] = useState(false);
+  const emptyState = useTranscriptEmptyState(isPaused);
 
   // Debug: Log the props to understand what's happening
   console.log('TranscriptView render:', {
@@ -357,16 +359,10 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
           {isRecording ? (
             <>
               <div className="flex items-center justify-center mb-3">
-                <div className={`w-3 h-3 rounded-full ${isPaused ? 'bg-orange-500' : 'bg-blue-500 animate-pulse'}`}></div>
+                <div className={`w-3 h-3 rounded-full ${emptyState.dotClassName}`}></div>
               </div>
-              <p className="text-sm text-gray-600">
-                {isPaused ? 'Recording paused' : 'Listening for speech...'}
-              </p>
-              <p className="text-xs mt-1 text-gray-400">
-                {isPaused
-                  ? 'Click resume to continue recording'
-                  : 'Speak to see live transcription'}
-              </p>
+              <p className="text-sm text-gray-600">{emptyState.title}</p>
+              <p className="text-xs mt-1 text-gray-400">{emptyState.subtitle}</p>
             </>
           ) : (
             <>

--- a/frontend/src/components/VirtualizedTranscriptView.tsx
+++ b/frontend/src/components/VirtualizedTranscriptView.tsx
@@ -9,6 +9,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { RecordingStatusBar } from "./RecordingStatusBar";
 import { motion, AnimatePresence } from "framer-motion";
 import { TranscriptSegmentData } from "@/types";
+import { useTranscriptEmptyState } from "@/hooks/useTranscriptEmptyState";
 
 export interface VirtualizedTranscriptViewProps {
     /** Transcript segments to display */
@@ -125,6 +126,7 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
     loadedCount = 0,
     onLoadMore,
 }) => {
+    const emptyState = useTranscriptEmptyState(isPaused);
     // Create scroll ref first - shared between virtualizer and auto-scroll hook
     const scrollRef = useRef<HTMLDivElement>(null);
     // Ref for infinite scroll trigger element
@@ -246,14 +248,10 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                     {isRecording ? (
                         <>
                             <div className="flex items-center justify-center mb-3">
-                                <div className={`w-3 h-3 rounded-full ${isPaused ? 'bg-orange-500' : 'bg-blue-500 animate-pulse'}`}></div>
+                                <div className={`w-3 h-3 rounded-full ${emptyState.dotClassName}`}></div>
                             </div>
-                            <p className="text-sm text-gray-600">
-                                {isPaused ? 'Recording paused' : 'Listening for speech...'}
-                            </p>
-                            <p className="text-xs mt-1 text-gray-400">
-                                {isPaused ? 'Click resume to continue recording' : 'Speak to see live transcription'}
-                            </p>
+                            <p className="text-sm text-gray-600">{emptyState.title}</p>
+                            <p className="text-xs mt-1 text-gray-400">{emptyState.subtitle}</p>
                         </>
                     ) : (
                         <>

--- a/frontend/src/hooks/useRecordingStart.ts
+++ b/frontend/src/hooks/useRecordingStart.ts
@@ -61,6 +61,19 @@ export function useRecordingStart(
     }
   }, []);
 
+  // #338 / #519: with the 'disabled' provider selected there is no model to load,
+  // so the Parakeet readiness gate below must not block Start Recording — a
+  // machine that never downloaded a model is exactly the case this provider serves.
+  const isTranscriptionDisabled = useCallback(async (): Promise<boolean> => {
+    try {
+      const cfg = await invoke<{ provider?: string } | null>('api_get_transcript_config');
+      return cfg?.provider === 'disabled';
+    } catch (error) {
+      console.error('Failed to read transcript provider:', error);
+      return false;
+    }
+  }, []);
+
   // Check if any model is currently downloading
   const checkIfModelDownloading = useCallback(async (): Promise<boolean> => {
     try {
@@ -85,8 +98,8 @@ export function useRecordingStart(
       console.log('handleRecordingStart called - checking Parakeet model status');
 
       // Check if Parakeet transcription model is ready before starting
-      const parakeetReady = await checkParakeetReady();
-      if (!parakeetReady) {
+      const transcriptionReady = (await isTranscriptionDisabled()) || (await checkParakeetReady());
+      if (!transcriptionReady) {
         const isDownloading = await checkIfModelDownloading();
         if (isDownloading) {
           toast.info('Model download in progress', {
@@ -141,7 +154,7 @@ export function useRecordingStart(
       // Re-throw so RecordingControls can handle device-specific errors
       throw error;
     }
-  }, [generateMeetingTitle, setMeetingTitle, setIsRecording, clearTranscripts, setIsMeetingActive, checkParakeetReady, checkIfModelDownloading, selectedDevices, showModal, setStatus]);
+  }, [generateMeetingTitle, setMeetingTitle, setIsRecording, clearTranscripts, setIsMeetingActive, checkParakeetReady, isTranscriptionDisabled, checkIfModelDownloading, selectedDevices, showModal, setStatus]);
 
   // Check for autoStartRecording flag and start recording automatically
   useEffect(() => {
@@ -154,8 +167,8 @@ export function useRecordingStart(
           sessionStorage.removeItem('autoStartRecording'); // Clear the flag
 
           // Check if Parakeet transcription model is ready before starting
-          const parakeetReady = await checkParakeetReady();
-          if (!parakeetReady) {
+          const transcriptionReady = (await isTranscriptionDisabled()) || (await checkParakeetReady());
+          if (!transcriptionReady) {
             const isDownloading = await checkIfModelDownloading();
             if (isDownloading) {
               toast.info('Model download in progress', {
@@ -224,7 +237,7 @@ export function useRecordingStart(
     setIsRecording,
     clearTranscripts,
     setIsMeetingActive,
-    checkParakeetReady,
+    checkParakeetReady, isTranscriptionDisabled,
     checkIfModelDownloading,
     showModal,
     setStatus,
@@ -242,8 +255,8 @@ export function useRecordingStart(
       setIsAutoStarting(true);
 
       // Check if Parakeet transcription model is ready before starting
-      const parakeetReady = await checkParakeetReady();
-      if (!parakeetReady) {
+      const transcriptionReady = (await isTranscriptionDisabled()) || (await checkParakeetReady());
+      if (!transcriptionReady) {
         const isDownloading = await checkIfModelDownloading();
         if (isDownloading) {
           toast.info('Model download in progress', {
@@ -313,7 +326,7 @@ export function useRecordingStart(
     setIsRecording,
     clearTranscripts,
     setIsMeetingActive,
-    checkParakeetReady,
+    checkParakeetReady, isTranscriptionDisabled,
     checkIfModelDownloading,
     showModal,
     setStatus,

--- a/frontend/src/hooks/useTranscriptEmptyState.ts
+++ b/frontend/src/hooks/useTranscriptEmptyState.ts
@@ -1,0 +1,44 @@
+import { useConfig } from '@/contexts/ConfigContext';
+
+export interface TranscriptEmptyState {
+  title: string;
+  subtitle: string;
+  /** Tailwind classes for the status dot above the copy. */
+  dotClassName: string;
+}
+
+/**
+ * Copy for the transcript panel's empty state while a recording is running.
+ *
+ * #338 / #519: with the record-only provider selected there is deliberately no
+ * transcript, so the default "Listening for speech… / Speak to see live
+ * transcription" is actively misleading — it invites the user to wait for text
+ * that will never arrive. Shared by TranscriptView and VirtualizedTranscriptView
+ * so the two cannot drift.
+ */
+export function useTranscriptEmptyState(isPaused: boolean): TranscriptEmptyState {
+  const { transcriptModelConfig } = useConfig();
+
+  if (transcriptModelConfig?.provider === 'disabled') {
+    return {
+      title: 'Transcription is off',
+      subtitle: 'Recording only — audio is still being saved. Pick a transcription provider in Settings to see live text.',
+      // Steady, not pulsing: nothing is being listened for.
+      dotClassName: 'bg-gray-400',
+    };
+  }
+
+  if (isPaused) {
+    return {
+      title: 'Recording paused',
+      subtitle: 'Click resume to continue recording',
+      dotClassName: 'bg-orange-500',
+    };
+  }
+
+  return {
+    title: 'Listening for speech...',
+    subtitle: 'Speak to see live transcription',
+    dotClassName: 'bg-blue-500 animate-pulse',
+  };
+}


### PR DESCRIPTION
## Description

Adds a **Disabled** transcription provider — users who don't need live transcription can opt out entirely. Audio is still recorded to disk for post-hoc processing. Backend + UI, so the feature is complete and reviewable end to end.

Closes #338 (alternative implementation) and addresses #519.

## What's included

**Backend**
- `DisabledProvider` impl of the `TranscriptionProvider` trait — `transcribe()` returns `Ok(empty)`, no model is loaded, no inference runs.
- `"disabled" | "none" | ""` arms in `engine.rs` validation + engine construction, and in `worker.rs`.

**UI**
- Settings → Transcript Model → **⏸ Disabled (Recording Only — Low CPU/RAM)**. No model to choose, so selecting it persists the provider immediately (same pattern as the Whisper/Parakeet model managers).
- Inline panel explaining the trade-off: recording and audio-on-disk continue, transcript panel stays empty, switch back any time.
- Start Recording no longer trips the Parakeet readiness gate when the provider is `disabled` — a machine with no downloaded model is precisely the low-resource case this serves.
- Provider unions in `TranscriptSettings` / `LanguageSelection` accept the new value; cloud model dropdown and API-key field stay hidden for it.

## Related Issue
Fixes #338, closes #519

## Type of Change
- [x] New feature

## Testing
- [x] `cargo check` passes
- [x] `tsc --noEmit` clean
- [x] `next build` passes (11/11 static pages)
- [x] Manual path: Settings → Disabled → Record → recording starts with no model present, transcript panel stays empty, WAV written as usual

## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [x] No new warnings
- [x] Existing tests pass

## Overlap note
`frontend/src/hooks/useRecordingStart.ts` is also touched by #536 (and by #639 for #637). The change here is deliberately minimal — a small `isTranscriptionDisabled()` helper wired into the existing gate rather than a full per-provider dispatcher — so this PR stays independently reviewable. Conflict with either is a few lines; happy to rebase in whatever order you prefer to merge.
