### PR TITLE
feat(models): load provider fallback lists from config

### DIFF
--- a/frontend/src-tauri/config/provider-models.json
+++ b/frontend/src-tauri/config/provider-models.json
@@ -1,0 +1,44 @@
+{
+  "providers": {
+    "openai": {
+      "models": [
+        "gpt-5",
+        "gpt-5-mini",
+        "gpt-4o",
+        "gpt-4.1",
+        "gpt-4-turbo",
+        "gpt-3.5-turbo",
+        "gpt-4o-2024-11-20",
+        "gpt-4o-2024-08-06",
+        "gpt-4o-mini-2024-07-18",
+        "gpt-4.1-2025-04-14",
+        "gpt-4.1-nano-2025-04-14",
+        "gpt-4.1-mini-2025-04-14",
+        "o4-mini-2025-04-16",
+        "o3-2025-04-16",
+        "o3-mini-2025-01-31",
+        "o1-2024-12-17",
+        "o1-mini-2024-09-12",
+        "gpt-4-turbo-2024-04-09",
+        "gpt-4-0125-Preview",
+        "gpt-4-vision-preview",
+        "gpt-4-1106-Preview",
+        "gpt-3.5-turbo-0125",
+        "gpt-3.5-turbo-1106"
+      ]
+    },
+    "anthropic": {
+      "models": [
+        { "id": "claude-sonnet-4-5-20250929", "displayName": "Claude 4.5 Sonnet" },
+        { "id": "claude-haiku-4-5-20251001", "displayName": "Claude 4.5 Haiku" },
+        { "id": "claude-opus-4-1-20250805", "displayName": "Claude 4.1 Opus" },
+        { "id": "claude-sonnet-4-20250514", "displayName": "Claude 4 Sonnet" }
+      ]
+    },
+    "groq": {
+      "models": [
+        "llama-3.3-70b-versatile"
+      ]
+    }
+  }
+}

--- a/frontend/src-tauri/src/anthropic/anthropic.rs
+++ b/frontend/src-tauri/src/anthropic/anthropic.rs
@@ -1,7 +1,8 @@
+use crate::model_config::load_provider_models;
 use serde::{Deserialize, Serialize};
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
-use tauri::command;
+use tauri::{AppHandle, Runtime};
 
 /// Anthropic (Claude) model information returned to frontend
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -37,21 +38,14 @@ static MODELS_CACHE: RwLock<Option<CacheEntry>> = RwLock::new(None);
 /// Cache TTL in seconds
 const CACHE_TTL_SECS: u64 = 300;
 
-/// Fallback models when API fetch fails (matches frontend hardcoded values)
-const FALLBACK_MODELS: &[(&str, &str)] = &[
-    ("claude-sonnet-4-5-20250929", "Claude 4.5 Sonnet"),
-    ("claude-haiku-4-5-20251001", "Claude 4.5 Haiku"),
-    ("claude-opus-4-1-20250805", "Claude 4.1 Opus"),
-    ("claude-sonnet-4-20250514", "Claude 4 Sonnet"),
-];
-
-/// Get fallback models as AnthropicModel vec
-fn get_fallback_models() -> Vec<AnthropicModel> {
-    FALLBACK_MODELS
-        .iter()
-        .map(|(id, name)| AnthropicModel {
-            id: id.to_string(),
-            display_name: Some(name.to_string()),
+/// Get configured fallback models as AnthropicModel vec.
+fn get_fallback_models<R: Runtime>(app: &AppHandle<R>) -> Vec<AnthropicModel> {
+    load_provider_models(Some(app), "anthropic")
+        .unwrap_or_default()
+        .into_iter()
+        .map(|model| AnthropicModel {
+            id: model.id,
+            display_name: model.display_name,
         })
         .collect()
 }
@@ -70,14 +64,17 @@ fn is_chat_model(model_id: &str) -> bool {
 ///
 /// # Returns
 /// Vector of available models, or fallback models on error
-#[command]
-pub async fn get_anthropic_models(api_key: Option<String>) -> Result<Vec<AnthropicModel>, String> {
+#[tauri::command]
+pub async fn get_anthropic_models<R: Runtime>(
+    app: AppHandle<R>,
+    api_key: Option<String>,
+) -> Result<Vec<AnthropicModel>, String> {
     // Return fallback if no API key provided
     let api_key = match api_key {
         Some(key) if !key.trim().is_empty() => key.trim().to_string(),
         _ => {
             log::info!("No Anthropic API key provided, returning fallback models");
-            return Ok(get_fallback_models());
+            return Ok(get_fallback_models(&app));
         }
     };
 
@@ -110,7 +107,7 @@ pub async fn get_anthropic_models(api_key: Option<String>) -> Result<Vec<Anthrop
         Ok(resp) => resp,
         Err(e) => {
             log::warn!("Failed to fetch Anthropic models: {}. Using fallback.", e);
-            return Ok(get_fallback_models());
+            return Ok(get_fallback_models(&app));
         }
     };
 
@@ -120,14 +117,14 @@ pub async fn get_anthropic_models(api_key: Option<String>) -> Result<Vec<Anthrop
             "Anthropic API returned status {}. Using fallback models.",
             status
         );
-        return Ok(get_fallback_models());
+        return Ok(get_fallback_models(&app));
     }
 
     let api_response: AnthropicApiResponse = match response.json().await {
         Ok(data) => data,
         Err(e) => {
             log::warn!("Failed to parse Anthropic response: {}. Using fallback.", e);
-            return Ok(get_fallback_models());
+            return Ok(get_fallback_models(&app));
         }
     };
 
@@ -145,7 +142,7 @@ pub async fn get_anthropic_models(api_key: Option<String>) -> Result<Vec<Anthrop
     // If no models returned, use fallback
     if models.is_empty() {
         log::warn!("No chat models returned from Anthropic API. Using fallback.");
-        return Ok(get_fallback_models());
+        return Ok(get_fallback_models(&app));
     }
 
     log::info!("Fetched {} Anthropic models from API", models.len());

--- a/frontend/src-tauri/src/groq/groq.rs
+++ b/frontend/src-tauri/src/groq/groq.rs
@@ -1,7 +1,8 @@
+use crate::model_config::load_provider_models;
 use serde::{Deserialize, Serialize};
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
-use tauri::command;
+use tauri::{AppHandle, Runtime};
 
 /// Groq model information returned to frontend
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -37,16 +38,14 @@ static MODELS_CACHE: RwLock<Option<CacheEntry>> = RwLock::new(None);
 /// Cache TTL in seconds
 const CACHE_TTL_SECS: u64 = 300;
 
-/// Fallback models when API fetch fails (matches frontend hardcoded values)
-const FALLBACK_MODELS: &[&str] = &["llama-3.3-70b-versatile"];
-
-/// Get fallback models as GroqModel vec
-fn get_fallback_models() -> Vec<GroqModel> {
-    FALLBACK_MODELS
-        .iter()
-        .map(|id| GroqModel {
-            id: id.to_string(),
-            owned_by: None,
+/// Get configured fallback models as GroqModel vec.
+fn get_fallback_models<R: Runtime>(app: &AppHandle<R>) -> Vec<GroqModel> {
+    load_provider_models(Some(app), "groq")
+        .unwrap_or_default()
+        .into_iter()
+        .map(|model| GroqModel {
+            id: model.id,
+            owned_by: model.owned_by,
         })
         .collect()
 }
@@ -68,14 +67,17 @@ fn is_chat_model(model_id: &str) -> bool {
 ///
 /// # Returns
 /// Vector of available models, or fallback models on error
-#[command]
-pub async fn get_groq_models(api_key: Option<String>) -> Result<Vec<GroqModel>, String> {
+#[tauri::command]
+pub async fn get_groq_models<R: Runtime>(
+    app: AppHandle<R>,
+    api_key: Option<String>,
+) -> Result<Vec<GroqModel>, String> {
     // Return fallback if no API key provided
     let api_key = match api_key {
         Some(key) if !key.trim().is_empty() => key.trim().to_string(),
         _ => {
             log::info!("No Groq API key provided, returning fallback models");
-            return Ok(get_fallback_models());
+            return Ok(get_fallback_models(&app));
         }
     };
 
@@ -104,7 +106,7 @@ pub async fn get_groq_models(api_key: Option<String>) -> Result<Vec<GroqModel>, 
         Ok(resp) => resp,
         Err(e) => {
             log::warn!("Failed to fetch Groq models: {}. Using fallback.", e);
-            return Ok(get_fallback_models());
+            return Ok(get_fallback_models(&app));
         }
     };
 
@@ -114,14 +116,14 @@ pub async fn get_groq_models(api_key: Option<String>) -> Result<Vec<GroqModel>, 
             "Groq API returned status {}. Using fallback models.",
             status
         );
-        return Ok(get_fallback_models());
+        return Ok(get_fallback_models(&app));
     }
 
     let api_response: GroqApiResponse = match response.json().await {
         Ok(data) => data,
         Err(e) => {
             log::warn!("Failed to parse Groq response: {}. Using fallback.", e);
-            return Ok(get_fallback_models());
+            return Ok(get_fallback_models(&app));
         }
     };
 
@@ -139,7 +141,7 @@ pub async fn get_groq_models(api_key: Option<String>) -> Result<Vec<GroqModel>, 
     // If no models returned, use fallback
     if models.is_empty() {
         log::warn!("No chat models returned from Groq API. Using fallback.");
-        return Ok(get_fallback_models());
+        return Ok(get_fallback_models(&app));
     }
 
     log::info!("Fetched {} Groq models from API", models.len());

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -47,6 +47,7 @@ pub mod onboarding;
 pub mod openai;
 pub mod anthropic;
 pub mod groq;
+pub mod model_config;
 pub mod openrouter;
 pub mod parakeet_engine;
 pub mod state;

--- a/frontend/src-tauri/src/model_config.rs
+++ b/frontend/src-tauri/src/model_config.rs
@@ -1,0 +1,165 @@
+use serde::Deserialize;
+use std::{collections::HashMap, fs, path::PathBuf};
+use tauri::{AppHandle, Manager, Runtime};
+
+pub const PROVIDER_MODELS_CONFIG: &str = "config/provider-models.json";
+const DEFAULT_PROVIDER_MODELS_CONFIG: &str = include_str!("../config/provider-models.json");
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfiguredModel {
+    pub id: String,
+    pub display_name: Option<String>,
+    pub owned_by: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProviderModelConfig {
+    providers: HashMap<String, ProviderModels>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProviderModels {
+    models: Vec<ModelEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ModelEntry {
+    Id(String),
+    Details(ModelDetails),
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelDetails {
+    id: String,
+    #[serde(rename = "displayName", alias = "display_name")]
+    display_name: Option<String>,
+    owned_by: Option<String>,
+}
+
+impl From<ModelEntry> for ConfiguredModel {
+    fn from(entry: ModelEntry) -> Self {
+        match entry {
+            ModelEntry::Id(id) => Self {
+                id,
+                display_name: None,
+                owned_by: None,
+            },
+            ModelEntry::Details(details) => Self {
+                id: details.id,
+                display_name: details.display_name,
+                owned_by: details.owned_by,
+            },
+        }
+    }
+}
+
+pub fn load_provider_models<R: Runtime>(app: Option<&AppHandle<R>>, provider: &str) -> Option<Vec<ConfiguredModel>> {
+    load_provider_models_from_paths(provider, config_paths(app))
+        .or_else(|| parse_provider_models(provider, DEFAULT_PROVIDER_MODELS_CONFIG))
+}
+
+fn config_paths<R: Runtime>(app: Option<&AppHandle<R>>) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if let Some(app) = app {
+        if let Ok(resource_dir) = app.path().resource_dir() {
+            paths.push(resource_dir.join(PROVIDER_MODELS_CONFIG));
+        }
+    }
+
+    if let Ok(current_dir) = std::env::current_dir() {
+        paths.push(current_dir.join(PROVIDER_MODELS_CONFIG));
+        paths.push(current_dir.join("frontend/src-tauri").join(PROVIDER_MODELS_CONFIG));
+    }
+
+    paths
+}
+
+fn load_provider_models_from_paths(provider: &str, paths: Vec<PathBuf>) -> Option<Vec<ConfiguredModel>> {
+    paths
+        .into_iter()
+        .find_map(|path| fs::read_to_string(path).ok())
+        .and_then(|json| parse_provider_models(provider, &json))
+}
+
+fn parse_provider_models(provider: &str, json: &str) -> Option<Vec<ConfiguredModel>> {
+    let config: ProviderModelConfig = serde_json::from_str(json).ok()?;
+    let models: Vec<_> = config
+        .providers
+        .get(provider)?
+        .models
+        .iter()
+        .filter_map(|entry| match entry {
+            ModelEntry::Id(id) if !id.trim().is_empty() => Some(ConfiguredModel {
+                id: id.trim().to_string(),
+                display_name: None,
+                owned_by: None,
+            }),
+            ModelEntry::Details(details) if !details.id.trim().is_empty() => Some(ConfiguredModel {
+                id: details.id.trim().to_string(),
+                display_name: details.display_name.clone(),
+                owned_by: details.owned_by.clone(),
+            }),
+            _ => None,
+        })
+        .collect();
+
+    if models.is_empty() {
+        None
+    } else {
+        Some(models)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_string_and_object_model_entries() {
+        let json = r#"
+        {
+          "providers": {
+            "openai": { "models": ["gpt-5.5"] },
+            "anthropic": {
+              "models": [
+                { "id": "claude-test", "displayName": "Claude Test" },
+                { "id": "claude_alias", "display_name": "Claude Alias" }
+              ]
+            }
+          }
+        }
+        "#;
+
+        let openai = parse_provider_models("openai", json).unwrap();
+        assert_eq!(openai[0].id, "gpt-5.5");
+
+        let anthropic = parse_provider_models("anthropic", json).unwrap();
+        assert_eq!(anthropic[0].display_name.as_deref(), Some("Claude Test"));
+        assert_eq!(anthropic[1].display_name.as_deref(), Some("Claude Alias"));
+    }
+
+    #[test]
+    fn invalid_missing_or_empty_config_falls_back_to_none() {
+        assert!(parse_provider_models("openai", "not json").is_none());
+        assert!(parse_provider_models("missing", r#"{ "providers": {} }"#).is_none());
+        assert!(parse_provider_models("openai", r#"{ "providers": { "openai": { "models": [] } } }"#).is_none());
+    }
+
+    #[test]
+    fn bundled_default_config_contains_provider_models() {
+        assert!(parse_provider_models("openai", DEFAULT_PROVIDER_MODELS_CONFIG)
+            .unwrap()
+            .iter()
+            .any(|model| model.id == "gpt-5"));
+        assert!(parse_provider_models("anthropic", DEFAULT_PROVIDER_MODELS_CONFIG)
+            .unwrap()
+            .iter()
+            .any(|model| model.display_name.as_deref() == Some("Claude 4.5 Sonnet")));
+        assert_eq!(
+            parse_provider_models("groq", DEFAULT_PROVIDER_MODELS_CONFIG).unwrap()[0].id,
+            "llama-3.3-70b-versatile"
+        );
+    }
+}

--- a/frontend/src-tauri/src/openai/openai.rs
+++ b/frontend/src-tauri/src/openai/openai.rs
@@ -1,7 +1,8 @@
+use crate::model_config::load_provider_models;
 use serde::{Deserialize, Serialize};
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
-use tauri::command;
+use tauri::{AppHandle, Runtime};
 
 /// OpenAI model information returned to frontend
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -37,38 +38,12 @@ static MODELS_CACHE: RwLock<Option<CacheEntry>> = RwLock::new(None);
 /// Cache TTL in seconds
 const CACHE_TTL_SECS: u64 = 300;
 
-/// Fallback models when API fetch fails (matches frontend hardcoded values)
-const FALLBACK_MODELS: &[&str] = &[
-    "gpt-5",
-    "gpt-5-mini",
-    "gpt-4o",
-    "gpt-4.1",
-    "gpt-4-turbo",
-    "gpt-3.5-turbo",
-    "gpt-4o-2024-11-20",
-    "gpt-4o-2024-08-06",
-    "gpt-4o-mini-2024-07-18",
-    "gpt-4.1-2025-04-14",
-    "gpt-4.1-nano-2025-04-14",
-    "gpt-4.1-mini-2025-04-14",
-    "o4-mini-2025-04-16",
-    "o3-2025-04-16",
-    "o3-mini-2025-01-31",
-    "o1-2024-12-17",
-    "o1-mini-2024-09-12",
-    "gpt-4-turbo-2024-04-09",
-    "gpt-4-0125-Preview",
-    "gpt-4-vision-preview",
-    "gpt-4-1106-Preview",
-    "gpt-3.5-turbo-0125",
-    "gpt-3.5-turbo-1106",
-];
-
-/// Get fallback models as OpenAIModel vec
-fn get_fallback_models() -> Vec<OpenAIModel> {
-    FALLBACK_MODELS
-        .iter()
-        .map(|id| OpenAIModel { id: id.to_string() })
+/// Get configured fallback models as OpenAIModel vec.
+fn get_fallback_models<R: Runtime>(app: &AppHandle<R>) -> Vec<OpenAIModel> {
+    load_provider_models(Some(app), "openai")
+        .unwrap_or_default()
+        .into_iter()
+        .map(|model| OpenAIModel { id: model.id })
         .collect()
 }
 
@@ -100,14 +75,17 @@ fn is_chat_model(model_id: &str) -> bool {
 ///
 /// # Returns
 /// Vector of available models, or fallback models on error
-#[command]
-pub async fn get_openai_models(api_key: Option<String>) -> Result<Vec<OpenAIModel>, String> {
+#[tauri::command]
+pub async fn get_openai_models<R: Runtime>(
+    app: AppHandle<R>,
+    api_key: Option<String>,
+) -> Result<Vec<OpenAIModel>, String> {
     // Return fallback if no API key provided
     let api_key = match api_key {
         Some(key) if !key.trim().is_empty() => key.trim().to_string(),
         _ => {
             log::info!("No OpenAI API key provided, returning fallback models");
-            return Ok(get_fallback_models());
+            return Ok(get_fallback_models(&app));
         }
     };
 
@@ -136,7 +114,7 @@ pub async fn get_openai_models(api_key: Option<String>) -> Result<Vec<OpenAIMode
         Ok(resp) => resp,
         Err(e) => {
             log::warn!("Failed to fetch OpenAI models: {}. Using fallback.", e);
-            return Ok(get_fallback_models());
+            return Ok(get_fallback_models(&app));
         }
     };
 
@@ -146,14 +124,14 @@ pub async fn get_openai_models(api_key: Option<String>) -> Result<Vec<OpenAIMode
             "OpenAI API returned status {}. Using fallback models.",
             status
         );
-        return Ok(get_fallback_models());
+        return Ok(get_fallback_models(&app));
     }
 
     let api_response: OpenAIApiResponse = match response.json().await {
         Ok(data) => data,
         Err(e) => {
             log::warn!("Failed to parse OpenAI response: {}. Using fallback.", e);
-            return Ok(get_fallback_models());
+            return Ok(get_fallback_models(&app));
         }
     };
 
@@ -168,7 +146,7 @@ pub async fn get_openai_models(api_key: Option<String>) -> Result<Vec<OpenAIMode
     // If no models returned (e.g., restricted API key), use fallback
     if models.is_empty() {
         log::warn!("No chat models returned from OpenAI API. Using fallback.");
-        return Ok(get_fallback_models());
+        return Ok(get_fallback_models(&app));
     }
 
     log::info!("Fetched {} OpenAI models from API", models.len());

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -95,7 +95,8 @@
             "icons/app_icon.ico"
         ],
         "resources": [
-            "templates/*.json"
+            "templates/*.json",
+            "config/*.json"
         ],
         "externalBin": [
             "binaries/llama-helper",

--- a/frontend/src/app/_components/SettingsModal.tsx
+++ b/frontend/src/app/_components/SettingsModal.tsx
@@ -99,7 +99,7 @@ export function SettingsModals({
                         setModelConfig({
                           ...modelConfig,
                           provider,
-                          model: modelOptions[provider][0]
+                          model: modelOptions[provider][0] ?? modelConfig.model
                         });
                       }}
                     >

--- a/frontend/src/components/ModelSettingsModal.tsx
+++ b/frontend/src/components/ModelSettingsModal.tsx
@@ -74,33 +74,6 @@ interface GroqModel {
   owned_by?: string;
 }
 
-// Fallback models for when API fetch fails or no API key provided
-const OPENAI_FALLBACK_MODELS = [
-  'gpt-4o',
-  'gpt-4o-mini',
-  'gpt-4-turbo',
-  'gpt-4',
-  'gpt-3.5-turbo',
-  'o1',
-  'o1-mini',
-  'o3',
-  'o3-mini',
-];
-
-const CLAUDE_FALLBACK_MODELS = [
-  'claude-sonnet-4-5-20250929',
-  'claude-haiku-4-5-20251001',
-  'claude-opus-4-5-20251101',
-  'claude-3-5-sonnet-latest',
-];
-
-const GROQ_FALLBACK_MODELS = [
-  'llama-3.3-70b-versatile',
-  'llama-3.1-70b-versatile',
-  'mixtral-8x7b-32768',
-  'gemma2-9b-it',
-];
-
 interface ModelSettingsModalProps {
   modelConfig: ModelConfig;
   setModelConfig: (config: ModelConfig | ((prev: ModelConfig) => ModelConfig)) => void;
@@ -225,9 +198,9 @@ export function ModelSettingsModal({
 
   const modelOptions: Record<string, string[]> = {
     ollama: models.map((model) => model.name),
-    claude: claudeModels.length > 0 ? claudeModels : CLAUDE_FALLBACK_MODELS,
-    groq: groqModels.length > 0 ? groqModels : GROQ_FALLBACK_MODELS,
-    openai: openaiModels.length > 0 ? openaiModels : OPENAI_FALLBACK_MODELS,
+    claude: claudeModels,
+    groq: groqModels,
+    openai: openaiModels,
     openrouter: openRouterModels.map((m) => m.id),
     'builtin-ai': builtinAiModels.map((m) => m.name),
     'custom-openai': customOpenAIModel ? [customOpenAIModel] : [], // User specifies model manually
@@ -523,77 +496,63 @@ export function ModelSettingsModal({
     }
   };
 
-  // Fetch OpenAI models from API
+  // Fetch OpenAI models from API, or configured fallback when no API key is provided
   const loadOpenAIModels = async (key: string | null) => {
-    if (!key?.trim()) {
-      setOpenaiModels([]); // Will use fallback via modelOptions
-      return;
-    }
     setIsLoadingOpenAI(true);
     try {
-      const data = (await invoke('get_openai_models', { apiKey: key })) as OpenAIModel[];
+      const data = (await invoke('get_openai_models', { apiKey: key?.trim() || null })) as OpenAIModel[];
       setOpenaiModels(data.map((m) => m.id));
     } catch (err) {
       console.error('Error loading OpenAI models:', err);
-      setOpenaiModels([]); // Will use fallback via modelOptions
+      setOpenaiModels([]);
     } finally {
       setIsLoadingOpenAI(false);
     }
   };
 
-  // Fetch Anthropic (Claude) models from API
+  // Fetch Anthropic (Claude) models from API, or configured fallback when no API key is provided
   const loadClaudeModels = async (key: string | null) => {
-    if (!key?.trim()) {
-      setClaudeModels([]); // Will use fallback via modelOptions
-      return;
-    }
     setIsLoadingClaude(true);
     try {
-      const data = (await invoke('get_anthropic_models', { apiKey: key })) as AnthropicModel[];
+      const data = (await invoke('get_anthropic_models', { apiKey: key?.trim() || null })) as AnthropicModel[];
       setClaudeModels(data.map((m) => m.id));
     } catch (err) {
       console.error('Error loading Claude models:', err);
-      setClaudeModels([]); // Will use fallback via modelOptions
+      setClaudeModels([]);
     } finally {
       setIsLoadingClaude(false);
     }
   };
 
-  // Fetch Groq models from API
+  // Fetch Groq models from API, or configured fallback when no API key is provided
   const loadGroqModels = async (key: string | null) => {
-    if (!key?.trim()) {
-      setGroqModels([]); // Will use fallback via modelOptions
-      return;
-    }
     setIsLoadingGroq(true);
     try {
-      const data = (await invoke('get_groq_models', { apiKey: key })) as GroqModel[];
+      const data = (await invoke('get_groq_models', { apiKey: key?.trim() || null })) as GroqModel[];
       setGroqModels(data.map((m) => m.id));
     } catch (err) {
       console.error('Error loading Groq models:', err);
-      setGroqModels([]); // Will use fallback via modelOptions
+      setGroqModels([]);
     } finally {
       setIsLoadingGroq(false);
     }
   };
 
-  // Auto-fetch OpenAI models when provider is openai and we have an API key
+  // Auto-fetch API-backed model lists; commands return configured fallbacks when no API key is set
   useEffect(() => {
-    if (modelConfig.provider === 'openai' && apiKey?.trim()) {
+    if (modelConfig.provider === 'openai') {
       loadOpenAIModels(apiKey);
     }
   }, [modelConfig.provider, apiKey]);
 
-  // Auto-fetch Claude models when provider is claude and we have an API key
   useEffect(() => {
-    if (modelConfig.provider === 'claude' && apiKey?.trim()) {
+    if (modelConfig.provider === 'claude') {
       loadClaudeModels(apiKey);
     }
   }, [modelConfig.provider, apiKey]);
 
-  // Auto-fetch Groq models when provider is groq and we have an API key
   useEffect(() => {
-    if (modelConfig.provider === 'groq' && apiKey?.trim()) {
+    if (modelConfig.provider === 'groq') {
       loadGroqModels(apiKey);
     }
   }, [modelConfig.provider, apiKey]);

--- a/frontend/src/contexts/ConfigContext.tsx
+++ b/frontend/src/contexts/ConfigContext.tsx
@@ -129,6 +129,11 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
   // Ollama models list and error state
   const [models, setModels] = useState<OllamaModel[]>([]);
   const [error, setError] = useState<string>('');
+  const [apiProviderModels, setApiProviderModels] = useState<Pick<Record<ModelConfig['provider'], string[]>, 'claude' | 'groq' | 'openai'>>({
+    claude: [],
+    groq: [],
+    openai: [],
+  });
 
   // Device configuration state
   const [selectedDevices, setSelectedDevices] = useState<SelectedDevices>({
@@ -342,6 +347,29 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
+  // Load configured API provider model fallbacks on mount
+  useEffect(() => {
+    const loadApiProviderModels = async () => {
+      try {
+        const [claude, groq, openai] = await Promise.all([
+          invoke<Array<{ id: string }>>('get_anthropic_models', { apiKey: null }),
+          invoke<Array<{ id: string }>>('get_groq_models', { apiKey: null }),
+          invoke<Array<{ id: string }>>('get_openai_models', { apiKey: null }),
+        ]);
+
+        setApiProviderModels({
+          claude: claude.map(model => model.id),
+          groq: groq.map(model => model.id),
+          openai: openai.map(model => model.id),
+        });
+      } catch (error) {
+        console.error('Failed to load API provider model options:', error);
+      }
+    };
+
+    loadApiProviderModels();
+  }, []);
+
   // Load device preferences on mount
   useEffect(() => {
     const loadDevicePreferences = async () => {
@@ -364,10 +392,10 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
   // Calculate model options based on available models
   const modelOptions: Record<ModelConfig['provider'], string[]> = {
     ollama: models.map(model => model.name),
-    claude: ['claude-3-5-sonnet-latest'],
-    groq: ['llama-3.3-70b-versatile'],
+    claude: apiProviderModels.claude,
+    groq: apiProviderModels.groq,
     openrouter: [],
-    openai: ['gpt-4', 'gpt-4-turbo', 'gpt-3.5-turbo'],
+    openai: apiProviderModels.openai,
     'builtin-ai': [],
     'custom-openai': [],
   };


### PR DESCRIPTION
## Description
- Move OpenAI, Anthropic, and Groq fallback model lists into `frontend/src-tauri/config/provider-models.json`.
- Load configured provider model options from bundled resources at runtime, with embedded config fallback if the resource is missing or invalid.
- Remove duplicate frontend fallback arrays and have model settings use the existing Tauri model commands.

## Related Issue
Fixes #526

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [x] `python -m json.tool frontend/src-tauri/config/provider-models.json`
- [x] `git diff --check`
- [x] `pnpm build`
- [x] `cargo test -p meetily model_config --lib --no-default-features --no-run` in Docker (Linux deps installed; used temporary dummy `llama-helper-x86_64-unknown-linux-gnu` only because externalBin is required during Tauri build script)
- [ ] Manual testing performed
- [ ] All tests pass

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Additional Notes
Runtime API model discovery is unchanged and still takes precedence when a valid API key is available.