### PR TITLE
Add transcript source attribution labels

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  prosemirror-model: 1.25.3
+  prosemirror-state: 1.4.3
+  prosemirror-view: 1.41.3
+  prosemirror-transform: 1.10.4
+  prosemirror-tables: 1.8.1
+
 importers:
 
   .:
@@ -2930,10 +2937,10 @@ packages:
       '@types/hast': ^3.0.0
       highlight.js: ^11.9.0
       lowlight: ^3.1.0
-      prosemirror-model: ^1.19.3
-      prosemirror-state: ^1.4.3
-      prosemirror-transform: ^1.8.0
-      prosemirror-view: ^1.32.4
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.3
       refractor: ^5.0.0
       sugar-high: ^0.6.1 || ^0.7.0 || ^0.8.0 || ^0.9.0
     peerDependenciesMeta:
@@ -2979,9 +2986,9 @@ packages:
   prosemirror-paste-rules@3.0.0:
     resolution: {integrity: sha512-p2ayp2xtSTtDPZutoxZyK6UKJhJk0hEpIfdfVYfd3DSENE1Lyrcg96pju+ClgwXlTjPUykXx5DrsfRbHCY+gGQ==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-schema-basic@1.2.4:
     resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
@@ -2995,9 +3002,9 @@ packages:
   prosemirror-suggest@3.0.0:
     resolution: {integrity: sha512-cEYnJHOAnQ+ET7PKY1tY8SMSpyR2rQAuYfPEmVtet0V9exgHAeiaSEzyBcCSeLesxXJRIv8b9cofyqoqyMjlEw==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-tables@1.8.1:
     resolution: {integrity: sha512-DAgDoUYHCcc6tOGpLVPSU1k84kCUWTWnfWX3UDy2Delv4ryH0KqTD6RBI6k4yi9j9I8gl3j8MkPpRD/vWPZbug==}
@@ -3005,9 +3012,9 @@ packages:
   prosemirror-trailing-node@3.0.0:
     resolution: {integrity: sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-transform@1.10.4:
     resolution: {integrity: sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==}
@@ -3448,9 +3455,9 @@ packages:
     resolution: {integrity: sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     peerDependencies:
-      prosemirror-model: ^1.7.1
-      prosemirror-state: ^1.2.3
-      prosemirror-view: ^1.9.10
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
       y-protocols: ^1.0.1
       yjs: ^13.5.38
 

--- a/frontend/src-tauri/migrations/20260101000000_add_audio_source_fields.sql
+++ b/frontend/src-tauri/migrations/20260101000000_add_audio_source_fields.sql
@@ -1,0 +1,12 @@
+-- Migration: Add audio source attribution fields for transcript segments
+-- Values for audio_source: 'microphone', 'system', 'mixed', 'unknown'
+-- This is source attribution, not speaker diarization. Do not use transcripts.speaker.
+
+ALTER TABLE transcripts ADD COLUMN audio_source TEXT CHECK (
+    audio_source IS NULL
+    OR audio_source IN ('microphone', 'system', 'mixed', 'unknown')
+);
+ALTER TABLE transcripts ADD COLUMN source_confidence REAL CHECK (
+    source_confidence IS NULL
+    OR (source_confidence >= 0.0 AND source_confidence <= 1.0)
+);

--- a/frontend/src-tauri/migrations/20260101000000_add_audio_source_fields.sql
+++ b/frontend/src-tauri/migrations/20260101000000_add_audio_source_fields.sql
@@ -1,6 +1,17 @@
 -- Migration: Add audio source attribution fields for transcript segments
 -- Values for audio_source: 'microphone', 'system', 'mixed', 'unknown'
 -- This is source attribution, not speaker diarization. Do not use transcripts.speaker.
+--
+-- Columns are nullable with NO backfill, and that is intentional. Attribution is
+-- computed live from the SEPARATE microphone and system energy during recording;
+-- only the mixed audio is persisted to disk, so segments recorded before this
+-- feature, imported from an external file, or re-transcribed from the saved mix
+-- have no per-stream signal to attribute after the fact (recovering it from a
+-- finished mix is source separation / diarization, which is out of scope). Such
+-- rows keep audio_source = NULL and render with no source label in the UI, copy,
+-- and summary input (see frontend/src/lib/transcriptSource.ts). NULL therefore
+-- means "attribution unavailable", which is distinct from the 'unknown' value
+-- (attribution ran but could not confidently pick a source).
 
 ALTER TABLE transcripts ADD COLUMN audio_source TEXT CHECK (
     audio_source IS NULL

--- a/frontend/src-tauri/src/api/api.rs
+++ b/frontend/src-tauri/src/api/api.rs
@@ -5,6 +5,7 @@ use tauri::{AppHandle, Runtime};
 use tauri_plugin_store::StoreExt;
 
 use crate::{
+    audio::source_attribution::TranscriptAudioSource,
     database::{
         models::MeetingModel,
         repositories::{
@@ -198,21 +199,21 @@ pub struct TranscriptSegment {
     pub source_confidence: Option<f64>,
 }
 
+/// Normalize untrusted transcript source fields at the persistence boundary.
+///
+/// `audio_source` arrives as a free-form string (frontend IPC or an imported
+/// file), so it is parsed through [`TranscriptAudioSource::from_wire`] — the
+/// single source of truth for the canonical strings — and re-emitted in canonical
+/// lowercase form, or `None` if unrecognized. `source_confidence` is kept only
+/// when a valid source is present and the value is finite within `0.0..=1.0`,
+/// matching the DB `CHECK` constraint so invalid input can never reach the table.
 pub fn normalize_transcript_source_fields(
     audio_source: Option<&str>,
     source_confidence: Option<f64>,
 ) -> (Option<&'static str>, Option<f64>) {
-    let normalized_source = match audio_source
-        .map(str::trim)
-        .map(str::to_ascii_lowercase)
-        .as_deref()
-    {
-        Some("microphone") => Some("microphone"),
-        Some("system") => Some("system"),
-        Some("mixed") => Some("mixed"),
-        Some("unknown") => Some("unknown"),
-        _ => None,
-    };
+    let normalized_source = audio_source
+        .and_then(TranscriptAudioSource::from_wire)
+        .map(TranscriptAudioSource::as_wire);
 
     let normalized_confidence = source_confidence.filter(|confidence| {
         normalized_source.is_some()

--- a/frontend/src-tauri/src/api/api.rs
+++ b/frontend/src-tauri/src/api/api.rs
@@ -137,6 +137,10 @@ pub struct MeetingTranscript {
     pub audio_end_time: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio_source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_confidence: Option<f64>,
 }
 
 /// Meeting metadata without transcripts (for pagination)
@@ -188,6 +192,79 @@ pub struct TranscriptSegment {
     pub audio_end_time: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio_source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_confidence: Option<f64>,
+}
+
+pub fn normalize_transcript_source_fields(
+    audio_source: Option<&str>,
+    source_confidence: Option<f64>,
+) -> (Option<&'static str>, Option<f64>) {
+    let normalized_source = match audio_source
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("microphone") => Some("microphone"),
+        Some("system") => Some("system"),
+        Some("mixed") => Some("mixed"),
+        Some("unknown") => Some("unknown"),
+        _ => None,
+    };
+
+    let normalized_confidence = source_confidence.filter(|confidence| {
+        normalized_source.is_some()
+            && confidence.is_finite()
+            && (0.0..=1.0).contains(confidence)
+    });
+
+    (normalized_source, normalized_confidence)
+}
+
+#[cfg(test)]
+mod transcript_segment_source_tests {
+    use super::{normalize_transcript_source_fields, TranscriptSegment};
+
+    #[test]
+    fn parses_transcript_segment_source_fields_from_frontend_json() {
+        let raw = r#"{
+            "id": "seg_1",
+            "text": "Hello",
+            "timestamp": "12:00:00",
+            "audio_start_time": 0.0,
+            "audio_end_time": 1.2,
+            "duration": 1.2,
+            "audio_source": "microphone",
+            "source_confidence": 0.91
+        }"#;
+
+        let segment: TranscriptSegment = serde_json::from_str(raw).unwrap();
+
+        assert_eq!(segment.audio_source.as_deref(), Some("microphone"));
+        assert_eq!(segment.source_confidence, Some(0.91));
+    }
+
+    #[test]
+    fn normalizes_transcript_source_fields() {
+        assert_eq!(
+            normalize_transcript_source_fields(Some(" Microphone "), Some(0.91)),
+            (Some("microphone"), Some(0.91))
+        );
+        assert_eq!(
+            normalize_transcript_source_fields(Some("bad-source"), Some(0.91)),
+            (None, None)
+        );
+        assert_eq!(
+            normalize_transcript_source_fields(Some("system"), Some(1.2)),
+            (Some("system"), None)
+        );
+        assert_eq!(
+            normalize_transcript_source_fields(Some("mixed"), Some(f64::NAN)),
+            (Some("mixed"), None)
+        );
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -878,6 +955,8 @@ pub async fn api_get_meeting_transcripts<R: Runtime>(
                     audio_start_time: t.audio_start_time,
                     audio_end_time: t.audio_end_time,
                     duration: t.duration,
+                    audio_source: t.audio_source,
+                    source_confidence: t.source_confidence,
                 })
                 .collect::<Vec<_>>();
 

--- a/frontend/src-tauri/src/audio/common.rs
+++ b/frontend/src-tauri/src/audio/common.rs
@@ -63,6 +63,8 @@ pub(crate) fn create_transcript_segments(transcripts: &[(String, f64, f64)]) -> 
                 audio_start_time: Some(start_seconds),
                 audio_end_time: Some(end_seconds),
                 duration: Some(duration),
+                audio_source: None,
+                source_confidence: None,
             }
         })
         .collect()
@@ -85,6 +87,8 @@ pub(crate) fn write_transcripts_json(folder: &Path, segments: &[TranscriptSegmen
                 "audio_start_time": s.audio_start_time,
                 "audio_end_time": s.audio_end_time,
                 "duration": s.duration,
+                "audio_source": s.audio_source,
+                "source_confidence": s.source_confidence,
                 "sequence_id": i
             })
         }).collect::<Vec<_>>()

--- a/frontend/src-tauri/src/audio/device_detection.rs
+++ b/frontend/src-tauri/src/audio/device_detection.rs
@@ -440,8 +440,9 @@ mod tests {
 
     #[test]
     fn test_builtin_mic_detection() {
-        let kind = InputDeviceKind::detect("MacBook Pro Microphone", 0, 0);
-        // Should fall through to Unknown (no Bluetooth pattern, no buffer size)
+        let kind = InputDeviceKind::detect_by_name("MacBook Pro Microphone")
+            .unwrap_or(InputDeviceKind::Unknown);
+        // Name heuristics should fall through to Unknown without native device data or buffer size.
         assert_eq!(kind, InputDeviceKind::Unknown);
     }
 
@@ -483,7 +484,13 @@ mod tests {
             3840,
             48000,
         );
-        assert_eq!(timeout, Duration::from_millis(160));
+        let expected = Duration::from_millis(160);
+        let delta = if timeout > expected {
+            timeout - expected
+        } else {
+            expected - timeout
+        };
+        assert!(delta <= Duration::from_micros(10));
     }
 
     #[test]

--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -1,6 +1,6 @@
 // Audio file import module - allows importing external audio files as new meetings
 
-use crate::api::TranscriptSegment;
+use crate::api::{normalize_transcript_source_fields, TranscriptSegment};
 use crate::audio::decoder::{decode_audio_file, decode_audio_file_with_progress};
 use crate::audio::vad::get_speech_chunks_with_progress;
 use crate::config::{DEFAULT_WHISPER_MODEL, DEFAULT_PARAKEET_MODEL};
@@ -718,9 +718,17 @@ async fn create_meeting_with_transcripts(
 
     // Insert transcripts
     for segment in segments {
+        let (audio_source, source_confidence) = normalize_transcript_source_fields(
+            segment.audio_source.as_deref(),
+            segment.source_confidence,
+        );
         sqlx::query(
-            "INSERT INTO transcripts (id, meeting_id, transcript, timestamp, audio_start_time, audio_end_time, duration)
-             VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO transcripts (
+                id, meeting_id, transcript, timestamp,
+                audio_start_time, audio_end_time, duration,
+                audio_source, source_confidence
+             )
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&segment.id)
         .bind(&meeting_id)
@@ -729,6 +737,8 @@ async fn create_meeting_with_transcripts(
         .bind(segment.audio_start_time)
         .bind(segment.audio_end_time)
         .bind(segment.duration)
+        .bind(audio_source)
+        .bind(source_confidence)
         .execute(&mut *tx)
         .await
         .map_err(|e| anyhow!("Failed to insert transcript: {}", e))?;
@@ -1181,6 +1191,8 @@ mod tests {
                 audio_start_time: Some(0.0),
                 audio_end_time: Some(1.5),
                 duration: Some(1.5),
+                audio_source: Some("microphone".to_string()),
+                source_confidence: Some(0.91),
             },
             TranscriptSegment {
                 id: "t-2".to_string(),
@@ -1189,6 +1201,8 @@ mod tests {
                 audio_start_time: Some(2.0),
                 audio_end_time: Some(3.5),
                 duration: Some(1.5),
+                audio_source: None,
+                source_confidence: None,
             },
         ];
 

--- a/frontend/src-tauri/src/audio/incremental_saver.rs
+++ b/frontend/src-tauri/src/audio/incremental_saver.rs
@@ -436,10 +436,12 @@ mod tests {
         for i in 0..120 {  // 120 chunks of 0.5s each
             let chunk = AudioChunk {
                 data: vec![0.5f32; 24000],  // 0.5s at 48kHz
+                source_attribution_data: None,
                 sample_rate: 48000,
                 timestamp: i as f64 * 0.5,  // timestamp in seconds
                 chunk_id: i as u64,
                 device_type: DeviceType::Microphone,
+                source_attribution: None,
             };
             saver.add_chunk(chunk).unwrap();
         }

--- a/frontend/src-tauri/src/audio/mod.rs
+++ b/frontend/src-tauri/src/audio/mod.rs
@@ -35,6 +35,7 @@ pub mod system_detector;
 pub mod system_audio_commands;
 pub mod device_monitor;  // NEW: Device disconnect/reconnect monitoring
 pub mod playback_monitor; // NEW: Playback device detection for BT warnings
+pub mod source_attribution;
 
 // Transcription module (provider abstraction, engine management, worker pool)
 pub mod transcription;
@@ -118,4 +119,3 @@ pub use decoder::{decode_audio_file, DecodedAudio};
 
 // Export audio constants
 pub use constants::AUDIO_EXTENSIONS;
-

--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -11,6 +11,7 @@ use rubato::{Resampler, SincFixedIn, SincInterpolationParameters, SincInterpolat
 use super::devices::AudioDevice;
 use super::recording_state::{AudioChunk, AudioError, RecordingState, DeviceType};
 use super::audio_processing::{audio_to_mono, LoudnessNormalizer, NoiseSuppressionProcessor, HighPassFilter};
+use super::source_attribution::SourceAttributionTimeline;
 use super::vad::{ContinuousVadProcessor};
 
 /// Ring buffer for synchronized audio mixing
@@ -18,8 +19,17 @@ use super::vad::{ContinuousVadProcessor};
 struct AudioMixerRingBuffer {
     mic_buffer: VecDeque<f32>,
     system_buffer: VecDeque<f32>,
+    mic_attribution_buffer: VecDeque<f32>,
+    system_attribution_buffer: VecDeque<f32>,
     window_size_samples: usize,  // Fixed mixing window (e.g., 50ms)
     max_buffer_size: usize,  // Safety limit (e.g., 100ms)
+}
+
+struct AudioMixerWindow {
+    mic_window: Vec<f32>,
+    system_window: Vec<f32>,
+    mic_attribution_window: Vec<f32>,
+    system_attribution_window: Vec<f32>,
 }
 
 impl AudioMixerRingBuffer {
@@ -41,12 +51,19 @@ impl AudioMixerRingBuffer {
         Self {
             mic_buffer: VecDeque::with_capacity(max_buffer_size),
             system_buffer: VecDeque::with_capacity(max_buffer_size),
+            mic_attribution_buffer: VecDeque::with_capacity(max_buffer_size),
+            system_attribution_buffer: VecDeque::with_capacity(max_buffer_size),
             window_size_samples,
             max_buffer_size,
         }
     }
 
-    fn add_samples(&mut self, device_type: DeviceType, samples: Vec<f32>) {
+    fn add_samples(
+        &mut self,
+        device_type: DeviceType,
+        samples: Vec<f32>,
+        source_attribution_samples: Option<Vec<f32>>,
+    ) {
         // Log buffer health periodically for diagnostics
         static mut SAMPLE_COUNTER: u64 = 0;
         unsafe {
@@ -57,9 +74,24 @@ impl AudioMixerRingBuffer {
             }
         }
 
+        let sample_len = samples.len();
+        let mut attribution_samples =
+            source_attribution_samples.unwrap_or_else(|| samples.clone());
+        if attribution_samples.len() < sample_len {
+            attribution_samples.resize(sample_len, 0.0);
+        } else if attribution_samples.len() > sample_len {
+            attribution_samples.truncate(sample_len);
+        }
+
         match device_type {
-            DeviceType::Microphone => self.mic_buffer.extend(samples),
-            DeviceType::System => self.system_buffer.extend(samples),
+            DeviceType::Microphone => {
+                self.mic_buffer.extend(samples);
+                self.mic_attribution_buffer.extend(attribution_samples);
+            }
+            DeviceType::System => {
+                self.system_buffer.extend(samples);
+                self.system_attribution_buffer.extend(attribution_samples);
+            }
         }
 
         // CRITICAL FIX: Add warnings before dropping samples
@@ -78,9 +110,11 @@ impl AudioMixerRingBuffer {
         // Safety: prevent buffer overflow (keep only last 200ms)
         while self.mic_buffer.len() > self.max_buffer_size {
             self.mic_buffer.pop_front();
+            self.mic_attribution_buffer.pop_front();
         }
         while self.system_buffer.len() > self.max_buffer_size {
             self.system_buffer.pop_front();
+            self.system_attribution_buffer.pop_front();
         }
     }
 
@@ -89,7 +123,7 @@ impl AudioMixerRingBuffer {
         self.system_buffer.len() >= self.window_size_samples
     }
 
-    fn extract_window(&mut self) -> Option<(Vec<f32>, Vec<f32>)> {
+    fn extract_window(&mut self) -> Option<AudioMixerWindow> {
         if !self.can_mix() {
             return None;
         }
@@ -98,48 +132,37 @@ impl AudioMixerRingBuffer {
         // Zero-padding (silence) is preferred over last-sample-hold to prevent artifacts
 
         // Extract mic window (or pad with zeros if insufficient data)
-        let mic_window = if self.mic_buffer.len() >= self.window_size_samples {
-            // Enough mic data - drain window
-            self.mic_buffer.drain(0..self.window_size_samples).collect()
-        } else if !self.mic_buffer.is_empty() {
-            // Some mic data but not enough - consume all + pad with zeros
-            let available: Vec<f32> = self.mic_buffer.drain(..).collect();
-            let mut padded = Vec::with_capacity(self.window_size_samples);
-            padded.extend_from_slice(&available);
-
-            // Use zero-padding (silence) to prevent repetition artifacts
-            // Zero-padding is inaudible at 48kHz sample rate
-            padded.resize(self.window_size_samples, 0.0);
-
-            padded
-        } else {
-            // No mic data - return silence
-            vec![0.0; self.window_size_samples]
-        };
+        let mic_window = drain_or_pad_window(&mut self.mic_buffer, self.window_size_samples);
+        let mic_attribution_window =
+            drain_or_pad_window(&mut self.mic_attribution_buffer, self.window_size_samples);
 
         // Extract system window (or pad with zeros if insufficient data)
-        let sys_window = if self.system_buffer.len() >= self.window_size_samples {
-            // Enough system data - drain window
-            self.system_buffer.drain(0..self.window_size_samples).collect()
-        } else if !self.system_buffer.is_empty() {
-            // Some system data but not enough - consume all + pad with zeros
-            let available: Vec<f32> = self.system_buffer.drain(..).collect();
-            let mut padded = Vec::with_capacity(self.window_size_samples);
-            padded.extend_from_slice(&available);
+        let system_window = drain_or_pad_window(&mut self.system_buffer, self.window_size_samples);
+        let system_attribution_window =
+            drain_or_pad_window(&mut self.system_attribution_buffer, self.window_size_samples);
 
-            // Use zero-padding (silence) to prevent repetition artifacts
-            // Zero-padding is inaudible at 48kHz sample rate
-            padded.resize(self.window_size_samples, 0.0);
-
-            padded
-        } else {
-            // No system data - return silence
-            vec![0.0; self.window_size_samples]
-        };
-
-        Some((mic_window, sys_window))
+        Some(AudioMixerWindow {
+            mic_window,
+            system_window,
+            mic_attribution_window,
+            system_attribution_window,
+        })
     }
 
+}
+
+fn drain_or_pad_window(buffer: &mut VecDeque<f32>, window_size_samples: usize) -> Vec<f32> {
+    if buffer.len() >= window_size_samples {
+        buffer.drain(0..window_size_samples).collect()
+    } else if !buffer.is_empty() {
+        let available: Vec<f32> = buffer.drain(..).collect();
+        let mut padded = Vec::with_capacity(window_size_samples);
+        padded.extend_from_slice(&available);
+        padded.resize(window_size_samples, 0.0);
+        padded
+    } else {
+        vec![0.0; window_size_samples]
+    }
 }
 
 /// Simple audio mixer without aggressive ducking
@@ -511,6 +534,7 @@ impl AudioCapture {
         // AUDIO ENHANCEMENT PIPELINE (Microphone Only)
         // Processing order is critical: high-pass → noise suppression → normalization
         // This ensures noise is removed before being amplified by the normalizer
+        let mut source_attribution_data = None;
         if matches!(self.device_type, DeviceType::Microphone) {
             // STEP 1: Apply high-pass filter to remove low-frequency rumble (< 80 Hz)
             if let Ok(mut hpf_lock) = self.high_pass_filter.lock() {
@@ -554,6 +578,8 @@ impl AudioCapture {
                     }
                 }
             }
+
+            source_attribution_data = Some(mono_data.clone());
 
             // STEP 3: Apply EBU R128 normalization (professional loudness standard)
             if let Ok(mut normalizer_lock) = self.normalizer.lock() {
@@ -609,10 +635,12 @@ impl AudioCapture {
         // Use 48kHz if we resampled, otherwise use original rate
         let audio_chunk = AudioChunk {
             data: mono_data,  // Raw audio (resampled if needed), no gain yet
+            source_attribution_data,
             sample_rate: if self.needs_resampling { 48000 } else { self.sample_rate },
             timestamp,
             chunk_id,
             device_type: self.device_type.clone(),
+            source_attribution: None,
         };
 
         // NOTE: Raw audio is NOT sent to recording saver to prevent echo
@@ -692,6 +720,7 @@ pub struct AudioPipeline {
     // PROFESSIONAL AUDIO MIXING: Ring buffer + RMS-based mixer
     ring_buffer: AudioMixerRingBuffer,
     mixer: ProfessionalAudioMixer,
+    source_timeline: SourceAttributionTimeline,
     // Recording sender for pre-mixed audio
     recording_sender_for_mixed: Option<mpsc::UnboundedSender<AudioChunk>>,
 }
@@ -740,6 +769,7 @@ impl AudioPipeline {
         // Initialize professional audio mixing components
         let ring_buffer = AudioMixerRingBuffer::new(sample_rate);
         let mixer = ProfessionalAudioMixer::new(sample_rate);
+        let source_timeline = SourceAttributionTimeline::new();
 
         // Note: target_chunk_duration_ms is ignored - VAD controls segmentation now
         let _ = target_chunk_duration_ms;
@@ -759,6 +789,7 @@ impl AudioPipeline {
             // Initialize professional audio mixing
             ring_buffer,
             mixer,
+            source_timeline,
             recording_sender_for_mixed: None,  // Will be set by manager
         }
     }
@@ -817,13 +848,27 @@ impl AudioPipeline {
                     // STEP 1: Add raw audio to ring buffer for mixing
                     // Microphone audio is already normalized at capture level (AudioCapture)
                     // System audio remains raw
-                    self.ring_buffer.add_samples(chunk.device_type.clone(), chunk.data);
+                    self.ring_buffer.add_samples(
+                        chunk.device_type.clone(),
+                        chunk.data,
+                        chunk.source_attribution_data,
+                    );
 
                     // STEP 2: Mix audio in fixed windows when both streams have sufficient data
                     while self.ring_buffer.can_mix() {
-                        if let Some((mic_window, sys_window)) = self.ring_buffer.extract_window() {
+                        if let Some(window) = self.ring_buffer.extract_window() {
+                            self.source_timeline
+                                .append_window(
+                                    &window.mic_attribution_window,
+                                    &window.system_attribution_window,
+                                    self.sample_rate,
+                                );
+                            self.source_timeline.prune_stale();
+
                             // Simple mixing without aggressive ducking
-                            let mixed_clean = self.mixer.mix_window(&mic_window, &sys_window);
+                            let mixed_clean = self
+                                .mixer
+                                .mix_window(&window.mic_window, &window.system_window);
 
                             // NO POST-GAIN NEEDED: Microphone already normalized by EBU R128 to -23 LUFS
                             // This is broadcast-standard loudness (Netflix/YouTube/Spotify level)
@@ -834,6 +879,11 @@ impl AudioPipeline {
                             // STEP 3: Send mixed audio for transcription (VAD + Whisper)
                             match self.vad_processor.process_audio(&mixed_with_gain) {
                                 Ok(speech_segments) => {
+                                    let latest_start_ms = speech_segments
+                                        .iter()
+                                        .map(|segment| segment.start_timestamp_ms)
+                                        .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
                                     for segment in speech_segments {
                                         let duration_ms = segment.end_timestamp_ms - segment.start_timestamp_ms;
 
@@ -841,12 +891,18 @@ impl AudioPipeline {
                                             info!("📤 Sending VAD segment: {:.1}ms, {} samples",
                                                   duration_ms, segment.samples.len());
 
+                                            let source_attribution = self
+                                                .source_timeline
+                                                .classify_segment(segment.start_timestamp_ms, segment.end_timestamp_ms);
+
                                             let transcription_chunk = AudioChunk {
                                                 data: segment.samples,
+                                                source_attribution_data: None,
                                                 sample_rate: 16000,
                                                 timestamp: segment.start_timestamp_ms / 1000.0,
                                                 chunk_id: self.chunk_id_counter,
                                                 device_type: DeviceType::Microphone,  // Mixed audio
+                                                source_attribution: Some(source_attribution),
                                             };
 
                                             if let Err(e) = self.transcription_sender.send(transcription_chunk) {
@@ -859,6 +915,10 @@ impl AudioPipeline {
                                                    duration_ms, segment.samples.len());
                                         }
                                     }
+
+                                    if let Some(latest_start_ms) = latest_start_ms {
+                                        self.source_timeline.prune_before(latest_start_ms);
+                                    }
                                 }
                                 Err(e) => {
                                     warn!("⚠️ VAD error: {}", e);
@@ -869,10 +929,12 @@ impl AudioPipeline {
                             if let Some(ref sender) = self.recording_sender_for_mixed {
                                 let recording_chunk = AudioChunk {
                                     data: mixed_with_gain.clone(),
+                                    source_attribution_data: None,
                                     sample_rate: self.sample_rate,
                                     timestamp: chunk.timestamp,
                                     chunk_id: self.chunk_id_counter,
                                     device_type: DeviceType::Microphone,  // Mixed audio
+                                    source_attribution: None,
                                 };
                                 let _ = sender.send(recording_chunk);
                             }
@@ -913,10 +975,15 @@ impl AudioPipeline {
 
                         let transcription_chunk = AudioChunk {
                             data: segment.samples,
+                            source_attribution_data: None,
                             sample_rate: 16000,
                             timestamp: segment.start_timestamp_ms / 1000.0,
                             chunk_id: self.chunk_id_counter,
                             device_type: DeviceType::Microphone,
+                            source_attribution: Some(
+                                self.source_timeline
+                                    .classify_segment(segment.start_timestamp_ms, segment.end_timestamp_ms)
+                            ),
                         };
 
                         if let Err(e) = self.transcription_sender.send(transcription_chunk) {
@@ -1033,12 +1100,14 @@ impl AudioPipelineManager {
         // If we have a sender, send a special flush signal first
         if let Some(sender) = &self.audio_sender {
             // Create a special flush chunk to trigger immediate processing
-            let flush_chunk = AudioChunk {
-                data: vec![], // Empty data signals flush
-                sample_rate: 16000,
+	            let flush_chunk = AudioChunk {
+	                data: vec![], // Empty data signals flush
+                    source_attribution_data: None,
+	                sample_rate: 16000,
                 timestamp: 0.0,
                 chunk_id: u64::MAX, // Special ID to indicate flush
                 device_type: super::recording_state::DeviceType::Microphone,
+                source_attribution: None,
             };
 
             if let Err(e) = sender.send(flush_chunk) {
@@ -1053,12 +1122,14 @@ impl AudioPipelineManager {
                 // Send multiple flush signals to ensure the pipeline catches it
                 // This aggressive approach eliminates shutdown delay issues
                 for i in 0..3 {
-                    let additional_flush = AudioChunk {
-                        data: vec![],
-                        sample_rate: 16000,
+	                    let additional_flush = AudioChunk {
+	                        data: vec![],
+                            source_attribution_data: None,
+	                        sample_rate: 16000,
                         timestamp: 0.0,
                         chunk_id: u64::MAX - (i as u64),
                         device_type: super::recording_state::DeviceType::Microphone,
+                        source_attribution: None,
                     };
                     let _ = sender.send(additional_flush);
                 }
@@ -1076,5 +1147,29 @@ impl AudioPipelineManager {
 impl Default for AudioPipelineManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_buffer_keeps_pre_normalized_attribution_samples_separate_from_mix_samples() {
+        let mut ring_buffer = AudioMixerRingBuffer::new(10);
+
+        ring_buffer.add_samples(
+            DeviceType::Microphone,
+            vec![0.8; 6],
+            Some(vec![0.01; 6]),
+        );
+        ring_buffer.add_samples(DeviceType::System, vec![0.2; 6], None);
+
+        let window = ring_buffer.extract_window().expect("window should be ready");
+
+        assert_eq!(window.mic_window, vec![0.8; 6]);
+        assert_eq!(window.system_window, vec![0.2; 6]);
+        assert_eq!(window.mic_attribution_window, vec![0.01; 6]);
+        assert_eq!(window.system_attribution_window, vec![0.2; 6]);
     }
 }

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -275,6 +275,8 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
                     display_time: update.timestamp.clone(), // Use wall-clock timestamp for display
                     confidence: update.confidence,
                     sequence_id: update.sequence_id,
+                    audio_source: update.audio_source,
+                    source_confidence: update.source_confidence,
                 };
 
                 // Save to recording manager
@@ -446,6 +448,8 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
                     display_time: update.timestamp.clone(), // Use wall-clock timestamp for display
                     confidence: update.confidence,
                     sequence_id: update.sequence_id,
+                    audio_source: update.audio_source,
+                    source_confidence: update.source_confidence,
                 };
 
                 // Save to recording manager

--- a/frontend/src-tauri/src/audio/recording_saver.rs
+++ b/frontend/src-tauri/src/audio/recording_saver.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use super::recording_state::AudioChunk;
 use super::audio_processing::create_meeting_folder;
 use super::incremental_saver::IncrementalAudioSaver;
+use super::source_attribution::TranscriptAudioSource;
 
 /// Structured transcript segment for JSON export
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -22,6 +23,8 @@ pub struct TranscriptSegment {
     pub display_time: String,   // Formatted time for display like "[02:15]"
     pub confidence: f32,
     pub sequence_id: u64,
+    pub audio_source: TranscriptAudioSource,
+    pub source_confidence: f32,
 }
 
 /// Meeting metadata structure
@@ -129,6 +132,8 @@ impl RecordingSaver {
             display_time: "[00:00]".to_string(),
             confidence: 1.0,
             sequence_id: 0,
+            audio_source: TranscriptAudioSource::Unknown,
+            source_confidence: 0.0,
         };
         self.add_transcript_segment(segment);
     }

--- a/frontend/src-tauri/src/audio/recording_state.rs
+++ b/frontend/src-tauri/src/audio/recording_state.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 
 use super::devices::AudioDevice;
 use super::buffer_pool::AudioBufferPool;
+use super::source_attribution::SourceAttribution;
 
 /// Device type for audio chunks
 #[derive(Debug, Clone, PartialEq)]
@@ -18,10 +19,12 @@ pub enum DeviceType {
 #[derive(Debug, Clone)]
 pub struct AudioChunk {
     pub data: Vec<f32>,
+    pub source_attribution_data: Option<Vec<f32>>,
     pub sample_rate: u32,
     pub timestamp: f64,
     pub chunk_id: u64,
     pub device_type: DeviceType,
+    pub source_attribution: Option<SourceAttribution>,
 }
 
 /// Processed audio chunk (post-VAD) for recording

--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -1,5 +1,6 @@
 // Retranscription module - allows re-processing stored audio with different settings
 
+use crate::api::normalize_transcript_source_fields;
 use crate::audio::decoder::decode_audio_file;
 use crate::audio::vad::get_speech_chunks_with_progress;
 use super::common::{create_transcript_segments, split_segment_at_silence, write_transcripts_json};
@@ -440,9 +441,17 @@ async fn run_retranscription<R: Runtime>(
         .map_err(|e| anyhow!("Failed to delete existing transcripts: {}", e))?;
 
     for segment in &segments {
+        let (audio_source, source_confidence) = normalize_transcript_source_fields(
+            segment.audio_source.as_deref(),
+            segment.source_confidence,
+        );
         sqlx::query(
-            "INSERT INTO transcripts (id, meeting_id, transcript, timestamp, audio_start_time, audio_end_time, duration)
-             VALUES (?, ?, ?, ?, ?, ?, ?)"
+            "INSERT INTO transcripts (
+                id, meeting_id, transcript, timestamp,
+                audio_start_time, audio_end_time, duration,
+                audio_source, source_confidence
+             )
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
         )
         .bind(&segment.id)
         .bind(&meeting_id)
@@ -451,6 +460,8 @@ async fn run_retranscription<R: Runtime>(
         .bind(segment.audio_start_time)
         .bind(segment.audio_end_time)
         .bind(segment.duration)
+        .bind(audio_source)
+        .bind(source_confidence)
         .execute(&mut *tx)
         .await
         .map_err(|e| anyhow!("Failed to insert transcript: {}", e))?;

--- a/frontend/src-tauri/src/audio/source_attribution.rs
+++ b/frontend/src-tauri/src/audio/source_attribution.rs
@@ -1,0 +1,338 @@
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+
+const ATTRIBUTION_FRAME_MS: f64 = 100.0;
+const ENERGY_FLOOR: f64 = 1.0e-8;
+const DOMINANCE_RATIO: f64 = 0.72;
+const MIN_DB_MARGIN: f64 = 4.0;
+const MIXED_RATIO_LOW: f64 = 1.0 - DOMINANCE_RATIO;
+const MIXED_RATIO_HIGH: f64 = DOMINANCE_RATIO;
+const PRUNE_SAFETY_MARGIN_MS: f64 = 3000.0;
+const MAX_TIMELINE_RETENTION_MS: f64 = 30.0 * 60.0 * 1000.0;
+const MIN_ALTERNATING_SOURCE_MS: f64 = 200.0;
+const MIN_ALTERNATING_SOURCE_RATIO: f64 = 0.20;
+const MIN_DISPLAY_CONFIDENCE: f32 = 0.55;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TranscriptAudioSource {
+    Microphone,
+    System,
+    Mixed,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct SourceAttribution {
+    pub audio_source: TranscriptAudioSource,
+    pub source_confidence: f32,
+}
+
+#[derive(Debug, Clone)]
+struct AttributionFrame {
+    start_ms: f64,
+    end_ms: f64,
+    mic_energy: f64,
+    system_energy: f64,
+}
+
+#[derive(Debug, Default)]
+pub struct SourceAttributionTimeline {
+    frames: VecDeque<AttributionFrame>,
+    cursor_ms: f64,
+}
+
+impl SourceAttributionTimeline {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn append_window(&mut self, mic_window: &[f32], system_window: &[f32], sample_rate: u32) {
+        let frame_samples = ((sample_rate as f64 * ATTRIBUTION_FRAME_MS) / 1000.0)
+            .round()
+            .max(1.0) as usize;
+        let len = mic_window.len().max(system_window.len());
+
+        if len == 0 || sample_rate == 0 {
+            return;
+        }
+
+        let mut offset = 0;
+        while offset < len {
+            let end = (offset + frame_samples).min(len);
+            let start_ms = self.cursor_ms + (offset as f64 / sample_rate as f64 * 1000.0);
+            let end_ms = self.cursor_ms + (end as f64 / sample_rate as f64 * 1000.0);
+
+            self.frames.push_back(AttributionFrame {
+                start_ms,
+                end_ms,
+                mic_energy: mean_square(slice_or_empty(mic_window, offset, end)),
+                system_energy: mean_square(slice_or_empty(system_window, offset, end)),
+            });
+
+            offset = end;
+        }
+
+        self.cursor_ms += len as f64 / sample_rate as f64 * 1000.0;
+    }
+
+    pub fn classify_segment(&self, start_ms: f64, end_ms: f64) -> SourceAttribution {
+        if end_ms <= start_ms {
+            return unknown();
+        }
+
+        let mut mic_energy = 0.0;
+        let mut system_energy = 0.0;
+        let mut mic_dominant_ms = 0.0;
+        let mut system_dominant_ms = 0.0;
+        let mut covered_ms = 0.0;
+
+        for frame in &self.frames {
+            let overlap_start = start_ms.max(frame.start_ms);
+            let overlap_end = end_ms.min(frame.end_ms);
+            let overlap_ms = overlap_end - overlap_start;
+
+            if overlap_ms > 0.0 {
+                mic_energy += frame.mic_energy * overlap_ms;
+                system_energy += frame.system_energy * overlap_ms;
+                covered_ms += overlap_ms;
+
+                match classify_energy(frame.mic_energy, frame.system_energy).audio_source {
+                    TranscriptAudioSource::Microphone => mic_dominant_ms += overlap_ms,
+                    TranscriptAudioSource::System => system_dominant_ms += overlap_ms,
+                    TranscriptAudioSource::Mixed | TranscriptAudioSource::Unknown => {}
+                }
+            }
+        }
+
+        if covered_ms <= 0.0 {
+            return unknown();
+        }
+
+        if has_alternating_sources(mic_dominant_ms, system_dominant_ms, covered_ms) {
+            return SourceAttribution {
+                audio_source: TranscriptAudioSource::Mixed,
+                source_confidence: ((mic_dominant_ms + system_dominant_ms) / covered_ms) as f32,
+            };
+        }
+
+        classify_energy(mic_energy / covered_ms, system_energy / covered_ms)
+    }
+
+    pub fn prune_before(&mut self, cutoff_ms: f64) {
+        let safe_cutoff = (cutoff_ms - PRUNE_SAFETY_MARGIN_MS).max(0.0);
+
+        while self
+            .frames
+            .front()
+            .is_some_and(|frame| frame.end_ms < safe_cutoff)
+        {
+            self.frames.pop_front();
+        }
+    }
+
+    pub fn prune_stale(&mut self) {
+        if self.cursor_ms > MAX_TIMELINE_RETENTION_MS {
+            self.prune_before(self.cursor_ms - MAX_TIMELINE_RETENTION_MS);
+        }
+    }
+}
+
+pub fn display_label(source: TranscriptAudioSource, confidence: f32) -> &'static str {
+    if confidence < MIN_DISPLAY_CONFIDENCE {
+        return "Speaker";
+    }
+
+    match source {
+        TranscriptAudioSource::Microphone => "Me",
+        TranscriptAudioSource::System => "Speaker",
+        TranscriptAudioSource::Mixed | TranscriptAudioSource::Unknown => "Speaker",
+    }
+}
+
+pub fn unknown() -> SourceAttribution {
+    SourceAttribution {
+        audio_source: TranscriptAudioSource::Unknown,
+        source_confidence: 0.0,
+    }
+}
+
+fn classify_energy(mic_energy: f64, system_energy: f64) -> SourceAttribution {
+    let total = mic_energy + system_energy;
+
+    if total < ENERGY_FLOOR {
+        return unknown();
+    }
+
+    let mic_ratio = mic_energy / total;
+    let system_ratio = system_energy / total;
+    let db_margin = 10.0 * ((mic_energy + ENERGY_FLOOR) / (system_energy + ENERGY_FLOOR)).log10();
+
+    if mic_ratio >= DOMINANCE_RATIO && db_margin >= MIN_DB_MARGIN {
+        return SourceAttribution {
+            audio_source: TranscriptAudioSource::Microphone,
+            source_confidence: mic_ratio as f32,
+        };
+    }
+
+    if system_ratio >= DOMINANCE_RATIO && -db_margin >= MIN_DB_MARGIN {
+        return SourceAttribution {
+            audio_source: TranscriptAudioSource::System,
+            source_confidence: system_ratio as f32,
+        };
+    }
+
+    if mic_ratio >= MIXED_RATIO_LOW && mic_ratio <= MIXED_RATIO_HIGH {
+        return SourceAttribution {
+            audio_source: TranscriptAudioSource::Mixed,
+            source_confidence: (1.0 - (mic_ratio - 0.5).abs() * 2.0) as f32,
+        };
+    }
+
+    unknown()
+}
+
+fn has_alternating_sources(mic_dominant_ms: f64, system_dominant_ms: f64, covered_ms: f64) -> bool {
+    if covered_ms <= 0.0 {
+        return false;
+    }
+
+    mic_dominant_ms >= MIN_ALTERNATING_SOURCE_MS
+        && system_dominant_ms >= MIN_ALTERNATING_SOURCE_MS
+        && mic_dominant_ms / covered_ms >= MIN_ALTERNATING_SOURCE_RATIO
+        && system_dominant_ms / covered_ms >= MIN_ALTERNATING_SOURCE_RATIO
+}
+
+fn mean_square(samples: &[f32]) -> f64 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+
+    samples
+        .iter()
+        .map(|sample| {
+            let value = *sample as f64;
+            value * value
+        })
+        .sum::<f64>()
+        / samples.len() as f64
+}
+
+fn slice_or_empty(samples: &[f32], start: usize, end: usize) -> &[f32] {
+    if start >= samples.len() {
+        &[]
+    } else {
+        &samples[start..end.min(samples.len())]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn repeated(value: f32, len: usize) -> Vec<f32> {
+        vec![value; len]
+    }
+
+    #[test]
+    fn classifies_microphone_dominant_segment() {
+        let mut timeline = SourceAttributionTimeline::new();
+        timeline.append_window(&repeated(0.8, 4800), &repeated(0.05, 4800), 48_000);
+
+        let result = timeline.classify_segment(0.0, 100.0);
+
+        assert_eq!(result.audio_source, TranscriptAudioSource::Microphone);
+        assert!(result.source_confidence >= 0.72);
+    }
+
+    #[test]
+    fn classifies_system_dominant_segment() {
+        let mut timeline = SourceAttributionTimeline::new();
+        timeline.append_window(&repeated(0.05, 4800), &repeated(0.8, 4800), 48_000);
+
+        let result = timeline.classify_segment(0.0, 100.0);
+
+        assert_eq!(result.audio_source, TranscriptAudioSource::System);
+        assert!(result.source_confidence >= 0.72);
+    }
+
+    #[test]
+    fn classifies_balanced_active_sources_as_mixed() {
+        let mut timeline = SourceAttributionTimeline::new();
+        timeline.append_window(&repeated(0.5, 4800), &repeated(0.5, 4800), 48_000);
+
+        let result = timeline.classify_segment(0.0, 100.0);
+
+        assert_eq!(result.audio_source, TranscriptAudioSource::Mixed);
+    }
+
+    #[test]
+    fn ambiguous_active_ratios_are_mixed_not_unknown() {
+        let mut timeline = SourceAttributionTimeline::new();
+        timeline.append_window(&repeated(0.83666, 4800), &repeated(0.54772, 4800), 48_000);
+
+        let result = timeline.classify_segment(0.0, 100.0);
+
+        assert_eq!(result.audio_source, TranscriptAudioSource::Mixed);
+        assert!(result.source_confidence >= 0.55);
+    }
+
+    #[test]
+    fn ambiguous_active_ratios_are_mixed_not_unknown_on_system_side() {
+        let mut timeline = SourceAttributionTimeline::new();
+        timeline.append_window(&repeated(0.54772, 4800), &repeated(0.83666, 4800), 48_000);
+
+        let result = timeline.classify_segment(0.0, 100.0);
+
+        assert_eq!(result.audio_source, TranscriptAudioSource::Mixed);
+        assert!(result.source_confidence >= 0.55);
+    }
+
+    #[test]
+    fn classifies_silence_as_unknown() {
+        let mut timeline = SourceAttributionTimeline::new();
+        timeline.append_window(&repeated(0.0, 4800), &repeated(0.0, 4800), 48_000);
+
+        let result = timeline.classify_segment(0.0, 100.0);
+
+        assert_eq!(result.audio_source, TranscriptAudioSource::Unknown);
+        assert_eq!(result.source_confidence, 0.0);
+    }
+
+    #[test]
+    fn weights_partial_frame_overlap() {
+        let mut timeline = SourceAttributionTimeline::new();
+        timeline.append_window(&repeated(0.7, 4800), &repeated(0.05, 4800), 48_000);
+        timeline.append_window(&repeated(0.05, 4800), &repeated(0.7, 4800), 48_000);
+
+        let result = timeline.classify_segment(25.0, 75.0);
+
+        assert_eq!(result.audio_source, TranscriptAudioSource::Microphone);
+    }
+
+    #[test]
+    fn alternating_dominant_sources_are_mixed() {
+        let mut timeline = SourceAttributionTimeline::new();
+        timeline.append_window(&repeated(0.7, 9600), &repeated(0.05, 9600), 48_000);
+        timeline.append_window(&repeated(0.05, 9600), &repeated(0.7, 9600), 48_000);
+
+        let result = timeline.classify_segment(0.0, 400.0);
+
+        assert_eq!(result.audio_source, TranscriptAudioSource::Mixed);
+    }
+
+    #[test]
+    fn display_label_hides_low_confidence() {
+        assert_eq!(
+            display_label(TranscriptAudioSource::Microphone, 0.54),
+            "Speaker"
+        );
+        assert_eq!(display_label(TranscriptAudioSource::Microphone, 0.90), "Me");
+        assert_eq!(
+            display_label(TranscriptAudioSource::System, 0.90),
+            "Speaker"
+        );
+        assert_eq!(display_label(TranscriptAudioSource::Mixed, 0.90), "Speaker");
+        assert_eq!(display_label(TranscriptAudioSource::Unknown, 0.0), "Speaker");
+    }
+}

--- a/frontend/src-tauri/src/audio/source_attribution.rs
+++ b/frontend/src-tauri/src/audio/source_attribution.rs
@@ -1,18 +1,93 @@
+//! Per-segment audio **source attribution** — deciding which capture stream
+//! (the local microphone vs. the system/loopback output) dominated a given
+//! transcript segment. This is **not speaker diarization**: it never identifies
+//! *who* spoke, only *which device* the audio came from, and it never writes
+//! `transcripts.speaker`.
+//!
+//! # How it works
+//! Attribution is computed **live during recording**. As the pipeline mixes the
+//! two streams it appends the *pre-normalization* mic energy and the raw system
+//! energy for each 100 ms frame to a [`SourceAttributionTimeline`]. When VAD
+//! emits a speech segment, [`SourceAttributionTimeline::classify_segment`]
+//! compares the accumulated per-stream energy over that segment's time span.
+//!
+//! # Why historical segments cannot be backfilled
+//! Attribution requires the **separate** mic and system energy, which only
+//! exists while the two streams are live. Only the *mixed* audio is persisted to
+//! disk (see `pipeline.rs`), so segments produced before this feature, imported
+//! from an external file, or re-transcribed from the saved mix have no per-stream
+//! signal to attribute. Recovering source from a finished mix is source
+//! separation / diarization, which is deliberately out of scope. Those segments
+//! carry `audio_source = NULL` and render with **no** source label (see the
+//! frontend `transcriptSource.ts` and the migration notes).
+//!
+//! # Single-stream recordings
+//! - **Microphone only** (no meeting audio playing): system energy stays near
+//!   the silence floor (`ENERGY_FLOOR`), so segments classify as `Microphone` → "Me".
+//! - **System only** (user silent / muted): mic energy stays near the floor, so
+//!   segments classify as `System` → "Speaker".
+//! - **Both below the floor** (silence): `Unknown`, which also displays as the
+//!   safe "Speaker" fallback.
+//!
+//! # Presentation vs. stored attribution
+//! [`display_label`] intentionally collapses the four raw states into a **binary**
+//! "Me" / "Speaker" label (see its docs). The raw `audio_source` and
+//! `source_confidence` are preserved end-to-end in the DB and API for any
+//! downstream consumer that wants the full four-state signal.
+//!
+//! # Thresholds
+//! The constants below are heuristics tuned for this pipeline's energy profile
+//! (mic normalized to −23 LUFS at capture, system left raw — attribution uses the
+//! *pre-normalization* mic so the comparison is like-for-like). They are
+//! documented here rather than exposed as configuration because the app has no
+//! calibration/telemetry surface to tune them against; adding knobs nobody can
+//! meaningfully set would be premature (YAGNI). Revisit if such a surface exists.
+
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 
+/// Granularity of energy analysis. 100 ms ≈ syllable scale: fine enough to catch
+/// turn-taking *within* a single VAD segment, coarse enough that per-frame energy
+/// is statistically stable.
 const ATTRIBUTION_FRAME_MS: f64 = 100.0;
+/// Mean-square energy (≈ a −80 dBFS / 1e-4 RMS signal) below which a stream is
+/// treated as silent. Also guards the divisions and `log10` in [`classify_energy`].
 const ENERGY_FLOOR: f64 = 1.0e-8;
+/// Fraction of total segment energy a single stream must hold to be declared the
+/// sole source. 0.72 (≈ +4 dB over the other stream) requires *clear* dominance,
+/// not a slim majority, so crosstalk is not confidently mislabeled as one source.
 const DOMINANCE_RATIO: f64 = 0.72;
+/// Additional guard alongside [`DOMINANCE_RATIO`]: the dominant stream must also
+/// exceed the other by ≥ 4 dB (~2.5× power). Blocks a confident single-source
+/// call when a loud-but-close second source is present.
 const MIN_DB_MARGIN: f64 = 4.0;
+/// Lower edge of the "both streams meaningfully active" band. Derived from
+/// [`DOMINANCE_RATIO`] so the Mixed band and the dominance thresholds are exact
+/// complements — there is no unclassifiable gap between them.
 const MIXED_RATIO_LOW: f64 = 1.0 - DOMINANCE_RATIO;
+/// Upper edge of the Mixed band (symmetric with [`MIXED_RATIO_LOW`]).
 const MIXED_RATIO_HIGH: f64 = DOMINANCE_RATIO;
+/// Retain at least this much timeline behind the most recently classified segment
+/// so late-arriving or overlapping VAD segments still find their frames before
+/// pruning removes them.
 const PRUNE_SAFETY_MARGIN_MS: f64 = 3000.0;
+/// Hard cap on how far back frames are kept, to bound memory on very long
+/// recordings (30 minutes of 100 ms frames ≈ 18k frames).
 const MAX_TIMELINE_RETENTION_MS: f64 = 30.0 * 60.0 * 1000.0;
+/// For a segment to be called Mixed via *alternation* (each source dominating in
+/// turn), each source must dominate for at least this many milliseconds…
 const MIN_ALTERNATING_SOURCE_MS: f64 = 200.0;
+/// …and for at least this fraction of the segment's covered time. Together these
+/// require genuine back-and-forth, not a single brief blip from the other stream.
 const MIN_ALTERNATING_SOURCE_RATIO: f64 = 0.20;
+/// Confidence below which the attribution is too weak to surface as a distinct
+/// label; [`display_label`] falls back to the safe "Speaker". Mirrored on the
+/// frontend as `DISPLAY_CONFIDENCE_THRESHOLD` in `transcriptSource.ts`.
 const MIN_DISPLAY_CONFIDENCE: f32 = 0.55;
 
+/// Which capture stream a transcript segment was attributed to. Serialized as
+/// snake_case (`"microphone"`, `"system"`, `"mixed"`, `"unknown"`) on the wire
+/// and stored as that same TEXT in the `transcripts.audio_source` column.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TranscriptAudioSource {
@@ -20,6 +95,35 @@ pub enum TranscriptAudioSource {
     System,
     Mixed,
     Unknown,
+}
+
+impl TranscriptAudioSource {
+    /// The canonical lowercase wire/DB string for this source — the canonical
+    /// Rust-side mapping. The DB `CHECK` constraint (see the migration) and the
+    /// frontend `transcriptSource.ts` hold parallel copies of these literals and
+    /// must be updated together whenever a variant is added or renamed.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            TranscriptAudioSource::Microphone => "microphone",
+            TranscriptAudioSource::System => "system",
+            TranscriptAudioSource::Mixed => "mixed",
+            TranscriptAudioSource::Unknown => "unknown",
+        }
+    }
+
+    /// Parse an untrusted wire/DB string (from frontend IPC or an imported file)
+    /// into a source, tolerating surrounding whitespace and any casing. Returns
+    /// `None` for anything outside the known set so the persistence boundary can
+    /// reject invalid input instead of storing it.
+    pub fn from_wire(raw: &str) -> Option<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "microphone" => Some(TranscriptAudioSource::Microphone),
+            "system" => Some(TranscriptAudioSource::System),
+            "mixed" => Some(TranscriptAudioSource::Mixed),
+            "unknown" => Some(TranscriptAudioSource::Unknown),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -138,6 +242,19 @@ impl SourceAttributionTimeline {
     }
 }
 
+/// Map a raw attribution to the **binary presentation label** shown to users.
+///
+/// This is deliberately lossy: only a confident `Microphone` becomes "Me"; every
+/// other case — `System`, `Mixed`, `Unknown`, or any source below
+/// `MIN_DISPLAY_CONFIDENCE` — becomes "Speaker". The design goal is to never
+/// assert a false "Me" (attributing the remote party's words to the user is worse
+/// than the conservative default), so "Speaker" doubles as the safe fallback.
+///
+/// This collapses `System`/`Mixed`/`Unknown`/low-confidence into one visible
+/// label **on purpose**. Callers that need to distinguish those states must read
+/// the raw `audio_source` / `source_confidence` fields (preserved in the DB and
+/// API), e.g. the UI badge tooltip — do not infer the underlying state from this
+/// string.
 pub fn display_label(source: TranscriptAudioSource, confidence: f32) -> &'static str {
     if confidence < MIN_DISPLAY_CONFIDENCE {
         return "Speaker";
@@ -334,5 +451,24 @@ mod tests {
         );
         assert_eq!(display_label(TranscriptAudioSource::Mixed, 0.90), "Speaker");
         assert_eq!(display_label(TranscriptAudioSource::Unknown, 0.0), "Speaker");
+    }
+
+    #[test]
+    fn wire_mapping_round_trips_and_rejects_unknown_strings() {
+        for source in [
+            TranscriptAudioSource::Microphone,
+            TranscriptAudioSource::System,
+            TranscriptAudioSource::Mixed,
+            TranscriptAudioSource::Unknown,
+        ] {
+            assert_eq!(TranscriptAudioSource::from_wire(source.as_wire()), Some(source));
+        }
+
+        assert_eq!(
+            TranscriptAudioSource::from_wire("  Microphone "),
+            Some(TranscriptAudioSource::Microphone)
+        );
+        assert_eq!(TranscriptAudioSource::from_wire("speaker"), None);
+        assert_eq!(TranscriptAudioSource::from_wire(""), None);
     }
 }

--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -5,6 +5,7 @@
 use super::engine::TranscriptionEngine;
 use super::provider::TranscriptionError;
 use crate::audio::AudioChunk;
+use crate::audio::source_attribution::{display_label, unknown, TranscriptAudioSource};
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -28,6 +29,8 @@ pub struct TranscriptUpdate {
     pub text: String,
     pub timestamp: String, // Wall-clock time for reference (e.g., "14:30:05")
     pub source: String,
+    pub audio_source: TranscriptAudioSource,
+    pub source_confidence: f32,
     pub sequence_id: u64,
     pub chunk_start_time: f64, // Legacy field, kept for compatibility
     pub is_partial: bool,
@@ -36,6 +39,35 @@ pub struct TranscriptUpdate {
     pub audio_start_time: f64, // Seconds from recording start (e.g., 125.3)
     pub audio_end_time: f64,   // Seconds from recording start (e.g., 128.6)
     pub duration: f64,          // Segment duration in seconds (e.g., 3.3)
+}
+
+#[cfg(test)]
+mod source_metadata_tests {
+    use super::*;
+
+    #[test]
+    fn transcript_update_serializes_source_metadata() {
+        let update = TranscriptUpdate {
+            text: "hello".to_string(),
+            timestamp: "12:00:00".to_string(),
+            source: "Me".to_string(),
+            audio_source: TranscriptAudioSource::Microphone,
+            source_confidence: 0.91,
+            sequence_id: 1,
+            chunk_start_time: 0.0,
+            is_partial: false,
+            confidence: 0.8,
+            audio_start_time: 0.0,
+            audio_end_time: 1.0,
+            duration: 1.0,
+        };
+
+        let json = serde_json::to_value(update).unwrap();
+
+        assert_eq!(json["audio_source"], "microphone");
+        let confidence = json["source_confidence"].as_f64().unwrap();
+        assert!((confidence - 0.91).abs() < 0.0001);
+    }
 }
 
 // NOTE: get_transcript_history and get_recording_meeting_name functions
@@ -142,6 +174,7 @@ pub fn start_transcription_task<R: Runtime>(
 
                             let chunk_timestamp = chunk.timestamp;
                             let chunk_duration = chunk.data.len() as f64 / chunk.sample_rate as f64;
+                            let chunk_source_attribution = chunk.source_attribution;
 
                             // Transcribe with provider-agnostic approach
                             match transcribe_chunk_with_provider(
@@ -204,11 +237,18 @@ pub fn start_transcription_task<R: Runtime>(
                                         // This decouples the transcription worker from direct RECORDING_MANAGER access
 
                                         // Emit transcript update with NEW recording-relative timestamps
+                                        let attribution = chunk_source_attribution.unwrap_or_else(unknown);
+                                        let source_label = display_label(
+                                            attribution.audio_source,
+                                            attribution.source_confidence,
+                                        );
 
                                         let update = TranscriptUpdate {
                                             text: transcript,
                                             timestamp: format_current_timestamp(), // Wall-clock for reference
-                                            source: "Audio".to_string(),
+                                            source: source_label.to_string(),
+                                            audio_source: attribution.audio_source,
+                                            source_confidence: attribution.source_confidence,
                                             sequence_id,
                                             chunk_start_time: chunk_timestamp, // Legacy compatibility
                                             is_partial,

--- a/frontend/src-tauri/src/database/manager.rs
+++ b/frontend/src-tauri/src/database/manager.rs
@@ -3,6 +3,12 @@ use std::fs;
 use std::path::Path;
 use tauri::Manager;
 
+fn embedded_migrator() -> sqlx::migrate::Migrator {
+    let mut migrator = sqlx::migrate!("./migrations");
+    migrator.set_ignore_missing(true);
+    migrator
+}
+
 #[derive(Clone)]
 pub struct DatabaseManager {
     pool: SqlitePool,
@@ -32,7 +38,7 @@ impl DatabaseManager {
 
         let pool = SqlitePool::connect(tauri_db_path).await?;
 
-        sqlx::migrate!("./migrations").run(&pool).await?;
+        embedded_migrator().run(&pool).await?;
 
         Ok(DatabaseManager { pool })
     }
@@ -204,5 +210,15 @@ impl DatabaseManager {
         log::info!("Database connection pool closed");
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_migrator_ignores_missing_forward_migrations() {
+        assert!(embedded_migrator().ignore_missing);
     }
 }

--- a/frontend/src-tauri/src/database/models.rs
+++ b/frontend/src-tauri/src/database/models.rs
@@ -35,6 +35,8 @@ pub struct Transcript {
     pub audio_start_time: Option<f64>,
     pub audio_end_time: Option<f64>,
     pub duration: Option<f64>,
+    pub audio_source: Option<String>,
+    pub source_confidence: Option<f64>,
 }
 
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]

--- a/frontend/src-tauri/src/database/repositories/meeting.rs
+++ b/frontend/src-tauri/src/database/repositories/meeting.rs
@@ -92,6 +92,8 @@ impl MeetingsRepository {
                     audio_start_time: t.audio_start_time,
                     audio_end_time: t.audio_end_time,
                     duration: t.duration,
+                    audio_source: t.audio_source,
+                    source_confidence: t.source_confidence,
                 })
                 .collect::<Vec<_>>();
 

--- a/frontend/src-tauri/src/database/repositories/transcript.rs
+++ b/frontend/src-tauri/src/database/repositories/transcript.rs
@@ -1,4 +1,6 @@
-use crate::api::{TranscriptSearchResult, TranscriptSegment};
+use crate::api::{
+    normalize_transcript_source_fields, TranscriptSearchResult, TranscriptSegment,
+};
 use chrono::Utc;
 use sqlx::{Connection, Error as SqlxError, SqlitePool};
 use tracing::{error, info};
@@ -46,9 +48,17 @@ impl TranscriptsRepository {
         // 2. Save each transcript segment with audio timing fields
         for segment in transcripts {
             let transcript_id = format!("transcript-{}", Uuid::new_v4());
+            let (audio_source, source_confidence) = normalize_transcript_source_fields(
+                segment.audio_source.as_deref(),
+                segment.source_confidence,
+            );
             let result = sqlx::query(
-                "INSERT INTO transcripts (id, meeting_id, transcript, timestamp, audio_start_time, audio_end_time, duration)
-                 VALUES (?, ?, ?, ?, ?, ?, ?)"
+                "INSERT INTO transcripts (
+                    id, meeting_id, transcript, timestamp,
+                    audio_start_time, audio_end_time, duration,
+                    audio_source, source_confidence
+                 )
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
             )
             .bind(&transcript_id)
             .bind(&meeting_id)
@@ -57,6 +67,8 @@ impl TranscriptsRepository {
             .bind(segment.audio_start_time)
             .bind(segment.audio_end_time)
             .bind(segment.duration)
+            .bind(audio_source)
+            .bind(source_confidence)
             .execute(&mut *transaction)
             .await;
 

--- a/frontend/src/app/_components/TranscriptPanel.tsx
+++ b/frontend/src/app/_components/TranscriptPanel.tsx
@@ -45,6 +45,8 @@ export function TranscriptPanel({
       endTime: t.audio_end_time,
       text: t.text,
       confidence: t.confidence,
+      audio_source: t.audio_source,
+      source_confidence: t.source_confidence,
     })),
     [transcripts]
   );

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -61,6 +61,8 @@ export function TranscriptPanel({
       endTime: t.audio_end_time,
       text: t.text,
       confidence: t.confidence,
+      audio_source: t.audio_source,
+      source_confidence: t.source_confidence,
     }));
   }, [transcripts, usePagination, segments]);
 

--- a/frontend/src/components/TranscriptRecovery/TranscriptRecovery.tsx
+++ b/frontend/src/components/TranscriptRecovery/TranscriptRecovery.tsx
@@ -21,6 +21,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { MeetingMetadata, StoredTranscript } from '@/services/indexedDBService';
 import { cn } from '@/lib/utils';
+import { transcriptSourceLabel } from '@/lib/transcriptSource';
 
 interface TranscriptRecoveryProps {
   isOpen: boolean;
@@ -234,10 +235,19 @@ export function TranscriptRecovery({
                               return '--:--';
                             }
                           };
+                          const sourceLabel = transcriptSourceLabel(
+                            transcript.audio_source,
+                            transcript.source_confidence,
+                          );
 
                           return (
                             <div key={index} className="text-sm">
                               <span className="text-muted-foreground">[{getTimestamp()}]</span>{' '}
+                              {sourceLabel && (
+                                <span className="text-muted-foreground">
+                                  {sourceLabel}:{' '}
+                                </span>
+                              )}
                               <span>{transcript.text}</span>
                             </div>
                           );

--- a/frontend/src/components/TranscriptView.tsx
+++ b/frontend/src/components/TranscriptView.tsx
@@ -6,7 +6,7 @@ import { ConfidenceIndicator } from './ConfidenceIndicator';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { RecordingStatusBar } from './RecordingStatusBar';
 import { motion, AnimatePresence } from 'framer-motion';
-import { transcriptSourceLabel } from '@/lib/transcriptSource';
+import { transcriptSourceLabel, transcriptSourceTooltip } from '@/lib/transcriptSource';
 
 interface TranscriptViewProps {
   transcripts: Transcript[];
@@ -274,6 +274,7 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
         const sizerText = cleanStopWords(isStreaming ? streamingTranscript.fullText : transcript.text)
           || (originalWasEmpty && !isStreaming ? '[Silence]' : '');
         const sourceLabel = transcriptSourceLabel(transcript.audio_source, transcript.source_confidence);
+        const sourceTooltip = transcriptSourceTooltip(transcript.audio_source, transcript.source_confidence);
         const sourceBadgeClass = sourceLabel === 'Me'
           ? 'border-blue-200 bg-blue-50 text-blue-700'
           : 'border-emerald-200 bg-emerald-50 text-emerald-700';
@@ -310,7 +311,10 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
                 </TooltipContent>
               </Tooltip>
               {sourceLabel && (
-                <span className={`mt-0.5 min-w-[58px] rounded border px-1.5 py-0.5 text-center text-[11px] font-medium leading-4 ${sourceBadgeClass}`}>
+                <span
+                  title={sourceTooltip ?? undefined}
+                  className={`mt-0.5 min-w-[58px] rounded border px-1.5 py-0.5 text-center text-[11px] font-medium leading-4 ${sourceBadgeClass}`}
+                >
                   {sourceLabel}
                 </span>
               )}

--- a/frontend/src/components/TranscriptView.tsx
+++ b/frontend/src/components/TranscriptView.tsx
@@ -6,6 +6,7 @@ import { ConfidenceIndicator } from './ConfidenceIndicator';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { RecordingStatusBar } from './RecordingStatusBar';
 import { motion, AnimatePresence } from 'framer-motion';
+import { transcriptSourceLabel } from '@/lib/transcriptSource';
 
 interface TranscriptViewProps {
   transcripts: Transcript[];
@@ -272,6 +273,10 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
         // Sizer text: use cleaned version for proper sizing, fallback to [Silence] only if original was empty
         const sizerText = cleanStopWords(isStreaming ? streamingTranscript.fullText : transcript.text)
           || (originalWasEmpty && !isStreaming ? '[Silence]' : '');
+        const sourceLabel = transcriptSourceLabel(transcript.audio_source, transcript.source_confidence);
+        const sourceBadgeClass = sourceLabel === 'Me'
+          ? 'border-blue-200 bg-blue-50 text-blue-700'
+          : 'border-emerald-200 bg-emerald-50 text-emerald-700';
 
         return (
           <motion.div
@@ -304,6 +309,11 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
                   )}
                 </TooltipContent>
               </Tooltip>
+              {sourceLabel && (
+                <span className={`mt-0.5 min-w-[58px] rounded border px-1.5 py-0.5 text-center text-[11px] font-medium leading-4 ${sourceBadgeClass}`}>
+                  {sourceLabel}
+                </span>
+              )}
               <div className="flex-1">
                 {isStreaming ? (
                   // Streaming transcript - show in bubble (full width)

--- a/frontend/src/components/VirtualizedTranscriptView.tsx
+++ b/frontend/src/components/VirtualizedTranscriptView.tsx
@@ -9,6 +9,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { RecordingStatusBar } from "./RecordingStatusBar";
 import { motion, AnimatePresence } from "framer-motion";
 import { TranscriptSegmentData } from "@/types";
+import { transcriptSourceLabel } from "@/lib/transcriptSource";
 
 export interface VirtualizedTranscriptViewProps {
     /** Transcript segments to display */
@@ -69,6 +70,8 @@ const TranscriptSegment = memo(function TranscriptSegment({
     timestamp,
     text,
     confidence,
+    audio_source,
+    source_confidence,
     isStreaming,
     showConfidence,
 }: {
@@ -76,10 +79,16 @@ const TranscriptSegment = memo(function TranscriptSegment({
     timestamp: number;
     text: string;
     confidence?: number;
+    audio_source?: string | null;
+    source_confidence?: number | null;
     isStreaming: boolean;
     showConfidence: boolean;
 }) {
     const displayText = cleanStopWords(text) || (text.trim() === '' ? '[Silence]' : text);
+    const sourceLabel = transcriptSourceLabel(audio_source, source_confidence);
+    const sourceBadgeClass = sourceLabel === 'Me'
+        ? 'border-blue-200 bg-blue-50 text-blue-700'
+        : 'border-emerald-200 bg-emerald-50 text-emerald-700';
 
     return (
         <div id={`segment-${id}`} className="mb-3">
@@ -96,6 +105,11 @@ const TranscriptSegment = memo(function TranscriptSegment({
                         )}
                     </TooltipContent>
                 </Tooltip>
+                {sourceLabel && (
+                    <span className={`mt-0.5 min-w-[58px] rounded border px-1.5 py-0.5 text-center text-[11px] font-medium leading-4 ${sourceBadgeClass}`}>
+                        {sourceLabel}
+                    </span>
+                )}
                 <div className="flex-1">
                     {isStreaming ? (
                         <div className="bg-gray-100 border border-gray-200 rounded-lg px-3 py-2">
@@ -294,6 +308,8 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                                         timestamp={segment.timestamp}
                                         text={getDisplayText(segment)}
                                         confidence={segment.confidence}
+                                        audio_source={segment.audio_source}
+                                        source_confidence={segment.source_confidence}
                                         isStreaming={isStreaming}
                                         showConfidence={showConfidence}
                                     />
@@ -350,6 +366,8 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                                         timestamp={segment.timestamp}
                                         text={getDisplayText(segment)}
                                         confidence={segment.confidence}
+                                        audio_source={segment.audio_source}
+                                        source_confidence={segment.source_confidence}
                                         isStreaming={isStreaming}
                                         showConfidence={showConfidence}
                                     />

--- a/frontend/src/components/VirtualizedTranscriptView.tsx
+++ b/frontend/src/components/VirtualizedTranscriptView.tsx
@@ -9,7 +9,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { RecordingStatusBar } from "./RecordingStatusBar";
 import { motion, AnimatePresence } from "framer-motion";
 import { TranscriptSegmentData } from "@/types";
-import { transcriptSourceLabel } from "@/lib/transcriptSource";
+import { transcriptSourceLabel, transcriptSourceTooltip } from "@/lib/transcriptSource";
 
 export interface VirtualizedTranscriptViewProps {
     /** Transcript segments to display */
@@ -86,6 +86,7 @@ const TranscriptSegment = memo(function TranscriptSegment({
 }) {
     const displayText = cleanStopWords(text) || (text.trim() === '' ? '[Silence]' : text);
     const sourceLabel = transcriptSourceLabel(audio_source, source_confidence);
+    const sourceTooltip = transcriptSourceTooltip(audio_source, source_confidence);
     const sourceBadgeClass = sourceLabel === 'Me'
         ? 'border-blue-200 bg-blue-50 text-blue-700'
         : 'border-emerald-200 bg-emerald-50 text-emerald-700';
@@ -106,7 +107,10 @@ const TranscriptSegment = memo(function TranscriptSegment({
                     </TooltipContent>
                 </Tooltip>
                 {sourceLabel && (
-                    <span className={`mt-0.5 min-w-[58px] rounded border px-1.5 py-0.5 text-center text-[11px] font-medium leading-4 ${sourceBadgeClass}`}>
+                    <span
+                        title={sourceTooltip ?? undefined}
+                        className={`mt-0.5 min-w-[58px] rounded border px-1.5 py-0.5 text-center text-[11px] font-medium leading-4 ${sourceBadgeClass}`}
+                    >
                         {sourceLabel}
                     </span>
                 )}

--- a/frontend/src/contexts/TranscriptContext.tsx
+++ b/frontend/src/contexts/TranscriptContext.tsx
@@ -7,6 +7,7 @@ import { useRecordingState } from './RecordingStateContext';
 import { transcriptService } from '@/services/transcriptService';
 import { recordingService } from '@/services/recordingService';
 import { indexedDBService } from '@/services/indexedDBService';
+import { formatTranscriptLine } from '@/lib/transcriptSource';
 
 interface TranscriptContextType {
   transcripts: Transcript[];
@@ -315,6 +316,8 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
             audio_start_time: update.audio_start_time,
             audio_end_time: update.audio_end_time,
             duration: update.duration,
+            audio_source: update.audio_source,
+            source_confidence: update.source_confidence,
           };
 
           // Add to buffer
@@ -383,6 +386,8 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
             audio_start_time: segment.audio_start_time,
             audio_end_time: segment.audio_end_time,
             duration: segment.duration,
+            audio_source: segment.audio_source,
+            source_confidence: segment.source_confidence,
           }));
 
           setTranscripts(formattedTranscripts);
@@ -424,6 +429,8 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
       audio_start_time: update.audio_start_time,
       audio_end_time: update.audio_end_time,
       duration: update.duration,
+      audio_source: update.audio_source,
+      source_confidence: update.source_confidence,
     };
 
     setTranscripts(prev => {
@@ -465,7 +472,7 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
     };
 
     const fullTranscript = transcripts
-      .map(t => `${formatTime(t.audio_start_time)} ${t.text}`)
+      .map(t => formatTranscriptLine(t, formatTime(t.audio_start_time)))
       .join('\n');
     navigator.clipboard.writeText(fullTranscript);
 

--- a/frontend/src/hooks/meeting-details/useCopyOperations.ts
+++ b/frontend/src/hooks/meeting-details/useCopyOperations.ts
@@ -4,6 +4,7 @@ import { BlockNoteSummaryViewRef } from '@/components/AISummary/BlockNoteSummary
 import { toast } from 'sonner';
 import Analytics from '@/lib/analytics';
 import { invoke as invokeTauri } from '@tauri-apps/api/core';
+import { formatTranscriptLine } from '@/lib/transcriptSource';
 
 interface UseCopyOperationsProps {
   meeting: any;
@@ -86,7 +87,7 @@ export function useCopyOperations({
     const header = `# Transcript of the Meeting: ${meeting.id} - ${meetingTitle ?? meeting.title}\n\n`;
     const date = `## Date: ${new Date(meeting.created_at).toLocaleDateString()}\n\n`;
     const fullTranscript = allTranscripts
-      .map(t => `${formatTime(t.audio_start_time, t.timestamp)} ${t.text}  `)
+      .map(t => `${formatTranscriptLine(t, formatTime(t.audio_start_time, t.timestamp))}  `)
       .join('\n');
 
     await navigator.clipboard.writeText(header + date + fullTranscript);

--- a/frontend/src/hooks/meeting-details/useSummaryGeneration.ts
+++ b/frontend/src/hooks/meeting-details/useSummaryGeneration.ts
@@ -7,6 +7,7 @@ import { toast } from 'sonner';
 import Analytics from '@/lib/analytics';
 import { isOllamaNotInstalledError } from '@/lib/utils';
 import { BuiltInModelInfo } from '@/lib/builtin-ai';
+import { formatTranscriptLine } from '@/lib/transcriptSource';
 import {
   detectAndCacheSummaryLanguage,
   readMeetingSummaryLanguage,
@@ -446,7 +447,7 @@ export function useSummaryGeneration({
 
     return {
       transcriptText: allTranscripts
-        .map(t => `${formatTime(t.audio_start_time, t.timestamp)} ${t.text}`)
+        .map(t => formatTranscriptLine(t, formatTime(t.audio_start_time, t.timestamp)))
         .join('\n'),
       transcriptTexts: allTranscripts.map(t => t.text),
     };

--- a/frontend/src/hooks/usePaginatedTranscripts.ts
+++ b/frontend/src/hooks/usePaginatedTranscripts.ts
@@ -37,6 +37,8 @@ function convertTranscriptsToSegments(transcripts: Transcript[]): TranscriptSegm
         endTime: t.audio_end_time,
         text: t.text,
         confidence: t.confidence,
+        audio_source: t.audio_source,
+        source_confidence: t.source_confidence,
     }));
 }
 

--- a/frontend/src/hooks/useTranscriptRecovery.ts
+++ b/frontend/src/hooks/useTranscriptRecovery.ts
@@ -173,6 +173,8 @@ export function useTranscriptRecovery(): UseTranscriptRecoveryReturn {
         audio_start_time: (t as any).audio_start_time,
         audio_end_time: (t as any).audio_end_time,
         duration: (t as any).duration,
+        audio_source: (t as any).audio_source,
+        source_confidence: (t as any).source_confidence,
       }));
 
       // 6. Save to backend database using existing save utilities

--- a/frontend/src/lib/transcriptSource.ts
+++ b/frontend/src/lib/transcriptSource.ts
@@ -2,6 +2,19 @@ import type { Transcript } from '@/types';
 
 const DISPLAY_CONFIDENCE_THRESHOLD = 0.55;
 
+/**
+ * Map a transcript's raw attribution to the BINARY presentation label.
+ *
+ * This is intentionally lossy and mirrors the backend `display_label`: only a
+ * confident `microphone` becomes "Me"; `system`, `mixed`, `unknown`, and any
+ * source below {@link DISPLAY_CONFIDENCE_THRESHOLD} all become "Speaker". The
+ * goal is to never assert a false "Me", so "Speaker" doubles as the safe
+ * fallback. Returns `null` when there is no attribution at all (`audio_source`
+ * missing/NULL — e.g. pre-feature, imported, or re-transcribed segments), so the
+ * UI can render no badge and copy/summary output can omit the label rather than
+ * fabricating one. Callers needing the underlying four-state signal must read
+ * `audio_source` / `source_confidence` directly (see {@link transcriptSourceTooltip}).
+ */
 export function transcriptSourceLabel(
   audioSource?: string | null,
   sourceConfidence?: number | null
@@ -27,6 +40,30 @@ export function transcriptSourceLabel(
     default:
       return 'Speaker';
   }
+}
+
+/**
+ * Human-readable raw attribution for the badge tooltip: the underlying
+ * four-state `audio_source` plus confidence, e.g. "Source: microphone (91%
+ * confidence)". Unlike {@link transcriptSourceLabel} this does NOT collapse the
+ * state, so a hover reveals whether a "Speaker" badge was actually system,
+ * mixed, unknown, or a low-confidence microphone. Returns `null` when there is
+ * no attribution, so no tooltip is attached.
+ */
+export function transcriptSourceTooltip(
+  audioSource?: string | null,
+  sourceConfidence?: number | null
+): string | null {
+  if (audioSource == null) {
+    return null;
+  }
+
+  const source = audioSource.charAt(0).toUpperCase() + audioSource.slice(1);
+  if (typeof sourceConfidence === 'number' && Number.isFinite(sourceConfidence)) {
+    const pct = Math.round(Math.max(0, Math.min(1, sourceConfidence)) * 100);
+    return `Source: ${source} (${pct}% confidence)`;
+  }
+  return `Source: ${source}`;
 }
 
 export function formatTranscriptLine(transcript: Transcript, formattedTime: string): string {

--- a/frontend/src/lib/transcriptSource.ts
+++ b/frontend/src/lib/transcriptSource.ts
@@ -1,0 +1,37 @@
+import type { Transcript } from '@/types';
+
+const DISPLAY_CONFIDENCE_THRESHOLD = 0.55;
+
+export function transcriptSourceLabel(
+  audioSource?: string | null,
+  sourceConfidence?: number | null
+): 'Me' | 'Speaker' | null {
+  if (audioSource == null) {
+    return null;
+  }
+
+  if (
+    typeof sourceConfidence !== 'number'
+    || !Number.isFinite(sourceConfidence)
+    || sourceConfidence > 1
+    || sourceConfidence < DISPLAY_CONFIDENCE_THRESHOLD
+  ) {
+    return 'Speaker';
+  }
+
+  switch (audioSource) {
+    case 'microphone':
+      return 'Me';
+    case 'system':
+      return 'Speaker';
+    default:
+      return 'Speaker';
+  }
+}
+
+export function formatTranscriptLine(transcript: Transcript, formattedTime: string): string {
+  const label = transcriptSourceLabel(transcript.audio_source, transcript.source_confidence);
+  return label
+    ? `${formattedTime} ${label}: ${transcript.text}`
+    : `${formattedTime} ${transcript.text}`;
+}

--- a/frontend/src/services/indexedDBService.ts
+++ b/frontend/src/services/indexedDBService.ts
@@ -26,6 +26,8 @@ export interface StoredTranscript {
   audio_start_time?: number;  // Recording-relative start time in seconds
   audio_end_time?: number;    // Recording-relative end time in seconds
   duration?: number;          // Duration in seconds
+  audio_source?: string | null; // Canonical audio source: microphone, system, mixed, unknown
+  source_confidence?: number | null; // Confidence in the source attribution, 0.0-1.0
   [key: string]: any;         // Allow additional fields from TranscriptUpdate
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -16,6 +16,8 @@ export interface Transcript {
   audio_start_time?: number; // Seconds from recording start (e.g., 125.3)
   audio_end_time?: number;   // Seconds from recording start (e.g., 128.6)
   duration?: number;          // Segment duration in seconds (e.g., 3.3)
+  audio_source?: string | null; // Canonical audio source: microphone, system, mixed, unknown
+  source_confidence?: number | null; // Confidence in the source attribution, 0.0-1.0
 }
 
 export interface TranscriptUpdate {
@@ -30,6 +32,8 @@ export interface TranscriptUpdate {
   audio_start_time: number; // Seconds from recording start
   audio_end_time: number;   // Seconds from recording start
   duration: number;          // Segment duration in seconds
+  audio_source?: string | null; // Canonical audio source: microphone, system, mixed, unknown
+  source_confidence?: number | null; // Confidence in the source attribution, 0.0-1.0
 }
 
 export interface Block {
@@ -107,4 +111,6 @@ export interface TranscriptSegmentData {
   endTime?: number; // audio_end_time in seconds
   text: string;
   confidence?: number;
+  audio_source?: string | null;
+  source_confidence?: number | null;
 }

--- a/frontend/tests/lib/transcriptSource.test.ts
+++ b/frontend/tests/lib/transcriptSource.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { formatTranscriptLine, transcriptSourceLabel } from "../../src/lib/transcriptSource";
+import {
+  formatTranscriptLine,
+  transcriptSourceLabel,
+  transcriptSourceTooltip,
+} from "../../src/lib/transcriptSource";
 
 describe("transcript source labels", () => {
   test("labels confident microphone and system audio sources", () => {
@@ -49,5 +53,30 @@ describe("transcript source labels", () => {
         "[00:01]",
       ),
     ).toBe("[00:01] Speaker: hello");
+  });
+});
+
+describe("transcript source tooltip", () => {
+  test("exposes the raw four-state source and confidence behind the binary badge", () => {
+    expect(transcriptSourceTooltip("microphone", 0.91)).toBe(
+      "Source: Microphone (91% confidence)",
+    );
+    // "Speaker" badge, but the tooltip reveals it was actually mixed audio.
+    expect(transcriptSourceTooltip("mixed", 0.63)).toBe(
+      "Source: Mixed (63% confidence)",
+    );
+    expect(transcriptSourceTooltip("system", 0.88)).toBe(
+      "Source: System (88% confidence)",
+    );
+  });
+
+  test("omits the confidence when it is missing or non-finite", () => {
+    expect(transcriptSourceTooltip("unknown", null)).toBe("Source: Unknown");
+    expect(transcriptSourceTooltip("microphone", undefined)).toBe("Source: Microphone");
+  });
+
+  test("returns null when there is no attribution", () => {
+    expect(transcriptSourceTooltip(null, null)).toBeNull();
+    expect(transcriptSourceTooltip(undefined, 0.9)).toBeNull();
   });
 });

--- a/frontend/tests/lib/transcriptSource.test.ts
+++ b/frontend/tests/lib/transcriptSource.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { formatTranscriptLine, transcriptSourceLabel } from "../../src/lib/transcriptSource";
+
+describe("transcript source labels", () => {
+  test("labels confident microphone and system audio sources", () => {
+    expect(transcriptSourceLabel("microphone", 0.91)).toBe("Me");
+    expect(transcriptSourceLabel("system", 0.88)).toBe("Speaker");
+  });
+
+  test("omits labels when a transcript has no source metadata", () => {
+    expect(transcriptSourceLabel(null, null)).toBeNull();
+    expect(transcriptSourceLabel(undefined, undefined)).toBeNull();
+  });
+
+  test("labels every attributed non-confident-microphone source as Speaker", () => {
+    expect(transcriptSourceLabel("mixed", 0.9)).toBe("Speaker");
+    expect(transcriptSourceLabel("unknown", 0.9)).toBe("Speaker");
+    expect(transcriptSourceLabel("microphone", undefined)).toBe("Speaker");
+    expect(transcriptSourceLabel("microphone", 0.54)).toBe("Speaker");
+    expect(transcriptSourceLabel("microphone", 1.2)).toBe("Speaker");
+    expect(transcriptSourceLabel("not-valid", 0.9)).toBe("Speaker");
+  });
+
+  test("formats legacy transcript lines without fabricated source labels", () => {
+    expect(
+      formatTranscriptLine(
+        {
+          id: "legacy",
+          text: "historical transcript",
+          timestamp: "12:00:00",
+          audio_source: null,
+          source_confidence: null,
+        },
+        "[00:01]",
+      ),
+    ).toBe("[00:01] historical transcript");
+  });
+
+  test("formats transcript lines with the Speaker fallback label", () => {
+    expect(
+      formatTranscriptLine(
+        {
+          id: "1",
+          text: "hello",
+          timestamp: "12:00:00",
+          audio_source: "microphone",
+          source_confidence: null,
+        },
+        "[00:01]",
+      ),
+    ).toBe("[00:01] Speaker: hello");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds transcript source attribution so segments can be labeled as `Me` for confident microphone speech and `Speaker` for system/mixed/uncertain audio.
- Persists source metadata through live transcription, retranscription/import paths, IndexedDB, SQLite, transcript copy, and summary generation.
- Uses pre-normalized mic audio for source classification while preserving the existing normalized mixed audio path for VAD, Whisper, and recording output.

## Notes / caveats
- This is channel attribution, not speaker diarization: it distinguishes microphone vs system audio, not individual people on the same channel.
- Accuracy is strongest with headphones. If speaker output bleeds into the mic, ambiguous segments intentionally fall back to `Speaker` instead of risking false `Me` labels.
- Legacy/imported transcript rows with no source metadata keep the previous no-label format instead of fabricating a `Speaker` label.
- The migrator now ignores missing forward migrations so newer local DBs do not break newer fixed builds; this cannot retroactively fix an already-shipped older binary if it is launched against a forward-migrated DB.
- `pnpm-lock.yaml` was updated to match existing package overrides so frozen installs remain valid.

## Test plan
- `pnpm run build`
- `bun test tests/lib`
- `git diff --check && git diff --cached --check`
- `cargo check`
- `cargo test --lib` (202 passed, 0 failed, 3 ignored)
- Manual macOS app test from `/Applications/meetily.app`: microphone speech labels as `Me`; system audio labels as `Speaker`.