### PR TITLE
feat(ui): meeting recording playback with transcript-synced seeking

### DIFF
--- a/frontend/src-tauri/src/audio/mod.rs
+++ b/frontend/src-tauri/src/audio/mod.rs
@@ -51,6 +51,9 @@ pub mod retranscription;
 // Import module (import external audio files as new meetings)
 pub mod import;
 
+// Playback module (serve stored meeting recordings to the webview)
+pub mod playback;
+
 pub use devices::{
     default_input_device, default_output_device, get_device_and_config, list_audio_devices,
     parse_audio_device, trigger_audio_permission,

--- a/frontend/src-tauri/src/audio/playback.rs
+++ b/frontend/src-tauri/src/audio/playback.rs
@@ -1,0 +1,50 @@
+// Meeting recording playback support
+//
+// Exposes the stored audio recording of a meeting to the webview so the
+// frontend can play it back (and sync it with transcript timestamps).
+// Recordings live in the user-configurable recordings folder, which is
+// outside the static asset protocol scope, so the located file is allowed
+// into the scope at runtime before its path is returned.
+
+use log::{info, warn};
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager, Runtime};
+
+/// Locate the audio recording inside a meeting folder and make it playable.
+///
+/// Returns the absolute path of the audio file (e.g. `audio.mp4`) after
+/// adding it to the asset protocol scope, so the frontend can stream it via
+/// `convertFileSrc`. Returns `None` when the meeting has no folder on disk
+/// or the folder contains no audio file (e.g. legacy/folderless meetings).
+#[tauri::command]
+pub async fn get_meeting_audio_path<R: Runtime>(
+    app: AppHandle<R>,
+    meeting_folder_path: String,
+) -> Result<Option<String>, String> {
+    let folder = PathBuf::from(&meeting_folder_path);
+    if !folder.is_dir() {
+        warn!(
+            "Playback: meeting folder does not exist: {}",
+            meeting_folder_path
+        );
+        return Ok(None);
+    }
+
+    let audio_path = match super::retranscription::find_audio_file(&folder) {
+        Ok(path) => path,
+        Err(e) => {
+            info!(
+                "Playback: no audio recording found in {}: {}",
+                meeting_folder_path, e
+            );
+            return Ok(None);
+        }
+    };
+
+    app.asset_protocol_scope()
+        .allow_file(&audio_path)
+        .map_err(|e| format!("Failed to allow audio file for playback: {}", e))?;
+
+    info!("Playback: serving audio file {}", audio_path.display());
+    Ok(Some(audio_path.to_string_lossy().to_string()))
+}

--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -138,7 +138,7 @@ pub async fn start_retranscription<R: Runtime>(
 
 /// Find audio file in meeting folder
 /// Tries common names first, then scans for any file with an audio extension
-fn find_audio_file(folder: &Path) -> Result<PathBuf> {
+pub(crate) fn find_audio_file(folder: &Path) -> Result<PathBuf> {
     let candidates = [
         "audio.mp4", "audio.m4a", "audio.wav", "audio.mp3",
         "audio.flac", "audio.ogg", "recording.mp4",

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -616,6 +616,8 @@ pub fn run() {
             audio::recording_commands::attempt_device_reconnect,
             // Playback device detection (Bluetooth warning)
             audio::recording_commands::get_active_audio_output,
+            // Meeting recording playback (transcript-synced audio player)
+            audio::playback::get_meeting_audio_path,
             // Audio recovery commands (for transcript recovery feature)
             audio::incremental_saver::recover_audio_from_checkpoints,
             audio::incremental_saver::cleanup_checkpoints,

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -27,6 +27,7 @@
                 "default-src": "'self'",
                 "style-src": "'self' 'unsafe-inline'",
                 "img-src": "'self' asset: https://asset.localhost data:",
+                "media-src": "'self' asset: https://asset.localhost",
                 "connect-src": "'self' http://localhost:11434 http://localhost:5167 http://localhost:8178 https://api.ollama.ai"
             },
             "assetProtocol": {

--- a/frontend/src/app/meeting-details/page-content.tsx
+++ b/frontend/src/app/meeting-details/page-content.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import { Summary, SummaryResponse } from '@/types';
 import { useSidebar } from '@/components/Sidebar/SidebarProvider';
@@ -7,7 +7,8 @@ import Analytics from '@/lib/analytics';
 import { invoke } from '@tauri-apps/api/core';
 import { toast } from 'sonner';
 import { TranscriptPanel } from '@/components/MeetingDetails/TranscriptPanel';
-import { SummaryPanel } from '@/components/MeetingDetails/SummaryPanel';
+import { SummaryPanel, SummaryPanelTab } from '@/components/MeetingDetails/SummaryPanel';
+import { RecordingPanelRef } from '@/components/MeetingDetails/RecordingPanel';
 import { ModelConfig } from '@/components/ModelSettingsModal';
 
 // Custom hooks
@@ -16,6 +17,7 @@ import { useSummaryGeneration } from '@/hooks/meeting-details/useSummaryGenerati
 import { useTemplates } from '@/hooks/meeting-details/useTemplates';
 import { useCopyOperations } from '@/hooks/meeting-details/useCopyOperations';
 import { useMeetingOperations } from '@/hooks/meeting-details/useMeetingOperations';
+import { useMeetingAudio } from '@/hooks/meeting-details/useMeetingAudio';
 import { useConfig } from '@/contexts/ConfigContext';
 
 export default function PageContent({
@@ -57,9 +59,19 @@ export default function PageContent({
   const [customPrompt, setCustomPrompt] = useState<string>('');
   const [isRecording] = useState(false);
   const [summaryResponse] = useState<SummaryResponse | null>(null);
+  const [summaryPanelTab, setSummaryPanelTab] = useState<SummaryPanelTab>('summary');
 
   // Ref to store the modal open function from SummaryGeneratorButtonGroup
   const openModelSettingsRef = useRef<(() => void) | null>(null);
+
+  // Ref to control the recording player (seek from transcript timestamps)
+  const recordingPanelRef = useRef<RecordingPanelRef>(null);
+
+  // Locate the stored recording for playback (null when none exists)
+  const { audioSrc } = useMeetingAudio({
+    meetingId: meeting.id,
+    meetingFolderPath: meeting.folder_path,
+  });
 
   // Sidebar context
   const { serverAddress } = useSidebar();
@@ -139,6 +151,18 @@ export default function PageContent({
     Analytics.trackPageView('meeting_details');
   }, []);
 
+  // Reset to the summary tab when switching meetings
+  useEffect(() => {
+    setSummaryPanelTab('summary');
+  }, [meeting.id]);
+
+  // Jump the recording player to a transcript timestamp
+  const handleSeekToTimestamp = useCallback((seconds: number) => {
+    Analytics.trackButtonClick('transcript_timestamp_seek', 'meeting_details');
+    setSummaryPanelTab('recording');
+    recordingPanelRef.current?.seekTo(seconds);
+  }, []);
+
   // Auto-generate summary when flag is set
   useEffect(() => {
     let cancelled = false;
@@ -191,6 +215,8 @@ export default function PageContent({
           meetingId={meeting.id}
           meetingFolderPath={meeting.folder_path}
           onRefetchTranscripts={onRefetchTranscripts}
+          // Recording playback (timestamps clickable only when a recording exists)
+          onSeekToTimestamp={audioSrc ? handleSeekToTimestamp : undefined}
         />
         <SummaryPanel
           meeting={meeting}
@@ -226,6 +252,10 @@ export default function PageContent({
           onTemplateSelect={templates.handleTemplateSelection}
           isModelConfigLoading={false}
           onOpenModelSettings={handleRegisterModalOpen}
+          audioSrc={audioSrc}
+          activeTab={summaryPanelTab}
+          onTabChange={setSummaryPanelTab}
+          recordingPanelRef={recordingPanelRef}
         />
       </div>
     </motion.div>

--- a/frontend/src/app/meeting-details/page-content.tsx
+++ b/frontend/src/app/meeting-details/page-content.tsx
@@ -60,6 +60,7 @@ export default function PageContent({
   const [isRecording] = useState(false);
   const [summaryResponse] = useState<SummaryResponse | null>(null);
   const [summaryPanelTab, setSummaryPanelTab] = useState<SummaryPanelTab>('summary');
+  const [activeSegmentId, setActiveSegmentId] = useState<string | null>(null);
 
   // Ref to store the modal open function from SummaryGeneratorButtonGroup
   const openModelSettingsRef = useRef<(() => void) | null>(null);
@@ -151,9 +152,10 @@ export default function PageContent({
     Analytics.trackPageView('meeting_details');
   }, []);
 
-  // Reset to the summary tab when switching meetings
+  // Reset playback-related state when switching meetings
   useEffect(() => {
     setSummaryPanelTab('summary');
+    setActiveSegmentId(null);
   }, [meeting.id]);
 
   // Jump the recording player to a transcript timestamp
@@ -162,6 +164,23 @@ export default function PageContent({
     setSummaryPanelTab('recording');
     recordingPanelRef.current?.seekTo(seconds);
   }, []);
+
+  // Follow playback in the transcript: highlight the segment being spoken.
+  // Only the id is stored, so timeupdate ticks inside the same segment are
+  // no-op renders.
+  const handlePlaybackTimeUpdate = useCallback((seconds: number) => {
+    const segs = segments ?? [];
+    let currentId: string | null = null;
+    for (let i = 0; i < segs.length; i++) {
+      if (segs[i].timestamp > seconds) break;
+      const end = segs[i].endTime ?? segs[i + 1]?.timestamp ?? Infinity;
+      if (seconds < end) {
+        currentId = segs[i].id;
+        break;
+      }
+    }
+    setActiveSegmentId((prev) => (prev === currentId ? prev : currentId));
+  }, [segments]);
 
   // Auto-generate summary when flag is set
   useEffect(() => {
@@ -217,6 +236,7 @@ export default function PageContent({
           onRefetchTranscripts={onRefetchTranscripts}
           // Recording playback (timestamps clickable only when a recording exists)
           onSeekToTimestamp={audioSrc ? handleSeekToTimestamp : undefined}
+          activeSegmentId={activeSegmentId}
         />
         <SummaryPanel
           meeting={meeting}
@@ -256,6 +276,7 @@ export default function PageContent({
           activeTab={summaryPanelTab}
           onTabChange={setSummaryPanelTab}
           recordingPanelRef={recordingPanelRef}
+          onPlaybackTimeUpdate={handlePlaybackTimeUpdate}
         />
       </div>
     </motion.div>

--- a/frontend/src/components/MeetingDetails/RecordingPanel.tsx
+++ b/frontend/src/components/MeetingDetails/RecordingPanel.tsx
@@ -25,6 +25,8 @@ interface RecordingPanelProps {
   /** Playable URL of the meeting recording (asset protocol). */
   audioSrc: string;
   meetingTitle: string;
+  /** Reports the playback position so the transcript can follow along */
+  onTimeUpdate?: (seconds: number) => void;
 }
 
 // Format seconds as M:SS (or H:MM:SS for recordings over an hour)
@@ -43,7 +45,7 @@ function formatPlaybackTime(seconds: number): string {
 }
 
 export const RecordingPanel = forwardRef<RecordingPanelRef, RecordingPanelProps>(
-  function RecordingPanel({ audioSrc, meetingTitle }, ref) {
+  function RecordingPanel({ audioSrc, meetingTitle, onTimeUpdate }, ref) {
     // A <video> element plays audio-only files too; when the recording has a
     // video track (e.g. an imported screen recording) we show the picture,
     // otherwise we keep the audio-player layout.
@@ -174,7 +176,11 @@ export const RecordingPanel = forwardRef<RecordingPanelRef, RecordingPanelProps>
           onPlay={() => setIsPlaying(true)}
           onPause={() => setIsPlaying(false)}
           onEnded={() => setIsPlaying(false)}
-          onTimeUpdate={() => setCurrentTime(mediaRef.current?.currentTime ?? 0)}
+          onTimeUpdate={() => {
+            const seconds = mediaRef.current?.currentTime ?? 0;
+            setCurrentTime(seconds);
+            onTimeUpdate?.(seconds);
+          }}
           onError={() => setLoadError(true)}
           className={hasVideo
             ? 'w-full max-w-3xl flex-1 min-h-0 rounded-lg bg-black object-contain mb-6 cursor-pointer'

--- a/frontend/src/components/MeetingDetails/RecordingPanel.tsx
+++ b/frontend/src/components/MeetingDetails/RecordingPanel.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+import { motion } from 'framer-motion';
+import { AudioLines, Pause, Play, RotateCcw, RotateCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import Analytics from '@/lib/analytics';
+
+const SKIP_SECONDS = 10;
+const PLAYBACK_RATES = [1, 1.25, 1.5, 2];
+
+export interface RecordingPanelRef {
+  /** Seek to a position (in seconds) and start playback. */
+  seekTo: (seconds: number) => void;
+}
+
+interface RecordingPanelProps {
+  /** Playable URL of the meeting recording (asset protocol). */
+  audioSrc: string;
+  meetingTitle: string;
+}
+
+// Format seconds as M:SS (or H:MM:SS for recordings over an hour)
+function formatPlaybackTime(seconds: number): string {
+  if (!isFinite(seconds) || seconds < 0) return '0:00';
+
+  const totalSeconds = Math.floor(seconds);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+  }
+  return `${minutes}:${secs.toString().padStart(2, '0')}`;
+}
+
+export const RecordingPanel = forwardRef<RecordingPanelRef, RecordingPanelProps>(
+  function RecordingPanel({ audioSrc, meetingTitle }, ref) {
+    const audioRef = useRef<HTMLAudioElement>(null);
+    // Seek requested before audio metadata finished loading
+    const pendingSeekRef = useRef<number | null>(null);
+
+    const [isPlaying, setIsPlaying] = useState(false);
+    const [currentTime, setCurrentTime] = useState(0);
+    const [duration, setDuration] = useState(0);
+    const [playbackRate, setPlaybackRate] = useState(1);
+    const [loadError, setLoadError] = useState(false);
+
+    const playFrom = useCallback((seconds: number) => {
+      const audio = audioRef.current;
+      if (!audio) return;
+
+      if (audio.readyState === 0) {
+        // Metadata not loaded yet - apply once it is
+        pendingSeekRef.current = seconds;
+        return;
+      }
+
+      audio.currentTime = Math.max(0, Math.min(seconds, audio.duration || seconds));
+      audio.play().catch((error) => {
+        console.error('Failed to start playback:', error);
+      });
+    }, []);
+
+    useImperativeHandle(ref, () => ({
+      seekTo: (seconds: number) => {
+        playFrom(seconds);
+      },
+    }), [playFrom]);
+
+    // Reset player state when the recording source changes (meeting switch)
+    useEffect(() => {
+      setIsPlaying(false);
+      setCurrentTime(0);
+      setDuration(0);
+      setLoadError(false);
+      pendingSeekRef.current = null;
+    }, [audioSrc]);
+
+    const handleLoadedMetadata = () => {
+      const audio = audioRef.current;
+      if (!audio) return;
+
+      setDuration(audio.duration);
+      setLoadError(false);
+
+      if (pendingSeekRef.current !== null) {
+        const seconds = pendingSeekRef.current;
+        pendingSeekRef.current = null;
+        playFrom(seconds);
+      }
+    };
+
+    const handleTogglePlayback = () => {
+      const audio = audioRef.current;
+      if (!audio) return;
+
+      if (audio.paused) {
+        Analytics.trackButtonClick('play_recording', 'meeting_details');
+        audio.play().catch((error) => {
+          console.error('Failed to start playback:', error);
+        });
+      } else {
+        audio.pause();
+      }
+    };
+
+    const handleSkip = (offsetSeconds: number) => {
+      const audio = audioRef.current;
+      if (!audio) return;
+      audio.currentTime = Math.max(0, Math.min(audio.currentTime + offsetSeconds, audio.duration || 0));
+    };
+
+    const handleSeekInput = (value: number) => {
+      const audio = audioRef.current;
+      if (!audio) return;
+      audio.currentTime = value;
+      setCurrentTime(value);
+    };
+
+    const handleCyclePlaybackRate = () => {
+      const audio = audioRef.current;
+      if (!audio) return;
+
+      const currentIndex = PLAYBACK_RATES.indexOf(playbackRate);
+      const nextRate = PLAYBACK_RATES[(currentIndex + 1) % PLAYBACK_RATES.length];
+      audio.playbackRate = nextRate;
+      setPlaybackRate(nextRate);
+    };
+
+    if (loadError) {
+      return (
+        <div className="flex flex-1 items-center justify-center p-6">
+          <div className="text-center text-gray-500">
+            <AudioLines className="mx-auto mb-3 h-8 w-8 text-gray-300" />
+            <p className="text-sm font-medium">Couldn&apos;t load the recording</p>
+            <p className="text-xs mt-1 text-gray-400">
+              The audio file may have been moved or is in an unsupported format
+            </p>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.2 }}
+        className="flex flex-1 flex-col items-center justify-center p-6"
+      >
+        <audio
+          ref={audioRef}
+          src={audioSrc}
+          preload="metadata"
+          onLoadedMetadata={handleLoadedMetadata}
+          onPlay={() => setIsPlaying(true)}
+          onPause={() => setIsPlaying(false)}
+          onEnded={() => setIsPlaying(false)}
+          onTimeUpdate={() => setCurrentTime(audioRef.current?.currentTime ?? 0)}
+          onError={() => setLoadError(true)}
+        />
+
+        <div className="w-full max-w-md">
+          {/* Recording header */}
+          <div className="flex flex-col items-center mb-8">
+            <div className={`flex items-center justify-center w-16 h-16 rounded-full mb-4 ${isPlaying ? 'bg-blue-100' : 'bg-gray-100'}`}>
+              <AudioLines className={`h-8 w-8 ${isPlaying ? 'text-blue-500' : 'text-gray-400'}`} />
+            </div>
+            <p className="text-sm font-medium text-gray-800 text-center break-words max-w-full">
+              {meetingTitle}
+            </p>
+            <p className="text-xs text-gray-400 mt-1">Meeting recording</p>
+          </div>
+
+          {/* Seek bar */}
+          <div className="mb-6">
+            <input
+              type="range"
+              min={0}
+              max={duration || 0}
+              step={0.1}
+              value={Math.min(currentTime, duration || 0)}
+              onChange={(e) => handleSeekInput(Number(e.target.value))}
+              disabled={!duration}
+              aria-label="Seek recording"
+              className="w-full h-1.5 cursor-pointer accent-blue-500 disabled:cursor-default"
+            />
+            <div className="flex justify-between mt-1 text-xs text-gray-500 tabular-nums">
+              <span>{formatPlaybackTime(currentTime)}</span>
+              <span>{formatPlaybackTime(duration)}</span>
+            </div>
+          </div>
+
+          {/* Transport controls */}
+          <div className="flex items-center justify-center gap-3">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => handleSkip(-SKIP_SECONDS)}
+              disabled={!duration}
+              title={`Back ${SKIP_SECONDS} seconds`}
+              aria-label={`Back ${SKIP_SECONDS} seconds`}
+            >
+              <RotateCcw className="h-5 w-5" />
+            </Button>
+
+            <button
+              onClick={handleTogglePlayback}
+              disabled={!duration}
+              title={isPlaying ? 'Pause' : 'Play'}
+              aria-label={isPlaying ? 'Pause recording' : 'Play recording'}
+              className="flex items-center justify-center w-12 h-12 rounded-full bg-blue-500 text-white hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+            >
+              {isPlaying ? (
+                <Pause className="h-5 w-5" />
+              ) : (
+                <Play className="h-5 w-5 ml-0.5" />
+              )}
+            </button>
+
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => handleSkip(SKIP_SECONDS)}
+              disabled={!duration}
+              title={`Forward ${SKIP_SECONDS} seconds`}
+              aria-label={`Forward ${SKIP_SECONDS} seconds`}
+            >
+              <RotateCw className="h-5 w-5" />
+            </Button>
+
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleCyclePlaybackRate}
+              disabled={!duration}
+              title="Playback speed"
+              aria-label={`Playback speed ${playbackRate}x`}
+              className="min-w-[52px] text-xs font-semibold text-gray-600 tabular-nums"
+            >
+              {playbackRate}x
+            </Button>
+          </div>
+
+          {/* Discoverability hint for transcript sync */}
+          <p className="text-xs text-gray-400 text-center mt-8">
+            Tip: click a timestamp in the transcript to jump to that moment
+          </p>
+        </div>
+      </motion.div>
+    );
+  }
+);

--- a/frontend/src/components/MeetingDetails/RecordingPanel.tsx
+++ b/frontend/src/components/MeetingDetails/RecordingPanel.tsx
@@ -44,28 +44,32 @@ function formatPlaybackTime(seconds: number): string {
 
 export const RecordingPanel = forwardRef<RecordingPanelRef, RecordingPanelProps>(
   function RecordingPanel({ audioSrc, meetingTitle }, ref) {
-    const audioRef = useRef<HTMLAudioElement>(null);
-    // Seek requested before audio metadata finished loading
+    // A <video> element plays audio-only files too; when the recording has a
+    // video track (e.g. an imported screen recording) we show the picture,
+    // otherwise we keep the audio-player layout.
+    const mediaRef = useRef<HTMLVideoElement>(null);
+    // Seek requested before media metadata finished loading
     const pendingSeekRef = useRef<number | null>(null);
 
     const [isPlaying, setIsPlaying] = useState(false);
     const [currentTime, setCurrentTime] = useState(0);
     const [duration, setDuration] = useState(0);
     const [playbackRate, setPlaybackRate] = useState(1);
+    const [hasVideo, setHasVideo] = useState(false);
     const [loadError, setLoadError] = useState(false);
 
     const playFrom = useCallback((seconds: number) => {
-      const audio = audioRef.current;
-      if (!audio) return;
+      const media = mediaRef.current;
+      if (!media) return;
 
-      if (audio.readyState === 0) {
+      if (media.readyState === 0) {
         // Metadata not loaded yet - apply once it is
         pendingSeekRef.current = seconds;
         return;
       }
 
-      audio.currentTime = Math.max(0, Math.min(seconds, audio.duration || seconds));
-      audio.play().catch((error) => {
+      media.currentTime = Math.max(0, Math.min(seconds, media.duration || seconds));
+      media.play().catch((error) => {
         console.error('Failed to start playback:', error);
       });
     }, []);
@@ -81,15 +85,17 @@ export const RecordingPanel = forwardRef<RecordingPanelRef, RecordingPanelProps>
       setIsPlaying(false);
       setCurrentTime(0);
       setDuration(0);
+      setHasVideo(false);
       setLoadError(false);
       pendingSeekRef.current = null;
     }, [audioSrc]);
 
     const handleLoadedMetadata = () => {
-      const audio = audioRef.current;
-      if (!audio) return;
+      const media = mediaRef.current;
+      if (!media) return;
 
-      setDuration(audio.duration);
+      setDuration(media.duration);
+      setHasVideo(media.videoWidth > 0 && media.videoHeight > 0);
       setLoadError(false);
 
       if (pendingSeekRef.current !== null) {
@@ -100,39 +106,39 @@ export const RecordingPanel = forwardRef<RecordingPanelRef, RecordingPanelProps>
     };
 
     const handleTogglePlayback = () => {
-      const audio = audioRef.current;
-      if (!audio) return;
+      const media = mediaRef.current;
+      if (!media) return;
 
-      if (audio.paused) {
+      if (media.paused) {
         Analytics.trackButtonClick('play_recording', 'meeting_details');
-        audio.play().catch((error) => {
+        media.play().catch((error) => {
           console.error('Failed to start playback:', error);
         });
       } else {
-        audio.pause();
+        media.pause();
       }
     };
 
     const handleSkip = (offsetSeconds: number) => {
-      const audio = audioRef.current;
-      if (!audio) return;
-      audio.currentTime = Math.max(0, Math.min(audio.currentTime + offsetSeconds, audio.duration || 0));
+      const media = mediaRef.current;
+      if (!media) return;
+      media.currentTime = Math.max(0, Math.min(media.currentTime + offsetSeconds, media.duration || 0));
     };
 
     const handleSeekInput = (value: number) => {
-      const audio = audioRef.current;
-      if (!audio) return;
-      audio.currentTime = value;
+      const media = mediaRef.current;
+      if (!media) return;
+      media.currentTime = value;
       setCurrentTime(value);
     };
 
     const handleCyclePlaybackRate = () => {
-      const audio = audioRef.current;
-      if (!audio) return;
+      const media = mediaRef.current;
+      if (!media) return;
 
       const currentIndex = PLAYBACK_RATES.indexOf(playbackRate);
       const nextRate = PLAYBACK_RATES[(currentIndex + 1) % PLAYBACK_RATES.length];
-      audio.playbackRate = nextRate;
+      media.playbackRate = nextRate;
       setPlaybackRate(nextRate);
     };
 
@@ -155,31 +161,39 @@ export const RecordingPanel = forwardRef<RecordingPanelRef, RecordingPanelProps>
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.2 }}
-        className="flex flex-1 flex-col items-center justify-center p-6"
+        className="flex flex-1 min-h-0 flex-col items-center justify-center p-6"
       >
-        <audio
-          ref={audioRef}
+        {/* Also the playback element for audio-only recordings (hidden then) */}
+        <video
+          ref={mediaRef}
           src={audioSrc}
           preload="metadata"
+          playsInline
+          onClick={hasVideo ? handleTogglePlayback : undefined}
           onLoadedMetadata={handleLoadedMetadata}
           onPlay={() => setIsPlaying(true)}
           onPause={() => setIsPlaying(false)}
           onEnded={() => setIsPlaying(false)}
-          onTimeUpdate={() => setCurrentTime(audioRef.current?.currentTime ?? 0)}
+          onTimeUpdate={() => setCurrentTime(mediaRef.current?.currentTime ?? 0)}
           onError={() => setLoadError(true)}
+          className={hasVideo
+            ? 'w-full max-w-3xl flex-1 min-h-0 rounded-lg bg-black object-contain mb-6 cursor-pointer'
+            : 'hidden'}
         />
 
         <div className="w-full max-w-md">
-          {/* Recording header */}
-          <div className="flex flex-col items-center mb-8">
-            <div className={`flex items-center justify-center w-16 h-16 rounded-full mb-4 ${isPlaying ? 'bg-blue-100' : 'bg-gray-100'}`}>
-              <AudioLines className={`h-8 w-8 ${isPlaying ? 'text-blue-500' : 'text-gray-400'}`} />
+          {/* Recording header - only for audio-only recordings */}
+          {!hasVideo && (
+            <div className="flex flex-col items-center mb-8">
+              <div className={`flex items-center justify-center w-16 h-16 rounded-full mb-4 ${isPlaying ? 'bg-blue-100' : 'bg-gray-100'}`}>
+                <AudioLines className={`h-8 w-8 ${isPlaying ? 'text-blue-500' : 'text-gray-400'}`} />
+              </div>
+              <p className="text-sm font-medium text-gray-800 text-center break-words max-w-full">
+                {meetingTitle}
+              </p>
+              <p className="text-xs text-gray-400 mt-1">Meeting recording</p>
             </div>
-            <p className="text-sm font-medium text-gray-800 text-center break-words max-w-full">
-              {meetingTitle}
-            </p>
-            <p className="text-xs text-gray-400 mt-1">Meeting recording</p>
-          </div>
+          )}
 
           {/* Seek bar */}
           <div className="mb-6">

--- a/frontend/src/components/MeetingDetails/SummaryPanel.tsx
+++ b/frontend/src/components/MeetingDetails/SummaryPanel.tsx
@@ -7,11 +7,13 @@ import { EmptyStateSummary } from '@/components/EmptyStateSummary';
 import { ModelConfig } from '@/components/ModelSettingsModal';
 import { SummaryGeneratorButtonGroup } from './SummaryGeneratorButtonGroup';
 import { SummaryUpdaterButtonGroup } from './SummaryUpdaterButtonGroup';
+import { RecordingPanel, RecordingPanelRef } from './RecordingPanel';
 import Analytics from '@/lib/analytics';
 import { useEffect, useRef, useState, RefObject } from 'react';
 import { toast } from 'sonner';
-import { Languages, ChevronDown } from 'lucide-react';
+import { Languages, ChevronDown, FileText, AudioLines } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
 import { LanguagePickerPopover } from '@/components/LanguagePickerPopover';
 import { useRecentLanguages } from '@/hooks/useRecentLanguages';
@@ -21,6 +23,8 @@ import {
   saveMeetingSummaryLanguage,
   SummaryLanguageStorage,
 } from '@/lib/summary-language-preferences';
+
+export type SummaryPanelTab = 'summary' | 'recording';
 
 interface SummaryPanelProps {
   meeting: {
@@ -60,6 +64,11 @@ interface SummaryPanelProps {
   onTemplateSelect: (templateId: string, templateName: string) => void;
   isModelConfigLoading?: boolean;
   onOpenModelSettings?: (openFn: () => void) => void;
+  // Recording playback (tab only shown when a recording exists on disk)
+  audioSrc?: string | null;
+  activeTab?: SummaryPanelTab;
+  onTabChange?: (tab: SummaryPanelTab) => void;
+  recordingPanelRef?: RefObject<RecordingPanelRef>;
 }
 
 export function SummaryPanel({
@@ -95,7 +104,11 @@ export function SummaryPanel({
   selectedTemplate,
   onTemplateSelect,
   isModelConfigLoading = false,
-  onOpenModelSettings
+  onOpenModelSettings,
+  audioSrc = null,
+  activeTab = 'summary',
+  onTabChange,
+  recordingPanelRef,
 }: SummaryPanelProps) {
   const [summaryLang, setSummaryLang] = useState<string | null>(null);
   const [summaryLangStorage, setSummaryLangStorage] = useState<SummaryLanguageStorage>('metadata');
@@ -254,193 +267,237 @@ export function SummaryPanel({
 
   return (
     <div className="flex-1 min-w-0 flex flex-col bg-white overflow-hidden">
-      {/* Title area */}
-      <div className="p-4 border-b border-gray-200">
-        {/* <EditableTitle
-          title={meetingTitle}
-          isEditing={isEditingTitle}
-          onStartEditing={onStartEditTitle}
-          onFinishEditing={onFinishEditTitle}
-          onChange={onTitleChange}
-        /> */}
-
-        {/* Button groups - only show when summary exists */}
-        {aiSummary && !isSummaryLoading && (
-          <div className="flex items-center justify-center w-full pt-0 gap-2">
-            {/* Left-aligned: Summary Generator Button Group */}
-            <div className="flex-shrink-0">
-              <SummaryGeneratorButtonGroup
-                modelConfig={modelConfig}
-                setModelConfig={setModelConfig}
-                onSaveModelConfig={onSaveModelConfig}
-                onGenerateSummary={onGenerateSummary}
-                onStopGeneration={onStopGeneration}
-                customPrompt={customPrompt}
-                summaryStatus={summaryStatus}
-                availableTemplates={availableTemplates}
-                selectedTemplate={selectedTemplate}
-                onTemplateSelect={onTemplateSelect}
-                hasTranscripts={transcripts.length > 0}
-                hasSummary={!!aiSummary}
-                isModelConfigLoading={isModelConfigLoading}
-                onOpenModelSettings={onOpenModelSettings}
-                languageSlot={languageSlot}
-              />
-            </div>
-
-            {/* Right-aligned: Summary Updater Button Group */}
-            <div className="flex-shrink-0">
-              <SummaryUpdaterButtonGroup
-                isSaving={isSaving}
-                isDirty={isTitleDirty || (summaryRef.current?.isDirty || false)}
-                onSave={onSaveAll}
-                onCopy={onCopySummary}
-                onFind={() => {
-                  // TODO: Implement find in summary functionality
-                  console.log('Find in summary clicked');
-                }}
-                onOpenFolder={onOpenFolder}
-                hasSummary={!!aiSummary}
-              />
-            </div>
+      <Tabs
+        value={audioSrc ? activeTab : 'summary'}
+        onValueChange={(value) => onTabChange?.(value as SummaryPanelTab)}
+        className="flex flex-1 flex-col min-h-0"
+      >
+        {/* Summary / Recording switcher - only when a recording exists */}
+        {audioSrc && (
+          <div className="flex justify-center px-4 pt-3">
+            <TabsList>
+              <TabsTrigger value="summary" className="gap-1.5">
+                <FileText size={14} />
+                Summary
+              </TabsTrigger>
+              <TabsTrigger value="recording" className="gap-1.5">
+                <AudioLines size={14} />
+                Recording
+              </TabsTrigger>
+            </TabsList>
           </div>
         )}
-      </div>
 
-      {isSummaryLoading ? (
-        <div className="flex flex-col h-full">
-          {/* Show button group during generation */}
-          <div className="flex items-center justify-center pt-8 pb-4">
-            <SummaryGeneratorButtonGroup
-              modelConfig={modelConfig}
-              setModelConfig={setModelConfig}
-              onSaveModelConfig={onSaveModelConfig}
-              onGenerateSummary={onGenerateSummary}
-              onStopGeneration={onStopGeneration}
-              customPrompt={customPrompt}
-              summaryStatus={summaryStatus}
-              availableTemplates={availableTemplates}
-              selectedTemplate={selectedTemplate}
-              onTemplateSelect={onTemplateSelect}
-              hasTranscripts={transcripts.length > 0}
-              isModelConfigLoading={isModelConfigLoading}
-              onOpenModelSettings={onOpenModelSettings}
-            />
-          </div>
-          {/* Loading spinner */}
-          <div className="flex items-center justify-center flex-1">
-            <div className="text-center">
-              <div className="inline-block animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500 mb-4"></div>
-              <p className="text-gray-600">Generating AI Summary...</p>
-            </div>
-          </div>
-        </div>
-      ) : !aiSummary ? (
-        <div className="flex flex-col h-full">
-          {/* Centered Summary Generator Button Group when no summary */}
-          <div className="flex items-center justify-center gap-2 pt-8 pb-4">
-            <SummaryGeneratorButtonGroup
-              modelConfig={modelConfig}
-              setModelConfig={setModelConfig}
-              onSaveModelConfig={onSaveModelConfig}
-              onGenerateSummary={onGenerateSummary}
-              onStopGeneration={onStopGeneration}
-              customPrompt={customPrompt}
-              summaryStatus={summaryStatus}
-              availableTemplates={availableTemplates}
-              selectedTemplate={selectedTemplate}
-              onTemplateSelect={onTemplateSelect}
-              hasTranscripts={transcripts.length > 0}
-              hasSummary={false}
-              isModelConfigLoading={isModelConfigLoading}
-              onOpenModelSettings={onOpenModelSettings}
-              languageSlot={transcripts.length > 0 ? languageSlot : undefined}
-            />
-          </div>
-          {/* Empty state message */}
-          <EmptyStateSummary
-            onGenerate={() => onGenerateSummary(customPrompt)}
-            hasModel={modelConfig.provider !== null && modelConfig.model !== null}
-            isGenerating={isSummaryLoading}
-          />
-        </div>
-      ) : transcripts?.length > 0 && (
-        <div className="flex-1 overflow-y-auto min-h-0">
-          {summaryResponse && (
-            <div className="fixed bottom-0 left-0 right-0 bg-white shadow-lg p-4 max-h-1/3 overflow-y-auto">
-              <h3 className="text-lg font-semibold mb-2">Meeting Summary</h3>
-              <div className="grid grid-cols-2 gap-4">
-                <div className="bg-white p-4 rounded-lg shadow-sm">
-                  <h4 className="font-medium mb-1">Key Points</h4>
-                  <ul className="list-disc pl-4">
-                    {summaryResponse.summary.key_points.blocks.map((block, i) => (
-                      <li key={i} className="text-sm">{block.content}</li>
-                    ))}
-                  </ul>
+        {/* Keep the summary mounted while the recording tab is open so editor state survives tab switches */}
+        <TabsContent
+          value="summary"
+          forceMount
+          className="mt-0 flex flex-1 flex-col min-h-0 data-[state=inactive]:hidden"
+        >
+          {/* Title area */}
+          <div className="p-4 border-b border-gray-200">
+            {/* <EditableTitle
+              title={meetingTitle}
+              isEditing={isEditingTitle}
+              onStartEditing={onStartEditTitle}
+              onFinishEditing={onFinishEditTitle}
+              onChange={onTitleChange}
+            /> */}
+
+            {/* Button groups - only show when summary exists */}
+            {aiSummary && !isSummaryLoading && (
+              <div className="flex items-center justify-center w-full pt-0 gap-2">
+                {/* Left-aligned: Summary Generator Button Group */}
+                <div className="flex-shrink-0">
+                  <SummaryGeneratorButtonGroup
+                    modelConfig={modelConfig}
+                    setModelConfig={setModelConfig}
+                    onSaveModelConfig={onSaveModelConfig}
+                    onGenerateSummary={onGenerateSummary}
+                    onStopGeneration={onStopGeneration}
+                    customPrompt={customPrompt}
+                    summaryStatus={summaryStatus}
+                    availableTemplates={availableTemplates}
+                    selectedTemplate={selectedTemplate}
+                    onTemplateSelect={onTemplateSelect}
+                    hasTranscripts={transcripts.length > 0}
+                    hasSummary={!!aiSummary}
+                    isModelConfigLoading={isModelConfigLoading}
+                    onOpenModelSettings={onOpenModelSettings}
+                    languageSlot={languageSlot}
+                  />
                 </div>
-                <div className="bg-white p-4 rounded-lg shadow-sm mt-4">
-                  <h4 className="font-medium mb-1">Action Items</h4>
-                  <ul className="list-disc pl-4">
-                    {summaryResponse.summary.action_items.blocks.map((block, i) => (
-                      <li key={i} className="text-sm">{block.content}</li>
-                    ))}
-                  </ul>
-                </div>
-                <div className="bg-white p-4 rounded-lg shadow-sm mt-4">
-                  <h4 className="font-medium mb-1">Decisions</h4>
-                  <ul className="list-disc pl-4">
-                    {summaryResponse.summary.decisions.blocks.map((block, i) => (
-                      <li key={i} className="text-sm">{block.content}</li>
-                    ))}
-                  </ul>
-                </div>
-                <div className="bg-white p-4 rounded-lg shadow-sm mt-4">
-                  <h4 className="font-medium mb-1">Main Topics</h4>
-                  <ul className="list-disc pl-4">
-                    {summaryResponse.summary.main_topics.blocks.map((block, i) => (
-                      <li key={i} className="text-sm">{block.content}</li>
-                    ))}
-                  </ul>
+
+                {/* Right-aligned: Summary Updater Button Group */}
+                <div className="flex-shrink-0">
+                  <SummaryUpdaterButtonGroup
+                    isSaving={isSaving}
+                    isDirty={isTitleDirty || (summaryRef.current?.isDirty || false)}
+                    onSave={onSaveAll}
+                    onCopy={onCopySummary}
+                    onFind={() => {
+                      // TODO: Implement find in summary functionality
+                      console.log('Find in summary clicked');
+                    }}
+                    onOpenFolder={onOpenFolder}
+                    hasSummary={!!aiSummary}
+                  />
                 </div>
               </div>
-              {summaryResponse.raw_summary ? (
-                <div className="mt-4">
-                  <h4 className="font-medium mb-1">Full Summary</h4>
-                  <p className="text-sm whitespace-pre-wrap">{summaryResponse.raw_summary}</p>
-                </div>
-              ) : null}
-            </div>
-          )}
-          <div className="p-6 w-full">
-            <BlockNoteSummaryView
-              ref={summaryRef}
-              summaryData={aiSummary}
-              onSave={onSaveSummary}
-              onSummaryChange={onSummaryChange}
-              onDirtyChange={onDirtyChange}
-              status={summaryStatus}
-              error={summaryError}
-              onRegenerateSummary={() => {
-                Analytics.trackButtonClick('regenerate_summary', 'meeting_details');
-                onRegenerateSummary();
-              }}
-              meeting={{
-                id: meeting.id,
-                title: meetingTitle,
-                created_at: meeting.created_at
-              }}
-            />
+            )}
           </div>
-          {summaryStatus !== 'idle' && (
-            <div className={`mt-4 p-4 rounded-lg ${summaryStatus === 'error' ? 'bg-red-100 text-red-700' :
-              summaryStatus === 'completed' ? 'bg-green-100 text-green-700' :
-                'bg-blue-100 text-blue-700'
-              }`}>
-              <p className="text-sm font-medium">{getSummaryStatusMessage(summaryStatus)}</p>
+
+          {isSummaryLoading ? (
+            <div className="flex flex-col h-full">
+              {/* Show button group during generation */}
+              <div className="flex items-center justify-center pt-8 pb-4">
+                <SummaryGeneratorButtonGroup
+                  modelConfig={modelConfig}
+                  setModelConfig={setModelConfig}
+                  onSaveModelConfig={onSaveModelConfig}
+                  onGenerateSummary={onGenerateSummary}
+                  onStopGeneration={onStopGeneration}
+                  customPrompt={customPrompt}
+                  summaryStatus={summaryStatus}
+                  availableTemplates={availableTemplates}
+                  selectedTemplate={selectedTemplate}
+                  onTemplateSelect={onTemplateSelect}
+                  hasTranscripts={transcripts.length > 0}
+                  isModelConfigLoading={isModelConfigLoading}
+                  onOpenModelSettings={onOpenModelSettings}
+                />
+              </div>
+              {/* Loading spinner */}
+              <div className="flex items-center justify-center flex-1">
+                <div className="text-center">
+                  <div className="inline-block animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500 mb-4"></div>
+                  <p className="text-gray-600">Generating AI Summary...</p>
+                </div>
+              </div>
+            </div>
+          ) : !aiSummary ? (
+            <div className="flex flex-col h-full">
+              {/* Centered Summary Generator Button Group when no summary */}
+              <div className="flex items-center justify-center gap-2 pt-8 pb-4">
+                <SummaryGeneratorButtonGroup
+                  modelConfig={modelConfig}
+                  setModelConfig={setModelConfig}
+                  onSaveModelConfig={onSaveModelConfig}
+                  onGenerateSummary={onGenerateSummary}
+                  onStopGeneration={onStopGeneration}
+                  customPrompt={customPrompt}
+                  summaryStatus={summaryStatus}
+                  availableTemplates={availableTemplates}
+                  selectedTemplate={selectedTemplate}
+                  onTemplateSelect={onTemplateSelect}
+                  hasTranscripts={transcripts.length > 0}
+                  hasSummary={false}
+                  isModelConfigLoading={isModelConfigLoading}
+                  onOpenModelSettings={onOpenModelSettings}
+                  languageSlot={transcripts.length > 0 ? languageSlot : undefined}
+                />
+              </div>
+              {/* Empty state message */}
+              <EmptyStateSummary
+                onGenerate={() => onGenerateSummary(customPrompt)}
+                hasModel={modelConfig.provider !== null && modelConfig.model !== null}
+                isGenerating={isSummaryLoading}
+              />
+            </div>
+          ) : transcripts?.length > 0 && (
+            <div className="flex-1 overflow-y-auto min-h-0">
+              {summaryResponse && (
+                <div className="fixed bottom-0 left-0 right-0 bg-white shadow-lg p-4 max-h-1/3 overflow-y-auto">
+                  <h3 className="text-lg font-semibold mb-2">Meeting Summary</h3>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div className="bg-white p-4 rounded-lg shadow-sm">
+                      <h4 className="font-medium mb-1">Key Points</h4>
+                      <ul className="list-disc pl-4">
+                        {summaryResponse.summary.key_points.blocks.map((block, i) => (
+                          <li key={i} className="text-sm">{block.content}</li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div className="bg-white p-4 rounded-lg shadow-sm mt-4">
+                      <h4 className="font-medium mb-1">Action Items</h4>
+                      <ul className="list-disc pl-4">
+                        {summaryResponse.summary.action_items.blocks.map((block, i) => (
+                          <li key={i} className="text-sm">{block.content}</li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div className="bg-white p-4 rounded-lg shadow-sm mt-4">
+                      <h4 className="font-medium mb-1">Decisions</h4>
+                      <ul className="list-disc pl-4">
+                        {summaryResponse.summary.decisions.blocks.map((block, i) => (
+                          <li key={i} className="text-sm">{block.content}</li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div className="bg-white p-4 rounded-lg shadow-sm mt-4">
+                      <h4 className="font-medium mb-1">Main Topics</h4>
+                      <ul className="list-disc pl-4">
+                        {summaryResponse.summary.main_topics.blocks.map((block, i) => (
+                          <li key={i} className="text-sm">{block.content}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                  {summaryResponse.raw_summary ? (
+                    <div className="mt-4">
+                      <h4 className="font-medium mb-1">Full Summary</h4>
+                      <p className="text-sm whitespace-pre-wrap">{summaryResponse.raw_summary}</p>
+                    </div>
+                  ) : null}
+                </div>
+              )}
+              <div className="p-6 w-full">
+                <BlockNoteSummaryView
+                  ref={summaryRef}
+                  summaryData={aiSummary}
+                  onSave={onSaveSummary}
+                  onSummaryChange={onSummaryChange}
+                  onDirtyChange={onDirtyChange}
+                  status={summaryStatus}
+                  error={summaryError}
+                  onRegenerateSummary={() => {
+                    Analytics.trackButtonClick('regenerate_summary', 'meeting_details');
+                    onRegenerateSummary();
+                  }}
+                  meeting={{
+                    id: meeting.id,
+                    title: meetingTitle,
+                    created_at: meeting.created_at
+                  }}
+                />
+              </div>
+              {summaryStatus !== 'idle' && (
+                <div className={`mt-4 p-4 rounded-lg ${summaryStatus === 'error' ? 'bg-red-100 text-red-700' :
+                  summaryStatus === 'completed' ? 'bg-green-100 text-green-700' :
+                    'bg-blue-100 text-blue-700'
+                  }`}>
+                  <p className="text-sm font-medium">{getSummaryStatusMessage(summaryStatus)}</p>
+                </div>
+              )}
             </div>
           )}
-        </div>
-      )}
+        </TabsContent>
+
+        {/* Keep the player mounted while the summary tab is open so playback continues */}
+        {audioSrc && (
+          <TabsContent
+            value="recording"
+            forceMount
+            className="mt-0 flex flex-1 flex-col min-h-0 data-[state=inactive]:hidden"
+          >
+            <RecordingPanel
+              ref={recordingPanelRef}
+              audioSrc={audioSrc}
+              meetingTitle={meetingTitle}
+            />
+          </TabsContent>
+        )}
+      </Tabs>
     </div>
   );
 }

--- a/frontend/src/components/MeetingDetails/SummaryPanel.tsx
+++ b/frontend/src/components/MeetingDetails/SummaryPanel.tsx
@@ -69,6 +69,7 @@ interface SummaryPanelProps {
   activeTab?: SummaryPanelTab;
   onTabChange?: (tab: SummaryPanelTab) => void;
   recordingPanelRef?: RefObject<RecordingPanelRef>;
+  onPlaybackTimeUpdate?: (seconds: number) => void;
 }
 
 export function SummaryPanel({
@@ -109,6 +110,7 @@ export function SummaryPanel({
   activeTab = 'summary',
   onTabChange,
   recordingPanelRef,
+  onPlaybackTimeUpdate,
 }: SummaryPanelProps) {
   const [summaryLang, setSummaryLang] = useState<string | null>(null);
   const [summaryLangStorage, setSummaryLangStorage] = useState<SummaryLanguageStorage>('metadata');
@@ -494,6 +496,7 @@ export function SummaryPanel({
               ref={recordingPanelRef}
               audioSrc={audioSrc}
               meetingTitle={meetingTitle}
+              onTimeUpdate={onPlaybackTimeUpdate}
             />
           </TabsContent>
         )}

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -31,6 +31,8 @@ interface TranscriptPanelProps {
 
   // Recording playback: makes timestamps clickable when provided
   onSeekToTimestamp?: (seconds: number) => void;
+  // Segment currently being played back (highlighted)
+  activeSegmentId?: string | null;
 }
 
 export function TranscriptPanel({
@@ -52,6 +54,7 @@ export function TranscriptPanel({
   meetingFolderPath,
   onRefetchTranscripts,
   onSeekToTimestamp,
+  activeSegmentId,
 }: TranscriptPanelProps) {
   // Convert transcripts to segments if pagination is not used but we want virtualization
   const convertedSegments = useMemo(() => {
@@ -99,6 +102,7 @@ export function TranscriptPanel({
           loadedCount={loadedCount}
           onLoadMore={onLoadMore}
           onSeekToTimestamp={onSeekToTimestamp}
+          activeSegmentId={activeSegmentId}
         />
       </div>
 

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -28,6 +28,9 @@ interface TranscriptPanelProps {
   meetingId?: string;
   meetingFolderPath?: string | null;
   onRefetchTranscripts?: () => Promise<void>;
+
+  // Recording playback: makes timestamps clickable when provided
+  onSeekToTimestamp?: (seconds: number) => void;
 }
 
 export function TranscriptPanel({
@@ -48,6 +51,7 @@ export function TranscriptPanel({
   meetingId,
   meetingFolderPath,
   onRefetchTranscripts,
+  onSeekToTimestamp,
 }: TranscriptPanelProps) {
   // Convert transcripts to segments if pagination is not used but we want virtualization
   const convertedSegments = useMemo(() => {
@@ -94,6 +98,7 @@ export function TranscriptPanel({
           totalCount={totalCount}
           loadedCount={loadedCount}
           onLoadMore={onLoadMore}
+          onSeekToTimestamp={onSeekToTimestamp}
         />
       </div>
 

--- a/frontend/src/components/VirtualizedTranscriptView.tsx
+++ b/frontend/src/components/VirtualizedTranscriptView.tsx
@@ -34,6 +34,9 @@ export interface VirtualizedTranscriptViewProps {
     totalCount?: number;
     loadedCount?: number;
     onLoadMore?: () => void;
+
+    /** When provided, timestamps become clickable and seek the meeting recording */
+    onSeekToTimestamp?: (seconds: number) => void;
 }
 
 // Threshold for enabling virtualization (below this, use simple rendering)
@@ -71,6 +74,7 @@ const TranscriptSegment = memo(function TranscriptSegment({
     confidence,
     isStreaming,
     showConfidence,
+    onSeek,
 }: {
     id: string;
     timestamp: number;
@@ -78,6 +82,7 @@ const TranscriptSegment = memo(function TranscriptSegment({
     confidence?: number;
     isStreaming: boolean;
     showConfidence: boolean;
+    onSeek?: (seconds: number) => void;
 }) {
     const displayText = cleanStopWords(text) || (text.trim() === '' ? '[Silence]' : text);
 
@@ -85,12 +90,19 @@ const TranscriptSegment = memo(function TranscriptSegment({
         <div id={`segment-${id}`} className="mb-3">
             <div className="flex items-start gap-2">
                 <Tooltip>
-                    <TooltipTrigger>
-                        <span className="text-xs text-gray-400 mt-1 flex-shrink-0 min-w-[50px]">
+                    <TooltipTrigger
+                        onClick={onSeek ? () => onSeek(timestamp) : undefined}
+                        className={onSeek ? 'cursor-pointer' : 'cursor-default'}
+                        aria-label={onSeek ? `Play recording from ${formatRecordingTime(timestamp)}` : undefined}
+                    >
+                        <span className={`text-xs mt-1 flex-shrink-0 min-w-[50px] ${onSeek ? 'text-gray-400 hover:text-blue-600 hover:underline' : 'text-gray-400'}`}>
                             {formatRecordingTime(timestamp)}
                         </span>
                     </TooltipTrigger>
                     <TooltipContent>
+                        {onSeek && (
+                            <p className="text-xs">Play recording from here</p>
+                        )}
                         {confidence !== undefined && showConfidence && (
                             <ConfidenceIndicator confidence={confidence} showIndicator={showConfidence} />
                         )}
@@ -124,6 +136,7 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
     totalCount = 0,
     loadedCount = 0,
     onLoadMore,
+    onSeekToTimestamp,
 }) => {
     // Create scroll ref first - shared between virtualizer and auto-scroll hook
     const scrollRef = useRef<HTMLDivElement>(null);
@@ -296,6 +309,7 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                                         confidence={segment.confidence}
                                         isStreaming={isStreaming}
                                         showConfidence={showConfidence}
+                                        onSeek={onSeekToTimestamp}
                                     />
                                 </div>
                             );
@@ -352,6 +366,7 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                                         confidence={segment.confidence}
                                         isStreaming={isStreaming}
                                         showConfidence={showConfidence}
+                                        onSeek={onSeekToTimestamp}
                                     />
                                 </motion.div>
                             );

--- a/frontend/src/components/VirtualizedTranscriptView.tsx
+++ b/frontend/src/components/VirtualizedTranscriptView.tsx
@@ -37,6 +37,8 @@ export interface VirtualizedTranscriptViewProps {
 
     /** When provided, timestamps become clickable and seek the meeting recording */
     onSeekToTimestamp?: (seconds: number) => void;
+    /** Segment currently being played back - rendered highlighted */
+    activeSegmentId?: string | null;
 }
 
 // Threshold for enabling virtualization (below this, use simple rendering)
@@ -75,6 +77,7 @@ const TranscriptSegment = memo(function TranscriptSegment({
     isStreaming,
     showConfidence,
     onSeek,
+    isActive = false,
 }: {
     id: string;
     timestamp: number;
@@ -83,11 +86,15 @@ const TranscriptSegment = memo(function TranscriptSegment({
     isStreaming: boolean;
     showConfidence: boolean;
     onSeek?: (seconds: number) => void;
+    isActive?: boolean;
 }) {
     const displayText = cleanStopWords(text) || (text.trim() === '' ? '[Silence]' : text);
 
     return (
-        <div id={`segment-${id}`} className="mb-3">
+        <div
+            id={`segment-${id}`}
+            className={`mb-3 -mx-2 rounded-md px-2 py-1 transition-colors duration-300 ${isActive ? 'bg-blue-50' : ''}`}
+        >
             <div className="flex items-start gap-2">
                 <Tooltip>
                     <TooltipTrigger
@@ -137,6 +144,7 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
     loadedCount = 0,
     onLoadMore,
     onSeekToTimestamp,
+    activeSegmentId = null,
 }) => {
     // Create scroll ref first - shared between virtualizer and auto-scroll hook
     const scrollRef = useRef<HTMLDivElement>(null);
@@ -310,6 +318,7 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                                         isStreaming={isStreaming}
                                         showConfidence={showConfidence}
                                         onSeek={onSeekToTimestamp}
+                                        isActive={segment.id === activeSegmentId}
                                     />
                                 </div>
                             );
@@ -367,6 +376,7 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                                         isStreaming={isStreaming}
                                         showConfidence={showConfidence}
                                         onSeek={onSeekToTimestamp}
+                                        isActive={segment.id === activeSegmentId}
                                     />
                                 </motion.div>
                             );

--- a/frontend/src/hooks/meeting-details/useMeetingAudio.ts
+++ b/frontend/src/hooks/meeting-details/useMeetingAudio.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { invoke, convertFileSrc } from '@tauri-apps/api/core';
+
+interface UseMeetingAudioProps {
+  meetingId: string;
+  meetingFolderPath?: string | null;
+}
+
+/**
+ * Locates the stored audio recording for a meeting and exposes a playable URL.
+ *
+ * Resolution happens in the Rust backend (get_meeting_audio_path), which also
+ * adds the file to the asset protocol scope so the webview can stream it.
+ * Returns a null audioSrc for meetings without a recording on disk
+ * (e.g. legacy/folderless meetings), letting callers hide playback UI.
+ */
+export function useMeetingAudio({ meetingId, meetingFolderPath }: UseMeetingAudioProps) {
+  const [audioSrc, setAudioSrc] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setAudioSrc(null);
+
+    if (!meetingFolderPath) {
+      return;
+    }
+
+    const locateAudio = async () => {
+      setIsLoading(true);
+      try {
+        const audioPath = await invoke<string | null>('get_meeting_audio_path', {
+          meetingFolderPath,
+        });
+
+        if (!cancelled) {
+          setAudioSrc(audioPath ? convertFileSrc(audioPath) : null);
+        }
+      } catch (error) {
+        console.error('Failed to locate meeting audio for playback:', error);
+        if (!cancelled) {
+          setAudioSrc(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    locateAudio();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [meetingId, meetingFolderPath]);
+
+  return {
+    audioSrc,
+    isAudioAvailable: !!audioSrc,
+    isLoading,
+  };
+}


### PR DESCRIPTION
## What

Adds playback of the stored meeting recording to the meeting details page, synced with the transcript:

- The summary panel gets a **Summary / Recording** tab switcher (only when a recording exists on disk for the meeting)
- The Recording tab is an audio player: play/pause, seek bar, ±10s skip, playback speed (1x / 1.25x / 1.5x / 2x)
- **Transcript timestamps become clickable** — clicking `[MM:SS]` switches to the Recording tab and jumps the player to that moment
- Both tabs stay mounted, so playback keeps running while you read/edit the summary, and editor state survives tab switches

## How

**Rust**
- New `get_meeting_audio_path` command (`audio/playback.rs`): locates the audio file in the meeting folder (reuses `find_audio_file` from the retranscription module, now `pub(crate)`) and adds it to the asset protocol scope at runtime — the recordings folder is user-configurable, so it can't be covered by the static `$APPDATA/**` scope
- `media-src 'self' asset: https://asset.localhost` CSP entry so the webview can stream the file (range requests → instant seeking, no full-file loads)

**Frontend**
- `useMeetingAudio` hook resolves the recording via the backend and converts it with `convertFileSrc`
- `RecordingPanel` component with a `seekTo()` imperative handle; seeks requested before metadata loads are queued and applied on `loadedmetadata`
- `SummaryPanel` wraps its content in the existing shadcn `Tabs` primitives; `TranscriptPanel`/`VirtualizedTranscriptView` get an optional `onSeekToTimestamp` — when absent (recording view, meetings without audio) nothing changes

## Degradation

Meetings without a recording on disk (legacy/folderless) are untouched: no tab is rendered and timestamps stay non-interactive.

## Testing

- `pnpm build` passes, `tsc --noEmit` clean
- Manually verified on real meetings (macOS, Apple Silicon): tab switching, timestamp seeking mid-playback, playback continuing on the Summary tab, meetings with no recording unaffected