### PR TITLE
fix(build): support custom FFmpeg binary path

### DIFF
--- a/frontend/build-gpu.sh
+++ b/frontend/build-gpu.sh
@@ -31,6 +31,11 @@ else
   exit 1
 fi
 
+# Resolve FFMPEG_PATH before this script changes directories
+if [ -n "${FFMPEG_PATH:-}" ] && [[ "$FFMPEG_PATH" != /* ]]; then
+  FFMPEG_PATH="$(pwd -P)/$FFMPEG_PATH"
+fi
+
 # Function to check if command exists
 command_exists() {
   command -v "$1" >/dev/null 2>&1
@@ -63,6 +68,16 @@ elif command_exists npm; then
 else
   echo -e "${RED}❌ Neither npm nor pnpm found${NC}"
   exit 1
+fi
+
+# Allow distro/package-manager builds to provide FFmpeg and skip build-time download
+if [ -n "${FFMPEG_PATH:-}" ]; then
+  if [ ! -f "$FFMPEG_PATH" ]; then
+    echo -e "${RED}❌ FFMPEG_PATH does not point to a file: $FFMPEG_PATH${NC}"
+    exit 1
+  fi
+  export FFMPEG_PATH
+  echo -e "${GREEN}✅ Using FFmpeg from FFMPEG_PATH: $FFMPEG_PATH${NC}"
 fi
 
 # Detect GPU feature if not already set

--- a/frontend/src-tauri/build/ffmpeg.rs
+++ b/frontend/src-tauri/build/ffmpeg.rs
@@ -6,6 +6,8 @@
 /// Download and bundle FFmpeg binary for current target platform
 /// Checks cache first, downloads only if missing or corrupted
 pub fn ensure_ffmpeg_binary() {
+    println!("cargo:rerun-if-env-changed=FFMPEG_PATH");
+
     let target = std::env::var("TARGET")
         .or_else(|_| std::env::var("HOST"))
         .expect("Neither TARGET nor HOST environment variable set");
@@ -22,6 +24,17 @@ pub fn ensure_ffmpeg_binary() {
         .expect("CARGO_MANIFEST_DIR environment variable not set");
     let binaries_dir = std::path::PathBuf::from(&manifest_dir).join("binaries");
     let binary_path = binaries_dir.join(&binary_name);
+
+    if let Some(ffmpeg_path) = configured_ffmpeg_path() {
+        println!(
+            "cargo:warning=📦 Using FFmpeg from FFMPEG_PATH: {}",
+            ffmpeg_path.display()
+        );
+        copy_configured_ffmpeg(&ffmpeg_path, &binary_path)
+            .unwrap_or_else(|e| panic!("⚠️  Failed to use FFMPEG_PATH: {}", e));
+        println!("cargo:warning=✅ FFmpeg copied from FFMPEG_PATH: {}", binary_name);
+        return;
+    }
 
     // Cache check: Skip download if binary exists and works
     if binary_path.exists() {
@@ -56,6 +69,56 @@ pub fn ensure_ffmpeg_binary() {
         Err(e) => {
             panic!("⚠️  Failed to download FFmpeg: {}", e);
         }
+    }
+}
+
+fn configured_ffmpeg_path() -> Option<std::path::PathBuf> {
+    std::env::var_os("FFMPEG_PATH")
+        .filter(|value| !value.is_empty())
+        .map(std::path::PathBuf::from)
+}
+
+fn copy_configured_ffmpeg(
+    source_path: &std::path::Path,
+    output_path: &std::path::Path,
+) -> Result<(), String> {
+    if !source_path.is_file() {
+        return Err(format!("{} is not a file", source_path.display()));
+    }
+
+    if !verify_ffmpeg_binary(source_path) {
+        return Err(format!(
+            "{} is not a working FFmpeg binary",
+            source_path.display()
+        ));
+    }
+
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create binaries directory: {}", e))?;
+    }
+
+    std::fs::copy(source_path, output_path)
+        .map_err(|e| format!("Failed to copy FFmpeg binary: {}", e))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(output_path)
+            .map_err(|e| format!("Failed to get copied FFmpeg metadata: {}", e))?
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(output_path, perms)
+            .map_err(|e| format!("Failed to set executable permissions: {}", e))?;
+    }
+
+    if verify_ffmpeg_binary(output_path) {
+        Ok(())
+    } else {
+        Err(format!(
+            "Copied FFmpeg binary failed verification: {}",
+            output_path.display()
+        ))
     }
 }
 
@@ -330,7 +393,7 @@ fn find_ffmpeg_in_extracted_dir(
 }
 
 /// Verify FFmpeg binary is functional (runs -version successfully)
-fn verify_ffmpeg_binary(path: &std::path::PathBuf) -> bool {
+fn verify_ffmpeg_binary(path: &std::path::Path) -> bool {
     match std::process::Command::new(path)
         .arg("-version")
         .output()


### PR DESCRIPTION
## Description
- Add `FFMPEG_PATH` support to the Rust FFmpeg bundling build script.
- When `FFMPEG_PATH` is set, verify and copy that binary into `src-tauri/binaries` instead of downloading FFmpeg.
- Add `build-gpu.sh` validation/export for `FFMPEG_PATH`, preserving the existing download behavior when it is not set.

## Related Issue
Fixes #494

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [x] `git diff --check`
- [x] `bash -n frontend/build-gpu.sh`
- [x] Docker harness compiled `frontend/src-tauri/build/ffmpeg.rs` and ran it with `FFMPEG_PATH=/usr/bin/ffmpeg`
- [x] Verified copied binary with `ffmpeg -version`
- [ ] Manual testing performed
- [ ] All tests pass

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Additional Notes
Existing behavior is unchanged when `FFMPEG_PATH` is not set.