### PR TITLE
Add Clinician Focus Mode with MedGemma 4B summary model

### DIFF
--- a/MEDGEMMA_NOTICE.md
+++ b/MEDGEMMA_NOTICE.md
@@ -1,0 +1,33 @@
+# MedGemma Model Notice
+
+Meetily's optional **Clinician Focus Mode** can download and run **MedGemma 4B**
+(`medgemma-4b-it`), a model from Google's Health AI Developer Foundations (HAI-DEF)
+program, as the local summary model.
+
+## License / Terms of Use
+
+MedGemma is provided under and subject to the
+[Health AI Developer Foundations Terms of Use](https://developers.google.com/health-ai-developer-foundations/terms).
+
+By downloading or using the MedGemma model through Meetily you agree to those terms,
+including the use restrictions in the
+[HAI-DEF Prohibited Use Policy](https://developers.google.com/health-ai-developer-foundations/prohibited-use-policy).
+Any redistribution of the model or derivatives must pass these terms through to
+recipients.
+
+## Where the model comes from
+
+Meetily downloads a community GGUF quantization of the official
+[`google/medgemma-4b-it`](https://huggingface.co/google/medgemma-4b-it) weights from
+[`unsloth/medgemma-4b-it-GGUF`](https://huggingface.co/unsloth/medgemma-4b-it-GGUF)
+(`medgemma-4b-it-Q4_K_M.gguf`). The download happens directly from Hugging Face to
+your device; the model runs fully locally.
+
+## Important disclaimers
+
+- Summaries and notes generated with MedGemma are **AI-generated and may contain
+  errors or omissions**. Always review outputs before any clinical use.
+- Meetily is **not a medical device** and does not provide medical advice,
+  diagnosis, or treatment recommendations.
+- MedGemma outputs are intended as a starting point for developer/clinician review,
+  not as a substitute for professional judgment.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,25 @@ Whether you're a defense consultant, enterprise executive, legal professional, o
 - **Multi-Platform:** Works on macOS, Windows, and Linux.
 - **Open Source:** Meetily is open source and free to use.
 - **Flexible AI Provider Support:** Choose from Ollama (local), Claude, Groq, OpenRouter, or use your own OpenAI-compatible endpoint.
+- **Clinician Focus Mode:** Optional clinical setup with the MedGemma 4B model and a SOAP-style session note template.
+
+## Clinician Focus Mode
+
+During onboarding, Meetily asks whether you want a **General** or **Clinician-focused**
+setup. Choosing the clinician focus:
+
+- Downloads **MedGemma 4B (Clinical)** — a Google [Health AI Developer Foundations](https://developers.google.com/health-ai-developer-foundations) model tuned for clinical text — as the local summary model (a community GGUF build, ~2.3 GiB, running fully on-device).
+- Makes the bundled **Psychiatric Session Note (SOAP + AI Hybrid)** template the default for summaries.
+- Keeps MedGemma available in the summary model settings (it is hidden for general-focus users).
+
+To switch focus later, reset onboarding by deleting `onboarding-status.json` from the
+app data directory and relaunching the app.
+
+> **Disclaimer:** Summaries are AI-generated and may contain errors — always review
+> them before clinical use. Meetily is not a medical device and does not provide
+> medical advice or diagnosis. Use of the MedGemma model is governed by Google's
+> [Health AI Developer Foundations terms](https://developers.google.com/health-ai-developer-foundations/terms).
+> See [MEDGEMMA_NOTICE.md](MEDGEMMA_NOTICE.md) for details.
 
 ## Installation
 

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -45,6 +45,7 @@ pub mod notifications;
 pub mod ollama;
 pub mod onboarding;
 pub mod openai;
+pub mod preferences;
 pub mod anthropic;
 pub mod groq;
 pub mod openrouter;
@@ -735,6 +736,11 @@ pub fn run() {
             onboarding::save_onboarding_status_cmd,
             onboarding::reset_onboarding_status_cmd,
             onboarding::complete_onboarding,
+            onboarding::set_product_focus,
+            onboarding::get_product_focus,
+            // App preferences commands
+            preferences::get_default_summary_template,
+            preferences::set_default_summary_template,
             // System settings commands
             #[cfg(target_os = "macos")]
             utils::open_system_settings,

--- a/frontend/src-tauri/src/onboarding.rs
+++ b/frontend/src-tauri/src/onboarding.rs
@@ -14,6 +14,9 @@ pub struct OnboardingStatus {
     pub completed: bool,
     pub current_step: u8,
     pub model_status: ModelStatus,
+    /// Product focus chosen during onboarding: "general" | "clinician"
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub product_focus: Option<String>,
     pub last_updated: String,
 }
 
@@ -36,6 +39,7 @@ impl Default for OnboardingStatus {
                 summary: "not_downloaded".to_string(),  // Changed from gemma
                 selected_summary_model: None,
             },
+            product_focus: None,
             last_updated: chrono::Utc::now().to_rfc3339(),
         }
     }
@@ -107,6 +111,15 @@ pub async fn save_onboarding_status<R: Runtime>(
     Ok(())
 }
 
+/// Load the persisted product focus ("general" | "clinician"), if any.
+/// Used to gate focus-specific models (e.g. clinical models) in the UI.
+pub async fn load_product_focus<R: Runtime>(app: &AppHandle<R>) -> Option<String> {
+    load_onboarding_status(app)
+        .await
+        .ok()
+        .and_then(|status| status.product_focus)
+}
+
 /// Reset onboarding status (delete from store)
 pub async fn reset_onboarding_status<R: Runtime>(
     app: &AppHandle<R>,
@@ -167,6 +180,35 @@ pub async fn reset_onboarding_status_cmd<R: Runtime>(
         .map_err(|e| format!("Failed to reset onboarding status: {}", e))
 }
 
+/// Persist the product focus immediately (not subject to the frontend's
+/// debounced auto-save, so a following step can rely on it).
+#[tauri::command]
+pub async fn set_product_focus<R: Runtime>(
+    app: AppHandle<R>,
+    focus: String,
+) -> Result<(), String> {
+    if focus != "general" && focus != "clinician" {
+        return Err(format!("Invalid product focus: {}", focus));
+    }
+
+    let mut status = load_onboarding_status(&app)
+        .await
+        .map_err(|e| format!("Failed to load onboarding status: {}", e))?;
+
+    status.product_focus = Some(focus);
+
+    save_onboarding_status(&app, &status)
+        .await
+        .map_err(|e| format!("Failed to save product focus: {}", e))
+}
+
+#[tauri::command]
+pub async fn get_product_focus<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<Option<String>, String> {
+    Ok(load_product_focus(&app).await)
+}
+
 #[tauri::command]
 pub async fn complete_onboarding<R: Runtime>(
     app: AppHandle<R>,
@@ -208,7 +250,7 @@ pub async fn complete_onboarding<R: Runtime>(
         .map_err(|e| format!("Failed to load onboarding status: {}", e))?;
 
     status.completed = true;
-    status.current_step = 4; // Max step (4 on macOS with permissions, 3 on other platforms)
+    status.current_step = 5; // Max step (5 on macOS with permissions, 4 on other platforms)
     status.model_status.parakeet = "downloaded".to_string();
     status.model_status.summary = "downloaded".to_string();
     status.model_status.selected_summary_model = Some(model.clone());
@@ -242,5 +284,18 @@ mod tests {
         .expect("old onboarding status should remain compatible");
 
         assert_eq!(status.model_status.selected_summary_model, None);
+        assert_eq!(status.product_focus, None);
+    }
+
+    #[test]
+    fn onboarding_status_round_trips_product_focus() {
+        let mut status = OnboardingStatus::default();
+        status.product_focus = Some("clinician".to_string());
+
+        let json = serde_json::to_string(&status).expect("status should serialize");
+        let restored: OnboardingStatus =
+            serde_json::from_str(&json).expect("status should deserialize");
+
+        assert_eq!(restored.product_focus, Some("clinician".to_string()));
     }
 }

--- a/frontend/src-tauri/src/preferences.rs
+++ b/frontend/src-tauri/src/preferences.rs
@@ -1,0 +1,48 @@
+// Lightweight app preferences persisted via tauri-plugin-store (app-preferences.json).
+// Currently holds the default summary template preference set during onboarding
+// (clinician focus) or when the user picks a template in meeting details.
+
+use log::{info, warn};
+use tauri::{AppHandle, Runtime};
+use tauri_plugin_store::StoreExt;
+
+const PREFERENCES_STORE: &str = "app-preferences.json";
+const DEFAULT_SUMMARY_TEMPLATE_KEY: &str = "default_summary_template";
+
+#[tauri::command]
+pub async fn get_default_summary_template<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<Option<String>, String> {
+    let store = match app.store(PREFERENCES_STORE) {
+        Ok(store) => store,
+        Err(e) => {
+            warn!("Failed to access preferences store: {}", e);
+            return Ok(None);
+        }
+    };
+
+    let template = store
+        .get(DEFAULT_SUMMARY_TEMPLATE_KEY)
+        .and_then(|value| value.as_str().map(|s| s.to_string()));
+
+    Ok(template)
+}
+
+#[tauri::command]
+pub async fn set_default_summary_template<R: Runtime>(
+    app: AppHandle<R>,
+    template_id: String,
+) -> Result<(), String> {
+    let store = app
+        .store(PREFERENCES_STORE)
+        .map_err(|e| format!("Failed to access preferences store: {}", e))?;
+
+    store.set(DEFAULT_SUMMARY_TEMPLATE_KEY, serde_json::json!(template_id));
+
+    store
+        .save()
+        .map_err(|e| format!("Failed to save preferences store: {}", e))?;
+
+    info!("Saved default summary template: {}", template_id);
+    Ok(())
+}

--- a/frontend/src-tauri/src/summary/summary_engine/commands.rs
+++ b/frontend/src-tauri/src/summary/summary_engine/commands.rs
@@ -12,6 +12,7 @@ const QWEN35_4B_RECOMMENDED_RAM_GB: u64 = 14;
 
 pub(crate) fn summary_model_priority(model_name: &str) -> u8 {
     match model_name {
+        "medgemma:4b" => 5,
         "qwen3.5:4b" => 4,
         "qwen3.5:2b" => 3,
         "gemma3:4b" => 2,
@@ -93,6 +94,15 @@ pub async fn builtin_ai_list_models<R: Runtime>(
     };
 
     let models = manager.list_models().await;
+
+    // Focus-gated models (e.g. clinical models) are only listed when the
+    // matching product focus was chosen during onboarding.
+    let focus = crate::onboarding::load_product_focus(&app).await;
+    let models = models
+        .into_iter()
+        .filter(|m| super::models::is_model_visible_for_focus(&m.name, focus.as_deref()))
+        .collect();
+
     Ok(models)
 }
 
@@ -425,6 +435,7 @@ mod tests {
 
     #[test]
     fn available_summary_model_priority_prefers_qwen_over_gemma() {
+        assert!(summary_model_priority("medgemma:4b") > summary_model_priority("qwen3.5:4b"));
         assert!(summary_model_priority("qwen3.5:4b") > summary_model_priority("qwen3.5:2b"));
         assert!(summary_model_priority("qwen3.5:2b") > summary_model_priority("gemma3:4b"));
         assert!(summary_model_priority("gemma3:4b") > summary_model_priority("gemma3:1b"));

--- a/frontend/src-tauri/src/summary/summary_engine/models.rs
+++ b/frontend/src-tauri/src/summary/summary_engine/models.rs
@@ -157,6 +157,11 @@ pub struct ModelDef {
 
     /// Short description for UI
     pub description: String,
+
+    /// Product focus required for this model to be visible in the UI
+    /// (e.g., Some("clinician") for clinical models). None = visible to everyone.
+    #[serde(default)]
+    pub requires_focus: Option<String>,
 }
 
 /// Get all available built-in AI models
@@ -175,6 +180,7 @@ pub fn get_available_models() -> Vec<ModelDef> {
             layer_count: 24,
             sampling: SamplingParams::qwen35_summary(vec!["<|im_end|>".to_string()]),
             description: "Balanced Qwen 3.5 model for built-in summaries. Higher quality with modest local requirements.".to_string(),
+            requires_focus: None,
         },
         // Qwen 3.5 4B - High quality tier
         ModelDef {
@@ -188,6 +194,7 @@ pub fn get_available_models() -> Vec<ModelDef> {
             layer_count: 32,
             sampling: SamplingParams::qwen35_summary(vec!["<|im_end|>".to_string()]),
             description: "High-quality Qwen 3.5 model for built-in summaries. Best local Qwen option in the current lineup.".to_string(),
+            requires_focus: None,
         },
         // Gemma 3 4B - Legacy alternative retained for users who prefer Gemma output.
         ModelDef {
@@ -201,6 +208,7 @@ pub fn get_available_models() -> Vec<ModelDef> {
             layer_count: 35,
             sampling: SamplingParams::gemma3_instruct(vec!["<end_of_turn>".to_string()]),
             description: "Balanced model. Great quality/speed trade-off. Requires ~3.5GB RAM.".to_string(),
+            requires_focus: None,
         },
         // Gemma 3 1B - Visible legacy tier retained for already-shipped users.
         ModelDef {
@@ -214,8 +222,50 @@ pub fn get_available_models() -> Vec<ModelDef> {
             layer_count: 26,
             sampling: SamplingParams::gemma3_instruct(vec!["<end_of_turn>".to_string()]),
             description: "Fastest model. Runs on any hardware with ~1GB RAM. Good for quick summaries.".to_string(),
+            requires_focus: None,
+        },
+        // MedGemma 4B - Clinical tier, only visible when the clinician product focus is active.
+        // Community GGUF conversion of google/medgemma-4b-it (Gemma 3 4B architecture).
+        // Use is governed by Google's Health AI Developer Foundations terms - see MEDGEMMA_NOTICE.md.
+        ModelDef {
+            name: "medgemma:4b".to_string(),
+            display_name: "MedGemma 4B (Clinical)".to_string(),
+            gguf_file: "medgemma-4b-it-Q4_K_M.gguf".to_string(),
+            template: "gemma3".to_string(),
+            download_url: "https://huggingface.co/unsloth/medgemma-4b-it-GGUF/resolve/main/medgemma-4b-it-Q4_K_M.gguf".to_string(),
+            size_mb: 2374,
+            context_size: 32768,
+            layer_count: 35,
+            sampling: SamplingParams::gemma3_instruct(vec!["<end_of_turn>".to_string()]),
+            description: "Google MedGemma model tuned for clinical text. Provided under the Health AI Developer Foundations terms. Requires ~3.5GB RAM.".to_string(),
+            requires_focus: Some("clinician".to_string()),
         },
     ]
+}
+
+/// Check whether a model should be visible for the given product focus.
+/// Models without a `requires_focus` are visible to everyone; focus-gated models
+/// are only visible when the active focus matches. Unknown model names are
+/// treated as visible (filtering only hides registry-gated entries).
+pub fn is_model_visible_for_focus(model_name: &str, focus: Option<&str>) -> bool {
+    match get_model_by_name(model_name) {
+        Some(model) => match model.requires_focus {
+            None => true,
+            Some(required) => focus == Some(required.as_str()),
+        },
+        None => true,
+    }
+}
+
+/// Get the built-in AI models visible for the given product focus.
+pub fn get_available_models_for_focus(focus: Option<&str>) -> Vec<ModelDef> {
+    get_available_models()
+        .into_iter()
+        .filter(|m| match &m.requires_focus {
+            None => true,
+            Some(required) => focus == Some(required.as_str()),
+        })
+        .collect()
 }
 
 /// Get a specific model by name
@@ -390,6 +440,43 @@ mod tests {
         assert_eq!(gemma_4b.sampling.frequency_penalty, 0.0);
         assert_eq!(gemma_4b.sampling.repeat_penalty, 1.0);
         assert_eq!(gemma_4b.sampling.penalty_last_n, 0);
+    }
+
+    #[test]
+    fn medgemma_model_is_registered_with_expected_metadata() {
+        let medgemma = get_model_by_name("medgemma:4b").expect("medgemma 4b model should exist");
+        assert_eq!(medgemma.display_name, "MedGemma 4B (Clinical)");
+        assert_eq!(medgemma.gguf_file, "medgemma-4b-it-Q4_K_M.gguf");
+        assert_eq!(medgemma.template, "gemma3");
+        assert_eq!(
+            medgemma.download_url,
+            "https://huggingface.co/unsloth/medgemma-4b-it-GGUF/resolve/main/medgemma-4b-it-Q4_K_M.gguf"
+        );
+        assert_eq!(medgemma.size_mb, 2374);
+        assert_eq!(medgemma.context_size, 32768);
+        assert_eq!(medgemma.layer_count, 35);
+        assert_eq!(medgemma.sampling, SamplingParams::gemma3_instruct(vec!["<end_of_turn>".to_string()]));
+        assert_eq!(medgemma.requires_focus, Some("clinician".to_string()));
+    }
+
+    #[test]
+    fn focus_filter_hides_medgemma_unless_clinician() {
+        let general_models = get_available_models_for_focus(None);
+        assert!(!general_models.iter().any(|m| m.name == "medgemma:4b"));
+        assert_eq!(general_models.len(), 4);
+
+        let general_focus_models = get_available_models_for_focus(Some("general"));
+        assert!(!general_focus_models.iter().any(|m| m.name == "medgemma:4b"));
+
+        let clinician_models = get_available_models_for_focus(Some("clinician"));
+        assert!(clinician_models.iter().any(|m| m.name == "medgemma:4b"));
+        assert_eq!(clinician_models.len(), 5);
+
+        assert!(!is_model_visible_for_focus("medgemma:4b", None));
+        assert!(!is_model_visible_for_focus("medgemma:4b", Some("general")));
+        assert!(is_model_visible_for_focus("medgemma:4b", Some("clinician")));
+        assert!(is_model_visible_for_focus("qwen3.5:2b", None));
+        assert!(is_model_visible_for_focus("unknown:model", None));
     }
 
     #[test]

--- a/frontend/src-tauri/src/summary/templates/defaults.rs
+++ b/frontend/src-tauri/src/summary/templates/defaults.rs
@@ -9,6 +9,11 @@ pub const DAILY_STANDUP: &str = include_str!("../../../templates/daily_standup.j
 /// Standard meeting notes template
 pub const STANDARD_MEETING: &str = include_str!("../../../templates/standard_meeting.json");
 
+/// Psychiatric session note template (SOAP + AI hybrid), the default for the
+/// clinician product focus. Embedded so the clinician default is guaranteed
+/// even if bundled resource resolution fails.
+pub const PSYCHIATRIC_SESSION: &str = include_str!("../../../templates/psychatric_session.json");
+
 /// Registry of all built-in templates
 ///
 /// Maps template identifiers to their embedded JSON content
@@ -16,6 +21,7 @@ pub fn get_builtin_templates() -> Vec<(&'static str, &'static str)> {
     vec![
         ("daily_standup", DAILY_STANDUP),
         ("standard_meeting", STANDARD_MEETING),
+        ("psychatric_session", PSYCHIATRIC_SESSION),
     ]
 }
 
@@ -30,13 +36,14 @@ pub fn get_builtin_template(id: &str) -> Option<&'static str> {
     match id {
         "daily_standup" => Some(DAILY_STANDUP),
         "standard_meeting" => Some(STANDARD_MEETING),
+        "psychatric_session" => Some(PSYCHIATRIC_SESSION),
         _ => None,
     }
 }
 
 /// List all built-in template identifiers
 pub fn list_builtin_template_ids() -> Vec<&'static str> {
-    vec!["daily_standup", "standard_meeting"]
+    vec!["daily_standup", "standard_meeting", "psychatric_session"]
 }
 
 #[cfg(test)]
@@ -60,6 +67,7 @@ mod tests {
     fn test_get_builtin_template() {
         assert!(get_builtin_template("daily_standup").is_some());
         assert!(get_builtin_template("standard_meeting").is_some());
+        assert!(get_builtin_template("psychatric_session").is_some());
         assert!(get_builtin_template("nonexistent").is_none());
     }
 }

--- a/frontend/src/components/onboarding/OnboardingFlow.tsx
+++ b/frontend/src/components/onboarding/OnboardingFlow.tsx
@@ -5,6 +5,7 @@ import {
   PermissionsStep,
   DownloadProgressStep,
   SetupOverviewStep,
+  FocusStep,
 } from './steps';
 
 interface OnboardingFlowProps {
@@ -31,18 +32,20 @@ export function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
     checkPlatform();
   }, []);
 
-  // 4-Step Onboarding Flow (System-Recommended Models):
+  // 5-Step Onboarding Flow:
   // Step 1: Welcome - Introduce Meetily features
   // Step 2: Setup Overview - Database initialization + show recommended downloads
-  // Step 3: Download Progress - Download Parakeet + Summary Model (auto-selected based on platform/RAM)
-  // Step 4: Permissions - Request mic + system audio (macOS only)
+  // Step 3: Focus - Choose General vs Clinician-focused (selects model + template)
+  // Step 4: Download Progress - Download Parakeet + Summary Model
+  // Step 5: Permissions - Request mic + system audio (macOS only)
 
   return (
     <div className="onboarding-flow">
       {currentStep === 1 && <WelcomeStep />}
       {currentStep === 2 && <SetupOverviewStep />}
-      {currentStep === 3 && <DownloadProgressStep />}
-      {currentStep === 4 && isMac && <PermissionsStep />}
+      {currentStep === 3 && <FocusStep />}
+      {currentStep === 4 && <DownloadProgressStep />}
+      {currentStep === 5 && isMac && <PermissionsStep />}
     </div>
   );
 }

--- a/frontend/src/components/onboarding/shared/ProgressIndicator.tsx
+++ b/frontend/src/components/onboarding/shared/ProgressIndicator.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Check, Lock, Download, CheckCircle2, BrainCircuit } from 'lucide-react';
+import { Check, Lock, Download, CheckCircle2, BrainCircuit, Stethoscope } from 'lucide-react';
 
 interface ProgressIndicatorProps {
   current: number;
@@ -10,8 +10,9 @@ interface ProgressIndicatorProps {
 const stepIcons = [
   Lock,         // 1. Welcome
   BrainCircuit, // 2. Setup Overview
-  Download,     // 3. Download Progress
-  // Step 4 (Permissions) doesn't need icon - auto-skipped on non-macOS
+  Stethoscope,  // 3. Focus (General vs Clinician)
+  Download,     // 4. Download Progress
+  // Step 5 (Permissions) doesn't need icon - auto-skipped on non-macOS
 ];
 
 export function ProgressIndicator({ current, total, onStepClick }: ProgressIndicatorProps) {

--- a/frontend/src/components/onboarding/steps/DownloadProgressStep.tsx
+++ b/frontend/src/components/onboarding/steps/DownloadProgressStep.tsx
@@ -475,8 +475,8 @@ export function DownloadProgressStep() {
     <OnboardingContainer
       title="Getting things ready"
       description="You can start using Meetily after downloading the Transcription Engine."
-      step={3}
-      totalSteps={isMac ? 4 : 3}
+      step={4}
+      totalSteps={isMac ? 5 : 4}
     >
       <div className="flex flex-col items-center space-y-6">
         {/* Download Cards */}

--- a/frontend/src/components/onboarding/steps/FocusStep.tsx
+++ b/frontend/src/components/onboarding/steps/FocusStep.tsx
@@ -1,0 +1,170 @@
+import React, { useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { Users, Stethoscope, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { OnboardingContainer } from '../OnboardingContainer';
+import { useOnboarding } from '@/contexts/OnboardingContext';
+import type { ProductFocus } from '@/types/onboarding';
+
+const CLINICAL_SUMMARY_MODEL = 'medgemma:4b';
+const CLINICAL_TEMPLATE_ID = 'psychatric_session';
+const HAI_DEF_TERMS_URL = 'https://developers.google.com/health-ai-developer-foundations/terms';
+
+export function FocusStep() {
+  const {
+    goNext,
+    setProductFocus,
+    setSelectedSummaryModel,
+    selectedSummaryModel,
+    recommendedSummaryModel,
+  } = useOnboarding();
+  const [choice, setChoice] = useState<ProductFocus>('general');
+  const [disclaimerAccepted, setDisclaimerAccepted] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isMac, setIsMac] = useState(false);
+
+  useEffect(() => {
+    const checkPlatform = async () => {
+      try {
+        const { platform } = await import('@tauri-apps/plugin-os');
+        setIsMac(platform() === 'macos');
+      } catch (e) {
+        setIsMac(navigator.userAgent.includes('Mac'));
+      }
+    };
+    checkPlatform();
+  }, []);
+
+  const options: Array<{
+    value: ProductFocus;
+    icon: React.ElementType;
+    title: string;
+    description: string;
+  }> = [
+    {
+      value: 'general',
+      icon: Users,
+      title: 'General',
+      description: 'Meetings, standups, and everyday notes.',
+    },
+    {
+      value: 'clinician',
+      icon: Stethoscope,
+      title: 'Clinician-focused',
+      description:
+        'Clinical session notes with a SOAP template and the MedGemma 4B clinical model.',
+    },
+  ];
+
+  const canContinue = choice === 'general' || disclaimerAccepted;
+
+  const handleContinue = async () => {
+    if (!canContinue || isSaving) return;
+
+    setIsSaving(true);
+    try {
+      setProductFocus(choice);
+      await invoke('set_product_focus', { focus: choice });
+
+      if (choice === 'clinician') {
+        setSelectedSummaryModel(CLINICAL_SUMMARY_MODEL);
+        await invoke('set_default_summary_template', { templateId: CLINICAL_TEMPLATE_ID });
+      } else if (selectedSummaryModel === CLINICAL_SUMMARY_MODEL) {
+        // User came back and switched from clinician to general - undo the clinical defaults
+        if (recommendedSummaryModel) {
+          setSelectedSummaryModel(recommendedSummaryModel);
+        }
+        await invoke('set_default_summary_template', { templateId: 'standard_meeting' });
+      }
+
+      goNext();
+    } catch (error) {
+      console.error('[FocusStep] Failed to save product focus:', error);
+      // Continue anyway - the debounced onboarding auto-save will retry persistence
+      goNext();
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <OnboardingContainer
+      title="Choose your focus"
+      description="Pick how you'll use Meetily. This selects the AI model and note template that fit best."
+      step={3}
+      totalSteps={isMac ? 5 : 4}
+    >
+      <div className="flex flex-col items-center space-y-6">
+        {/* Focus Option Cards */}
+        <div className="w-full max-w-lg space-y-3">
+          {options.map((option) => {
+            const Icon = option.icon;
+            const isSelected = choice === option.value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => setChoice(option.value)}
+                className={`w-full text-left bg-white rounded-xl border p-5 transition-colors ${
+                  isSelected
+                    ? 'border-gray-900 ring-1 ring-gray-900'
+                    : 'border-gray-200 hover:border-gray-400'
+                }`}
+              >
+                <div className="flex items-start gap-4">
+                  <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+                    <Icon className="w-5 h-5 text-gray-600" />
+                  </div>
+                  <div>
+                    <h3 className="font-medium text-gray-900">{option.title}</h3>
+                    <p className="text-sm text-gray-500 mt-1">{option.description}</p>
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Clinical Disclaimer */}
+        {choice === 'clinician' && (
+          <div className="w-full max-w-lg bg-gray-100 rounded-lg p-4 text-sm text-gray-800 space-y-3">
+            <p>
+              Summaries are AI-generated and may contain errors — always review them before
+              clinical use. Meetily is not a medical device and does not provide medical advice
+              or diagnosis. The MedGemma model is provided under and subject to{' '}
+              <a
+                href={HAI_DEF_TERMS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-gray-900"
+              >
+                Google&apos;s Health AI Developer Foundations terms
+              </a>
+              .
+            </p>
+            <label className="flex items-start gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={disclaimerAccepted}
+                onChange={(e) => setDisclaimerAccepted(e.target.checked)}
+                className="mt-0.5"
+              />
+              <span>I understand and agree to these terms.</span>
+            </label>
+          </div>
+        )}
+
+        {/* Continue Button */}
+        <div className="w-full max-w-xs">
+          <Button
+            onClick={handleContinue}
+            disabled={!canContinue || isSaving}
+            className="w-full h-11 bg-gray-900 hover:bg-gray-800 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSaving ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : 'Continue'}
+          </Button>
+        </div>
+      </div>
+    </OnboardingContainer>
+  );
+}

--- a/frontend/src/components/onboarding/steps/PermissionsStep.tsx
+++ b/frontend/src/components/onboarding/steps/PermissionsStep.tsx
@@ -115,7 +115,7 @@ export function PermissionsStep() {
     <OnboardingContainer
       title="Grant Permissions"
       description="Meetily needs access to your microphone and system audio to record meetings"
-      step={4}
+      step={5}
       hideProgress={true}
       showNavigation={allPermissionsGranted}
       canGoNext={allPermissionsGranted}

--- a/frontend/src/components/onboarding/steps/SetupOverviewStep.tsx
+++ b/frontend/src/components/onboarding/steps/SetupOverviewStep.tsx
@@ -48,7 +48,7 @@ export function SetupOverviewStep() {
       title="Setup Overview"
       description="Meetily requires that you download the Transcription & Summarization AI models for the software to work."
       step={2}
-      totalSteps={isMac ? 4 : 3}
+      totalSteps={isMac ? 5 : 4}
     >
       <div className="flex flex-col items-center space-y-10">
         {/* Steps Card */}

--- a/frontend/src/components/onboarding/steps/index.ts
+++ b/frontend/src/components/onboarding/steps/index.ts
@@ -2,3 +2,4 @@ export { WelcomeStep } from './WelcomeStep';
 export { PermissionsStep } from './PermissionsStep';
 export { DownloadProgressStep } from './DownloadProgressStep';
 export { SetupOverviewStep } from './SetupOverviewStep';
+export { FocusStep } from './FocusStep';

--- a/frontend/src/contexts/OnboardingContext.tsx
+++ b/frontend/src/contexts/OnboardingContext.tsx
@@ -3,7 +3,7 @@
 import React, { createContext, useContext, useState, useEffect, useRef, useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
-import type { PermissionStatus, OnboardingPermissions } from '@/types/onboarding';
+import type { PermissionStatus, OnboardingPermissions, ProductFocus } from '@/types/onboarding';
 import { resolveOnboardingSummaryModelStatus } from '@/lib/onboarding-summary-model';
 
 const PARAKEET_MODEL = 'parakeet-tdt-0.6b-v3-int8';
@@ -17,6 +17,7 @@ interface OnboardingStatus {
     summary: string;
     selected_summary_model?: string;
   };
+  product_focus?: ProductFocus;
   last_updated: string;
 }
 
@@ -44,6 +45,7 @@ interface OnboardingContextType {
   summaryModelProgressInfo: SummaryModelProgressInfo;
   selectedSummaryModel: string;
   recommendedSummaryModel: string;
+  productFocus: ProductFocus | '';
   databaseExists: boolean;
   isBackgroundDownloading: boolean;
   // Permissions
@@ -57,6 +59,7 @@ interface OnboardingContextType {
   setParakeetDownloaded: (value: boolean) => void;
   setSummaryModelDownloaded: (value: boolean) => void;
   setSelectedSummaryModel: (value: string) => void;
+  setProductFocus: (value: ProductFocus) => void;
   setDatabaseExists: (value: boolean) => void;
   setPermissionStatus: (permission: keyof OnboardingPermissions, status: PermissionStatus) => void;
   setPermissionsSkipped: (skipped: boolean) => void;
@@ -92,8 +95,9 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
     totalMb: 0,
     speedMbps: 0,
   });
-  const [selectedSummaryModel, setSelectedSummaryModel] = useState<string>('');
+  const [selectedSummaryModel, setSelectedSummaryModelState] = useState<string>('');
   const [recommendedSummaryModel, setRecommendedSummaryModel] = useState<string>('');
+  const [productFocus, setProductFocus] = useState<ProductFocus | ''>('');
   const [databaseExists, setDatabaseExists] = useState(false);
   const [isBackgroundDownloading, setIsBackgroundDownloading] = useState(false);
 
@@ -107,12 +111,25 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
 
   const saveTimeoutRef = useRef<NodeJS.Timeout>();
 
+  // Tracks an explicit model choice made in the UI (e.g. the clinician focus
+  // selecting MedGemma). Async initialization/verification must not overwrite it.
+  const userSelectedModelRef = useRef(false);
+
+  const setSelectedSummaryModel = useCallback((value: string) => {
+    userSelectedModelRef.current = true;
+    setSelectedSummaryModelState(value);
+  }, []);
+
   const initializeSummaryModelSelection = async (preferredModel = selectedSummaryModel) => {
     try {
       const recommendedModel = await invoke<string>('builtin_ai_get_recommended_model');
       setRecommendedSummaryModel(recommendedModel);
+      if (userSelectedModelRef.current) {
+        console.log('[OnboardingContext] User already selected a model, keeping selection');
+        return null;
+      }
       const modelToCheck = preferredModel || recommendedModel;
-      setSelectedSummaryModel(modelToCheck);
+      setSelectedSummaryModelState(modelToCheck);
 
       const selectedModelReady = await invoke<boolean>('builtin_ai_is_model_ready', {
         modelName: modelToCheck,
@@ -124,7 +141,11 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
         selectedModelReady,
       });
 
-      setSelectedSummaryModel(resolved.selectedSummaryModel);
+      if (userSelectedModelRef.current) {
+        console.log('[OnboardingContext] User selected a model during initialization, keeping selection');
+        return null;
+      }
+      setSelectedSummaryModelState(resolved.selectedSummaryModel);
       setSummaryModelDownloaded(resolved.summaryModelDownloaded);
       console.log('[OnboardingContext] Set recommended model:', resolved.selectedSummaryModel);
 
@@ -230,7 +251,7 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
     return () => {
       if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
     };
-  }, [currentStep, parakeetDownloaded, summaryModelDownloaded, completed]);
+  }, [currentStep, parakeetDownloaded, summaryModelDownloaded, completed, selectedSummaryModel, productFocus]);
 
   // Listen to Parakeet download progress
   useEffect(() => {
@@ -344,7 +365,10 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
           setParakeetDownloaded(status.model_status.parakeet === 'downloaded');
           setSummaryModelDownloaded(status.model_status.summary === 'downloaded');
           if (status.model_status.selected_summary_model) {
-            setSelectedSummaryModel(status.model_status.selected_summary_model);
+            setSelectedSummaryModelState(status.model_status.selected_summary_model);
+          }
+          if (status.product_focus) {
+            setProductFocus(status.product_focus);
           }
           console.log('[OnboardingContext] Restored completed onboarding status without model verification');
           return;
@@ -357,8 +381,11 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
         setCompleted(verifiedStatus.completed);
         setParakeetDownloaded(verifiedStatus.parakeetDownloaded);
         setSummaryModelDownloaded(verifiedStatus.summaryModelDownloaded);
-        if (verifiedStatus.selectedSummaryModel) {
-          setSelectedSummaryModel(verifiedStatus.selectedSummaryModel);
+        if (verifiedStatus.selectedSummaryModel && !userSelectedModelRef.current) {
+          setSelectedSummaryModelState(verifiedStatus.selectedSummaryModel);
+        }
+        if (status.product_focus) {
+          setProductFocus(status.product_focus);
         }
 
         console.log('[OnboardingContext] Verified status:', verifiedStatus);
@@ -413,13 +440,13 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
     }
 
     // Determine the correct step based on verified status
-    // New simplified flow: Step 1: Welcome, Step 2: Setup Overview, Step 3: Download Progress, Step 4: Permissions (macOS)
+    // Flow: Step 1: Welcome, Step 2: Setup Overview, Step 3: Focus, Step 4: Download Progress, Step 5: Permissions (macOS)
     let currentStep = savedStatus.current_step;
     let completed = savedStatus.completed;
 
-    // Clamp step to new max (4)
-    if (currentStep > 4) {
-      currentStep = 3; // Go to download progress step
+    // Clamp step to new max (5)
+    if (currentStep > 5) {
+      currentStep = 4; // Go to download progress step
     }
 
     // Trust the completed status - don't revert based on model downloads
@@ -453,6 +480,7 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
             summary: summaryModelDownloaded ? 'downloaded' : 'not_downloaded',
             selected_summary_model: selectedSummaryModel || undefined,
           },
+          product_focus: productFocus || undefined,
           last_updated: new Date().toISOString(),
         },
       });
@@ -475,7 +503,7 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
       let modelToSave = selectedSummaryModel;
       if (!modelToSave) {
         modelToSave = await invoke<string>('builtin_ai_get_recommended_model');
-        setSelectedSummaryModel(modelToSave);
+        setSelectedSummaryModelState(modelToSave);
       }
 
       const selectedModelReady = await invoke<boolean>('builtin_ai_is_model_ready', {
@@ -582,14 +610,14 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
   }, []);
 
   const goToStep = useCallback((step: number) => {
-    setCurrentStep(Math.max(1, Math.min(step, 4)));
+    setCurrentStep(Math.max(1, Math.min(step, 5)));
   }, []);
 
   const goNext = useCallback(() => {
     setCurrentStep((prev: number) => {
       const next = prev + 1;
-      // Don't go past step 4
-      return Math.min(next, 4);
+      // Don't go past step 5
+      return Math.min(next, 5);
     });
   }, []);
 
@@ -613,6 +641,7 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
         summaryModelProgressInfo,
         selectedSummaryModel,
         recommendedSummaryModel,
+        productFocus,
         databaseExists,
         isBackgroundDownloading,
         permissions,
@@ -623,6 +652,7 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
         setParakeetDownloaded,
         setSummaryModelDownloaded,
         setSelectedSummaryModel,
+        setProductFocus,
         setDatabaseExists,
         setPermissionStatus,
         setPermissionsSkipped,

--- a/frontend/src/hooks/meeting-details/useTemplates.ts
+++ b/frontend/src/hooks/meeting-details/useTemplates.ts
@@ -11,7 +11,7 @@ export function useTemplates() {
   }>>([]);
   const [selectedTemplate, setSelectedTemplate] = useState<string>('standard_meeting');
 
-  // Fetch available templates on mount
+  // Fetch available templates and the persisted default on mount
   useEffect(() => {
     const fetchTemplates = async () => {
       try {
@@ -22,6 +22,11 @@ export function useTemplates() {
         }>;
         console.log('Available templates:', templates);
         setAvailableTemplates(templates);
+
+        const savedDefault = await invokeTauri('get_default_summary_template') as string | null;
+        if (savedDefault && templates.some(t => t.id === savedDefault)) {
+          setSelectedTemplate(savedDefault);
+        }
       } catch (error) {
         console.error('Failed to fetch templates:', error);
       }
@@ -32,6 +37,8 @@ export function useTemplates() {
   // Handle template selection
   const handleTemplateSelection = useCallback((templateId: string, templateName: string) => {
     setSelectedTemplate(templateId);
+    invokeTauri('set_default_summary_template', { templateId })
+      .catch(error => console.error('Failed to persist default template:', error));
     toast.success('Template selected', {
       description: `Using "${templateName}" template for summary generation`,
     });

--- a/frontend/src/lib/onboarding-summary-model.ts
+++ b/frontend/src/lib/onboarding-summary-model.ts
@@ -14,6 +14,7 @@ const SUMMARY_MODEL_SIZES_MB: Record<string, number> = {
   'qwen3.5:4b': 2614,
   'gemma3:1b': 1019,
   'gemma3:4b': 2374,
+  'medgemma:4b': 2374,
 };
 
 export function resolveOnboardingSummaryModelStatus({

--- a/frontend/src/types/onboarding.ts
+++ b/frontend/src/types/onboarding.ts
@@ -1,4 +1,6 @@
-export type OnboardingStep = 1 | 2 | 3 | 4;
+export type OnboardingStep = 1 | 2 | 3 | 4 | 5;
+
+export type ProductFocus = 'general' | 'clinician';
 
 export type PermissionStatus = 'checking' | 'not_determined' | 'authorized' | 'denied';
 


### PR DESCRIPTION
## Summary

Adds an optional **Clinician Focus Mode**: a new onboarding step (before model downloads) where users choose a **General** or **Clinician-focused** setup. Choosing the clinician focus:

- Downloads **MedGemma 4B (Clinical)** as the built-in summary model instead of the RAM-based Qwen recommendation
- Defaults summaries to the already-bundled **Psychiatric Session Note (SOAP + AI Hybrid)** template (`psychatric_session.json`), persisted via a small new `app-preferences.json` store
- Shows a required disclaimer (AI-generated output, not a medical device / medical advice, link to Google's HAI-DEF terms) that must be acknowledged before continuing

The onboarding flow grows to 5 steps: Welcome → Setup Overview → **Focus (new)** → Downloads → Permissions (macOS).

## Design notes

- **Visibility gating:** MedGemma is only visible when the clinician focus is active. `ModelDef` gains an optional `requires_focus` field and `builtin_ai_list_models` filters on the persisted focus — the single point both `BuiltInModelManager` and `ModelSettingsModal` read from — so general users never see the model. Download/inference by name stay unfiltered.
- **Model entry:** `medgemma:4b` reuses the existing `gemma3` prompt template and `gemma3_instruct` sampling (MedGemma-4b-it is the Gemma 3 4B architecture), `context_size` 32768, `layer_count` 35, `size_mb` 2374.
- **Race guard:** an explicit onboarding model selection is protected from being overwritten by the async `builtin_ai_get_recommended_model` initialization in `OnboardingContext`.
- **Reliability:** the psychiatric template is now also embedded via `include_str!` in `defaults.rs`, so the clinician default works even if bundled-resource resolution fails.
- **Focus persistence:** new `product_focus` field on `OnboardingStatus` (serde-defaulted, backward compatible) plus `set_product_focus`/`get_product_focus` commands; `set_product_focus` writes immediately so it isn't subject to the debounced frontend auto-save.

## Model hosting / licensing

- The official `google/medgemma-4b-it` repo on Hugging Face is gated, but the HAI-DEF terms permit redistribution with pass-through of the use restrictions and a notice. The app downloads the **ungated** community GGUF `unsloth/medgemma-4b-it-GGUF` (`medgemma-4b-it-Q4_K_M.gguf`, 2,489,894,720 bytes — verified downloadable with a plain unauthenticated GET, matching the existing downloader which has no HF-token support).
- `MEDGEMMA_NOTICE.md` (modeled on `BLUETOOTH_PLAYBACK_NOTICE.md`) carries the HAI-DEF pass-through notice and disclaimers; the README gets a "Clinician Focus Mode" section.
- If you'd prefer first-party hosting, the GGUF could alternatively be mirrored on `meetily.towardsgeneralintelligence.com` alongside the Parakeet v3 models — happy to switch the URL if you want that.

## Testing

- `cargo test`: 189 passed; the only 2 failures (`audio::device_detection`) are machine-dependent and fail identically on an untouched `main` checkout.
- New unit tests: MedGemma registry metadata, focus filtering, `product_focus` serde backward-compat/round-trip, embedded psychiatric template validity, updated model-priority test.
- `next build` + `tsc --noEmit` pass.
- Manual flow not yet exercised end-to-end on all platforms; the Focus step appears on macOS/Windows/Linux (progress totals become 5/4 respectively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)