### PR TITLE
fix(audio): resolve Linux system-audio monitor devices by real name

### DIFF
--- a/frontend/src-tauri/src/audio/devices/configuration.rs
+++ b/frontend/src-tauri/src/audio/devices/configuration.rs
@@ -154,11 +154,17 @@ pub async fn get_device_and_config(
 
                 #[cfg(target_os = "linux")]
                 {
-                    // For Linux, we use PulseAudio monitor sources for system audio
+                    // For Linux, we use PulseAudio monitor sources for system audio.
+                    // The device list appends " (System Audio)" to the name (see
+                    // platform/linux.rs); strip it to match the real device name.
+                    let target_name = audio_device
+                        .name
+                        .strip_suffix(" (System Audio)")
+                        .unwrap_or(&audio_device.name);
                     if let Ok(pulse_host) = cpal::host_from_id(cpal::HostId::Alsa) {
                         for device in pulse_host.input_devices()? {
                             if let Ok(name) = device.name() {
-                                if name == audio_device.name {
+                                if name == target_name {
                                     let default_config = device
                                         .default_input_config()
                                         .map_err(|e| anyhow!("Failed to get default input config: {}", e))?;

--- a/frontend/src-tauri/src/audio/level_monitor.rs
+++ b/frontend/src-tauri/src/audio/level_monitor.rs
@@ -138,6 +138,9 @@ impl AudioLevelMonitor {
 
     /// Find a CPAL device by name
     fn find_device_by_name(&self, host: &cpal::Host, device_name: &str) -> Result<cpal::Device> {
+        // System-audio entries carry a " (System Audio)" suffix (platform/linux.rs);
+        // strip it so it matches the real cpal device name.
+        let device_name = device_name.strip_suffix(" (System Audio)").unwrap_or(device_name);
         // Try input devices first
         if let Ok(input_devices) = host.input_devices() {
             for device in input_devices {


### PR DESCRIPTION
## Description
On Linux, choosing a system-audio (monitor) source in the recording UI never captured system audio — recordings ended up microphone-only.

Root cause is a device-name mismatch between listing and lookup:
- `configure_linux_audio` (`audio/devices/platform/linux.rs`) adds monitor sources to the device list with a display suffix: `format!("{} (System Audio)", name)`.
- `get_device_and_config` (`audio/devices/configuration.rs`) and `AudioLevelMonitor::find_device_by_name` (`audio/level_monitor.rs`) resolve the selection back to a cpal device with an exact match (`name == audio_device.name`) against the raw device name.

The suffixed name (`"<name> (System Audio)"`) never equals the raw cpal name (`"<name>"`), so lookup fails with "Device not found"; `stream.rs` then logs `⚠️ Failed to create system audio stream` and continues without it — a silent, mic-only failure.

Fix: strip the trailing `" (System Audio)"` suffix before matching in both resolvers. macOS/Windows are unaffected (the suffix is only added on Linux).

## Related Issue
N/A — submitting the fix directly; happy to open a tracking issue if preferred.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] All tests pass — 186/189 pass; the single failure is pre-existing and unrelated (details below)

Ran the crate suite (`cargo test -p meetily --features cuda`): **186 passed, 2 ignored, 1 failed**. The failure — `audio::device_detection::tests::test_calculate_buffer_timeout_bluetooth` (`159.999996ms` vs `160ms`, a floating-point rounding assertion) — is present on `devtest` independently of this PR, which only changes `configuration.rs` and `level_monitor.rs`.

Manually verified on Arch Linux + PipeWire: selecting a monitor source under System Audio now captures system audio and mixes it with the microphone; before the fix the same selection produced mic-only recordings.

## Documentation
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)
N/A (backend/audio change)

## Additional Notes
Two call sites shared the same bug (recording capture path + level meter); both are fixed. No behavior change on macOS/Windows.
