### PR TITLE
Add tri-state dark mode preference

### DIFF
--- a/.github/workflows/frontend-theme-checks.yml
+++ b/.github/workflows/frontend-theme-checks.yml
@@ -1,0 +1,58 @@
+name: "Frontend Theme Checks"
+
+# Lightweight guard for the semantic theme system: fails PRs that reintroduce
+# hardcoded light-only colors and typechecks the Playwright theme suite.
+# No app build or browser install — runs in well under a minute.
+
+on:
+  pull_request:
+    paths:
+      - "frontend/src/**"
+      - "frontend/tests/**"
+      - "frontend/scripts/check-theme-tokens.mjs"
+      - "frontend/tailwind.config.js"
+      - "frontend/tsconfig*.json"
+      - ".github/workflows/frontend-theme-checks.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  theme-checks:
+    name: Theme audit + test typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          # pnpm 9 is the one major that reads BOTH the v9.0 lockfile and the
+          # package.json `pnpm.overrides` field, so --frozen-lockfile matches
+          # cleanly. pnpm 8 can't read a v9 lockfile; pnpm 10+ ignore
+          # pnpm.overrides and fail with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+          # Overrides stay in package.json so the pnpm 8 build workflows keep
+          # working.
+          version: 9
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Theme token audit
+        working-directory: frontend
+        run: pnpm run test:theme-audit
+
+      - name: Typecheck Playwright theme suite
+        working-directory: frontend
+        run: pnpm exec tsc -p tsconfig.tests.json

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -24,6 +24,8 @@ whisper-server-package/
 # testing
 /coverage
 /dist
+/test-results
+/playwright-report
 
 # next.js
 /.next/

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -2,10 +2,6 @@ const path = require('path');
 const tiptapPmResolveBase = path.dirname(require.resolve('@tiptap/pm/model'));
 const resolveFromTiptapPm = (pkg) =>
   require.resolve(pkg, { paths: [tiptapPmResolveBase] });
-const tauriBrowserMocksFile =
-  process.env.NEXT_PUBLIC_E2E_TESTING === '1'
-    ? 'src/testing/tauri-browser-mocks.ts'
-    : 'src/testing/tauri-browser-mocks.noop.ts';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -19,11 +15,17 @@ const nextConfig = {
   assetPrefix: '/',
 
   // Add webpack configuration for Tauri
-  webpack: (config, { isServer }) => {
-    config.resolve.alias = {
-      ...config.resolve.alias,
-      './tauri-browser-mocks': path.resolve(__dirname, tauriBrowserMocksFile),
-    };
+  webpack: (config, { isServer, webpack }) => {
+    // Outside E2E builds, swap the E2E bootstrap for a noop component so the
+    // Tauri browser mocks never reach the production bundle.
+    if (process.env.NEXT_PUBLIC_E2E_TESTING !== '1') {
+      config.plugins.push(
+        new webpack.NormalModuleReplacementPlugin(
+          /^@\/testing\/E2EBootstrap$/,
+          path.resolve(__dirname, 'src/testing/E2ENoop.tsx'),
+        ),
+      );
+    }
 
     if (!isServer) {
       config.resolve.fallback = {

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -2,6 +2,10 @@ const path = require('path');
 const tiptapPmResolveBase = path.dirname(require.resolve('@tiptap/pm/model'));
 const resolveFromTiptapPm = (pkg) =>
   require.resolve(pkg, { paths: [tiptapPmResolveBase] });
+const tauriBrowserMocksFile =
+  process.env.NEXT_PUBLIC_E2E_TESTING === '1'
+    ? 'src/testing/tauri-browser-mocks.ts'
+    : 'src/testing/tauri-browser-mocks.noop.ts';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -16,6 +20,11 @@ const nextConfig = {
 
   // Add webpack configuration for Tauri
   webpack: (config, { isServer }) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      './tauri-browser-mocks': path.resolve(__dirname, tauriBrowserMocksFile),
+    };
+
     if (!isServer) {
       config.resolve.fallback = {
         ...config.resolve.fallback,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,8 +26,8 @@
         "tauri:build:openblas": "tauri build -- --features openblas",
         "tauri:build:hipblas": "tauri build -- --features hipblas",
         "lint": "next lint",
-        "test:e2e": "playwright test",
-        "test:e2e:update": "playwright test --update-snapshots",
+        "test:e2e": "tsc -p tsconfig.tests.json && playwright test",
+        "test:e2e:update": "tsc -p tsconfig.tests.json && playwright test --update-snapshots",
         "test:theme-audit": "node scripts/check-theme-tokens.mjs"
     },
     "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,10 @@
         "tauri:build:coreml": "tauri build -- --features coreml",
         "tauri:build:openblas": "tauri build -- --features openblas",
         "tauri:build:hipblas": "tauri build -- --features hipblas",
-        "lint": "next lint"
+        "lint": "next lint",
+        "test:e2e": "playwright test",
+        "test:e2e:update": "playwright test --update-snapshots",
+        "test:theme-audit": "node scripts/check-theme-tokens.mjs"
     },
     "dependencies": {
         "@blocknote/core": "0.36.0",
@@ -96,6 +99,7 @@
         }
     },
     "devDependencies": {
+        "@playwright/test": "^1.61.0",
         "@tailwindcss/typography": "^0.5.15",
         "@tauri-apps/cli": "^2.1.0",
         "@tauri-apps/plugin-fs": "~2.4.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.ts',
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  use: {
+    baseURL: 'http://127.0.0.1:3118',
+    viewport: { width: 1440, height: 1000 },
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1440, height: 1000 },
+      },
+    },
+  ],
+  webServer: {
+    command: 'NEXT_PUBLIC_E2E_TESTING=1 pnpm dev',
+    url: 'http://127.0.0.1:3118',
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -4,6 +4,8 @@ export default defineConfig({
   testDir: './tests',
   testMatch: '**/*.spec.ts',
   timeout: 30_000,
+  fullyParallel: true,
+  retries: process.env.CI ? 1 : 0,
   expect: {
     timeout: 5_000,
   },
@@ -23,9 +25,13 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'NEXT_PUBLIC_E2E_TESTING=1 pnpm dev',
+    command: 'pnpm dev',
+    env: { NEXT_PUBLIC_E2E_TESTING: '1' },
     url: 'http://127.0.0.1:3118',
-    reuseExistingServer: true,
+    // Never reuse a running server: the Tauri mocks are compiled in at build
+    // time, so a normal `pnpm dev` server on this port would run the whole
+    // suite without mocks and fail confusingly.
+    reuseExistingServer: false,
     timeout: 120_000,
   },
 });

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  prosemirror-model: 1.25.3
+  prosemirror-state: 1.4.3
+  prosemirror-view: 1.41.3
+  prosemirror-transform: 1.10.4
+  prosemirror-tables: 1.8.1
+
 importers:
 
   .:
@@ -148,7 +155,7 @@ importers:
         version: 0.469.0(react@18.3.1)
       next:
         specifier: ^14.2.25
-        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.61.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -180,6 +187,9 @@ importers:
         specifier: ^3.25.71
         version: 3.25.76
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.0
+        version: 1.61.0
       '@tailwindcss/typography':
         specifier: ^0.5.15
         version: 0.5.19(tailwindcss@3.4.19)
@@ -449,28 +459,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.33':
     resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.33':
     resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.33':
     resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.33':
     resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
@@ -504,6 +510,11 @@ packages:
 
   '@ocavue/svgmoji-cjs@0.1.1':
     resolution: {integrity: sha512-tCP6ggbtgIL4hPM5goVFSjL51jH/BLl/yBLy98wAV9a2L/Sn9iS3abfprPeQw6/nan5lLaz4Vz8ZP37LKh+xfQ==}
+
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
@@ -1597,35 +1608,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.1':
     resolution: {integrity: sha512-mNA5dbbqPqDUdTIwdUYYuhO2GvIe9UnB2r0VU2njxBOS3Opbx4gKNC5yP0Iu4rYmEmqdlwry9VzGZQ3wq9dyFg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.1':
     resolution: {integrity: sha512-fZj3Gwq+6fUs305T5WQiD5iSGJw+j/4w/HGmk4sHDAcy+rp9zU5eaxB7nOyz5/I/nkNAuKPqfp6uIbiUBXkBCw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.1':
     resolution: {integrity: sha512-XFxGxOvHM7jjeD6ozCKdGfhzJ7lERYDGZl1/Kb4fsvchaJsfLJ981TlyTG8Qy/gFq+f5GitH3bfrX9JAkjPEyw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.1':
     resolution: {integrity: sha512-d5C2/Zm+68v7R9wTuTCjRQEVrWjcdMkJBZ1+rXse+QdMMlTB9+u9PDNDLw9PQflWxYLaYZ7tjxxL9Nb9II6PbA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.1':
     resolution: {integrity: sha512-YdeVWFAR1pTXzUU6NLstPq4G6OLxuDrXCXEBdmBH+5EZIDXUx0D2kJlz3+YjpazkKvAzYpgziTsyRagls0OfRQ==}
@@ -2281,6 +2287,11 @@ packages:
       react-dom:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2847,6 +2858,16 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
@@ -2930,10 +2951,10 @@ packages:
       '@types/hast': ^3.0.0
       highlight.js: ^11.9.0
       lowlight: ^3.1.0
-      prosemirror-model: ^1.19.3
-      prosemirror-state: ^1.4.3
-      prosemirror-transform: ^1.8.0
-      prosemirror-view: ^1.32.4
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.3
       refractor: ^5.0.0
       sugar-high: ^0.6.1 || ^0.7.0 || ^0.8.0 || ^0.9.0
     peerDependenciesMeta:
@@ -2979,9 +3000,9 @@ packages:
   prosemirror-paste-rules@3.0.0:
     resolution: {integrity: sha512-p2ayp2xtSTtDPZutoxZyK6UKJhJk0hEpIfdfVYfd3DSENE1Lyrcg96pju+ClgwXlTjPUykXx5DrsfRbHCY+gGQ==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-schema-basic@1.2.4:
     resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
@@ -2995,9 +3016,9 @@ packages:
   prosemirror-suggest@3.0.0:
     resolution: {integrity: sha512-cEYnJHOAnQ+ET7PKY1tY8SMSpyR2rQAuYfPEmVtet0V9exgHAeiaSEzyBcCSeLesxXJRIv8b9cofyqoqyMjlEw==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-tables@1.8.1:
     resolution: {integrity: sha512-DAgDoUYHCcc6tOGpLVPSU1k84kCUWTWnfWX3UDy2Delv4ryH0KqTD6RBI6k4yi9j9I8gl3j8MkPpRD/vWPZbug==}
@@ -3005,9 +3026,9 @@ packages:
   prosemirror-trailing-node@3.0.0:
     resolution: {integrity: sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-transform@1.10.4:
     resolution: {integrity: sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==}
@@ -3448,9 +3469,9 @@ packages:
     resolution: {integrity: sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     peerDependencies:
-      prosemirror-model: ^1.7.1
-      prosemirror-state: ^1.2.3
-      prosemirror-view: ^1.9.10
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
       y-protocols: ^1.0.1
       yjs: ^13.5.38
 
@@ -3894,6 +3915,10 @@ snapshots:
   '@ocavue/svgmoji-cjs@0.1.1':
     dependencies:
       svgmoji: 3.2.0
+
+  '@playwright/test@1.61.0':
+    dependencies:
+      playwright: 1.61.0
 
   '@popperjs/core@2.11.8': {}
 
@@ -5914,6 +5939,9 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6661,7 +6689,7 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  next@14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.61.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -6682,6 +6710,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.33
       '@next/swc-win32-ia32-msvc': 14.2.33
       '@next/swc-win32-x64-msvc': 14.2.33
+      '@playwright/test': 1.61.0
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -6741,6 +6770,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.61.0: {}
+
+  playwright@1.61.0:
+    dependencies:
+      playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-import@15.1.0(postcss@8.5.14):
     dependencies:

--- a/frontend/scripts/check-theme-tokens.mjs
+++ b/frontend/scripts/check-theme-tokens.mjs
@@ -1,0 +1,46 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const roots = ['src'];
+const forbiddenPatterns = [
+  /\bbg-white\b/g,
+  /\bbg-black(?:\/\d+)?\b/g,
+  /\bbg-opacity-\d+\b/g,
+  /\bborder-white\b/g,
+  /\btext-white\b/g,
+  /\b(?:bg|border|border-[trblxy]|divide|placeholder|ring|text)-(?:slate|gray|zinc|neutral|stone)-\d+\b/g,
+  /\b(?:hover:)?(?:bg|border|ring|text)-[a-z-]+\/\d+\/\d+\b/g,
+  /#(?:fff(?:fff)?|f9fafb|f3f4f6|e5e7eb|d1d5db|9ca3af|6b7280|4b5563|374151|1f2937|111827|3b82f6)\b/gi,
+];
+const allowlist = new Set();
+const failures = [];
+
+async function walk(directory) {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const file = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      await walk(file);
+      continue;
+    }
+
+    if (!entry.isFile() || !/\.(css|js|jsx|ts|tsx)$/.test(entry.name)) continue;
+
+    const source = await readFile(file, 'utf8');
+    for (const pattern of forbiddenPatterns) {
+      for (const match of source.matchAll(pattern)) {
+        const key = `${file}:${match[0]}`;
+        if (!allowlist.has(key)) failures.push(key);
+      }
+    }
+  }
+}
+
+for (const root of roots) {
+  await walk(root);
+}
+
+if (failures.length) {
+  console.error(failures.join('\n'));
+  process.exit(1);
+}

--- a/frontend/scripts/check-theme-tokens.mjs
+++ b/frontend/scripts/check-theme-tokens.mjs
@@ -1,18 +1,27 @@
 import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const roots = ['src'];
+// Resolve scan roots relative to this script so the audit works from any cwd
+// (repo root, frontend/, CI checkout, …).
+const frontendDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const roots = [path.join(frontendDir, 'src')];
+
+// Hardcoded colors are forbidden in app code: every surface must go through
+// the semantic tokens in globals.css/tailwind.config.js so light and dark
+// modes stay in sync. Raw palette utilities, white/black shortcuts, and the
+// legacy hex values all bypass that layer.
 const forbiddenPatterns = [
   /\bbg-white\b/g,
   /\bbg-black(?:\/\d+)?\b/g,
-  /\bbg-opacity-\d+\b/g,
-  /\bborder-white\b/g,
   /\btext-white\b/g,
-  /\b(?:bg|border|border-[trblxy]|divide|placeholder|ring|text)-(?:slate|gray|zinc|neutral|stone)-\d+\b/g,
+  /\btext-black\b/g,
+  /\bborder-white\b/g,
+  /\bbg-opacity-\d+\b/g,
+  /\b(?:hover:|focus:|dark:)*(?:bg|border|border-[trblxy]|divide|placeholder|ring|text)-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d+(?:\/\d+)?\b/g,
   /\b(?:hover:)?(?:bg|border|ring|text)-[a-z-]+\/\d+\/\d+\b/g,
   /#(?:fff(?:fff)?|f9fafb|f3f4f6|e5e7eb|d1d5db|9ca3af|6b7280|4b5563|374151|1f2937|111827|3b82f6)\b/gi,
 ];
-const allowlist = new Set();
 const failures = [];
 
 async function walk(directory) {
@@ -29,8 +38,7 @@ async function walk(directory) {
     const source = await readFile(file, 'utf8');
     for (const pattern of forbiddenPatterns) {
       for (const match of source.matchAll(pattern)) {
-        const key = `${file}:${match[0]}`;
-        if (!allowlist.has(key)) failures.push(key);
+        failures.push(`${path.relative(frontendDir, file)}:${match[0]}`);
       }
     }
   }

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -17,7 +17,6 @@
                 "height": 700,
                 "resizable": true,
                 "fullscreen": false,
-                "theme": "Light",
                 "decorations": true
             }
         ],
@@ -56,6 +55,7 @@
                         "core:event:default",
                         "core:window:default",
                         "core:app:default",
+                        "core:app:allow-set-app-theme",
                         "core:resources:default",
                         "core:menu:default",
                         "core:tray:default",

--- a/frontend/src/app/_components/SettingsModal.tsx
+++ b/frontend/src/app/_components/SettingsModal.tsx
@@ -280,7 +280,7 @@ export function SettingsModals({
                   onChange={(e) => toggleConfidenceIndicator(e.target.checked)}
                   className="sr-only peer"
                 />
-                <div className="w-11 h-6 bg-muted peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-info rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-card after:border-border after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-info"></div>
+                <div className="w-11 h-6 bg-muted-foreground/30 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-info rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-background after:border-muted-foreground/40 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-info peer-checked:after:border-background"></div>
               </label>
               <div>
                 <p className="text-sm font-medium text-foreground">Show Confidence Indicators</p>
@@ -290,7 +290,7 @@ export function SettingsModals({
 
             <button
               onClick={() => onClose('modelSelector')}
-              className="px-4 py-2 text-sm font-medium text-foreground bg-muted rounded-md hover:bg-muted focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ring"
+              className="px-4 py-2 text-sm font-medium text-foreground bg-muted rounded-md hover:bg-muted-foreground/20 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ring"
             >
               {messages.modelSelector ? 'Cancel' : 'Done'}
             </button>
@@ -308,7 +308,7 @@ export function SettingsModals({
             {messages.errorAlert}
             <button
               onClick={() => onClose('errorAlert')}
-              className="ml-2 text-destructive hover:text-destructive underline"
+              className="ml-2 text-destructive hover:text-destructive/80 underline"
             >
               Dismiss
             </button>
@@ -321,12 +321,12 @@ export function SettingsModals({
     {modals.chunkDropWarning && (
       <div className="fixed inset-0 bg-overlay/50 flex items-center justify-center z-50">
         <Alert className="max-w-lg mx-4 border-warning/30 bg-card shadow-xl">
-          <AlertTitle className="text-warning">Transcription Performance Warning</AlertTitle>
-          <AlertDescription className="text-warning">
+          <AlertTitle className="text-warning-text">Transcription Performance Warning</AlertTitle>
+          <AlertDescription className="text-warning-text">
             {messages.chunkDropWarning}
             <button
               onClick={() => onClose('chunkDropWarning')}
-              className="ml-2 text-warning hover:text-warning underline"
+              className="ml-2 text-warning-text hover:text-warning-text/80 underline"
             >
               Dismiss
             </button>

--- a/frontend/src/app/_components/SettingsModal.tsx
+++ b/frontend/src/app/_components/SettingsModal.tsx
@@ -61,15 +61,15 @@ export function SettingsModals({
   return <>
     {/* Legacy Settings Modal */}
     {modals.modelSettings && (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-        <div className="bg-white rounded-lg shadow-xl max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col">
+      <div className="fixed inset-0 bg-overlay/50 flex items-center justify-center z-50 p-4">
+        <div className="bg-card rounded-lg shadow-xl max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col">
           {/* Header */}
           <div className="flex justify-between items-center p-6 border-b">
-            <h3 className="text-xl font-semibold text-gray-900">Preferences</h3>
+            <h3 className="text-xl font-semibold text-foreground">Preferences</h3>
             <button
               onClick={() => onClose("modelSettings")
               }
-              className="text-gray-500 hover:text-gray-700"
+              className="text-muted-foreground hover:text-foreground"
             >
               <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -84,15 +84,15 @@ export function SettingsModals({
 
             {/* Divider */}
             <div className="border-t pt-8">
-              <h4 className="text-lg font-semibold text-gray-900 mb-4">AI Model Configuration</h4>
+              <h4 className="text-lg font-semibold text-foreground mb-4">AI Model Configuration</h4>
               <div className="space-y-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                  <label className="block text-sm font-medium text-foreground mb-1">
                     Summarization Model
                   </label>
                   <div className="flex space-x-2">
                     <select
-                      className="px-3 py-2 text-sm bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                      className="px-3 py-2 text-sm bg-card border border-border rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-info focus:border-info"
                       value={modelConfig.provider}
                       onChange={(e) => {
                         const provider = e.target.value as ModelConfig['provider'];
@@ -112,7 +112,7 @@ export function SettingsModals({
                     </select>
 
                     <select
-                      className="flex-1 px-3 py-2 text-sm bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                      className="flex-1 px-3 py-2 text-sm bg-card border border-border rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-info focus:border-info"
                       value={modelConfig.model}
                       onChange={(e) => setModelConfig((prev: ModelConfig) => ({ ...prev, model: e.target.value }))}
                     >
@@ -128,7 +128,7 @@ export function SettingsModals({
                   <div>
                     <h4 className="text-lg font-bold mb-4">Available Ollama Models</h4>
                     {error && (
-                      <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+                      <div className="bg-destructive/15 border border-destructive/50 text-destructive px-4 py-3 rounded mb-4">
                         {error}
                       </div>
                     )}
@@ -136,13 +136,13 @@ export function SettingsModals({
                       {models.map((model) => (
                         <div
                           key={model.id}
-                          className={`bg-white p-4 rounded-lg shadow cursor-pointer transition-colors ${modelConfig.model === model.name ? 'ring-2 ring-blue-500 bg-blue-50' : 'hover:bg-gray-50'
+                          className={`bg-card p-4 rounded-lg shadow cursor-pointer transition-colors ${modelConfig.model === model.name ? 'ring-2 ring-info bg-info/10' : 'hover:bg-muted/40'
                             }`}
                           onClick={() => setModelConfig((prev: ModelConfig) => ({ ...prev, model: model.name }))}
                         >
                           <h3 className="font-bold">{model.name}</h3>
-                          <p className="text-gray-600">Size: {model.size}</p>
-                          <p className="text-gray-600">Modified: {model.modified}</p>
+                          <p className="text-muted-foreground">Size: {model.size}</p>
+                          <p className="text-muted-foreground">Modified: {model.modified}</p>
                         </div>
                       ))}
                     </div>
@@ -156,7 +156,7 @@ export function SettingsModals({
           <div className="border-t p-6 flex justify-end">
             <button
               onClick={() => onClose('modelSettings')}
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              className="px-4 py-2 text-sm font-medium text-info-foreground bg-info rounded-md hover:bg-info/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-info"
             >
               Done
             </button>
@@ -167,13 +167,13 @@ export function SettingsModals({
 
     {/* Device Settings Modal */}
     {modals.deviceSettings && (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-        <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4 shadow-xl">
+      <div className="fixed inset-0 bg-overlay/50 flex items-center justify-center z-50">
+        <div className="bg-card rounded-lg p-6 max-w-md w-full mx-4 shadow-xl">
           <div className="flex justify-between items-center mb-4">
-            <h3 className="text-lg font-semibold text-gray-900">Audio Device Settings</h3>
+            <h3 className="text-lg font-semibold text-foreground">Audio Device Settings</h3>
             <button
               onClick={() => onClose('deviceSettings')}
-              className="text-gray-500 hover:text-gray-700"
+              className="text-muted-foreground hover:text-foreground"
             >
               <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -197,7 +197,7 @@ export function SettingsModals({
                 });
                 onClose('deviceSettings');
               }}
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              className="px-4 py-2 text-sm font-medium text-info-foreground bg-info rounded-md hover:bg-info/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-info"
             >
               Done
             </button>
@@ -208,13 +208,13 @@ export function SettingsModals({
 
     {/* Language Settings Modal */}
     {modals.languageSettings && (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-        <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4 shadow-xl">
+      <div className="fixed inset-0 bg-overlay/50 flex items-center justify-center z-50">
+        <div className="bg-card rounded-lg p-6 max-w-md w-full mx-4 shadow-xl">
           <div className="flex justify-between items-center mb-4">
-            <h3 className="text-lg font-semibold text-gray-900">Language Settings</h3>
+            <h3 className="text-lg font-semibold text-foreground">Language Settings</h3>
             <button
               onClick={() => onClose('languageSettings')}
-              className="text-gray-500 hover:text-gray-700"
+              className="text-muted-foreground hover:text-foreground"
             >
               <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -232,7 +232,7 @@ export function SettingsModals({
           <div className="mt-6 flex justify-end">
             <button
               onClick={() => onClose('languageSettings')}
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              className="px-4 py-2 text-sm font-medium text-info-foreground bg-info rounded-md hover:bg-info/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-info"
             >
               Done
             </button>
@@ -243,16 +243,16 @@ export function SettingsModals({
 
     {/* Model Selection Modal */}
     {modals.modelSelector && (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-        <div className="bg-white rounded-lg max-w-4xl w-full mx-4 shadow-xl max-h-[90vh] flex flex-col">
+      <div className="fixed inset-0 bg-overlay/50 flex items-center justify-center z-50">
+        <div className="bg-card rounded-lg max-w-4xl w-full mx-4 shadow-xl max-h-[90vh] flex flex-col">
           {/* Fixed Header */}
-          <div className="flex justify-between items-center p-6 pb-4 border-b border-gray-200">
-            <h3 className="text-lg font-semibold text-gray-900">
+          <div className="flex justify-between items-center p-6 pb-4 border-b border-border">
+            <h3 className="text-lg font-semibold text-foreground">
               {messages.modelSelector ? 'Speech Recognition Setup Required' : 'Transcription Model Settings'}
             </h3>
             <button
               onClick={() => onClose('modelSelector')}
-              className="text-gray-500 hover:text-gray-700"
+              className="text-muted-foreground hover:text-foreground"
             >
               <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -270,7 +270,7 @@ export function SettingsModals({
           </div>
 
           {/* Fixed Footer */}
-          <div className="p-6 pt-4 border-t border-gray-200 flex items-center justify-between">
+          <div className="p-6 pt-4 border-t border-border flex items-center justify-between">
             {/* Confidence Indicator Toggle */}
             <div className="flex items-center gap-3">
               <label className="relative inline-flex items-center cursor-pointer">
@@ -280,17 +280,17 @@ export function SettingsModals({
                   onChange={(e) => toggleConfidenceIndicator(e.target.checked)}
                   className="sr-only peer"
                 />
-                <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+                <div className="w-11 h-6 bg-muted peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-info rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-card after:border-border after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-info"></div>
               </label>
               <div>
-                <p className="text-sm font-medium text-gray-700">Show Confidence Indicators</p>
-                <p className="text-xs text-gray-500">Display colored dots showing transcription confidence quality</p>
+                <p className="text-sm font-medium text-foreground">Show Confidence Indicators</p>
+                <p className="text-xs text-muted-foreground">Display colored dots showing transcription confidence quality</p>
               </div>
             </div>
 
             <button
               onClick={() => onClose('modelSelector')}
-              className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+              className="px-4 py-2 text-sm font-medium text-foreground bg-muted rounded-md hover:bg-muted focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ring"
             >
               {messages.modelSelector ? 'Cancel' : 'Done'}
             </button>
@@ -301,14 +301,14 @@ export function SettingsModals({
 
     {/* Error Alert Modal */}
     {modals.errorAlert && (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-        <Alert className="max-w-md mx-4 border-red-200 bg-white shadow-xl">
-          <AlertTitle className="text-red-800">Recording Stopped</AlertTitle>
-          <AlertDescription className="text-red-700">
+      <div className="fixed inset-0 bg-overlay/50 flex items-center justify-center z-50">
+        <Alert className="max-w-md mx-4 border-destructive/30 bg-card shadow-xl">
+          <AlertTitle className="text-destructive">Recording Stopped</AlertTitle>
+          <AlertDescription className="text-destructive">
             {messages.errorAlert}
             <button
               onClick={() => onClose('errorAlert')}
-              className="ml-2 text-red-600 hover:text-red-800 underline"
+              className="ml-2 text-destructive hover:text-destructive underline"
             >
               Dismiss
             </button>
@@ -319,14 +319,14 @@ export function SettingsModals({
 
     {/* Chunk Drop Warning Modal */}
     {modals.chunkDropWarning && (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-        <Alert className="max-w-lg mx-4 border-yellow-200 bg-white shadow-xl">
-          <AlertTitle className="text-yellow-800">Transcription Performance Warning</AlertTitle>
-          <AlertDescription className="text-yellow-700">
+      <div className="fixed inset-0 bg-overlay/50 flex items-center justify-center z-50">
+        <Alert className="max-w-lg mx-4 border-warning/30 bg-card shadow-xl">
+          <AlertTitle className="text-warning">Transcription Performance Warning</AlertTitle>
+          <AlertDescription className="text-warning">
             {messages.chunkDropWarning}
             <button
               onClick={() => onClose('chunkDropWarning')}
-              className="ml-2 text-yellow-600 hover:text-yellow-800 underline"
+              className="ml-2 text-warning hover:text-warning underline"
             >
               Dismiss
             </button>

--- a/frontend/src/app/_components/StatusOverlays.tsx
+++ b/frontend/src/app/_components/StatusOverlays.tsx
@@ -26,9 +26,9 @@ function StatusOverlay({ show, message, sidebarCollapsed }: StatusOverlayProps) 
         }}
       >
         <div className="w-2/3 max-w-[750px] flex justify-center">
-          <div className="bg-white rounded-lg shadow-lg px-4 py-2 flex items-center space-x-2">
-            <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-900"></div>
-            <span className="text-sm text-gray-700">{message}</span>
+          <div className="bg-card rounded-lg shadow-lg px-4 py-2 flex items-center space-x-2">
+            <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-primary"></div>
+            <span className="text-sm text-foreground">{message}</span>
           </div>
         </div>
       </div>

--- a/frontend/src/app/_components/TranscriptPanel.tsx
+++ b/frontend/src/app/_components/TranscriptPanel.tsx
@@ -50,9 +50,9 @@ export function TranscriptPanel({
   );
 
   return (
-    <div ref={transcriptContainerRef} className="w-full border-r border-gray-200 bg-white flex flex-col overflow-y-auto">
+    <div ref={transcriptContainerRef} className="w-full border-r border-border bg-card flex flex-col overflow-y-auto">
       {/* Title area - Sticky header */}
-      <div className="sticky top-0 z-10 bg-white p-4 border-gray-200">
+      <div className="sticky top-0 z-10 bg-card p-4 border-border">
         <div className="flex flex-col space-y-3">
           <div className="flex  flex-col space-y-2">
             <div className="flex justify-center  items-center space-x-2">

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -92,8 +92,18 @@
     --muted-foreground: 0 0% 45.1%;
     --accent: 0 0% 96.1%;
     --accent-foreground: 0 0% 9%;
-    --destructive: 0 84.2% 60.2%;
+    --destructive: 0 72% 51%;
     --destructive-foreground: 0 0% 98%;
+    --info: 217 91% 60%;
+    --info-foreground: 222 47% 11%;
+    --success: 142 71% 45%;
+    --success-foreground: 144 61% 8%;
+    --warning: 45 93% 47%;
+    --warning-foreground: 26 83% 14%;
+    --recording: 0 84% 60%;
+    --recording-foreground: 0 63% 12%;
+    --overlay: 0 0% 0%;
+    --overlay-foreground: 0 0% 98%;
     --border: 0 0% 89.8%;
     --input: 0 0% 89.8%;
     --ring: 0 0% 3.9%;
@@ -108,9 +118,9 @@
   .dark {
     --background: 0 0% 3.9%;
     --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
+    --card: 0 0% 7%;
     --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
+    --popover: 0 0% 9%;
     --popover-foreground: 0 0% 98%;
     --primary: 0 0% 98%;
     --primary-foreground: 0 0% 9%;
@@ -120,8 +130,18 @@
     --muted-foreground: 0 0% 63.9%;
     --accent: 0 0% 14.9%;
     --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
+    --destructive: 0 91% 71%;
+    --destructive-foreground: 0 63% 12%;
+    --info: 217 91% 65%;
+    --info-foreground: 222 47% 11%;
+    --success: 142 69% 58%;
+    --success-foreground: 144 61% 8%;
+    --warning: 48 96% 65%;
+    --warning-foreground: 26 83% 14%;
+    --recording: 0 91% 71%;
+    --recording-foreground: 0 63% 12%;
+    --overlay: 0 0% 0%;
+    --overlay-foreground: 0 0% 98%;
     --border: 0 0% 14.9%;
     --input: 0 0% 14.9%;
     --ring: 0 0% 83.1%;
@@ -166,18 +186,18 @@
   }
 
   .custom-scrollbar::-webkit-scrollbar-thumb {
-    background: #d1d5db;
+    background: hsl(var(--muted-foreground) / 0.35);
     border-radius: 3px;
   }
 
   .custom-scrollbar::-webkit-scrollbar-thumb:hover {
-    background: #9ca3af;
+    background: hsl(var(--muted-foreground) / 0.5);
   }
 
   /* Firefox scrollbar */
   .custom-scrollbar {
     scrollbar-width: thin;
-    scrollbar-color: #d1d5db transparent;
+    scrollbar-color: hsl(var(--muted-foreground) / 0.35) transparent;
   }
 
   /* BlockNote Editor - Override fixed dimensions for responsive layout */
@@ -211,4 +231,15 @@
   [data-node-type] {
     overflow: visible !important;
   }
+}
+.dark *::-webkit-scrollbar-thumb {
+  background-color: hsl(var(--muted-foreground) / 0.35);
+}
+
+.dark *::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground) / 0.5);
+}
+
+.dark * {
+  scrollbar-color: hsl(var(--muted-foreground) / 0.35) transparent;
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -100,6 +100,15 @@
     --success-foreground: 144 61% 8%;
     --warning: 45 93% 47%;
     --warning-foreground: 26 83% 14%;
+    --warning-strong: 25 95% 53%;
+    --warning-strong-foreground: 15 75% 15%;
+    /* Accessible ink for status text/icons on light app surfaces.
+       The fill tokens above are mid-tones for backgrounds and fail AA as
+       text on white (info 3.6:1, success 2.3:1, warning 2.0:1); these
+       darker tones clear 4.5:1. Use text-{info,success,warning}-text. */
+    --info-text: 217 91% 45%;
+    --success-text: 142 71% 27%;
+    --warning-text: 35 95% 32%;
     --recording: 0 84% 60%;
     --recording-foreground: 0 63% 12%;
     --overlay: 0 0% 0%;
@@ -138,6 +147,12 @@
     --success-foreground: 144 61% 8%;
     --warning: 48 96% 65%;
     --warning-foreground: 26 83% 14%;
+    --warning-strong: 27 96% 61%;
+    --warning-strong-foreground: 15 75% 15%;
+    /* Accessible ink for status text/icons on dark app surfaces. */
+    --info-text: 217 91% 70%;
+    --success-text: 142 65% 62%;
+    --warning-text: 45 95% 62%;
     --recording: 0 91% 71%;
     --recording-foreground: 0 63% 12%;
     --overlay: 0 0% 0%;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -25,13 +25,15 @@ import { RecordingPostProcessingProvider } from '@/contexts/RecordingPostProcess
 import { ImportAudioDialog, ImportDropOverlay } from '@/components/ImportAudio'
 import { ImportDialogProvider } from '@/contexts/ImportDialogContext'
 import { isAudioExtension, getAudioFormatsDisplayList } from '@/constants/audioFormats'
-
+import { E2EBootstrap } from '@/testing/E2EBootstrap'
+import { ThemeScript } from '@/components/ThemeScript'
 
 const sourceSans3 = Source_Sans_3({
   subsets: ['latin'],
   weight: ['400', '500', '600', '700'],
   variable: '--font-source-sans-3',
 })
+
 
 // Module-level component — stable reference across RootLayout re-renders.
 // Defined here (not inside RootLayout) so React never sees a new function type
@@ -231,8 +233,12 @@ export default function RootLayout({
   }
 
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <ThemeScript />
+      </head>
       <body className={`${sourceSans3.variable} font-sans antialiased`}>
+        <E2EBootstrap />
         <AnalyticsProvider>
           <RecordingStateProvider>
             <TranscriptProvider>

--- a/frontend/src/app/meeting-details/page-content.tsx
+++ b/frontend/src/app/meeting-details/page-content.tsx
@@ -168,9 +168,9 @@ export default function PageContent({
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3, ease: 'easeOut' }}
-      className="flex flex-col h-screen bg-gray-50"
+      className="flex flex-col h-screen bg-muted/40"
     >
-      <div className="flex flex-1 overflow-hidden">
+      <div className="flex flex-1 min-w-0 overflow-hidden">
         <TranscriptPanel
           transcripts={meetingData.transcripts}
           customPrompt={customPrompt}

--- a/frontend/src/app/meeting-details/page.tsx
+++ b/frontend/src/app/meeting-details/page.tsx
@@ -339,10 +339,10 @@ function MeetingDetailsContent() {
     return (
       <div className="flex items-center justify-center h-screen">
         <div className="text-center">
-          <p className="text-red-500 mb-4">{error}</p>
+          <p className="text-destructive mb-4">{error}</p>
           <button
             onClick={() => router.push('/')}
-            className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+            className="px-4 py-2 bg-info text-info-foreground rounded hover:bg-info/90"
           >
             Go Back
           </button>

--- a/frontend/src/app/notes/[id]/page.tsx
+++ b/frontend/src/app/notes/[id]/page.tsx
@@ -137,7 +137,7 @@ Quarterly product review session with stakeholders.
       <div className="mb-8">
         <h1 className="text-3xl font-bold mb-4">{note.title}</h1>
         
-        <div className="flex flex-wrap gap-4 text-gray-600">
+        <div className="flex flex-wrap gap-4 text-muted-foreground">
           {note.date && (
             <div className="flex items-center gap-1">
               <Calendar className="w-4 h-4" />
@@ -162,7 +162,7 @@ Quarterly product review session with stakeholders.
 
         <div className="flex gap-2 mt-4">
           {note.tags.map((tag) => (
-            <div key={tag} className="flex items-center gap-1 bg-blue-100 text-blue-800 px-2 py-1 rounded-full text-sm">
+            <div key={tag} className="flex items-center gap-1 bg-info/15 text-info px-2 py-1 rounded-full text-sm">
               <Tag className="w-3 h-3" />
               {tag}
             </div>

--- a/frontend/src/app/notes/[id]/page.tsx
+++ b/frontend/src/app/notes/[id]/page.tsx
@@ -162,7 +162,7 @@ Quarterly product review session with stakeholders.
 
         <div className="flex gap-2 mt-4">
           {note.tags.map((tag) => (
-            <div key={tag} className="flex items-center gap-1 bg-info/15 text-info px-2 py-1 rounded-full text-sm">
+            <div key={tag} className="flex items-center gap-1 bg-info/15 text-info-text px-2 py-1 rounded-full text-sm">
               <Tag className="w-3 h-3" />
               {tag}
             </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -194,7 +194,7 @@ export default function Home() {
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3, ease: 'easeOut' }}
-      className="flex flex-col h-screen bg-gray-50"
+      className="flex h-screen flex-col bg-background text-foreground"
     >
       {/* All Modals supported*/}
       <SettingsModals
@@ -231,7 +231,7 @@ export default function Home() {
                 }}
               >
                 <div className="w-2/3 max-w-[750px] flex justify-center">
-                  <div className="bg-white rounded-full shadow-lg flex items-center">
+                  <div className="flex items-center rounded-full border border-border bg-card text-card-foreground shadow-lg">
                     <RecordingControls
                       isRecording={recordingState.isRecording}
                       onRecordingStop={(callApi = true) => handleRecordingStop(callApi)}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -93,7 +93,7 @@ export default function SettingsPage() {
                     key={tab.value}
                     value={tab.value}
                     ref={el => { tabRefs.current[index] = el }}
-                    className="flex shrink-0 items-center gap-2 px-4 py-4 bg-transparent rounded-none border-0 data-[state=active]:bg-transparent data-[state=active]:text-info data-[state=active]:shadow-none text-muted-foreground hover:text-foreground relative z-10 sm:px-6"
+                    className="flex shrink-0 items-center gap-2 px-4 py-4 bg-transparent rounded-none border-0 data-[state=active]:bg-transparent data-[state=active]:text-info-text data-[state=active]:shadow-none text-muted-foreground hover:text-foreground relative z-10 sm:px-6"
                   >
                     <Icon className="w-4 h-4" />
                     {tab.label}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -63,14 +63,14 @@ export default function SettingsPage() {
   }, [activeTab]);
 
   return (
-    <div className="h-screen bg-gray-50 flex flex-col">
+    <div className="h-screen bg-muted/40 flex flex-col">
       {/* Fixed Header */}
-      <div className="sticky top-0 z-10 bg-gray-50 border-b border-gray-200">
-        <div className="max-w-6xl mx-auto px-8 py-6">
+      <div className="sticky top-0 z-10 bg-muted/40 border-b border-border">
+        <div className="max-w-6xl mx-auto px-4 py-6 sm:px-8">
           <div className="flex items-center gap-4">
             <button
               onClick={() => router.back()}
-              className="flex items-center gap-2 text-gray-600 hover:text-gray-900 transition-colors"
+              className="flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors"
             >
               <ArrowLeft className="w-5 h-5" />
               <span>Back</span>
@@ -82,10 +82,10 @@ export default function SettingsPage() {
 
       {/* Scrollable Content */}
       <div className="flex-1 overflow-y-auto">
-        <div className="max-w-6xl mx-auto p-8 pt-6">
+        <div className="max-w-6xl mx-auto p-4 pt-6 sm:p-8 sm:pt-6">
           {/* Tabs */}
           <Tabs value={activeTab} onValueChange={setActiveTab}>
-            <TabsList className="bg-transparent relative rounded-none border-b border-gray-200 p-0 h-auto">
+            <TabsList className="bg-transparent relative w-full overflow-x-auto rounded-none border-b border-border p-0 h-auto">
               {TABS.map((tab, index) => {
                 const Icon = tab.icon;
                 return (
@@ -93,7 +93,7 @@ export default function SettingsPage() {
                     key={tab.value}
                     value={tab.value}
                     ref={el => { tabRefs.current[index] = el }}
-                    className="flex items-center gap-2 px-6 py-4 bg-transparent rounded-none border-0 data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:shadow-none text-gray-600 hover:text-gray-900 relative z-10"
+                    className="flex shrink-0 items-center gap-2 px-4 py-4 bg-transparent rounded-none border-0 data-[state=active]:bg-transparent data-[state=active]:text-info data-[state=active]:shadow-none text-muted-foreground hover:text-foreground relative z-10 sm:px-6"
                   >
                     <Icon className="w-4 h-4" />
                     {tab.label}
@@ -102,7 +102,7 @@ export default function SettingsPage() {
               })}
 
               <motion.div
-                className="absolute bottom-0 z-20 h-0.5 bg-blue-600"
+                className="absolute bottom-0 z-20 h-0.5 bg-info"
                 layoutId="underline"
                 style={{ left: underlineStyle.left, width: underlineStyle.width }}
                 transition={{ type: 'spring', stiffness: 400, damping: 40 }}

--- a/frontend/src/components/AISummary/Block.tsx
+++ b/frontend/src/components/AISummary/Block.tsx
@@ -221,7 +221,7 @@ export const BlockComponent: React.FC<BlockProps> = ({
   return (
     <div 
       className={`group relative min-h-[24px] flex items-start rounded transition-all duration-150 ease-in-out
-        ${isSelected ? 'bg-blue-50 ring-1 ring-blue-200 shadow-sm' : 'hover:bg-gray-50'}`}
+        ${isSelected ? 'bg-info/10 ring-1 ring-info/30 shadow-sm' : 'hover:bg-muted/40'}`}
       onMouseDown={onMouseDown}
       onMouseEnter={onMouseEnter}
       onMouseUp={onMouseUp}
@@ -246,7 +246,7 @@ export const BlockComponent: React.FC<BlockProps> = ({
           className={`
             w-full resize-none overflow-hidden bg-transparent border-none p-0 focus:outline-none focus:ring-0
             transition-all duration-150 ease-in-out
-            ${block.color === 'gray' ? 'text-gray-500' : ''}
+            ${block.color === 'gray' ? 'text-muted-foreground' : ''}
             ${block.type === 'heading1' ? 'text-xl font-bold' : ''}
             ${block.type === 'heading2' ? 'text-lg font-semibold' : ''}
           `}
@@ -256,25 +256,25 @@ export const BlockComponent: React.FC<BlockProps> = ({
         {showCommands && (
           <div 
             ref={commandsRef}
-            className="absolute left-0 top-full mt-1 w-64 bg-white rounded-lg shadow-lg border border-gray-200 py-2 z-50
+            className="absolute left-0 top-full mt-1 w-64 bg-card rounded-lg shadow-lg border border-border py-2 z-50
                        animate-in fade-in slide-in-from-top-2 duration-150"
           >
             {filteredCommands.map((cmd, index) => (
               <button
                 key={cmd.id}
                 className={`
-                  w-full text-left px-3 py-2 flex items-center space-x-3 hover:bg-gray-50
-                  ${index === selectedCommandIndex ? 'bg-gray-50' : ''}
+                  w-full text-left px-3 py-2 flex items-center space-x-3 hover:bg-muted/40
+                  ${index === selectedCommandIndex ? 'bg-muted/40' : ''}
                 `}
                 onClick={() => handleCommandSelect(cmd)}
                 onMouseEnter={() => setSelectedCommandIndex(index)}
               >
-                <span className="flex-shrink-0 w-6 h-6 flex items-center justify-center bg-gray-100 rounded text-gray-600">
+                <span className="flex-shrink-0 w-6 h-6 flex items-center justify-center bg-muted rounded text-muted-foreground">
                   {cmd.icon}
                 </span>
                 <div className="flex-1">
                   <div className="font-medium">{cmd.label}</div>
-                  <div className="text-sm text-gray-500">{cmd.description}</div>
+                  <div className="text-sm text-muted-foreground">{cmd.description}</div>
                 </div>
               </button>
             ))}

--- a/frontend/src/components/AISummary/BlockNoteSummaryView.tsx
+++ b/frontend/src/components/AISummary/BlockNoteSummaryView.tsx
@@ -9,7 +9,7 @@ import { useCreateBlockNote } from '@blocknote/react';
 import { BlockNoteView } from '@blocknote/shadcn';
 import { blocksToMarkdownSafely } from '@/lib/blocknote-markdown';
 import "@blocknote/shadcn/style.css";
-import { useConfig } from '@/contexts/ConfigContext';
+import { useIsDarkTheme } from '@/hooks/useIsDarkTheme';
 
 // Dynamically import BlockNote Editor to avoid SSR issues
 const Editor = dynamic(() => import('../BlockNoteEditor/Editor'), { ssr: false });
@@ -81,7 +81,7 @@ export const BlockNoteSummaryView = forwardRef<BlockNoteSummaryViewRef, BlockNot
   const [currentBlocks, setCurrentBlocks] = useState<Block[]>([]);
   const [isSaving, setIsSaving] = useState(false);
   const isContentLoaded = useRef(false);
-  const { isDarkTheme } = useConfig();
+  const isDarkTheme = useIsDarkTheme();
 
   // Create BlockNote editor for markdown parsing
   const editor = useCreateBlockNote({

--- a/frontend/src/components/AISummary/BlockNoteSummaryView.tsx
+++ b/frontend/src/components/AISummary/BlockNoteSummaryView.tsx
@@ -9,6 +9,7 @@ import { useCreateBlockNote } from '@blocknote/react';
 import { BlockNoteView } from '@blocknote/shadcn';
 import { blocksToMarkdownSafely } from '@/lib/blocknote-markdown';
 import "@blocknote/shadcn/style.css";
+import { useConfig } from '@/contexts/ConfigContext';
 
 // Dynamically import BlockNote Editor to avoid SSR issues
 const Editor = dynamic(() => import('../BlockNoteEditor/Editor'), { ssr: false });
@@ -80,6 +81,7 @@ export const BlockNoteSummaryView = forwardRef<BlockNoteSummaryViewRef, BlockNot
   const [currentBlocks, setCurrentBlocks] = useState<Block[]>([]);
   const [isSaving, setIsSaving] = useState(false);
   const isContentLoaded = useRef(false);
+  const { isDarkTheme } = useConfig();
 
   // Create BlockNote editor for markdown parsing
   const editor = useCreateBlockNote({
@@ -266,7 +268,7 @@ export const BlockNoteSummaryView = forwardRef<BlockNoteSummaryViewRef, BlockNot
                 handleEditorChange(editor.document);
               }
             }}
-            theme="light"
+            theme={isDarkTheme ? "dark" : "light"}
           />
         </div>
       </div>

--- a/frontend/src/components/AISummary/Section.tsx
+++ b/frontend/src/components/AISummary/Section.tsx
@@ -75,7 +75,7 @@ export const Section: React.FC<SectionProps> = ({
         {onSectionDelete && (
           <button
             onClick={() => onSectionDelete(sectionKey)}
-            className="text-gray-400 hover:text-gray-600"
+            className="text-muted-foreground hover:text-muted-foreground"
           >
             Delete
           </button>

--- a/frontend/src/components/AISummary/index.tsx
+++ b/frontend/src/components/AISummary/index.tsx
@@ -621,10 +621,10 @@ export const AISummary = ({ summary, status, error, onSummaryChange, onRegenerat
       <div className="flex items-center space-x-3">
         <div className="animate-spin rounded-full h-5 w-5 border-2 border-info border-t-transparent"></div>
         <div>
-          <h3 className="text-info font-medium">
+          <h3 className="text-info-text font-medium">
             {status === 'processing' ? 'Processing Transcript' : 'Generating Summary'}
           </h3>
-          <p className="text-info text-sm">
+          <p className="text-info-text text-sm">
             {status === 'processing' 
               ? 'Analyzing your transcript...' 
               : 'Creating a detailed summary of your meeting...'}

--- a/frontend/src/components/AISummary/index.tsx
+++ b/frontend/src/components/AISummary/index.tsx
@@ -606,25 +606,25 @@ export const AISummary = ({ summary, status, error, onSummaryChange, onRegenerat
   };
 
   const renderErrorState = () => (
-    <div className="w-full p-4 bg-red-50 border border-red-200 rounded-lg">
+    <div className="w-full p-4 bg-destructive/10 border border-destructive/30 rounded-lg">
       <div className="flex items-center mb-2">
-        <ExclamationTriangleIcon className="h-5 w-5 text-red-500 mr-2" />
-        <h3 className="text-red-700 font-medium">Error Generating Summary</h3>
+        <ExclamationTriangleIcon className="h-5 w-5 text-destructive mr-2" />
+        <h3 className="text-destructive font-medium">Error Generating Summary</h3>
       </div>
-      <p className="text-red-600 text-sm">{error}</p>
-      <p className="text-red-500 text-xs mt-2">Please check your model configuration and API keys, or try again.</p>
+      <p className="text-destructive text-sm">{error}</p>
+      <p className="text-destructive text-xs mt-2">Please check your model configuration and API keys, or try again.</p>
     </div>
   );
 
   const renderLoadingState = () => (
-    <div className="w-full p-4 bg-blue-50 border border-blue-200 rounded-lg">
+    <div className="w-full p-4 bg-info/10 border border-info/30 rounded-lg">
       <div className="flex items-center space-x-3">
-        <div className="animate-spin rounded-full h-5 w-5 border-2 border-blue-500 border-t-transparent"></div>
+        <div className="animate-spin rounded-full h-5 w-5 border-2 border-info border-t-transparent"></div>
         <div>
-          <h3 className="text-blue-700 font-medium">
+          <h3 className="text-info font-medium">
             {status === 'processing' ? 'Processing Transcript' : 'Generating Summary'}
           </h3>
-          <p className="text-blue-600 text-sm">
+          <p className="text-info text-sm">
             {status === 'processing' 
               ? 'Analyzing your transcript...' 
               : 'Creating a detailed summary of your meeting...'}
@@ -648,9 +648,9 @@ export const AISummary = ({ summary, status, error, onSummaryChange, onRegenerat
 
   if (!hasContent && status === 'completed') {
     return (
-      <div className="w-full p-4 bg-gray-50 border border-gray-200 rounded-lg text-center">
-        <p className="text-gray-600">No summary content available.</p>
-        <p className="text-gray-500 text-sm mt-1">Try generating a new summary.</p>
+      <div className="w-full p-4 bg-muted/40 border border-border rounded-lg text-center">
+        <p className="text-muted-foreground">No summary content available.</p>
+        <p className="text-muted-foreground text-sm mt-1">Try generating a new summary.</p>
       </div>
     );
   }
@@ -672,7 +672,7 @@ export const AISummary = ({ summary, status, error, onSummaryChange, onRegenerat
       {/* Context Menu */}
       {contextMenu.visible && selectedBlocks.length > 0 && (
         <div
-          className="fixed z-50 bg-white shadow-lg rounded-lg py-1 min-w-[160px] border border-gray-200
+          className="fixed z-50 bg-card shadow-lg rounded-lg py-1 min-w-[160px] border border-border
                      animate-in fade-in zoom-in-95 duration-150"
           style={{ 
             left: contextMenu.x, 
@@ -681,14 +681,14 @@ export const AISummary = ({ summary, status, error, onSummaryChange, onRegenerat
           onClick={e => e.stopPropagation()}
         >
           <button
-            className="w-full px-4 py-2 text-left hover:bg-gray-100 flex items-center space-x-2"
+            className="w-full px-4 py-2 text-left hover:bg-muted flex items-center space-x-2"
             onClick={handleCopyBlocks}
           >
-            <span className="text-gray-600">📋</span>
+            <span className="text-muted-foreground">📋</span>
             <span>Copy {selectedBlocks.length > 1 ? `${selectedBlocks.length} blocks` : 'block'}</span>
           </button>
           <button
-            className="w-full px-4 py-2 text-left hover:bg-gray-100 text-red-600 flex items-center space-x-2"
+            className="w-full px-4 py-2 text-left hover:bg-muted text-destructive flex items-center space-x-2"
             onClick={handleDeleteBlocks}
           >
             <span>🗑️</span>
@@ -700,7 +700,7 @@ export const AISummary = ({ summary, status, error, onSummaryChange, onRegenerat
       {/* <div className="flex items-center justify-between mb-4">
         <div className="flex items-center space-x-2">
           <span className="text-2xl">✨</span>
-          <h2 className="text-2xl font-semibold bg-gradient-to-r from-purple-600 to-blue-500 bg-clip-text text-transparent">
+          <h2 className="text-2xl font-semibold bg-gradient-to-r from-info to-primary bg-clip-text text-transparent">
             AI Enhanced Summary
           </h2>
         </div>
@@ -708,7 +708,7 @@ export const AISummary = ({ summary, status, error, onSummaryChange, onRegenerat
           <button
             onClick={handleUndo}
             disabled={currentHistoryIndex === 0}
-            className="p-2 hover:bg-gray-100 rounded disabled:opacity-50"
+            className="p-2 hover:bg-muted rounded disabled:opacity-50"
             title="Undo"
           >
             <svg
@@ -729,7 +729,7 @@ export const AISummary = ({ summary, status, error, onSummaryChange, onRegenerat
           <button
             onClick={handleRedo}
             disabled={currentHistoryIndex === history.length - 1}
-            className="p-2 hover:bg-gray-100 rounded disabled:opacity-50"
+            className="p-2 hover:bg-muted rounded disabled:opacity-50"
             title="Redo"
           >
             <svg
@@ -749,7 +749,7 @@ export const AISummary = ({ summary, status, error, onSummaryChange, onRegenerat
           </button>
           <button
             onClick={handleAddSection}
-            className="p-2 hover:bg-gray-100 rounded"
+            className="p-2 hover:bg-muted rounded"
             title="Add new section"
           >
             <svg
@@ -772,14 +772,14 @@ export const AISummary = ({ summary, status, error, onSummaryChange, onRegenerat
               const markdown = convertToMarkdown();
               navigator.clipboard.writeText(markdown);
             }}
-            className="px-2 py-1 text-sm bg-gray-100 hover:bg-gray-200 rounded-md flex items-center space-x-1"
+            className="px-2 py-1 text-sm bg-muted hover:bg-muted rounded-md flex items-center space-x-1"
           >
             <span>📋</span>
             <span>Copy</span>
           </button>
           <button
             onClick={onRegenerateSummary}
-            className="px-2 py-1 text-sm bg-gray-100 hover:bg-gray-200 rounded-md flex items-center space-x-1"
+            className="px-2 py-1 text-sm bg-muted hover:bg-muted rounded-md flex items-center space-x-1"
             title="Regenerate Summary"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/frontend/src/components/About.tsx
+++ b/frontend/src/components/About.tsx
@@ -86,7 +86,7 @@ export function About() {
                         )}
                     </Button>
                     {updateInfo?.available && (
-                        <div className="mt-2 text-xs text-info">
+                        <div className="mt-2 text-xs text-info-text">
                             Update available: v{updateInfo.version}
                         </div>
                     )}
@@ -118,7 +118,7 @@ export function About() {
 
             {/* Coming Soon - Compact */}
             <div className="bg-info/10 rounded p-3">
-                <p className="text-s text-info">
+                <p className="text-s text-info-text">
                     <span className="font-bold">Coming soon:</span> A library of on-device AI agents-automating follow-ups, action tracking, and more.
                 </p>
             </div>

--- a/frontend/src/components/About.tsx
+++ b/frontend/src/components/About.tsx
@@ -60,9 +60,9 @@ export function About() {
                         className="mx-auto"
                     />
                 </div>
-                {/* <h1 className="text-xl font-bold text-gray-900">Meetily</h1> */}
-                <span className="text-sm text-gray-500"> v{currentVersion}</span>
-                <p className="text-medium text-gray-600 mt-1">
+                {/* <h1 className="text-xl font-bold text-foreground">Meetily</h1> */}
+                <span className="text-sm text-muted-foreground"> v{currentVersion}</span>
+                <p className="text-medium text-muted-foreground mt-1">
                     Real-time notes and summaries that never leave your machine.
                 </p>
                 <div className="mt-3">
@@ -86,7 +86,7 @@ export function About() {
                         )}
                     </Button>
                     {updateInfo?.available && (
-                        <div className="mt-2 text-xs text-blue-600">
+                        <div className="mt-2 text-xs text-info">
                             Update available: v{updateInfo.version}
                         </div>
                     )}
@@ -95,51 +95,51 @@ export function About() {
 
             {/* Features Grid - Compact */}
             <div className="space-y-3">
-                <h2 className="text-base font-semibold text-gray-800">What makes Meetily different</h2>
+                <h2 className="text-base font-semibold text-foreground">What makes Meetily different</h2>
                 <div className="grid grid-cols-2 gap-2">
-                    <div className="bg-gray-50 rounded p-3 hover:bg-gray-100 transition-colors">
-                        <h3 className="font-bold text-sm text-gray-900 mb-1">Privacy-first</h3>
-                        <p className="text-xs text-gray-600 leading-relaxed">Your data & AI processing workflow can now stay within your premise. No cloud, no leaks.</p>
+                    <div className="bg-muted/40 rounded p-3 hover:bg-muted transition-colors">
+                        <h3 className="font-bold text-sm text-foreground mb-1">Privacy-first</h3>
+                        <p className="text-xs text-muted-foreground leading-relaxed">Your data & AI processing workflow can now stay within your premise. No cloud, no leaks.</p>
                     </div>
-                    <div className="bg-gray-50 rounded p-3 hover:bg-gray-100 transition-colors">
-                        <h3 className="font-bold text-sm text-gray-900 mb-1">Use Any Model</h3>
-                        <p className="text-xs text-gray-600 leading-relaxed">Prefer local open-source model? Great. Want to plug in an external API? Also fine. No lock-in.</p>
+                    <div className="bg-muted/40 rounded p-3 hover:bg-muted transition-colors">
+                        <h3 className="font-bold text-sm text-foreground mb-1">Use Any Model</h3>
+                        <p className="text-xs text-muted-foreground leading-relaxed">Prefer local open-source model? Great. Want to plug in an external API? Also fine. No lock-in.</p>
                     </div>
-                    <div className="bg-gray-50 rounded p-3 hover:bg-gray-100 transition-colors">
-                        <h3 className="font-bold text-sm text-gray-900 mb-1">Cost-Smart</h3>
-                        <p className="text-xs text-gray-600 leading-relaxed">Avoid pay-per-minute bills by running models locally (or pay only for the calls you choose).</p>
+                    <div className="bg-muted/40 rounded p-3 hover:bg-muted transition-colors">
+                        <h3 className="font-bold text-sm text-foreground mb-1">Cost-Smart</h3>
+                        <p className="text-xs text-muted-foreground leading-relaxed">Avoid pay-per-minute bills by running models locally (or pay only for the calls you choose).</p>
                     </div>
-                    <div className="bg-gray-50 rounded p-3 hover:bg-gray-100 transition-colors">
-                        <h3 className="font-bold text-sm text-gray-900 mb-1">Works everywhere</h3>
-                        <p className="text-xs text-gray-600 leading-relaxed">Google Meet, Zoom, Teams-online or offline.</p>
+                    <div className="bg-muted/40 rounded p-3 hover:bg-muted transition-colors">
+                        <h3 className="font-bold text-sm text-foreground mb-1">Works everywhere</h3>
+                        <p className="text-xs text-muted-foreground leading-relaxed">Google Meet, Zoom, Teams-online or offline.</p>
                     </div>
                 </div>
             </div>
 
             {/* Coming Soon - Compact */}
-            <div className="bg-blue-50 rounded p-3">
-                <p className="text-s text-blue-800">
+            <div className="bg-info/10 rounded p-3">
+                <p className="text-s text-info">
                     <span className="font-bold">Coming soon:</span> A library of on-device AI agents-automating follow-ups, action tracking, and more.
                 </p>
             </div>
 
             {/* CTA Section - Compact */}
             <div className="text-center space-y-2">
-                <h3 className="text-medium font-semibold text-gray-800">Ready to push your business further?</h3>
-                <p className="text-s text-gray-600">
+                <h3 className="text-medium font-semibold text-foreground">Ready to push your business further?</h3>
+                <p className="text-s text-muted-foreground">
                     If you're planning to build privacy-first custom AI agents or a fully tailored product for your <span className="font-bold">business</span>, we can help you build it.
                 </p>
                 <button
                     onClick={handleContactClick}
-                    className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded transition-colors duration-200 shadow-sm hover:shadow-md"
+                    className="inline-flex items-center px-4 py-2 bg-info hover:bg-info/90 text-info-foreground text-sm font-medium rounded transition-colors duration-200 shadow-sm hover:shadow-md"
                 >
                     Chat with the Zackriya team
                 </button>
             </div>
 
             {/* Footer - Compact */}
-            <div className="pt-2 border-t border-gray-200 text-center">
-                <p className="text-xs text-gray-400">
+            <div className="pt-2 border-t border-border text-center">
+                <p className="text-xs text-muted-foreground">
                     Built by Zackriya Solutions
                 </p>
             </div>

--- a/frontend/src/components/AnalyticsConsentSwitch.tsx
+++ b/frontend/src/components/AnalyticsConsentSwitch.tsx
@@ -157,22 +157,22 @@ export default function AnalyticsConsentSwitch() {
     <>
       <div className="space-y-4">
         <div>
-          <h3 className="text-base font-semibold text-gray-800 mb-2">Usage Analytics</h3>
-          <p className="text-sm text-gray-600 mb-4">
+          <h3 className="text-base font-semibold text-foreground mb-2">Usage Analytics</h3>
+          <p className="text-sm text-muted-foreground mb-4">
             Usage analytics is off by default. You can turn it on to share anonymous product and performance data; no personal content is collected.
           </p>
         </div>
 
-        <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg border border-gray-200">
+        <div className="flex items-center justify-between p-3 bg-muted/40 rounded-lg border border-border">
           <div>
-            <h4 className="font-semibold text-gray-800">Enable Analytics</h4>
-            <p className="text-sm text-gray-600">
+            <h4 className="font-semibold text-foreground">Enable Analytics</h4>
+            <p className="text-sm text-muted-foreground">
               {isProcessing ? 'Updating...' : 'Off unless you choose to enable it'}
             </p>
           </div>
           <div className="flex items-center gap-2 ml-4">
             {isProcessing && (
-              <Loader2 className="w-4 h-4 animate-spin text-gray-500" />
+              <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
             )}
             <Switch
               checked={isAnalyticsOptedIn}
@@ -184,15 +184,15 @@ export default function AnalyticsConsentSwitch() {
 
         {/* User ID Display */}
         {isAnalyticsOptedIn && userId && (
-          <div className="p-4 border rounded-lg bg-gray-50">
+          <div className="p-4 border rounded-lg bg-muted/40">
             <div className="flex items-start justify-between gap-4">
               <div className="flex-1 min-w-0">
-                <div className="font-medium text-gray-800 mb-1">Your User ID</div>
-                <p className="text-xs text-gray-600 mb-2">
+                <div className="font-medium text-foreground mb-1">Your User ID</div>
+                <p className="text-xs text-muted-foreground mb-2">
                   Share this ID when reporting issues to help us investigate your issue logs
                 </p>
                 <div className="flex items-center gap-2">
-                  <code className="text-xs text-gray-700 bg-white px-2 py-1 rounded border border-gray-300 font-mono flex-1 truncate">
+                  <code className="text-xs text-foreground bg-card px-2 py-1 rounded border border-border font-mono flex-1 truncate">
                     {userId}
                   </code>
                   <Button
@@ -204,8 +204,8 @@ export default function AnalyticsConsentSwitch() {
                   >
                     {isCopied ? (
                       <>
-                        <Check className="w-3.5 h-3.5 text-green-600" />
-                        <span className="text-green-600">Copied!</span>
+                        <Check className="w-3.5 h-3.5 text-success" />
+                        <span className="text-success">Copied!</span>
                       </>
                     ) : (
                       <>
@@ -220,15 +220,15 @@ export default function AnalyticsConsentSwitch() {
           </div>
         )}
 
-        <div className="flex items-start gap-2 p-2 bg-blue-50 rounded border border-blue-200">
-          <Info className="w-4 h-4 text-blue-600 mt-0.5 flex-shrink-0" />
-          <div className="text-xs text-blue-700">
+        <div className="flex items-start gap-2 p-2 bg-info/10 rounded border border-info/30">
+          <Info className="w-4 h-4 text-info mt-0.5 flex-shrink-0" />
+          <div className="text-xs text-info">
             <p className="mb-1">
               Your meetings, transcripts, and recordings remain completely private and local.
             </p>
             <button
               onClick={handlePrivacyPolicyClick}
-              className="text-blue-600 hover:text-blue-800 underline hover:no-underline"
+              className="text-info hover:text-info underline hover:no-underline"
             >
               View Privacy Policy
             </button>

--- a/frontend/src/components/AnalyticsConsentSwitch.tsx
+++ b/frontend/src/components/AnalyticsConsentSwitch.tsx
@@ -204,8 +204,8 @@ export default function AnalyticsConsentSwitch() {
                   >
                     {isCopied ? (
                       <>
-                        <Check className="w-3.5 h-3.5 text-success" />
-                        <span className="text-success">Copied!</span>
+                        <Check className="w-3.5 h-3.5 text-success-text" />
+                        <span className="text-success-text">Copied!</span>
                       </>
                     ) : (
                       <>
@@ -221,14 +221,14 @@ export default function AnalyticsConsentSwitch() {
         )}
 
         <div className="flex items-start gap-2 p-2 bg-info/10 rounded border border-info/30">
-          <Info className="w-4 h-4 text-info mt-0.5 flex-shrink-0" />
-          <div className="text-xs text-info">
+          <Info className="w-4 h-4 text-info-text mt-0.5 flex-shrink-0" />
+          <div className="text-xs text-info-text">
             <p className="mb-1">
               Your meetings, transcripts, and recordings remain completely private and local.
             </p>
             <button
               onClick={handlePrivacyPolicyClick}
-              className="text-info hover:text-info underline hover:no-underline"
+              className="text-info-text hover:text-info-text underline hover:no-underline"
             >
               View Privacy Policy
             </button>

--- a/frontend/src/components/AnalyticsDataModal.tsx
+++ b/frontend/src/components/AnalyticsDataModal.tsx
@@ -18,7 +18,7 @@ export default function AnalyticsDataModal({ isOpen, onClose, onConfirmDisable }
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-border">
           <div className="flex items-center gap-3">
-            <Shield className="w-6 h-6 text-info" />
+            <Shield className="w-6 h-6 text-info-text" />
             <h2 className="text-xl font-semibold text-foreground">What Analytics Collects</h2>
           </div>
           <button
@@ -34,8 +34,8 @@ export default function AnalyticsDataModal({ isOpen, onClose, onConfirmDisable }
           {/* Privacy Notice */}
           <div className="bg-success/10 border border-success/30 rounded-lg p-4">
             <div className="flex items-start gap-3">
-              <Info className="w-5 h-5 text-success mt-0.5 flex-shrink-0" />
-              <div className="text-sm text-success">
+              <Info className="w-5 h-5 text-success-text mt-0.5 flex-shrink-0" />
+              <div className="text-sm text-success-text">
                 <p className="font-semibold mb-1">Your Privacy is Protected</p>
                 <p>Analytics is off by default. If you enable it, we collect <strong>anonymous usage data only</strong>. No meeting content, names, file paths, or personal information is ever collected.</p>
               </div>

--- a/frontend/src/components/AnalyticsDataModal.tsx
+++ b/frontend/src/components/AnalyticsDataModal.tsx
@@ -13,17 +13,17 @@ export default function AnalyticsDataModal({ isOpen, onClose, onConfirmDisable }
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto">
+    <div className="fixed inset-0 bg-overlay/50 flex items-center justify-center z-50">
+      <div className="bg-card rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto">
         {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-gray-200">
+        <div className="flex items-center justify-between p-6 border-b border-border">
           <div className="flex items-center gap-3">
-            <Shield className="w-6 h-6 text-blue-600" />
-            <h2 className="text-xl font-semibold text-gray-900">What Analytics Collects</h2>
+            <Shield className="w-6 h-6 text-info" />
+            <h2 className="text-xl font-semibold text-foreground">What Analytics Collects</h2>
           </div>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 transition-colors"
+            className="text-muted-foreground hover:text-muted-foreground transition-colors"
           >
             <X className="w-5 h-5" />
           </button>
@@ -32,10 +32,10 @@ export default function AnalyticsDataModal({ isOpen, onClose, onConfirmDisable }
         {/* Content */}
         <div className="p-6 space-y-6">
           {/* Privacy Notice */}
-          <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+          <div className="bg-success/10 border border-success/30 rounded-lg p-4">
             <div className="flex items-start gap-3">
-              <Info className="w-5 h-5 text-green-600 mt-0.5 flex-shrink-0" />
-              <div className="text-sm text-green-800">
+              <Info className="w-5 h-5 text-success mt-0.5 flex-shrink-0" />
+              <div className="text-sm text-success">
                 <p className="font-semibold mb-1">Your Privacy is Protected</p>
                 <p>Analytics is off by default. If you enable it, we collect <strong>anonymous usage data only</strong>. No meeting content, names, file paths, or personal information is ever collected.</p>
               </div>
@@ -44,69 +44,69 @@ export default function AnalyticsDataModal({ isOpen, onClose, onConfirmDisable }
 
           {/* Data Categories */}
           <div className="space-y-4">
-            <h3 className="text-lg font-semibold text-gray-900">Data We Collect When Enabled:</h3>
+            <h3 className="text-lg font-semibold text-foreground">Data We Collect When Enabled:</h3>
 
             {/* Model Preferences */}
-            <div className="border border-gray-200 rounded-lg p-4">
-              <h4 className="font-semibold text-gray-900 mb-2">1. Model Preferences</h4>
-              <ul className="text-sm text-gray-700 space-y-1 ml-4">
+            <div className="border border-border rounded-lg p-4">
+              <h4 className="font-semibold text-foreground mb-2">1. Model Preferences</h4>
+              <ul className="text-sm text-foreground space-y-1 ml-4">
                 <li>• Transcription model (e.g., "Whisper large-v3", "Parakeet")</li>
                 <li>• Summary model (e.g., "Llama 3.2", "Claude Sonnet")</li>
                 <li>• Model provider (e.g., "Local", "Ollama", "OpenRouter")</li>
               </ul>
-              <p className="text-xs text-gray-500 mt-2 italic">Helps us understand which models users prefer</p>
+              <p className="text-xs text-muted-foreground mt-2 italic">Helps us understand which models users prefer</p>
             </div>
 
             {/* Meeting Metrics */}
-            <div className="border border-gray-200 rounded-lg p-4">
-              <h4 className="font-semibold text-gray-900 mb-2">2. Anonymous Meeting Metrics</h4>
-              <ul className="text-sm text-gray-700 space-y-1 ml-4">
+            <div className="border border-border rounded-lg p-4">
+              <h4 className="font-semibold text-foreground mb-2">2. Anonymous Meeting Metrics</h4>
+              <ul className="text-sm text-foreground space-y-1 ml-4">
                 <li>• Recording duration (e.g., "125 seconds")</li>
                 <li>• Pause duration (e.g., "5 seconds")</li>
                 <li>• Number of transcript segments</li>
                 <li>• Number of audio chunks processed</li>
               </ul>
-              <p className="text-xs text-gray-500 mt-2 italic">Helps us optimize performance and understand usage patterns</p>
+              <p className="text-xs text-muted-foreground mt-2 italic">Helps us optimize performance and understand usage patterns</p>
             </div>
 
             {/* Device Types */}
-            <div className="border border-gray-200 rounded-lg p-4">
-              <h4 className="font-semibold text-gray-900 mb-2">3. Device Types (Not Names)</h4>
-              <ul className="text-sm text-gray-700 space-y-1 ml-4">
+            <div className="border border-border rounded-lg p-4">
+              <h4 className="font-semibold text-foreground mb-2">3. Device Types (Not Names)</h4>
+              <ul className="text-sm text-foreground space-y-1 ml-4">
                 <li>• Microphone type: "Bluetooth" or "Wired" or "Unknown"</li>
                 <li>• System audio type: "Bluetooth" or "Wired" or "Unknown"</li>
               </ul>
-              <p className="text-xs text-gray-500 mt-2 italic">Helps us improve compatibility, NOT the actual device names</p>
+              <p className="text-xs text-muted-foreground mt-2 italic">Helps us improve compatibility, NOT the actual device names</p>
             </div>
 
             {/* Usage Patterns */}
-            <div className="border border-gray-200 rounded-lg p-4">
-              <h4 className="font-semibold text-gray-900 mb-2">4. App Usage Patterns</h4>
-              <ul className="text-sm text-gray-700 space-y-1 ml-4">
+            <div className="border border-border rounded-lg p-4">
+              <h4 className="font-semibold text-foreground mb-2">4. App Usage Patterns</h4>
+              <ul className="text-sm text-foreground space-y-1 ml-4">
                 <li>• App started/stopped events</li>
                 <li>• Session duration</li>
                 <li>• Feature usage (e.g., "settings changed")</li>
                 <li>• Error occurrences (helps us fix bugs)</li>
               </ul>
-              <p className="text-xs text-gray-500 mt-2 italic">Helps us improve user experience</p>
+              <p className="text-xs text-muted-foreground mt-2 italic">Helps us improve user experience</p>
             </div>
 
             {/* Platform Info */}
-            <div className="border border-gray-200 rounded-lg p-4">
-              <h4 className="font-semibold text-gray-900 mb-2">5. Platform Information</h4>
-              <ul className="text-sm text-gray-700 space-y-1 ml-4">
+            <div className="border border-border rounded-lg p-4">
+              <h4 className="font-semibold text-foreground mb-2">5. Platform Information</h4>
+              <ul className="text-sm text-foreground space-y-1 ml-4">
                 <li>• Operating system (e.g., "macOS", "Windows")</li>
                 <li>• App version (automatically included in all events)</li>
                 <li>• Architecture (e.g., "x86_64", "aarch64")</li>
               </ul>
-              <p className="text-xs text-gray-500 mt-2 italic">Helps us prioritize platform support</p>
+              <p className="text-xs text-muted-foreground mt-2 italic">Helps us prioritize platform support</p>
             </div>
           </div>
 
           {/* What We DON'T Collect */}
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-            <h4 className="font-semibold text-red-900 mb-2">What We DON'T Collect:</h4>
-            <ul className="text-sm text-red-800 space-y-1 ml-4">
+          <div className="bg-destructive/10 border border-destructive/30 rounded-lg p-4">
+            <h4 className="font-semibold text-destructive mb-2">What We DON'T Collect:</h4>
+            <ul className="text-sm text-destructive space-y-1 ml-4">
               <li>• ❌ Meeting names or titles</li>
               <li>• ❌ File names, file paths, or meeting folders</li>
               <li>• ❌ Meeting transcripts or content</li>
@@ -118,9 +118,9 @@ export default function AnalyticsDataModal({ isOpen, onClose, onConfirmDisable }
           </div>
 
           {/* Example Event */}
-          <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
-            <h4 className="font-semibold text-gray-900 mb-2">Example Event:</h4>
-            <pre className="text-xs text-gray-700 overflow-x-auto">
+          <div className="bg-muted/40 border border-border rounded-lg p-4">
+            <h4 className="font-semibold text-foreground mb-2">Example Event:</h4>
+            <pre className="text-xs text-foreground overflow-x-auto">
               {`{
   "event": "meeting_ended",
   "app_version": "0.4.0",
@@ -139,16 +139,16 @@ export default function AnalyticsDataModal({ isOpen, onClose, onConfirmDisable }
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between gap-4 p-6 border-t border-gray-200 bg-gray-50">
+        <div className="flex items-center justify-between gap-4 p-6 border-t border-border bg-muted/40">
           <button
             onClick={onClose}
-            className="px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+            className="px-4 py-2 text-foreground bg-card border border-border rounded-md hover:bg-muted/40 transition-colors"
           >
             Keep Analytics Enabled
           </button>
           <button
             onClick={onConfirmDisable}
-            className="px-4 py-2 text-white bg-red-600 rounded-md hover:bg-red-700 transition-colors"
+            className="px-4 py-2 text-destructive-foreground bg-destructive rounded-md hover:bg-destructive/90 transition-colors"
           >
             Confirm: Disable Analytics
           </button>

--- a/frontend/src/components/AudioBackendSelector.tsx
+++ b/frontend/src/components/AudioBackendSelector.tsx
@@ -149,7 +149,7 @@ export function AudioBackendSelector({
                 checked={currentBackend === backend.id}
                 onChange={() => handleBackendChange(backend.id)}
                 disabled={isDisabled}
-                className="mt-1 h-4 w-4 text-info focus:ring-info border-border"
+                className="mt-1 h-4 w-4 text-info-text focus:ring-info border-border"
               />
               <div className="ml-3 flex-1">
                 <div className="flex items-center justify-between">
@@ -157,7 +157,7 @@ export function AudioBackendSelector({
                     {backend.name}
                   </span>
                   {currentBackend === backend.id && (
-                    <span className="text-xs font-medium text-info bg-info/15 px-2 py-0.5 rounded">
+                    <span className="text-xs font-medium text-info-text bg-info/15 px-2 py-0.5 rounded">
                       Active
                     </span>
                   )}

--- a/frontend/src/components/AudioBackendSelector.tsx
+++ b/frontend/src/components/AudioBackendSelector.tsx
@@ -77,8 +77,8 @@ export function AudioBackendSelector({
   if (loading) {
     return (
       <div className="animate-pulse">
-        <div className="h-4 bg-gray-200 rounded w-32 mb-2"></div>
-        <div className="h-10 bg-gray-200 rounded"></div>
+        <div className="h-4 bg-muted rounded w-32 mb-2"></div>
+        <div className="h-10 bg-muted rounded"></div>
       </div>
     );
   }
@@ -91,7 +91,7 @@ export function AudioBackendSelector({
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2">
-        <label className="text-sm font-medium text-gray-700">
+        <label className="text-sm font-medium text-foreground">
           System Audio Backend
         </label>
         <div className="relative">
@@ -99,12 +99,12 @@ export function AudioBackendSelector({
             type="button"
             onMouseEnter={() => setShowTooltip(true)}
             onMouseLeave={() => setShowTooltip(false)}
-            className="text-gray-400 hover:text-gray-600 transition-colors"
+            className="text-muted-foreground hover:text-muted-foreground transition-colors"
           >
             <Info className="h-4 w-4" />
           </button>
           {showTooltip && (
-            <div className="absolute z-10 left-6 top-0 w-64 p-3 text-xs bg-gray-900 text-white rounded-lg shadow-lg">
+            <div className="absolute z-10 left-6 top-0 w-64 p-3 text-xs bg-primary text-primary-foreground rounded-lg shadow-lg">
               <p className="font-semibold mb-1">Audio Capture Methods:</p>
               <ul className="space-y-1">
                 {backends.map((backend) => (
@@ -113,7 +113,7 @@ export function AudioBackendSelector({
                   </li>
                 ))}
               </ul>
-              <p className="mt-2 text-gray-300">
+              <p className="mt-2 text-primary-foreground/70">
                 Try different backends to find which works best for your system.
               </p>
             </div>
@@ -122,7 +122,7 @@ export function AudioBackendSelector({
       </div>
 
       {error && (
-        <div className="p-2 text-xs text-red-700 bg-red-50 border border-red-200 rounded-md">
+        <div className="p-2 text-xs text-destructive bg-destructive/10 border border-destructive/30 rounded-md">
           {error}
         </div>
       )}
@@ -138,8 +138,8 @@ export function AudioBackendSelector({
               key={backend.id}
               className={`flex items-start p-3 border rounded-lg transition-all ${
                 currentBackend === backend.id
-                  ? 'border-blue-500 bg-blue-50'
-                  : 'border-gray-300 hover:border-gray-400 bg-white'
+                  ? 'border-info bg-info/10'
+                  : 'border-border hover:border-border bg-card'
               } ${isDisabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
             >
               <input
@@ -149,32 +149,32 @@ export function AudioBackendSelector({
                 checked={currentBackend === backend.id}
                 onChange={() => handleBackendChange(backend.id)}
                 disabled={isDisabled}
-                className="mt-1 h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300"
+                className="mt-1 h-4 w-4 text-info focus:ring-info border-border"
               />
               <div className="ml-3 flex-1">
                 <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium text-gray-900">
+                  <span className="text-sm font-medium text-foreground">
                     {backend.name}
                   </span>
                   {currentBackend === backend.id && (
-                    <span className="text-xs font-medium text-blue-600 bg-blue-100 px-2 py-0.5 rounded">
+                    <span className="text-xs font-medium text-info bg-info/15 px-2 py-0.5 rounded">
                       Active
                     </span>
                   )}
                   {isCoreAudio && (
-                    <span className="text-xs font-medium text-gray-500 bg-gray-100 px-2 py-0.5 rounded">
+                    <span className="text-xs font-medium text-muted-foreground bg-muted px-2 py-0.5 rounded">
                       Disabled
                     </span>
                   )}
                 </div>
-                <p className="mt-1 text-xs text-gray-600">{backend.description}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{backend.description}</p>
               </div>
             </label>
           );
         })}
       </div>
 
-      <div className="text-xs text-gray-500 space-y-1">
+      <div className="text-xs text-muted-foreground space-y-1">
         <p>• Backend selection only affects system audio capture</p>
         <p>• Microphone always uses the default method</p>
         <p>• Changes apply to new recording sessions</p>

--- a/frontend/src/components/AudioLevelMeter.tsx
+++ b/frontend/src/components/AudioLevelMeter.tsx
@@ -31,9 +31,9 @@ export function AudioLevelMeter({
 
   // Color coding based on level
   const getLevelColor = (level: number) => {
-    if (level < 0.3) return 'bg-green-500';
-    if (level < 0.7) return 'bg-yellow-500';
-    return 'bg-red-500';
+    if (level < 0.3) return 'bg-success';
+    if (level < 0.7) return 'bg-warning';
+    return 'bg-destructive';
   };
 
   const rmsColor = getLevelColor(logRms);
@@ -64,13 +64,13 @@ export function AudioLevelMeter({
     <div className={`flex items-center space-x-2 ${className}`}>
       {/* Device activity indicator */}
       <div className={`w-2 h-2 rounded-full ${
-        isActive ? 'bg-green-400 animate-pulse' : 'bg-gray-300'
+        isActive ? 'bg-success animate-pulse' : 'bg-muted-foreground/30'
       }`} title={`${deviceName} - ${isActive ? 'Active' : 'Inactive'}`} />
 
       {/* Level meter container */}
       <div className={`flex-1 ${sizes.container} relative`}>
         {/* Background */}
-        <div className="w-full h-full bg-gray-200 rounded-sm overflow-hidden">
+        <div className="w-full h-full bg-muted rounded-sm overflow-hidden">
           {/* RMS level bar (main level) */}
           <div
             className={`${sizes.meter} ${rmsColor} transition-all duration-150 ease-out rounded-sm`}
@@ -89,16 +89,16 @@ export function AudioLevelMeter({
         {/* Level markers */}
         <div className="absolute inset-0 flex justify-between items-center px-1 pointer-events-none">
           {/* 25% marker */}
-          <div className="w-px h-full bg-gray-400 opacity-30" style={{ marginLeft: '25%' }} />
+          <div className="w-px h-full bg-muted-foreground/40 opacity-30" style={{ marginLeft: '25%' }} />
           {/* 50% marker */}
-          <div className="w-px h-full bg-gray-400 opacity-30" style={{ marginLeft: '50%' }} />
+          <div className="w-px h-full bg-muted-foreground/40 opacity-30" style={{ marginLeft: '50%' }} />
           {/* 75% marker */}
-          <div className="w-px h-full bg-gray-400 opacity-30" style={{ marginLeft: '75%' }} />
+          <div className="w-px h-full bg-muted-foreground/40 opacity-30" style={{ marginLeft: '75%' }} />
         </div>
       </div>
 
       {/* Level percentage display */}
-      <div className={`${sizes.text} text-gray-600 font-mono min-w-[3rem] text-right`}>
+      <div className={`${sizes.text} text-muted-foreground font-mono min-w-[3rem] text-right`}>
         {rmsPercent}%
       </div>
     </div>
@@ -124,20 +124,20 @@ export function CompactAudioLevelMeter({
   const rmsPercent = Math.round(logRms * 100);
 
   const getLevelColor = (level: number) => {
-    if (level < 0.3) return 'bg-green-400';
-    if (level < 0.7) return 'bg-yellow-400';
-    return 'bg-red-400';
+    if (level < 0.3) return 'bg-success';
+    if (level < 0.7) return 'bg-warning';
+    return 'bg-destructive';
   };
 
   return (
     <div className={`flex items-center space-x-1 ${className}`}>
       {/* Activity dot */}
       <div className={`w-1.5 h-1.5 rounded-full ${
-        isActive ? 'bg-green-400' : 'bg-gray-300'
+        isActive ? 'bg-success' : 'bg-muted-foreground/30'
       }`} />
 
       {/* Mini meter */}
-      <div className="w-8 h-1.5 bg-gray-200 rounded-sm overflow-hidden">
+      <div className="w-8 h-1.5 bg-muted rounded-sm overflow-hidden">
         <div
           className={`h-full ${getLevelColor(logRms)} transition-all duration-150`}
           style={{ width: `${rmsPercent}%` }}

--- a/frontend/src/components/BetaSettings.tsx
+++ b/frontend/src/components/BetaSettings.tsx
@@ -18,9 +18,9 @@ export function BetaSettings() {
   return (
     <div className="space-y-6">
       {/* Yellow Warning Banner */}
-      <div className="flex items-start gap-3 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
-        <AlertCircle className="h-5 w-5 text-yellow-600 flex-shrink-0 mt-0.5" />
-        <div className="text-sm text-yellow-800">
+      <div className="flex items-start gap-3 p-4 bg-warning/10 border border-warning/30 rounded-lg">
+        <AlertCircle className="h-5 w-5 text-warning flex-shrink-0 mt-0.5" />
+        <div className="text-sm text-warning">
           <p className="font-medium">Beta Features</p>
           <p className="mt-1">
             These features are still being tested. You may encounter issues, and we appreciate your feedback.
@@ -32,20 +32,20 @@ export function BetaSettings() {
       {featureOrder.map((featureKey) => (
         <div
           key={featureKey}
-          className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm"
+          className="bg-card rounded-lg border border-border p-6 shadow-sm"
         >
           <div className="flex items-center justify-between">
             <div className="flex-1">
               <div className="flex items-center gap-2 mb-2">
-                <FlaskConical className="h-5 w-5 text-gray-600" />
-                <h3 className="text-lg font-semibold text-gray-900">
+                <FlaskConical className="h-5 w-5 text-muted-foreground" />
+                <h3 className="text-lg font-semibold text-foreground">
                   {BETA_FEATURE_NAMES[featureKey]}
                 </h3>
-                <span className="px-2 py-0.5 text-xs font-medium bg-yellow-100 text-yellow-800 rounded-full">
+                <span className="px-2 py-0.5 text-xs font-medium bg-warning/15 text-warning rounded-full">
                   BETA
                 </span>
               </div>
-              <p className="text-sm text-gray-600">
+              <p className="text-sm text-muted-foreground">
                 {BETA_FEATURE_DESCRIPTIONS[featureKey]}
               </p>
             </div>
@@ -61,8 +61,8 @@ export function BetaSettings() {
       ))}
 
       {/* Info Box */}
-      <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
-        <p className="text-sm text-blue-800">
+      <div className="p-4 bg-info/10 border border-info/30 rounded-lg">
+        <p className="text-sm text-info">
           <strong>Note:</strong> When disabled, beta features will be hidden. Your existing meetings remain unaffected.
         </p>
       </div>

--- a/frontend/src/components/BetaSettings.tsx
+++ b/frontend/src/components/BetaSettings.tsx
@@ -19,8 +19,8 @@ export function BetaSettings() {
     <div className="space-y-6">
       {/* Yellow Warning Banner */}
       <div className="flex items-start gap-3 p-4 bg-warning/10 border border-warning/30 rounded-lg">
-        <AlertCircle className="h-5 w-5 text-warning flex-shrink-0 mt-0.5" />
-        <div className="text-sm text-warning">
+        <AlertCircle className="h-5 w-5 text-warning-text flex-shrink-0 mt-0.5" />
+        <div className="text-sm text-warning-text">
           <p className="font-medium">Beta Features</p>
           <p className="mt-1">
             These features are still being tested. You may encounter issues, and we appreciate your feedback.
@@ -41,7 +41,7 @@ export function BetaSettings() {
                 <h3 className="text-lg font-semibold text-foreground">
                   {BETA_FEATURE_NAMES[featureKey]}
                 </h3>
-                <span className="px-2 py-0.5 text-xs font-medium bg-warning/15 text-warning rounded-full">
+                <span className="px-2 py-0.5 text-xs font-medium bg-warning/15 text-warning-text rounded-full">
                   BETA
                 </span>
               </div>
@@ -62,7 +62,7 @@ export function BetaSettings() {
 
       {/* Info Box */}
       <div className="p-4 bg-info/10 border border-info/30 rounded-lg">
-        <p className="text-sm text-info">
+        <p className="text-sm text-info-text">
           <strong>Note:</strong> When disabled, beta features will be hidden. Your existing meetings remain unaffected.
         </p>
       </div>

--- a/frontend/src/components/BlockNoteEditor/Editor.tsx
+++ b/frontend/src/components/BlockNoteEditor/Editor.tsx
@@ -6,7 +6,7 @@ import { useCreateBlockNote } from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/shadcn";
 import "@blocknote/shadcn/style.css";
 import "@blocknote/core/fonts/inter.css";
-import { useConfig } from "@/contexts/ConfigContext";
+import { useIsDarkTheme } from "@/hooks/useIsDarkTheme";
 
 interface EditorProps {
   initialContent?: Block[];
@@ -15,7 +15,7 @@ interface EditorProps {
 }
 
 export default function Editor({ initialContent, onChange, editable = true }: EditorProps) {
-  const { isDarkTheme } = useConfig();
+  const isDarkTheme = useIsDarkTheme();
 
   console.log('📝 EDITOR: Initializing BlockNote editor with blocks:', {
     hasContent: !!initialContent,

--- a/frontend/src/components/BlockNoteEditor/Editor.tsx
+++ b/frontend/src/components/BlockNoteEditor/Editor.tsx
@@ -6,6 +6,7 @@ import { useCreateBlockNote } from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/shadcn";
 import "@blocknote/shadcn/style.css";
 import "@blocknote/core/fonts/inter.css";
+import { useConfig } from "@/contexts/ConfigContext";
 
 interface EditorProps {
   initialContent?: Block[];
@@ -14,6 +15,8 @@ interface EditorProps {
 }
 
 export default function Editor({ initialContent, onChange, editable = true }: EditorProps) {
+  const { isDarkTheme } = useConfig();
+
   console.log('📝 EDITOR: Initializing BlockNote editor with blocks:', {
     hasContent: !!initialContent,
     blocksCount: initialContent?.length || 0,
@@ -47,5 +50,5 @@ export default function Editor({ initialContent, onChange, editable = true }: Ed
     };
   }, [editor, onChange]);
 
-  return <BlockNoteView editor={editor} editable={editable} theme="light" />;
+  return <BlockNoteView editor={editor} editable={editable} theme={isDarkTheme ? "dark" : "light"} />;
 }

--- a/frontend/src/components/BluetoothPlaybackWarning.tsx
+++ b/frontend/src/components/BluetoothPlaybackWarning.tsx
@@ -64,17 +64,17 @@ export function BluetoothPlaybackWarning({
 
   return (
     <Alert
-      className="mb-4 border-warning bg-warning/10 text-warning"
+      className="mb-4 border-warning bg-warning/10 text-warning-text"
       role="alert"
       aria-live="polite"
     >
-      <Speaker className="h-4 w-4 text-warning" />
+      <Speaker className="h-4 w-4 text-warning-text" />
       <div className="flex items-start justify-between w-full">
         <div className="flex-1">
-          <AlertTitle className="text-warning font-semibold">
+          <AlertTitle className="text-warning-text font-semibold">
             Bluetooth Playback Detected
           </AlertTitle>
-          <AlertDescription className="text-warning mt-1">
+          <AlertDescription className="text-warning-text mt-1">
             You're using <strong>{deviceName}</strong> for playback.
             Recordings may sound distorted or sped up through Bluetooth devices.
             For accurate review, please use <strong>computer speakers</strong> or{' '}
@@ -84,7 +84,7 @@ export function BluetoothPlaybackWarning({
               href="https://github.com/your-org/meetily/blob/main/BLUETOOTH_PLAYBACK_NOTICE.md"
               target="_blank"
               rel="noopener noreferrer"
-              className="underline hover:text-warning font-medium mt-2 inline-block"
+              className="underline hover:text-warning-text font-medium mt-2 inline-block"
             >
               Learn why this happens →
             </a>
@@ -94,7 +94,7 @@ export function BluetoothPlaybackWarning({
           variant="ghost"
           size="icon"
           onClick={() => setIsDismissed(true)}
-          className="ml-4 h-6 w-6 text-warning hover:text-warning hover:bg-warning/15"
+          className="ml-4 h-6 w-6 text-warning-text hover:text-warning-text hover:bg-warning/15"
           aria-label="Dismiss warning"
         >
           <X className="h-4 w-4" />

--- a/frontend/src/components/BluetoothPlaybackWarning.tsx
+++ b/frontend/src/components/BluetoothPlaybackWarning.tsx
@@ -64,17 +64,17 @@ export function BluetoothPlaybackWarning({
 
   return (
     <Alert
-      className="mb-4 border-yellow-500 bg-yellow-50 text-yellow-900"
+      className="mb-4 border-warning bg-warning/10 text-warning"
       role="alert"
       aria-live="polite"
     >
-      <Speaker className="h-4 w-4 text-yellow-600" />
+      <Speaker className="h-4 w-4 text-warning" />
       <div className="flex items-start justify-between w-full">
         <div className="flex-1">
-          <AlertTitle className="text-yellow-900 font-semibold">
+          <AlertTitle className="text-warning font-semibold">
             Bluetooth Playback Detected
           </AlertTitle>
-          <AlertDescription className="text-yellow-800 mt-1">
+          <AlertDescription className="text-warning mt-1">
             You're using <strong>{deviceName}</strong> for playback.
             Recordings may sound distorted or sped up through Bluetooth devices.
             For accurate review, please use <strong>computer speakers</strong> or{' '}
@@ -84,7 +84,7 @@ export function BluetoothPlaybackWarning({
               href="https://github.com/your-org/meetily/blob/main/BLUETOOTH_PLAYBACK_NOTICE.md"
               target="_blank"
               rel="noopener noreferrer"
-              className="underline hover:text-yellow-900 font-medium mt-2 inline-block"
+              className="underline hover:text-warning font-medium mt-2 inline-block"
             >
               Learn why this happens →
             </a>
@@ -94,7 +94,7 @@ export function BluetoothPlaybackWarning({
           variant="ghost"
           size="icon"
           onClick={() => setIsDismissed(true)}
-          className="ml-4 h-6 w-6 text-yellow-700 hover:text-yellow-900 hover:bg-yellow-100"
+          className="ml-4 h-6 w-6 text-warning hover:text-warning hover:bg-warning/15"
           aria-label="Dismiss warning"
         >
           <X className="h-4 w-4" />

--- a/frontend/src/components/BuiltInModelManager.tsx
+++ b/frontend/src/components/BuiltInModelManager.tsx
@@ -302,11 +302,11 @@ export function BuiltInModelManager({
               className={cn(
                 'p-4 rounded-lg border transition-colors',
                 modelIsDownloading
-                  ? 'bg-white border-gray-200'
+                  ? 'bg-card border-border'
                   : 'bg-card',
                 selectedModel === model.name
-                  ? 'ring-2 ring-gray-800 border-gray-800'
-                  : 'border-gray-200 hover:border-gray-300',
+                  ? 'ring-2 ring-ring border-primary'
+                  : 'border-border hover:border-border',
                 isAvailable && !modelIsDownloading && 'cursor-pointer'
               )}
               onClick={() => {
@@ -319,28 +319,28 @@ export function BuiltInModelManager({
               <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                 <div className="min-w-0 flex-1">
                   <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-                    <span className="min-w-0 break-words text-base font-bold leading-snug text-gray-900">{model.display_name || model.name}</span>
+                    <span className="min-w-0 break-words text-base font-bold leading-snug text-foreground">{model.display_name || model.name}</span>
                     {isAvailable && (
                       <>
-                        <span className="flex shrink-0 items-center gap-1 text-xs font-medium text-green-600">
-                          <span className="h-2 w-2 rounded-full bg-green-600"></span>
+                        <span className="flex shrink-0 items-center gap-1 text-xs font-medium text-success">
+                          <span className="h-2 w-2 rounded-full bg-success"></span>
                           Ready
                         </span>
                         {selectedModel === model.name && (
-                          <span className="shrink-0 rounded bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
+                          <span className="shrink-0 rounded bg-info/15 px-2 py-0.5 text-xs font-medium text-info">
                             Selected
                           </span>
                         )}
                       </>
                     )}
                     {isCorrupted && (
-                      <span className="flex shrink-0 items-center gap-1 rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">
+                      <span className="flex shrink-0 items-center gap-1 rounded bg-destructive/15 px-2 py-0.5 text-xs font-medium text-destructive">
                         <BadgeAlert className="h-3 w-3" />
                         Corrupted
                       </span>
                     )}
                     {isError && (
-                      <span className="shrink-0 rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">
+                      <span className="shrink-0 rounded bg-destructive/15 px-2 py-0.5 text-xs font-medium text-destructive">
                         Error
                       </span>
                     )}
@@ -421,7 +421,7 @@ export function BuiltInModelManager({
                   {/* Available - Show small trash icon (only if not currently selected) */}
                   {isAvailable && !modelIsDownloading && selectedModel !== model.name && (
                     <button
-                      className="p-2 rounded hover:bg-gray-100 transition-colors text-gray-500 hover:text-red-600"
+                      className="p-2 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-destructive"
                       onClick={(e) => {
                         e.stopPropagation();
                         deleteModel(model.name);
@@ -433,12 +433,12 @@ export function BuiltInModelManager({
                   )}
                 </div>
               </div>
-              <div className="text-sm text-gray-600">
+              <div className="text-sm text-muted-foreground">
                 {model.description && (
                   <p className="mb-1">{model.description}</p>
                 )}
                 {(isError || isCorrupted) && (
-                  <p className="mb-1 text-xs text-red-600">
+                  <p className="mb-1 text-xs text-destructive">
                     {isError && typeof model.status === 'object' && 'Error' in model.status
                       ? (model.status as any).Error
                       : isCorrupted
@@ -446,7 +446,7 @@ export function BuiltInModelManager({
                       : 'An error occurred'}
                   </p>
                 )}
-                <div className="text-xs text-gray-500">
+                <div className="text-xs text-muted-foreground">
                   <span>{formatSummaryModelSizeLabelFromMb(model.size_mb)} • {model.context_size} tokens</span>
                 </div>
                 </div>
@@ -454,19 +454,19 @@ export function BuiltInModelManager({
 
               {/* Download progress bar */}
               {modelIsDownloading && progress !== undefined && (
-                <div className="mt-3 pt-3 border-t border-gray-200">
+                <div className="mt-3 pt-3 border-t border-border">
                   <div className="flex items-center justify-between mb-1">
-                    <span className="text-sm font-medium text-gray-900">Downloading...</span>
-                    <span className="text-sm font-semibold text-gray-900">
+                    <span className="text-sm font-medium text-foreground">Downloading...</span>
+                    <span className="text-sm font-semibold text-foreground">
                       {Math.round(progress)}%
                     </span>
                   </div>
-                  <div className="text-sm text-gray-600 mb-2">
+                  <div className="text-sm text-muted-foreground mb-2">
                     {progressInfo?.totalMb > 0 ? (
                       <>
                         {progressInfo.downloadedMb.toFixed(1)} MiB / {progressInfo.totalMb.toFixed(1)} MiB
                         {progressInfo.speedMbps > 0 && (
-                          <span className="ml-2 text-gray-500">
+                          <span className="ml-2 text-muted-foreground">
                             ({progressInfo.speedMbps.toFixed(1)} MiB/s)
                           </span>
                         )}
@@ -475,9 +475,9 @@ export function BuiltInModelManager({
                       <span>{formatSummaryModelSizeLabelFromMb(model.size_mb)}</span>
                     )}
                   </div>
-                  <div className="w-full h-2.5 bg-gray-200 rounded-full overflow-hidden">
+                  <div className="w-full h-2.5 bg-muted rounded-full overflow-hidden">
                     <div
-                      className="h-full bg-gradient-to-r from-gray-800 to-gray-900 rounded-full transition-all duration-300"
+                      className="h-full bg-primary rounded-full transition-all duration-300"
                       style={{ width: `${progress}%` }}
                     />
                   </div>

--- a/frontend/src/components/BuiltInModelManager.tsx
+++ b/frontend/src/components/BuiltInModelManager.tsx
@@ -322,12 +322,12 @@ export function BuiltInModelManager({
                     <span className="min-w-0 break-words text-base font-bold leading-snug text-foreground">{model.display_name || model.name}</span>
                     {isAvailable && (
                       <>
-                        <span className="flex shrink-0 items-center gap-1 text-xs font-medium text-success">
+                        <span className="flex shrink-0 items-center gap-1 text-xs font-medium text-success-text">
                           <span className="h-2 w-2 rounded-full bg-success"></span>
                           Ready
                         </span>
                         {selectedModel === model.name && (
-                          <span className="shrink-0 rounded bg-info/15 px-2 py-0.5 text-xs font-medium text-info">
+                          <span className="shrink-0 rounded bg-info/15 px-2 py-0.5 text-xs font-medium text-info-text">
                             Selected
                           </span>
                         )}

--- a/frontend/src/components/ChunkProgressDisplay.tsx
+++ b/frontend/src/components/ChunkProgressDisplay.tsx
@@ -76,27 +76,27 @@ export function ChunkProgressDisplay({
   const getChunkStatusColor = (status: ChunkStatus['status']) => {
     switch (status) {
       case 'completed':
-        return 'text-green-600 bg-green-50 border-green-200';
+        return 'text-success bg-success/10 border-success/30';
       case 'processing':
-        return 'text-blue-600 bg-blue-50 border-blue-200';
+        return 'text-info bg-info/10 border-info/30';
       case 'failed':
-        return 'text-red-600 bg-red-50 border-red-200';
+        return 'text-destructive bg-destructive/10 border-destructive/30';
       case 'pending':
       default:
-        return 'text-gray-600 bg-gray-50 border-gray-200';
+        return 'text-muted-foreground bg-muted/40 border-border';
     }
   };
 
   return (
-    <div className={`bg-white border border-gray-200 rounded-lg p-4 ${className}`}>
+    <div className={`bg-card border border-border rounded-lg p-4 ${className}`}>
       {/* Progress Header */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center space-x-3">
-          <h3 className="text-lg font-semibold text-gray-900">
+          <h3 className="text-lg font-semibold text-foreground">
             Processing Progress
           </h3>
           {isPaused && (
-            <span className="bg-yellow-100 text-yellow-800 px-2 py-1 rounded-full text-xs font-medium">
+            <span className="bg-warning/15 text-warning px-2 py-1 rounded-full text-xs font-medium">
               Paused
             </span>
           )}
@@ -106,7 +106,7 @@ export function ChunkProgressDisplay({
           {!isPaused ? (
             <button
               onClick={onPause}
-              className="bg-yellow-500 hover:bg-yellow-600 text-white px-3 py-1 rounded text-sm transition-colors"
+              className="bg-warning hover:bg-warning/90 text-warning-foreground px-3 py-1 rounded text-sm transition-colors"
               disabled={progress.processing_chunks === 0 && progress.completed_chunks === progress.total_chunks}
             >
               Pause
@@ -114,7 +114,7 @@ export function ChunkProgressDisplay({
           ) : (
             <button
               onClick={onResume}
-              className="bg-green-500 hover:bg-green-600 text-white px-3 py-1 rounded text-sm transition-colors"
+              className="bg-success hover:bg-success/90 text-success-foreground px-3 py-1 rounded text-sm transition-colors"
             >
               Resume
             </button>
@@ -122,7 +122,7 @@ export function ChunkProgressDisplay({
 
           <button
             onClick={onCancel}
-            className="bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded text-sm transition-colors"
+            className="bg-destructive hover:bg-destructive/90 text-destructive-foreground px-3 py-1 rounded text-sm transition-colors"
           >
             Cancel
           </button>
@@ -132,17 +132,17 @@ export function ChunkProgressDisplay({
       {/* Progress Bar */}
       <div className="mb-4">
         <div className="flex items-center justify-between mb-2">
-          <span className="text-sm font-medium text-gray-700">
+          <span className="text-sm font-medium text-foreground">
             {progress.completed_chunks} of {progress.total_chunks} chunks completed
           </span>
-          <span className="text-sm font-medium text-gray-700">
+          <span className="text-sm font-medium text-foreground">
             {completionPercentage}%
           </span>
         </div>
 
-        <div className="w-full bg-gray-200 rounded-full h-2">
+        <div className="w-full bg-muted rounded-full h-2">
           <div
-            className="bg-blue-600 h-2 rounded-full transition-all duration-300 ease-out"
+            className="bg-info h-2 rounded-full transition-all duration-300 ease-out"
             style={{ width: `${completionPercentage}%` }}
           />
         </div>
@@ -151,40 +151,40 @@ export function ChunkProgressDisplay({
       {/* Processing Stats */}
       <div className="grid grid-cols-4 gap-4 mb-4 text-sm">
         <div className="text-center">
-          <div className="text-lg font-semibold text-green-600">
+          <div className="text-lg font-semibold text-success">
             {progress.completed_chunks}
           </div>
-          <div className="text-gray-600">Completed</div>
+          <div className="text-muted-foreground">Completed</div>
         </div>
 
         <div className="text-center">
-          <div className="text-lg font-semibold text-blue-600">
+          <div className="text-lg font-semibold text-info">
             {progress.processing_chunks}
           </div>
-          <div className="text-gray-600">Processing</div>
+          <div className="text-muted-foreground">Processing</div>
         </div>
 
         <div className="text-center">
-          <div className="text-lg font-semibold text-gray-600">
+          <div className="text-lg font-semibold text-muted-foreground">
             {progress.total_chunks - progress.completed_chunks - progress.processing_chunks - progress.failed_chunks}
           </div>
-          <div className="text-gray-600">Pending</div>
+          <div className="text-muted-foreground">Pending</div>
         </div>
 
         <div className="text-center">
-          <div className="text-lg font-semibold text-red-600">
+          <div className="text-lg font-semibold text-destructive">
             {progress.failed_chunks}
           </div>
-          <div className="text-gray-600">Failed</div>
+          <div className="text-muted-foreground">Failed</div>
         </div>
       </div>
 
       {/* Time Estimate */}
       {progress.estimated_remaining_ms && progress.estimated_remaining_ms > 0 && (
-        <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 mb-4">
+        <div className="bg-info/10 border border-info/30 rounded-lg p-3 mb-4">
           <div className="flex items-center space-x-2">
-            <span className="text-blue-600">⏱️</span>
-            <span className="text-sm text-blue-800">
+            <span className="text-info">⏱️</span>
+            <span className="text-sm text-info">
               Estimated time remaining: {formatTimeRemaining(progress.estimated_remaining_ms)}
             </span>
           </div>
@@ -193,7 +193,7 @@ export function ChunkProgressDisplay({
 
       {/* Recent Chunks Grid */}
       <div className="space-y-2">
-        <h4 className="text-sm font-medium text-gray-700 mb-2">
+        <h4 className="text-sm font-medium text-foreground mb-2">
           Recent Chunks ({Math.min(progress.chunks.length, 10)} of {progress.total_chunks})
         </h4>
 
@@ -213,7 +213,7 @@ export function ChunkProgressDisplay({
                       Chunk {chunk.chunk_id}
                     </span>
                     {chunk.duration_ms && (
-                      <span className="text-gray-500">
+                      <span className="text-muted-foreground">
                         ({formatDuration(chunk.duration_ms)})
                       </span>
                     )}
@@ -221,19 +221,19 @@ export function ChunkProgressDisplay({
 
                   {chunk.status === 'processing' && (
                     <div className="flex items-center space-x-1">
-                      <div className="animate-spin w-3 h-3 border border-blue-600 border-t-transparent rounded-full"></div>
+                      <div className="animate-spin w-3 h-3 border border-info border-t-transparent rounded-full"></div>
                     </div>
                   )}
                 </div>
 
                 {chunk.text_preview && (
-                  <div className="mt-1 text-gray-700 text-xs truncate">
+                  <div className="mt-1 text-foreground text-xs truncate">
                     "{chunk.text_preview}"
                   </div>
                 )}
 
                 {chunk.error_message && (
-                  <div className="mt-1 text-red-700 text-xs">
+                  <div className="mt-1 text-destructive text-xs">
                     Error: {chunk.error_message}
                   </div>
                 )}
@@ -244,10 +244,10 @@ export function ChunkProgressDisplay({
 
       {/* Processing Complete */}
       {progress.completed_chunks === progress.total_chunks && progress.total_chunks > 0 && (
-        <div className="mt-4 bg-green-50 border border-green-200 rounded-lg p-3">
+        <div className="mt-4 bg-success/10 border border-success/30 rounded-lg p-3">
           <div className="flex items-center space-x-2">
-            <span className="text-green-600">🎉</span>
-            <span className="text-sm font-medium text-green-800">
+            <span className="text-success">🎉</span>
+            <span className="text-sm font-medium text-success">
               Processing completed! All {progress.total_chunks} chunks have been transcribed.
             </span>
           </div>
@@ -264,27 +264,27 @@ export function ChunkProgressMini({ progress, className = '' }: { progress: Proc
     : 0;
 
   return (
-    <div className={`bg-gray-50 border border-gray-200 rounded-lg p-3 ${className}`}>
+    <div className={`bg-muted/40 border border-border rounded-lg p-3 ${className}`}>
       <div className="flex items-center justify-between mb-2">
-        <span className="text-sm font-medium text-gray-700">
+        <span className="text-sm font-medium text-foreground">
           Processing
         </span>
-        <span className="text-sm font-medium text-gray-700">
+        <span className="text-sm font-medium text-foreground">
           {completionPercentage}%
         </span>
       </div>
 
-      <div className="w-full bg-gray-200 rounded-full h-1.5 mb-2">
+      <div className="w-full bg-muted rounded-full h-1.5 mb-2">
         <div
-          className="bg-blue-600 h-1.5 rounded-full transition-all duration-300"
+          className="bg-info h-1.5 rounded-full transition-all duration-300"
           style={{ width: `${completionPercentage}%` }}
         />
       </div>
 
-      <div className="text-xs text-gray-600">
+      <div className="text-xs text-muted-foreground">
         {progress.completed_chunks} / {progress.total_chunks} chunks
         {progress.processing_chunks > 0 && (
-          <span className="ml-2 text-blue-600">
+          <span className="ml-2 text-info">
             ({progress.processing_chunks} processing)
           </span>
         )}

--- a/frontend/src/components/ChunkProgressDisplay.tsx
+++ b/frontend/src/components/ChunkProgressDisplay.tsx
@@ -76,9 +76,9 @@ export function ChunkProgressDisplay({
   const getChunkStatusColor = (status: ChunkStatus['status']) => {
     switch (status) {
       case 'completed':
-        return 'text-success bg-success/10 border-success/30';
+        return 'text-success-text bg-success/10 border-success/30';
       case 'processing':
-        return 'text-info bg-info/10 border-info/30';
+        return 'text-info-text bg-info/10 border-info/30';
       case 'failed':
         return 'text-destructive bg-destructive/10 border-destructive/30';
       case 'pending':
@@ -96,7 +96,7 @@ export function ChunkProgressDisplay({
             Processing Progress
           </h3>
           {isPaused && (
-            <span className="bg-warning/15 text-warning px-2 py-1 rounded-full text-xs font-medium">
+            <span className="bg-warning/15 text-warning-text px-2 py-1 rounded-full text-xs font-medium">
               Paused
             </span>
           )}
@@ -151,14 +151,14 @@ export function ChunkProgressDisplay({
       {/* Processing Stats */}
       <div className="grid grid-cols-4 gap-4 mb-4 text-sm">
         <div className="text-center">
-          <div className="text-lg font-semibold text-success">
+          <div className="text-lg font-semibold text-success-text">
             {progress.completed_chunks}
           </div>
           <div className="text-muted-foreground">Completed</div>
         </div>
 
         <div className="text-center">
-          <div className="text-lg font-semibold text-info">
+          <div className="text-lg font-semibold text-info-text">
             {progress.processing_chunks}
           </div>
           <div className="text-muted-foreground">Processing</div>
@@ -183,8 +183,8 @@ export function ChunkProgressDisplay({
       {progress.estimated_remaining_ms && progress.estimated_remaining_ms > 0 && (
         <div className="bg-info/10 border border-info/30 rounded-lg p-3 mb-4">
           <div className="flex items-center space-x-2">
-            <span className="text-info">⏱️</span>
-            <span className="text-sm text-info">
+            <span className="text-info-text">⏱️</span>
+            <span className="text-sm text-info-text">
               Estimated time remaining: {formatTimeRemaining(progress.estimated_remaining_ms)}
             </span>
           </div>
@@ -246,8 +246,8 @@ export function ChunkProgressDisplay({
       {progress.completed_chunks === progress.total_chunks && progress.total_chunks > 0 && (
         <div className="mt-4 bg-success/10 border border-success/30 rounded-lg p-3">
           <div className="flex items-center space-x-2">
-            <span className="text-success">🎉</span>
-            <span className="text-sm font-medium text-success">
+            <span className="text-success-text">🎉</span>
+            <span className="text-sm font-medium text-success-text">
               Processing completed! All {progress.total_chunks} chunks have been transcribed.
             </span>
           </div>
@@ -284,7 +284,7 @@ export function ChunkProgressMini({ progress, className = '' }: { progress: Proc
       <div className="text-xs text-muted-foreground">
         {progress.completed_chunks} / {progress.total_chunks} chunks
         {progress.processing_chunks > 0 && (
-          <span className="ml-2 text-info">
+          <span className="ml-2 text-info-text">
             ({progress.processing_chunks} processing)
           </span>
         )}

--- a/frontend/src/components/ComplianceNotification.tsx
+++ b/frontend/src/components/ComplianceNotification.tsx
@@ -75,7 +75,7 @@ export const ComplianceNotification: React.FC<ComplianceNotificationProps> = ({
         {/* Header with close button */}
         <div className="flex items-start justify-between mb-2">
           <div className="flex items-center gap-1">
-            <AlertTriangle className="h-3 w-3 text-warning flex-shrink-0" />
+            <AlertTriangle className="h-3 w-3 text-warning-text flex-shrink-0" />
             <h3 className="text-xs font-semibold text-foreground">
               Recording Notice
             </h3>
@@ -94,7 +94,7 @@ export const ComplianceNotification: React.FC<ComplianceNotificationProps> = ({
             Inform participants about recording.
           </p>
           <div className="bg-warning/10 border border-warning/30 rounded p-1">
-            <p className="text-xs text-warning font-medium">
+            <p className="text-xs text-warning-text font-medium">
               US compliance required
             </p>
           </div>

--- a/frontend/src/components/ComplianceNotification.tsx
+++ b/frontend/src/components/ComplianceNotification.tsx
@@ -71,18 +71,18 @@ export const ComplianceNotification: React.FC<ComplianceNotificationProps> = ({
         width: `${position.width}px`,
       }}
     >
-      <div className="bg-white border border-gray-200 rounded-lg shadow-lg p-3">
+      <div className="bg-card border border-border rounded-lg shadow-lg p-3">
         {/* Header with close button */}
         <div className="flex items-start justify-between mb-2">
           <div className="flex items-center gap-1">
-            <AlertTriangle className="h-3 w-3 text-amber-500 flex-shrink-0" />
-            <h3 className="text-xs font-semibold text-gray-900">
+            <AlertTriangle className="h-3 w-3 text-warning flex-shrink-0" />
+            <h3 className="text-xs font-semibold text-foreground">
               Recording Notice
             </h3>
           </div>
           <button
             onClick={handleClose}
-            className="text-gray-400 hover:text-gray-600 transition-colors p-0.5 rounded hover:bg-gray-100"
+            className="text-muted-foreground hover:text-muted-foreground transition-colors p-0.5 rounded hover:bg-muted"
           >
             <X className="h-3 w-3" />
           </button>
@@ -90,11 +90,11 @@ export const ComplianceNotification: React.FC<ComplianceNotificationProps> = ({
 
         {/* Content */}
         <div className="mb-2">
-          <p className="text-xs text-gray-600 mb-1">
+          <p className="text-xs text-muted-foreground mb-1">
             Inform participants about recording.
           </p>
-          <div className="bg-amber-50 border border-amber-200 rounded p-1">
-            <p className="text-xs text-amber-800 font-medium">
+          <div className="bg-warning/10 border border-warning/30 rounded p-1">
+            <p className="text-xs text-warning font-medium">
               US compliance required
             </p>
           </div>
@@ -113,7 +113,7 @@ export const ComplianceNotification: React.FC<ComplianceNotificationProps> = ({
           <Button
             size="sm"
             onClick={handleAcknowledge}
-            className="text-xs px-2 py-0.5 h-6 bg-green-600 hover:bg-green-700 flex-1"
+            className="text-xs px-2 py-0.5 h-6 bg-success hover:bg-success/90 flex-1"
           >
             <CheckCircle className="h-2 w-2 mr-1" />
             Done

--- a/frontend/src/components/ConfidenceIndicator.tsx
+++ b/frontend/src/components/ConfidenceIndicator.tsx
@@ -16,10 +16,10 @@ export const ConfidenceIndicator: React.FC<ConfidenceIndicatorProps> = ({
 
   // Get color class based on confidence threshold
   const getColorClass = (conf: number): string => {
-    if (conf >= 0.8) return 'bg-green-500'; // 80-100%: High confidence
-    if (conf >= 0.7) return 'bg-yellow-500'; // 70-79%: Good confidence
-    if (conf >= 0.4) return 'bg-orange-500'; // 40-79%: Medium confidence
-    return 'bg-red-500'; // Below 50%: Low confidence
+    if (conf >= 0.8) return 'bg-success'; // 80-100%: High confidence
+    if (conf >= 0.7) return 'bg-warning'; // 70-79%: Good confidence
+    if (conf >= 0.4) return 'bg-warning'; // 40-79%: Medium confidence
+    return 'bg-destructive'; // Below 50%: Low confidence
   };
 
   // Get descriptive label for accessibility

--- a/frontend/src/components/ConfidenceIndicator.tsx
+++ b/frontend/src/components/ConfidenceIndicator.tsx
@@ -18,8 +18,8 @@ export const ConfidenceIndicator: React.FC<ConfidenceIndicatorProps> = ({
   const getColorClass = (conf: number): string => {
     if (conf >= 0.8) return 'bg-success'; // 80-100%: High confidence
     if (conf >= 0.7) return 'bg-warning'; // 70-79%: Good confidence
-    if (conf >= 0.4) return 'bg-warning'; // 40-79%: Medium confidence
-    return 'bg-destructive'; // Below 50%: Low confidence
+    if (conf >= 0.4) return 'bg-warning-strong'; // 40-69%: Medium confidence
+    return 'bg-destructive'; // Below 40%: Low confidence
   };
 
   // Get descriptive label for accessibility

--- a/frontend/src/components/ConfirmationModel/confirmation-modal.tsx
+++ b/frontend/src/components/ConfirmationModel/confirmation-modal.tsx
@@ -11,20 +11,20 @@ export function ConfirmationModal({ onConfirm, onCancel, text, isOpen }: Confirm
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
+    <div className="fixed inset-0 bg-overlay/50 flex items-center justify-center z-50">
+      <div className="bg-card rounded-lg p-6 max-w-md w-full mx-4">
         <h2 className="text-xl font-semibold mb-4">Confirm Delete</h2>
-        <p className="text-gray-600 mb-6">{text}</p>
+        <p className="text-muted-foreground mb-6">{text}</p>
         <div className="flex justify-end space-x-4">
           <button
             onClick={onCancel}
-            className="px-4 py-2 text-gray-600 hover:bg-gray-100 rounded-md transition-colors"
+            className="px-4 py-2 text-muted-foreground hover:bg-muted rounded-md transition-colors"
           >
             Cancel
           </button>
           <button
             onClick={onConfirm}
-            className="px-4 py-2 bg-red-600 text-white hover:bg-red-700 rounded-md transition-colors"
+            className="px-4 py-2 bg-destructive text-destructive-foreground hover:bg-destructive/90 rounded-md transition-colors"
           >
             Delete
           </button>

--- a/frontend/src/components/DatabaseImport/HomebrewDatabaseDetector.tsx
+++ b/frontend/src/components/DatabaseImport/HomebrewDatabaseDetector.tsx
@@ -92,26 +92,26 @@ export function HomebrewDatabaseDetector({ onImportSuccess, onDecline }: Homebre
   return (
     <div className="mb-4 p-4 bg-info/10 border-2 border-info/40 rounded-lg">
       <div className="flex items-start gap-3">
-        <Database className="h-6 w-6 text-info mt-0.5 flex-shrink-0" />
+        <Database className="h-6 w-6 text-info-text mt-0.5 flex-shrink-0" />
         <div className="flex-1">
           <div className="flex items-center gap-2 mb-1">
-            <AlertCircle className="h-4 w-4 text-info" />
-            <h3 className="text-sm font-semibold text-info">
+            <AlertCircle className="h-4 w-4 text-info-text" />
+            <h3 className="text-sm font-semibold text-info-text">
               Previous Meetily Installation Detected!
             </h3>
           </div>
-          <p className="text-sm text-info mb-2">
+          <p className="text-sm text-info-text mb-2">
             We found an existing database from your previous Meetily installation (Python backend version).
           </p>
           <div className="bg-card/50 rounded p-2 mb-3">
-            <p className="text-xs text-info font-mono break-all">
+            <p className="text-xs text-info-text font-mono break-all">
               {detectedPath}
             </p>
-            <p className="text-xs text-info mt-1">
+            <p className="text-xs text-info-text mt-1">
               Size: {formatFileSize(dbSize)}
             </p>
           </div>
-          <p className="text-sm text-info mb-3">
+          <p className="text-sm text-info-text mb-3">
             Would you like to import your previous meetings, transcripts, and summaries?
           </p>
           
@@ -138,7 +138,7 @@ export function HomebrewDatabaseDetector({ onImportSuccess, onDecline }: Homebre
             <button
               onClick={handleNo}
               disabled={isImporting}
-              className="flex-1 px-4 py-2 border-2 border-info/50 text-info rounded-lg hover:bg-info/15 disabled:bg-muted disabled:cursor-not-allowed transition-colors"
+              className="flex-1 px-4 py-2 border-2 border-info/50 text-info-text rounded-lg hover:bg-info/15 disabled:bg-muted disabled:cursor-not-allowed transition-colors"
             >
               No, Browse Manually
             </button>

--- a/frontend/src/components/DatabaseImport/HomebrewDatabaseDetector.tsx
+++ b/frontend/src/components/DatabaseImport/HomebrewDatabaseDetector.tsx
@@ -90,28 +90,28 @@ export function HomebrewDatabaseDetector({ onImportSuccess, onDecline }: Homebre
   };
 
   return (
-    <div className="mb-4 p-4 bg-blue-50 border-2 border-blue-300 rounded-lg">
+    <div className="mb-4 p-4 bg-info/10 border-2 border-info/40 rounded-lg">
       <div className="flex items-start gap-3">
-        <Database className="h-6 w-6 text-blue-600 mt-0.5 flex-shrink-0" />
+        <Database className="h-6 w-6 text-info mt-0.5 flex-shrink-0" />
         <div className="flex-1">
           <div className="flex items-center gap-2 mb-1">
-            <AlertCircle className="h-4 w-4 text-blue-600" />
-            <h3 className="text-sm font-semibold text-blue-900">
+            <AlertCircle className="h-4 w-4 text-info" />
+            <h3 className="text-sm font-semibold text-info">
               Previous Meetily Installation Detected!
             </h3>
           </div>
-          <p className="text-sm text-blue-800 mb-2">
+          <p className="text-sm text-info mb-2">
             We found an existing database from your previous Meetily installation (Python backend version).
           </p>
-          <div className="bg-white/50 rounded p-2 mb-3">
-            <p className="text-xs text-blue-700 font-mono break-all">
+          <div className="bg-card/50 rounded p-2 mb-3">
+            <p className="text-xs text-info font-mono break-all">
               {detectedPath}
             </p>
-            <p className="text-xs text-blue-600 mt-1">
+            <p className="text-xs text-info mt-1">
               Size: {formatFileSize(dbSize)}
             </p>
           </div>
-          <p className="text-sm text-blue-800 mb-3">
+          <p className="text-sm text-info mb-3">
             Would you like to import your previous meetings, transcripts, and summaries?
           </p>
           
@@ -120,7 +120,7 @@ export function HomebrewDatabaseDetector({ onImportSuccess, onDecline }: Homebre
             <button
               onClick={handleYes}
               disabled={isImporting}
-              className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+              className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-success text-success-foreground rounded-lg hover:bg-success/90 disabled:bg-muted-foreground/40 disabled:cursor-not-allowed transition-colors"
             >
               {isImporting ? (
                 <>
@@ -138,7 +138,7 @@ export function HomebrewDatabaseDetector({ onImportSuccess, onDecline }: Homebre
             <button
               onClick={handleNo}
               disabled={isImporting}
-              className="flex-1 px-4 py-2 border-2 border-blue-400 text-blue-700 rounded-lg hover:bg-blue-100 disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+              className="flex-1 px-4 py-2 border-2 border-info/50 text-info rounded-lg hover:bg-info/15 disabled:bg-muted disabled:cursor-not-allowed transition-colors"
             >
               No, Browse Manually
             </button>

--- a/frontend/src/components/DatabaseImport/LegacyDatabaseImport.tsx
+++ b/frontend/src/components/DatabaseImport/LegacyDatabaseImport.tsx
@@ -134,14 +134,14 @@ export function LegacyDatabaseImport({ isOpen, onComplete }: LegacyDatabaseImpor
 
           {/* Browse Section */}
           <div className="space-y-3">
-            <p className="text-sm text-gray-600">
+            <p className="text-sm text-muted-foreground">
               Select your previous Meetily folder, backend directory, or database file:
             </p>
 
             <button
               onClick={handleBrowse}
               disabled={isLoading}
-              className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+              className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-info text-info-foreground rounded-lg hover:bg-info/90 disabled:bg-muted-foreground/40 disabled:cursor-not-allowed transition-colors"
             >
               {importState === 'selecting' || importState === 'detecting' ? (
                 <>
@@ -159,12 +159,12 @@ export function LegacyDatabaseImport({ isOpen, onComplete }: LegacyDatabaseImpor
 
           {/* Detection Result */}
           {detectedPath && (
-            <div className="p-3 bg-green-50 border border-green-200 rounded-lg">
+            <div className="p-3 bg-success/10 border border-success/30 rounded-lg">
               <div className="flex items-start gap-2">
-                <CheckCircle2 className="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" />
+                <CheckCircle2 className="h-5 w-5 text-success mt-0.5 flex-shrink-0" />
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-green-800">Database found!</p>
-                  <p className="text-xs text-green-700 mt-1 break-all">{detectedPath}</p>
+                  <p className="text-sm font-medium text-success">Database found!</p>
+                  <p className="text-xs text-success mt-1 break-all">{detectedPath}</p>
                 </div>
               </div>
             </div>
@@ -172,11 +172,11 @@ export function LegacyDatabaseImport({ isOpen, onComplete }: LegacyDatabaseImpor
 
           {/* Error Message */}
           {importState === 'error' && errorMessage && (
-            <div className="p-3 bg-red-50 border border-red-200 rounded-lg">
+            <div className="p-3 bg-destructive/10 border border-destructive/30 rounded-lg">
               <div className="flex items-start gap-2">
-                <XCircle className="h-5 w-5 text-red-600 mt-0.5 flex-shrink-0" />
+                <XCircle className="h-5 w-5 text-destructive mt-0.5 flex-shrink-0" />
                 <div className="flex-1">
-                  <p className="text-sm text-red-800">{errorMessage}</p>
+                  <p className="text-sm text-destructive">{errorMessage}</p>
                 </div>
               </div>
             </div>
@@ -187,7 +187,7 @@ export function LegacyDatabaseImport({ isOpen, onComplete }: LegacyDatabaseImpor
             <button
               onClick={handleImport}
               disabled={!canImport || isLoading}
-              className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+              className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-success text-success-foreground rounded-lg hover:bg-success/90 disabled:bg-muted-foreground/30 disabled:cursor-not-allowed transition-colors"
             >
               {importState === 'importing' ? (
                 <>
@@ -209,17 +209,17 @@ export function LegacyDatabaseImport({ isOpen, onComplete }: LegacyDatabaseImpor
 
             <div className="relative">
               <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-gray-300"></div>
+                <div className="w-full border-t border-border"></div>
               </div>
               <div className="relative flex justify-center text-sm">
-                <span className="px-2 bg-white text-gray-500">or</span>
+                <span className="px-2 bg-card text-muted-foreground">or</span>
               </div>
             </div>
 
             <button
               onClick={handleStartFresh}
               disabled={isLoading}
-              className="w-full px-4 py-3 border-2 border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
+              className="w-full px-4 py-3 border-2 border-border text-foreground rounded-lg hover:bg-muted/40 disabled:bg-muted disabled:cursor-not-allowed transition-colors"
             >
               Start Fresh (No Import)
             </button>

--- a/frontend/src/components/DatabaseImport/LegacyDatabaseImport.tsx
+++ b/frontend/src/components/DatabaseImport/LegacyDatabaseImport.tsx
@@ -161,10 +161,10 @@ export function LegacyDatabaseImport({ isOpen, onComplete }: LegacyDatabaseImpor
           {detectedPath && (
             <div className="p-3 bg-success/10 border border-success/30 rounded-lg">
               <div className="flex items-start gap-2">
-                <CheckCircle2 className="h-5 w-5 text-success mt-0.5 flex-shrink-0" />
+                <CheckCircle2 className="h-5 w-5 text-success-text mt-0.5 flex-shrink-0" />
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-success">Database found!</p>
-                  <p className="text-xs text-success mt-1 break-all">{detectedPath}</p>
+                  <p className="text-sm font-medium text-success-text">Database found!</p>
+                  <p className="text-xs text-success-text mt-1 break-all">{detectedPath}</p>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/DeviceSelection.tsx
+++ b/frontend/src/components/DeviceSelection.tsx
@@ -235,7 +235,7 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
           {/*   className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${ */}
           {/*     isMonitoring */}
           {/*       ? 'bg-destructive/15 text-destructive hover:bg-destructive/15' */}
-          {/*       : 'bg-success/15 text-success hover:bg-success/20' */}
+          {/*       : 'bg-success/15 text-success-text hover:bg-success/20' */}
           {/*   } disabled:pointer-events-none disabled:opacity-50`} */}
           {/*   title={inputDevices.length === 0 ? 'No microphones available to test' : ''} */}
           {/* > */}

--- a/frontend/src/components/DeviceSelection.tsx
+++ b/frontend/src/components/DeviceSelection.tsx
@@ -215,9 +215,9 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
     return (
       <div className="p-4 space-y-4">
         <div className="animate-pulse">
-          <div className="h-4 bg-gray-200 rounded w-1/3 mb-4"></div>
-          <div className="h-10 bg-gray-200 rounded mb-3"></div>
-          <div className="h-10 bg-gray-200 rounded"></div>
+          <div className="h-4 bg-muted rounded w-1/3 mb-4"></div>
+          <div className="h-10 bg-muted rounded mb-3"></div>
+          <div className="h-10 bg-muted rounded"></div>
         </div>
       </div>
     );
@@ -226,7 +226,7 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h4 className="text-sm font-medium text-gray-900">Audio Devices</h4>
+        <h4 className="text-sm font-medium text-foreground">Audio Devices</h4>
         <div className="flex items-center space-x-2">
           {/* TODO: Monitoring */}
           {/* <button */}
@@ -234,8 +234,8 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
           {/*   disabled={disabled || inputDevices.length === 0} */}
           {/*   className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${ */}
           {/*     isMonitoring */}
-          {/*       ? 'bg-red-100 text-red-700 hover:bg-red-200' */}
-          {/*       : 'bg-green-100 text-green-700 hover:bg-green-200' */}
+          {/*       ? 'bg-destructive/15 text-destructive hover:bg-destructive/15' */}
+          {/*       : 'bg-success/15 text-success hover:bg-success/20' */}
           {/*   } disabled:pointer-events-none disabled:opacity-50`} */}
           {/*   title={inputDevices.length === 0 ? 'No microphones available to test' : ''} */}
           {/* > */}
@@ -244,7 +244,7 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
           <button
             onClick={handleRefresh}
             disabled={refreshing || disabled}
-            className="h-8 w-8 p-0 inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors hover:bg-gray-100 disabled:pointer-events-none disabled:opacity-50"
+            className="h-8 w-8 p-0 inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
           >
             <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
           </button>
@@ -252,7 +252,7 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
       </div>
 
       {error && (
-        <div className="p-3 text-sm text-red-700 bg-red-50 border border-red-200 rounded-md">
+        <div className="p-3 text-sm text-destructive bg-destructive/10 border border-destructive/30 rounded-md">
           {error}
         </div>
       )}
@@ -261,8 +261,8 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
         {/* Microphone Selection */}
         <div className="space-y-2">
           <div className="flex items-center gap-2">
-            <Mic className="h-4 w-4 text-gray-600" />
-            <Label htmlFor="mic-selection" className="text-sm font-medium text-gray-700">
+            <Mic className="h-4 w-4 text-muted-foreground" />
+            <Label htmlFor="mic-selection" className="text-sm font-medium text-foreground">
               Microphone
             </Label>
           </div>
@@ -287,19 +287,19 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
             </SelectContent>
           </Select>
           {inputDevices.length === 0 && (
-            <p className="text-xs text-gray-500">No microphone devices found</p>
+            <p className="text-xs text-muted-foreground">No microphone devices found</p>
           )}
 
           {/* Audio Level Meters for Input Devices */}
           {showLevels && inputDevices.length > 0 && (
-            <div className="space-y-2 pt-2 border-t border-gray-100">
-              <p className="text-xs text-gray-600 font-medium">Microphone Levels:</p>
+            <div className="space-y-2 pt-2 border-t border-border">
+              <p className="text-xs text-muted-foreground font-medium">Microphone Levels:</p>
               {inputDevices.map((device) => {
                 const levelData = audioLevels.get(device.name);
                 return (
                   <div key={`level-${device.name}`} className="space-y-1">
                     <div className="flex items-center justify-between">
-                      <span className="text-xs text-gray-600 truncate max-w-[200px]">
+                      <span className="text-xs text-muted-foreground truncate max-w-[200px]">
                         {device.name}
                       </span>
                       {levelData && (
@@ -329,8 +329,8 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
         {/* System Audio Selection */}
         <div className="space-y-2">
           <div className="flex items-center gap-2">
-            <Speaker className="h-4 w-4 text-gray-600" />
-            <Label htmlFor="system-selection" className="text-sm font-medium text-gray-700">
+            <Speaker className="h-4 w-4 text-muted-foreground" />
+            <Label htmlFor="system-selection" className="text-sm font-medium text-foreground">
               System Audio
             </Label>
           </div>
@@ -357,12 +357,12 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
           </Select>
 
           {outputDevices.length === 0 && (
-            <p className="text-xs text-gray-500">No system audio devices found</p>
+            <p className="text-xs text-muted-foreground">No system audio devices found</p>
           )}
 
           {/* Backend Selection - available on all platforms */}
           {!disabled && (
-            <div className="pt-3 border-t border-gray-100">
+            <div className="pt-3 border-t border-border">
               <AudioBackendSelector disabled={disabled} />
             </div>
           )}
@@ -370,7 +370,7 @@ export function DeviceSelection({ selectedDevices, onDeviceChange, disabled = fa
       </div>
 
       {/* Info text */}
-      <div className="text-xs text-gray-500 space-y-1">
+      <div className="text-xs text-muted-foreground space-y-1">
         <p>• <strong>Microphone:</strong> Records your voice and ambient sound</p>
         <p>• <strong>System Audio:</strong> Records computer audio (music, calls, etc.)</p>
         {isMonitoring && (

--- a/frontend/src/components/EditableTitle.tsx
+++ b/frontend/src/components/EditableTitle.tsx
@@ -49,7 +49,7 @@ export const EditableTitle: React.FC<EditableTitleProps> = ({
             onFinishEditing();
           }
         }}
-        className="text-2xl font-bold bg-gray-50 border border-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded px-3 py-1 w-full resize-none overflow-hidden"
+        className="text-2xl font-bold bg-muted/40 border border-border focus:outline-none focus:ring-2 focus:ring-info rounded px-3 py-1 w-full resize-none overflow-hidden"
         style={{ minWidth: '300px', minHeight: '40px' }}
         autoFocus
         rows={1}
@@ -58,7 +58,7 @@ export const EditableTitle: React.FC<EditableTitleProps> = ({
   ) : (
     <div className="group flex items-center space-x-2 flex-1">
       <h1
-        className="text-2xl font-bold cursor-pointer hover:bg-gray-50 rounded px-1 flex-1 whitespace-pre-wrap"
+        className="text-2xl font-bold cursor-pointer hover:bg-muted/40 rounded px-1 flex-1 whitespace-pre-wrap"
         onClick={onStartEditing}
       >
         {title}
@@ -66,7 +66,7 @@ export const EditableTitle: React.FC<EditableTitleProps> = ({
       <div className="flex space-x-1">
         <button 
           onClick={onStartEditing}
-          className="opacity-0 group-hover:opacity-100 transition-opacity duration-200 p-1 hover:bg-gray-100 rounded"
+          className="opacity-0 group-hover:opacity-100 transition-opacity duration-200 p-1 hover:bg-muted rounded"
           title="Edit section title"
         >
           <svg 
@@ -86,7 +86,7 @@ export const EditableTitle: React.FC<EditableTitleProps> = ({
         {onDelete && (
           <button 
             onClick={onDelete}
-            className="opacity-0 group-hover:opacity-100 transition-opacity duration-200 p-1 hover:bg-gray-100 rounded text-red-600"
+            className="opacity-0 group-hover:opacity-100 transition-opacity duration-200 p-1 hover:bg-muted rounded text-destructive"
             title="Delete section"
           >
             <svg 

--- a/frontend/src/components/EmptyStateSummary.tsx
+++ b/frontend/src/components/EmptyStateSummary.tsx
@@ -55,7 +55,7 @@ export function EmptyStateSummary({ onGenerate, hasModel, isGenerating = false }
       </TooltipProvider>
 
       {!hasModel && (
-        <p className="text-xs text-warning mt-3">
+        <p className="text-xs text-warning-text mt-3">
           Please select a model in Settings first
         </p>
       )}

--- a/frontend/src/components/EmptyStateSummary.tsx
+++ b/frontend/src/components/EmptyStateSummary.tsx
@@ -24,11 +24,11 @@ export function EmptyStateSummary({ onGenerate, hasModel, isGenerating = false }
       transition={{ duration: 0.3, ease: 'easeOut' }}
       className="flex flex-col items-center justify-center h-full p-8 text-center"
     >
-      <FileQuestion className="w-16 h-16 text-gray-300 mb-4" />
-      <h3 className="text-lg font-semibold text-gray-900 mb-2">
+      <FileQuestion className="w-16 h-16 text-muted-foreground mb-4" />
+      <h3 className="text-lg font-semibold text-foreground mb-2">
         No Summary Generated Yet
       </h3>
-      <p className="text-sm text-gray-500 mb-6 max-w-md">
+      <p className="text-sm text-muted-foreground mb-6 max-w-md">
         Generate an AI-powered summary of your meeting transcript to get key points, action items, and decisions.
       </p>
 
@@ -55,7 +55,7 @@ export function EmptyStateSummary({ onGenerate, hasModel, isGenerating = false }
       </TooltipProvider>
 
       {!hasModel && (
-        <p className="text-xs text-amber-600 mt-3">
+        <p className="text-xs text-warning mt-3">
           Please select a model in Settings first
         </p>
       )}

--- a/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
+++ b/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
@@ -235,22 +235,22 @@ export function ImportAudioDialog({
           <DialogTitle className="flex items-center gap-2">
             {isProcessing ? (
               <>
-                <Loader2 className="h-5 w-5 animate-spin text-blue-600" />
+                <Loader2 className="h-5 w-5 animate-spin text-info" />
                 Importing Audio...
               </>
             ) : error ? (
               <>
-                <AlertCircle className="h-5 w-5 text-red-600" />
+                <AlertCircle className="h-5 w-5 text-destructive" />
                 Import Failed
               </>
             ) : status === 'complete' ? (
               <>
-                <CheckCircle2 className="h-5 w-5 text-green-600" />
+                <CheckCircle2 className="h-5 w-5 text-success" />
                 Import Complete
               </>
             ) : (
               <>
-                <Upload className="h-5 w-5 text-blue-600" />
+                <Upload className="h-5 w-5 text-info" />
                 Import Audio File
               </>
             )}
@@ -269,12 +269,12 @@ export function ImportAudioDialog({
           {!isProcessing && !error && (
             <>
               {fileInfo ? (
-                <div className="bg-gray-50 rounded-lg p-4 space-y-3">
+                <div className="bg-muted/40 rounded-lg p-4 space-y-3">
                   <div className="flex items-start gap-3">
-                    <FileAudio className="h-8 w-8 text-blue-600 flex-shrink-0" />
+                    <FileAudio className="h-8 w-8 text-info flex-shrink-0" />
                     <div className="flex-1 min-w-0">
-                      <p className="font-medium text-gray-900 truncate">{fileInfo.filename}</p>
-                      <div className="flex items-center gap-4 text-sm text-gray-500 mt-1">
+                      <p className="font-medium text-foreground truncate">{fileInfo.filename}</p>
+                      <div className="flex items-center gap-4 text-sm text-muted-foreground mt-1">
                         <span className="flex items-center gap-1">
                           <Clock className="h-3.5 w-3.5" />
                           {formatDuration(fileInfo.duration_seconds)}
@@ -283,14 +283,14 @@ export function ImportAudioDialog({
                           <HardDrive className="h-3.5 w-3.5" />
                           {formatFileSize(fileInfo.size_bytes)}
                         </span>
-                        <span className="text-blue-600 font-medium">{fileInfo.format}</span>
+                        <span className="text-info font-medium">{fileInfo.format}</span>
                       </div>
                     </div>
                   </div>
 
                   {/* Editable title */}
                   <div className="space-y-1">
-                    <label className="text-sm font-medium text-gray-700">Meeting Title</label>
+                    <label className="text-sm font-medium text-foreground">Meeting Title</label>
                     <Input
                       value={title}
                       onChange={(e) => {
@@ -306,8 +306,8 @@ export function ImportAudioDialog({
                   </Button>
                 </div>
               ) : (
-                <div className="border-2 border-dashed border-gray-300 rounded-lg p-8 text-center">
-                  <FileAudio className="h-12 w-12 text-gray-400 mx-auto mb-4" />
+                <div className="border-2 border-dashed border-border rounded-lg p-8 text-center">
+                  <FileAudio className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
                   <Button onClick={handleSelectFile} disabled={status === 'validating'}>
                     {status === 'validating' ? (
                       <>
@@ -321,7 +321,7 @@ export function ImportAudioDialog({
                       </>
                     )}
                   </Button>
-                  <p className="text-sm text-gray-500 mt-2">MP4, WAV, MP3, FLAC, OGG, MKV, WebM, WMA</p>
+                  <p className="text-sm text-muted-foreground mt-2">MP4, WAV, MP3, FLAC, OGG, MKV, WebM, WMA</p>
                 </div>
               )}
 
@@ -330,7 +330,7 @@ export function ImportAudioDialog({
                 <div className="border rounded-lg">
                   <button
                     onClick={() => setShowAdvanced(!showAdvanced)}
-                    className="w-full flex items-center justify-between p-3 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                    className="w-full flex items-center justify-between p-3 text-sm font-medium text-foreground hover:bg-muted/40"
                   >
                     <span>Advanced Options</span>
                     {showAdvanced ? (
@@ -413,13 +413,13 @@ export function ImportAudioDialog({
           {isProcessing && progress && (
             <div className="space-y-2">
               <div className="relative">
-                <div className="w-full bg-gray-200 rounded-full h-3">
+                <div className="w-full bg-muted rounded-full h-3">
                   <div
-                    className="bg-blue-600 h-3 rounded-full transition-all duration-300 ease-out"
+                    className="bg-info h-3 rounded-full transition-all duration-300 ease-out"
                     style={{ width: `${Math.min(progress.progress_percentage, 100)}%` }}
                   />
                 </div>
-                <div className="flex justify-between text-xs text-gray-600 mt-1">
+                <div className="flex justify-between text-xs text-muted-foreground mt-1">
                   <span>{progress.stage}</span>
                   <span>{Math.round(progress.progress_percentage)}%</span>
                 </div>
@@ -430,8 +430,8 @@ export function ImportAudioDialog({
 
           {/* Error display */}
           {error && (
-            <div className="bg-red-50 border border-red-200 rounded-lg p-3">
-              <p className="text-sm text-red-800">{error}</p>
+            <div className="bg-destructive/10 border border-destructive/30 rounded-lg p-3">
+              <p className="text-sm text-destructive">{error}</p>
             </div>
           )}
         </div>
@@ -444,7 +444,7 @@ export function ImportAudioDialog({
               </Button>
               <Button
                 onClick={handleStartImport}
-                className="bg-blue-600 hover:bg-blue-700"
+                className="bg-info hover:bg-info/90"
                 disabled={!fileInfo}
               >
                 <Upload className="h-4 w-4 mr-2" />

--- a/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
+++ b/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
@@ -235,7 +235,7 @@ export function ImportAudioDialog({
           <DialogTitle className="flex items-center gap-2">
             {isProcessing ? (
               <>
-                <Loader2 className="h-5 w-5 animate-spin text-info" />
+                <Loader2 className="h-5 w-5 animate-spin text-info-text" />
                 Importing Audio...
               </>
             ) : error ? (
@@ -245,12 +245,12 @@ export function ImportAudioDialog({
               </>
             ) : status === 'complete' ? (
               <>
-                <CheckCircle2 className="h-5 w-5 text-success" />
+                <CheckCircle2 className="h-5 w-5 text-success-text" />
                 Import Complete
               </>
             ) : (
               <>
-                <Upload className="h-5 w-5 text-info" />
+                <Upload className="h-5 w-5 text-info-text" />
                 Import Audio File
               </>
             )}
@@ -271,7 +271,7 @@ export function ImportAudioDialog({
               {fileInfo ? (
                 <div className="bg-muted/40 rounded-lg p-4 space-y-3">
                   <div className="flex items-start gap-3">
-                    <FileAudio className="h-8 w-8 text-info flex-shrink-0" />
+                    <FileAudio className="h-8 w-8 text-info-text flex-shrink-0" />
                     <div className="flex-1 min-w-0">
                       <p className="font-medium text-foreground truncate">{fileInfo.filename}</p>
                       <div className="flex items-center gap-4 text-sm text-muted-foreground mt-1">
@@ -283,7 +283,7 @@ export function ImportAudioDialog({
                           <HardDrive className="h-3.5 w-3.5" />
                           {formatFileSize(fileInfo.size_bytes)}
                         </span>
-                        <span className="text-info font-medium">{fileInfo.format}</span>
+                        <span className="text-info-text font-medium">{fileInfo.format}</span>
                       </div>
                     </div>
                   </div>

--- a/frontend/src/components/ImportAudio/ImportDropOverlay.tsx
+++ b/frontend/src/components/ImportAudio/ImportDropOverlay.tsx
@@ -11,16 +11,16 @@ export function ImportDropOverlay({ visible }: ImportDropOverlayProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm
+      className="fixed inset-0 z-50 bg-overlay/60 backdrop-blur-sm
                  flex items-center justify-center pointer-events-none
                  transition-opacity duration-200"
     >
-      <div className="border-2 border-dashed border-blue-400 rounded-2xl
-                      p-12 text-center bg-blue-950/50 shadow-2xl
+      <div className="border-2 border-dashed border-info/50 rounded-2xl
+                      p-12 text-center bg-info/20 shadow-2xl
                       transform scale-100 transition-transform">
-        <Upload className="h-16 w-16 text-blue-400 mx-auto mb-4" />
-        <p className="text-xl font-medium text-white">Drop audio file to import</p>
-        <p className="text-sm text-blue-300 mt-2">{getAudioFormatsDisplayList()}</p>
+        <Upload className="h-16 w-16 text-info mx-auto mb-4" />
+        <p className="text-xl font-medium text-overlay-foreground">Drop audio file to import</p>
+        <p className="text-sm text-info mt-2">{getAudioFormatsDisplayList()}</p>
       </div>
     </div>
   );

--- a/frontend/src/components/ImportAudio/ImportDropOverlay.tsx
+++ b/frontend/src/components/ImportAudio/ImportDropOverlay.tsx
@@ -18,9 +18,9 @@ export function ImportDropOverlay({ visible }: ImportDropOverlayProps) {
       <div className="border-2 border-dashed border-info/50 rounded-2xl
                       p-12 text-center bg-info/20 shadow-2xl
                       transform scale-100 transition-transform">
-        <Upload className="h-16 w-16 text-info mx-auto mb-4" />
+        <Upload className="h-16 w-16 text-info-text mx-auto mb-4" />
         <p className="text-xl font-medium text-overlay-foreground">Drop audio file to import</p>
-        <p className="text-sm text-info mt-2">{getAudioFormatsDisplayList()}</p>
+        <p className="text-sm text-info-text mt-2">{getAudioFormatsDisplayList()}</p>
       </div>
     </div>
   );

--- a/frontend/src/components/Info.tsx
+++ b/frontend/src/components/Info.tsx
@@ -16,14 +16,14 @@ const Info = React.forwardRef<HTMLButtonElement, InfoProps>(({ isCollapsed }, re
           ref={ref} 
           className={`flex items-center justify-center mb-2 cursor-pointer border-none transition-colors ${
             isCollapsed 
-              ? "bg-transparent p-2 hover:bg-gray-100 rounded-lg" 
-              : "w-full px-3 py-1.5 mt-1 text-sm font-medium text-gray-700 bg-gray-200 hover:bg-gray-200 rounded-lg shadow-sm"
+              ? "bg-transparent p-2 hover:bg-muted rounded-lg"
+              : "w-full px-3 py-1.5 mt-1 text-sm font-medium text-foreground bg-muted hover:bg-muted rounded-lg shadow-sm"
           }`}
           title="About Meetily"
         >
-          <InfoIcon className={`text-gray-600 ${isCollapsed ? "w-5 h-5" : "w-4 h-4"}`} />
+          <InfoIcon className={`text-muted-foreground ${isCollapsed ? "w-5 h-5" : "w-4 h-4"}`} />
           {!isCollapsed && (
-            <span className="ml-2 text-sm text-gray-700">About</span>
+            <span className="ml-2 text-sm text-foreground">About</span>
           )}
         </button>
       </DialogTrigger>
@@ -39,4 +39,4 @@ const Info = React.forwardRef<HTMLButtonElement, InfoProps>(({ isCollapsed }, re
 
 Info.displayName = "About";
 
-export default Info; 
+export default Info;

--- a/frontend/src/components/LanguagePickerPopover.tsx
+++ b/frontend/src/components/LanguagePickerPopover.tsx
@@ -81,26 +81,26 @@ export function LanguagePickerPopover({
   return (
     <div
       ref={containerRef}
-      className="w-72 rounded-lg bg-white border border-gray-200 shadow-lg overflow-hidden"
+      className="w-72 rounded-lg bg-card border border-border shadow-lg overflow-hidden"
       role="dialog"
       aria-label="Pick summary language"
     >
-      <div className="flex items-center gap-2 px-3 py-2.5 border-b border-gray-100">
-        <span className="text-gray-400 text-sm">🔍</span>
+      <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border">
+        <span className="text-muted-foreground text-sm">🔍</span>
         <input
           ref={inputRef}
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search language..."
-          className="flex-1 text-sm text-gray-900 bg-transparent border-none outline-none placeholder-gray-400"
+          className="flex-1 text-sm text-foreground bg-transparent border-none outline-none placeholder-muted-foreground"
         />
       </div>
 
       <div className="max-h-80 overflow-y-auto py-1">
         {showRecents && (
           <>
-            <div className="px-3 pt-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-400">
+            <div className="px-3 pt-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
               Recently Used
             </div>
             {recentsResolved.map((opt) => (
@@ -109,18 +109,18 @@ export function LanguagePickerPopover({
                 type="button"
                 aria-pressed={value === opt.code}
                 onClick={() => onChange(opt.code)}
-                className={`flex w-full items-center justify-between px-3 py-1.5 text-sm hover:bg-gray-50 text-left ${
-                  value === opt.code ? "text-blue-600 font-medium" : "text-gray-800"
+                className={`flex w-full items-center justify-between px-3 py-1.5 text-sm hover:bg-muted/40 text-left ${
+                  value === opt.code ? "text-info font-medium" : "text-foreground"
                 }`}
               >
                 <span>
                   {opt.label}{" "}
-                  <span className="text-xs text-gray-400">({opt.code})</span>
+                  <span className="text-xs text-muted-foreground">({opt.code})</span>
                 </span>
-                {value === opt.code && <span className="text-blue-600" aria-hidden="true">✓</span>}
+                {value === opt.code && <span className="text-info" aria-hidden="true">✓</span>}
               </button>
             ))}
-            <div className="my-1 h-px bg-gray-100" />
+            <div className="my-1 h-px bg-muted" />
           </>
         )}
 
@@ -129,22 +129,22 @@ export function LanguagePickerPopover({
             type="button"
             aria-pressed={value === null}
             onClick={() => onChange(null)}
-            className={`flex w-full items-center justify-between px-3 py-1.5 text-sm hover:bg-gray-50 text-left ${
-              value === null ? "text-blue-600 font-medium" : "text-gray-800"
+            className={`flex w-full items-center justify-between px-3 py-1.5 text-sm hover:bg-muted/40 text-left ${
+              value === null ? "text-info font-medium" : "text-foreground"
             }`}
           >
             <span className="flex flex-col">
               <span>Auto</span>
               {autoSubtitle && (
-                <span className="text-xs font-normal text-gray-400">{autoSubtitle}</span>
+                <span className="text-xs font-normal text-muted-foreground">{autoSubtitle}</span>
               )}
             </span>
-            {value === null && <span className="text-blue-600" aria-hidden="true">✓</span>}
+            {value === null && <span className="text-info" aria-hidden="true">✓</span>}
           </button>
         )}
 
         {filteredAll.length > 0 && (
-          <div className="px-3 pt-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-400">
+          <div className="px-3 pt-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
             {mode === "meeting" ? "Other Languages" : "All Languages"}
           </div>
         )}
@@ -155,20 +155,20 @@ export function LanguagePickerPopover({
             type="button"
             aria-pressed={value === opt.code}
             onClick={() => onChange(opt.code)}
-            className={`flex w-full items-center justify-between px-3 py-1.5 text-sm hover:bg-gray-50 text-left ${
-              value === opt.code ? "text-blue-600 font-medium" : "text-gray-800"
+            className={`flex w-full items-center justify-between px-3 py-1.5 text-sm hover:bg-muted/40 text-left ${
+              value === opt.code ? "text-info font-medium" : "text-foreground"
             }`}
           >
             <span>
               {opt.label}{" "}
-              <span className="text-xs text-gray-400">({opt.code})</span>
+              <span className="text-xs text-muted-foreground">({opt.code})</span>
             </span>
-            {value === opt.code && <span className="text-blue-600" aria-hidden="true">✓</span>}
+            {value === opt.code && <span className="text-info" aria-hidden="true">✓</span>}
           </button>
         ))}
 
         {hasNoResults && (
-          <div className="px-3 py-2 text-sm text-gray-400">No matches</div>
+          <div className="px-3 py-2 text-sm text-muted-foreground">No matches</div>
         )}
       </div>
     </div>

--- a/frontend/src/components/LanguagePickerPopover.tsx
+++ b/frontend/src/components/LanguagePickerPopover.tsx
@@ -110,14 +110,14 @@ export function LanguagePickerPopover({
                 aria-pressed={value === opt.code}
                 onClick={() => onChange(opt.code)}
                 className={`flex w-full items-center justify-between px-3 py-1.5 text-sm hover:bg-muted/40 text-left ${
-                  value === opt.code ? "text-info font-medium" : "text-foreground"
+                  value === opt.code ? "text-info-text font-medium" : "text-foreground"
                 }`}
               >
                 <span>
                   {opt.label}{" "}
                   <span className="text-xs text-muted-foreground">({opt.code})</span>
                 </span>
-                {value === opt.code && <span className="text-info" aria-hidden="true">✓</span>}
+                {value === opt.code && <span className="text-info-text" aria-hidden="true">✓</span>}
               </button>
             ))}
             <div className="my-1 h-px bg-muted" />
@@ -130,7 +130,7 @@ export function LanguagePickerPopover({
             aria-pressed={value === null}
             onClick={() => onChange(null)}
             className={`flex w-full items-center justify-between px-3 py-1.5 text-sm hover:bg-muted/40 text-left ${
-              value === null ? "text-info font-medium" : "text-foreground"
+              value === null ? "text-info-text font-medium" : "text-foreground"
             }`}
           >
             <span className="flex flex-col">
@@ -139,7 +139,7 @@ export function LanguagePickerPopover({
                 <span className="text-xs font-normal text-muted-foreground">{autoSubtitle}</span>
               )}
             </span>
-            {value === null && <span className="text-info" aria-hidden="true">✓</span>}
+            {value === null && <span className="text-info-text" aria-hidden="true">✓</span>}
           </button>
         )}
 
@@ -156,14 +156,14 @@ export function LanguagePickerPopover({
             aria-pressed={value === opt.code}
             onClick={() => onChange(opt.code)}
             className={`flex w-full items-center justify-between px-3 py-1.5 text-sm hover:bg-muted/40 text-left ${
-              value === opt.code ? "text-info font-medium" : "text-foreground"
+              value === opt.code ? "text-info-text font-medium" : "text-foreground"
             }`}
           >
             <span>
               {opt.label}{" "}
               <span className="text-xs text-muted-foreground">({opt.code})</span>
             </span>
-            {value === opt.code && <span className="text-info" aria-hidden="true">✓</span>}
+            {value === opt.code && <span className="text-info-text" aria-hidden="true">✓</span>}
           </button>
         ))}
 

--- a/frontend/src/components/LanguageSelection.tsx
+++ b/frontend/src/components/LanguageSelection.tsx
@@ -177,8 +177,8 @@ export function LanguageSelection({
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Globe className="h-4 w-4 text-gray-600" />
-          <h4 className="text-sm font-medium text-gray-900">Transcription Language</h4>
+          <Globe className="h-4 w-4 text-muted-foreground" />
+          <h4 className="text-sm font-medium text-foreground">Transcription Language</h4>
         </div>
       </div>
 
@@ -187,7 +187,7 @@ export function LanguageSelection({
           value={selectedLanguage}
           onChange={(e) => handleLanguageChange(e.target.value)}
           disabled={disabled || saving}
-          className="w-full px-3 py-2 text-sm bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-50 disabled:text-gray-500"
+          className="w-full px-3 py-2 text-sm bg-card border border-border rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-info focus:border-info disabled:bg-muted/40 disabled:text-muted-foreground"
         >
           {availableLanguages.map((language) => (
             <option key={language.code} value={language.code}>
@@ -199,7 +199,7 @@ export function LanguageSelection({
 
         {/* Parakeet language limitation warning */}
         {isParakeet && (
-          <div className="p-2 bg-amber-50 border border-amber-200 rounded text-amber-800">
+          <div className="p-2 bg-warning/10 border border-warning/30 rounded text-warning">
             <p className="font-medium">ℹ️ Parakeet Language Support</p>
             <p className="mt-1 text-xs">Parakeet currently only supports automatic language detection. Manual language selection is not available. Use Whisper if you need to specify a particular language.</p>
           </div>
@@ -207,23 +207,23 @@ export function LanguageSelection({
 
         {/* Info text */}
         <div className="text-xs space-y-2 pt-2">
-          <p className="text-gray-600">
+          <p className="text-muted-foreground">
             <strong>Current:</strong> {selectedLanguageName}
           </p>
           {selectedLanguage === 'auto' && (
-            <div className="p-2 bg-yellow-50 border border-yellow-200 rounded text-yellow-800">
+            <div className="p-2 bg-warning/10 border border-warning/30 rounded text-warning">
               <p className="font-medium">⚠️ Auto Detect may produce incorrect results</p>
               <p className="mt-1">For best accuracy, select your specific language (e.g., English, Spanish, etc.)</p>
             </div>
           )}
           {selectedLanguage === 'auto-translate' && (
-            <div className="p-2 bg-blue-50 border border-blue-200 rounded text-blue-800">
+            <div className="p-2 bg-info/10 border border-info/30 rounded text-info">
               <p className="font-medium">🌐 Translation Mode Active</p>
               <p className="mt-1">All audio will be automatically translated to English. Best for multilingual meetings where you need English output.</p>
             </div>
           )}
           {selectedLanguage !== 'auto' && selectedLanguage !== 'auto-translate' && (
-            <p className="text-gray-600">
+            <p className="text-muted-foreground">
               Transcription will be optimized for <strong>{selectedLanguageName}</strong>
             </p>
           )}

--- a/frontend/src/components/LanguageSelection.tsx
+++ b/frontend/src/components/LanguageSelection.tsx
@@ -199,7 +199,7 @@ export function LanguageSelection({
 
         {/* Parakeet language limitation warning */}
         {isParakeet && (
-          <div className="p-2 bg-warning/10 border border-warning/30 rounded text-warning">
+          <div className="p-2 bg-warning/10 border border-warning/30 rounded text-warning-text">
             <p className="font-medium">ℹ️ Parakeet Language Support</p>
             <p className="mt-1 text-xs">Parakeet currently only supports automatic language detection. Manual language selection is not available. Use Whisper if you need to specify a particular language.</p>
           </div>
@@ -211,13 +211,13 @@ export function LanguageSelection({
             <strong>Current:</strong> {selectedLanguageName}
           </p>
           {selectedLanguage === 'auto' && (
-            <div className="p-2 bg-warning/10 border border-warning/30 rounded text-warning">
+            <div className="p-2 bg-warning/10 border border-warning/30 rounded text-warning-text">
               <p className="font-medium">⚠️ Auto Detect may produce incorrect results</p>
               <p className="mt-1">For best accuracy, select your specific language (e.g., English, Spanish, etc.)</p>
             </div>
           )}
           {selectedLanguage === 'auto-translate' && (
-            <div className="p-2 bg-info/10 border border-info/30 rounded text-info">
+            <div className="p-2 bg-info/10 border border-info/30 rounded text-info-text">
               <p className="font-medium">🌐 Translation Mode Active</p>
               <p className="mt-1">All audio will be automatically translated to English. Best for multilingual meetings where you need English output.</p>
             </div>

--- a/frontend/src/components/Logo.tsx
+++ b/frontend/src/components/Logo.tsx
@@ -13,13 +13,17 @@ const Logo = React.forwardRef<HTMLButtonElement, LogoProps>(({ isCollapsed }, re
     <Dialog aria-describedby={undefined}>
       {isCollapsed ? (
         <DialogTrigger asChild>
-          <button ref={ref} className="flex items-center justify-start mb-2 cursor-pointer bg-transparent border-none p-0 hover:opacity-80 transition-opacity">
+          <button
+            ref={ref}
+            aria-label="About Meetily"
+            className="mb-2 flex cursor-pointer items-center justify-start border-none bg-transparent p-0 transition-opacity hover:opacity-80"
+          >
             <Image src="/logo-collapsed.png" alt="Logo" width={40} height={32} />
           </button>
         </DialogTrigger>
       ) : (
         <DialogTrigger asChild>
-          <span className="text-lg text-center border rounded-full bg-blue-50 border-white font-semibold text-gray-700 mb-2 block items-center cursor-pointer hover:opacity-80 transition-opacity">
+          <span className="mb-2 block cursor-pointer items-center rounded-full border border-info/30 bg-info/10 text-center text-lg font-semibold text-foreground transition-opacity hover:opacity-80">
             <span>Meetily</span>
           </span>
         </DialogTrigger>

--- a/frontend/src/components/MainContent/index.tsx
+++ b/frontend/src/components/MainContent/index.tsx
@@ -1,15 +1,20 @@
 'use client';
 
 import React from 'react';
+import { useSidebar } from '@/components/Sidebar/SidebarProvider';
 
 interface MainContentProps {
   children: React.ReactNode;
 }
 
 const MainContent: React.FC<MainContentProps> = ({ children }) => {
+  const { isCollapsed } = useSidebar();
+
   return (
-    <main 
-      className="min-h-screen min-w-0 flex-1 overflow-hidden bg-background text-foreground transition-all duration-300"
+    <main
+      className={`min-h-screen min-w-0 flex-1 overflow-hidden bg-background text-foreground transition-all duration-300 ${
+        isCollapsed ? 'pl-16' : 'pl-64'
+      }`}
     >
       <div className="min-w-0 pl-4 sm:pl-8">
         {children}

--- a/frontend/src/components/MainContent/index.tsx
+++ b/frontend/src/components/MainContent/index.tsx
@@ -1,22 +1,17 @@
 'use client';
 
 import React from 'react';
-import { useSidebar } from '@/components/Sidebar/SidebarProvider';
 
 interface MainContentProps {
   children: React.ReactNode;
 }
 
 const MainContent: React.FC<MainContentProps> = ({ children }) => {
-  const { isCollapsed } = useSidebar();
-
   return (
     <main 
-      className={`flex-1 transition-all duration-300 ${
-        isCollapsed ? 'ml-16' : 'ml-64'
-      }`}
+      className="min-h-screen min-w-0 flex-1 overflow-hidden bg-background text-foreground transition-all duration-300"
     >
-      <div className="pl-8">
+      <div className="min-w-0 pl-4 sm:pl-8">
         {children}
       </div>
     </main>

--- a/frontend/src/components/MeetingDetails/RetranscribeDialog.tsx
+++ b/frontend/src/components/MeetingDetails/RetranscribeDialog.tsx
@@ -275,17 +275,17 @@ export function RetranscribeDialog({
           <DialogTitle className="flex items-center gap-2">
             {isProcessing ? (
               <>
-                <Loader2 className="h-5 w-5 animate-spin text-blue-600" />
+                <Loader2 className="h-5 w-5 animate-spin text-info" />
                 Retranscribing...
               </>
             ) : error ? (
               <>
-                <AlertCircle className="h-5 w-5 text-red-600" />
+                <AlertCircle className="h-5 w-5 text-destructive" />
                 Retranscription Failed
               </>
             ) : (
               <>
-                <RefreshCw className="h-5 w-5 text-blue-600" />
+                <RefreshCw className="h-5 w-5 text-info" />
                 Retranscribe Meeting
               </>
             )}
@@ -363,13 +363,13 @@ export function RetranscribeDialog({
           {isProcessing && progress && (
             <div className="space-y-2">
               <div className="relative">
-                <div className="w-full bg-gray-200 rounded-full h-3">
+                <div className="w-full bg-muted rounded-full h-3">
                   <div
-                    className="bg-blue-600 h-3 rounded-full transition-all duration-300 ease-out"
+                    className="bg-info h-3 rounded-full transition-all duration-300 ease-out"
                     style={{ width: `${Math.min(progress.progress_percentage, 100)}%` }}
                   />
                 </div>
-                <div className="flex justify-between text-xs text-gray-600 mt-1">
+                <div className="flex justify-between text-xs text-muted-foreground mt-1">
                   <span>{progress.stage}</span>
                   <span>{Math.round(progress.progress_percentage)}%</span>
                 </div>
@@ -381,8 +381,8 @@ export function RetranscribeDialog({
           )}
 
           {error && (
-            <div className="bg-red-50 border border-red-200 rounded-lg p-3">
-              <p className="text-sm text-red-800">{error}</p>
+            <div className="bg-destructive/10 border border-destructive/30 rounded-lg p-3">
+              <p className="text-sm text-destructive">{error}</p>
             </div>
           )}
         </div>
@@ -395,7 +395,7 @@ export function RetranscribeDialog({
               </Button>
               <Button
                 onClick={handleStartRetranscription}
-                className="bg-blue-600 hover:bg-blue-700"
+                className="bg-info hover:bg-info/90"
                 disabled={!meetingFolderPath}
               >
                 <RefreshCw className="h-4 w-4 mr-2" />

--- a/frontend/src/components/MeetingDetails/RetranscribeDialog.tsx
+++ b/frontend/src/components/MeetingDetails/RetranscribeDialog.tsx
@@ -275,7 +275,7 @@ export function RetranscribeDialog({
           <DialogTitle className="flex items-center gap-2">
             {isProcessing ? (
               <>
-                <Loader2 className="h-5 w-5 animate-spin text-info" />
+                <Loader2 className="h-5 w-5 animate-spin text-info-text" />
                 Retranscribing...
               </>
             ) : error ? (
@@ -285,7 +285,7 @@ export function RetranscribeDialog({
               </>
             ) : (
               <>
-                <RefreshCw className="h-5 w-5 text-info" />
+                <RefreshCw className="h-5 w-5 text-info-text" />
                 Retranscribe Meeting
               </>
             )}

--- a/frontend/src/components/MeetingDetails/SummaryGeneratorButtonGroup.tsx
+++ b/frontend/src/components/MeetingDetails/SummaryGeneratorButtonGroup.tsx
@@ -347,7 +347,7 @@ export function SummaryGeneratorButtonGroup({
               >
                 <span>{template.name}</span>
                 {selectedTemplate === template.id && (
-                  <Check className="h-4 w-4 text-success" />
+                  <Check className="h-4 w-4 text-success-text" />
                 )}
               </DropdownMenuItem>
             ))}

--- a/frontend/src/components/MeetingDetails/SummaryGeneratorButtonGroup.tsx
+++ b/frontend/src/components/MeetingDetails/SummaryGeneratorButtonGroup.tsx
@@ -249,7 +249,7 @@ export function SummaryGeneratorButtonGroup({
         <Button
           variant="outline"
           size="sm"
-          className="bg-gradient-to-r from-red-50 to-orange-50 hover:from-red-100 hover:to-orange-100 border-red-200 xl:px-4"
+          className="bg-gradient-to-r from-destructive/10 to-warning/15 hover:from-destructive/10 hover:to-warning/15 border-destructive/30 xl:px-4"
           onClick={() => {
             Analytics.trackButtonClick('stop_summary_generation', 'meeting_details');
             onStopGeneration();
@@ -263,7 +263,7 @@ export function SummaryGeneratorButtonGroup({
         <Button
           variant="outline"
           size="sm"
-          className="bg-gradient-to-r from-blue-50 to-purple-50 hover:from-blue-100 hover:to-purple-100 border-blue-200 xl:px-4"
+          className="bg-gradient-to-r from-info/10 to-info/20 hover:from-info/10 hover:to-info/20 border-info/30 xl:px-4"
           onClick={() => {
             Analytics.trackButtonClick('generate_summary', 'meeting_details');
             checkOllamaModelsAndGenerate();
@@ -347,7 +347,7 @@ export function SummaryGeneratorButtonGroup({
               >
                 <span>{template.name}</span>
                 {selectedTemplate === template.id && (
-                  <Check className="h-4 w-4 text-green-600" />
+                  <Check className="h-4 w-4 text-success" />
                 )}
               </DropdownMenuItem>
             ))}

--- a/frontend/src/components/MeetingDetails/SummaryPanel.tsx
+++ b/frontend/src/components/MeetingDetails/SummaryPanel.tsx
@@ -433,8 +433,8 @@ export function SummaryPanel({
           </div>
           {summaryStatus !== 'idle' && (
             <div className={`mt-4 p-4 rounded-lg ${summaryStatus === 'error' ? 'bg-destructive/15 text-destructive' :
-              summaryStatus === 'completed' ? 'bg-success/15 text-success' :
-                'bg-info/15 text-info'
+              summaryStatus === 'completed' ? 'bg-success/15 text-success-text' :
+                'bg-info/15 text-info-text'
               }`}>
               <p className="text-sm font-medium">{getSummaryStatusMessage(summaryStatus)}</p>
             </div>

--- a/frontend/src/components/MeetingDetails/SummaryPanel.tsx
+++ b/frontend/src/components/MeetingDetails/SummaryPanel.tsx
@@ -235,7 +235,7 @@ export function SummaryPanel({
         >
           <Languages size={18} />
           <span className="hidden lg:inline">{effectiveLangLabel}</span>
-          <ChevronDown size={14} className="text-gray-400" />
+          <ChevronDown size={14} className="text-muted-foreground" />
         </Button>
       </PopoverTrigger>
       <PopoverContent
@@ -253,9 +253,9 @@ export function SummaryPanel({
   );
 
   return (
-    <div className="flex-1 min-w-0 flex flex-col bg-white overflow-hidden">
+    <div className="flex-1 min-w-0 flex flex-col bg-card overflow-hidden">
       {/* Title area */}
-      <div className="p-4 border-b border-gray-200">
+      <div className="p-4 border-b border-border">
         {/* <EditableTitle
           title={meetingTitle}
           isEditing={isEditingTitle}
@@ -330,8 +330,8 @@ export function SummaryPanel({
           {/* Loading spinner */}
           <div className="flex items-center justify-center flex-1">
             <div className="text-center">
-              <div className="inline-block animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500 mb-4"></div>
-              <p className="text-gray-600">Generating AI Summary...</p>
+              <div className="inline-block animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-info mb-4"></div>
+              <p className="text-muted-foreground">Generating AI Summary...</p>
             </div>
           </div>
         </div>
@@ -367,10 +367,10 @@ export function SummaryPanel({
       ) : transcripts?.length > 0 && (
         <div className="flex-1 overflow-y-auto min-h-0">
           {summaryResponse && (
-            <div className="fixed bottom-0 left-0 right-0 bg-white shadow-lg p-4 max-h-1/3 overflow-y-auto">
+            <div className="fixed bottom-0 left-0 right-0 bg-card shadow-lg p-4 max-h-1/3 overflow-y-auto">
               <h3 className="text-lg font-semibold mb-2">Meeting Summary</h3>
               <div className="grid grid-cols-2 gap-4">
-                <div className="bg-white p-4 rounded-lg shadow-sm">
+                <div className="bg-card p-4 rounded-lg shadow-sm">
                   <h4 className="font-medium mb-1">Key Points</h4>
                   <ul className="list-disc pl-4">
                     {summaryResponse.summary.key_points.blocks.map((block, i) => (
@@ -378,7 +378,7 @@ export function SummaryPanel({
                     ))}
                   </ul>
                 </div>
-                <div className="bg-white p-4 rounded-lg shadow-sm mt-4">
+                <div className="bg-card p-4 rounded-lg shadow-sm mt-4">
                   <h4 className="font-medium mb-1">Action Items</h4>
                   <ul className="list-disc pl-4">
                     {summaryResponse.summary.action_items.blocks.map((block, i) => (
@@ -386,7 +386,7 @@ export function SummaryPanel({
                     ))}
                   </ul>
                 </div>
-                <div className="bg-white p-4 rounded-lg shadow-sm mt-4">
+                <div className="bg-card p-4 rounded-lg shadow-sm mt-4">
                   <h4 className="font-medium mb-1">Decisions</h4>
                   <ul className="list-disc pl-4">
                     {summaryResponse.summary.decisions.blocks.map((block, i) => (
@@ -394,7 +394,7 @@ export function SummaryPanel({
                     ))}
                   </ul>
                 </div>
-                <div className="bg-white p-4 rounded-lg shadow-sm mt-4">
+                <div className="bg-card p-4 rounded-lg shadow-sm mt-4">
                   <h4 className="font-medium mb-1">Main Topics</h4>
                   <ul className="list-disc pl-4">
                     {summaryResponse.summary.main_topics.blocks.map((block, i) => (
@@ -432,9 +432,9 @@ export function SummaryPanel({
             />
           </div>
           {summaryStatus !== 'idle' && (
-            <div className={`mt-4 p-4 rounded-lg ${summaryStatus === 'error' ? 'bg-red-100 text-red-700' :
-              summaryStatus === 'completed' ? 'bg-green-100 text-green-700' :
-                'bg-blue-100 text-blue-700'
+            <div className={`mt-4 p-4 rounded-lg ${summaryStatus === 'error' ? 'bg-destructive/15 text-destructive' :
+              summaryStatus === 'completed' ? 'bg-success/15 text-success' :
+                'bg-info/15 text-info'
               }`}>
               <p className="text-sm font-medium">{getSummaryStatusMessage(summaryStatus)}</p>
             </div>

--- a/frontend/src/components/MeetingDetails/SummaryUpdaterButtonGroup.tsx
+++ b/frontend/src/components/MeetingDetails/SummaryUpdaterButtonGroup.tsx
@@ -30,7 +30,7 @@ export function SummaryUpdaterButtonGroup({
       <Button
         variant="outline"
         size="sm"
-        className={`${isDirty ? 'bg-green-200' : ""}`}
+        className={`${isDirty ? 'bg-success/20' : ""}`}
         title={isSaving ? "Saving" : "Save Changes"}
         onClick={() => {
           Analytics.trackButtonClick('save_changes', 'meeting_details');

--- a/frontend/src/components/MeetingDetails/TranscriptButtonGroup.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptButtonGroup.tsx
@@ -72,7 +72,7 @@ export function TranscriptButtonGroup({
           <Button
             size="sm"
             variant="outline"
-            className="bg-gradient-to-r from-blue-50 to-purple-50 hover:from-blue-100 hover:to-purple-100 border-blue-200 xl:px-4"
+            className="bg-gradient-to-r from-info/10 to-info/20 hover:from-info/10 hover:to-info/20 border-info/30 xl:px-4"
             onClick={() => {
               Analytics.trackButtonClick('enhance_transcript', 'meeting_details');
               setShowRetranscribeDialog(true);

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -65,9 +65,9 @@ export function TranscriptPanel({
   }, [transcripts, usePagination, segments]);
 
   return (
-    <div className="hidden md:flex md:w-1/4 lg:w-1/3 min-w-0 border-r border-gray-200 bg-white flex-col relative shrink-0">
+    <div className="hidden md:flex md:w-1/4 lg:w-1/3 min-w-0 border-r border-border bg-card flex-col relative shrink-0">
       {/* Title area */}
-      <div className="p-4 border-b border-gray-200">
+      <div className="p-4 border-b border-border">
         <TranscriptButtonGroup
           transcriptCount={usePagination ? (totalCount ?? convertedSegments.length) : (transcripts?.length || 0)}
           onCopyTranscript={onCopyTranscript}
@@ -99,10 +99,10 @@ export function TranscriptPanel({
 
       {/* Custom prompt input at bottom of transcript section */}
       {!isRecording && convertedSegments.length > 0 && (
-        <div className="p-1 border-t border-gray-200">
+        <div className="p-1 border-t border-border">
           <textarea
             placeholder="Add context for AI summary. For example people involved, meeting overview, objective etc..."
-            className="w-full px-3 py-2 border border-gray-200 rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 bg-white shadow-sm min-h-[80px] resize-y"
+            className="w-full px-3 py-2 border border-border rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-info focus:border-info bg-card shadow-sm min-h-[80px] resize-y"
             value={customPrompt}
             onChange={(e) => onPromptChange(e.target.value)}
           />

--- a/frontend/src/components/MessageToast.tsx
+++ b/frontend/src/components/MessageToast.tsx
@@ -19,7 +19,7 @@ export function MessageToast({ message, type, show, setShow }: MessageToastProps
     
     return (
         show && (
-            <span className={`${type === 'success' ? 'text-green-500' : 'text-red-500'}`}>{message}</span>
+            <span className={`${type === 'success' ? 'text-success' : 'text-destructive'}`}>{message}</span>
         )
     );
 }

--- a/frontend/src/components/MessageToast.tsx
+++ b/frontend/src/components/MessageToast.tsx
@@ -19,7 +19,7 @@ export function MessageToast({ message, type, show, setShow }: MessageToastProps
     
     return (
         show && (
-            <span className={`${type === 'success' ? 'text-success' : 'text-destructive'}`}>{message}</span>
+            <span className={`${type === 'success' ? 'text-success-text' : 'text-destructive'}`}>{message}</span>
         )
     );
 }

--- a/frontend/src/components/ModelDownloadProgress.tsx
+++ b/frontend/src/components/ModelDownloadProgress.tsx
@@ -17,24 +17,24 @@ export function ModelDownloadProgress({ status, modelName, onCancel }: ModelDown
   const isCompleted = progress >= 100;
 
   return (
-    <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+    <div className="bg-info/10 border border-info/30 rounded-lg p-4">
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center space-x-2">
-          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"></div>
-          <span className="text-sm font-medium text-blue-900">
+          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-info"></div>
+          <span className="text-sm font-medium text-info">
             {isCompleted ? 'Finalizing...' : `Downloading ${modelName}`}
           </span>
         </div>
       </div>
       
       <div className="relative">
-        <div className="w-full bg-blue-200 rounded-full h-2">
+        <div className="w-full bg-info/20 rounded-full h-2">
           <div 
-            className="bg-blue-600 h-2 rounded-full transition-all duration-300 ease-out"
+            className="bg-info h-2 rounded-full transition-all duration-300 ease-out"
             style={{ width: `${Math.min(progress, 100)}%` }}
           />
         </div>
-        <div className="flex justify-between text-xs text-blue-700 mt-1">
+        <div className="flex justify-between text-xs text-info mt-1">
           <span>{Math.round(progress)}% complete</span>
           {!isCompleted && (
             <span className="animate-pulse">Downloading...</span>
@@ -43,7 +43,7 @@ export function ModelDownloadProgress({ status, modelName, onCancel }: ModelDown
       </div>
       
       {isCompleted && (
-        <div className="mt-2 text-xs text-green-700">
+        <div className="mt-2 text-xs text-success">
           ✓ Download completed, loading model...
         </div>
       )}
@@ -74,7 +74,7 @@ export function ProgressRing({ progress, size = 40, strokeWidth = 3 }: ProgressR
           cx={size / 2}
           cy={size / 2}
           r={radius}
-          stroke="#e5e7eb"
+          stroke="hsl(var(--border))"
           strokeWidth={strokeWidth}
           fill="transparent"
         />
@@ -82,7 +82,7 @@ export function ProgressRing({ progress, size = 40, strokeWidth = 3 }: ProgressR
           cx={size / 2}
           cy={size / 2}
           r={radius}
-          stroke="#3b82f6"
+          stroke="hsl(var(--info))"
           strokeWidth={strokeWidth}
           strokeDasharray={strokeDasharray}
           strokeDashoffset={strokeDashoffset}
@@ -91,7 +91,7 @@ export function ProgressRing({ progress, size = 40, strokeWidth = 3 }: ProgressR
           className="transition-all duration-300 ease-in-out"
         />
       </svg>
-      <span className="absolute text-xs font-medium text-blue-600">
+      <span className="absolute text-xs font-medium text-info">
         {Math.round(progress)}%
       </span>
     </div>
@@ -111,17 +111,17 @@ export function DownloadSummary({ totalModels, downloadedModels, totalSizeMb }: 
   };
 
   return (
-    <div className="bg-gray-50 rounded-lg p-3 text-sm">
+    <div className="bg-muted/40 rounded-lg p-3 text-sm">
       <div className="flex items-center justify-between">
-        <span className="text-gray-700">
+        <span className="text-foreground">
           📦 {downloadedModels} of {totalModels} models available
         </span>
-        <span className="text-gray-600">
+        <span className="text-muted-foreground">
           💾 {formatSize(totalSizeMb)} total
         </span>
       </div>
       {downloadedModels > 0 && (
-        <div className="mt-1 text-xs text-green-600">
+        <div className="mt-1 text-xs text-success">
           ✓ Models run locally - no internet required for transcription
         </div>
       )}

--- a/frontend/src/components/ModelDownloadProgress.tsx
+++ b/frontend/src/components/ModelDownloadProgress.tsx
@@ -21,7 +21,7 @@ export function ModelDownloadProgress({ status, modelName, onCancel }: ModelDown
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center space-x-2">
           <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-info"></div>
-          <span className="text-sm font-medium text-info">
+          <span className="text-sm font-medium text-info-text">
             {isCompleted ? 'Finalizing...' : `Downloading ${modelName}`}
           </span>
         </div>
@@ -34,7 +34,7 @@ export function ModelDownloadProgress({ status, modelName, onCancel }: ModelDown
             style={{ width: `${Math.min(progress, 100)}%` }}
           />
         </div>
-        <div className="flex justify-between text-xs text-info mt-1">
+        <div className="flex justify-between text-xs text-info-text mt-1">
           <span>{Math.round(progress)}% complete</span>
           {!isCompleted && (
             <span className="animate-pulse">Downloading...</span>
@@ -43,7 +43,7 @@ export function ModelDownloadProgress({ status, modelName, onCancel }: ModelDown
       </div>
       
       {isCompleted && (
-        <div className="mt-2 text-xs text-success">
+        <div className="mt-2 text-xs text-success-text">
           ✓ Download completed, loading model...
         </div>
       )}
@@ -91,7 +91,7 @@ export function ProgressRing({ progress, size = 40, strokeWidth = 3 }: ProgressR
           className="transition-all duration-300 ease-in-out"
         />
       </svg>
-      <span className="absolute text-xs font-medium text-info">
+      <span className="absolute text-xs font-medium text-info-text">
         {Math.round(progress)}%
       </span>
     </div>
@@ -121,7 +121,7 @@ export function DownloadSummary({ totalModels, downloadedModels, totalSizeMb }: 
         </span>
       </div>
       {downloadedModels > 0 && (
-        <div className="mt-1 text-xs text-success">
+        <div className="mt-1 text-xs text-success-text">
           ✓ Models run locally - no internet required for transcription
         </div>
       )}

--- a/frontend/src/components/ModelSettingsModal.tsx
+++ b/frontend/src/components/ModelSettingsModal.tsx
@@ -1153,7 +1153,7 @@ export function ModelSettingsModal({
                       )}
                     />
                     {endpointValidationState === 'valid' && (
-                      <CheckCircle2 className="absolute right-3 top-1/2 -translate-y-1/2 h-5 w-5 text-success" />
+                      <CheckCircle2 className="absolute right-3 top-1/2 -translate-y-1/2 h-5 w-5 text-success-text" />
                     )}
                     {endpointValidationState === 'invalid' && (
                       <XCircle className="absolute right-3 top-1/2 -translate-y-1/2 h-5 w-5 text-destructive" />
@@ -1182,7 +1182,7 @@ export function ModelSettingsModal({
                 </div>
                 {ollamaEndpointChanged && !error && (
                   <Alert className="mt-3 border-warning bg-warning/10">
-                    <AlertDescription className="text-warning">
+                    <AlertDescription className="text-warning-text">
                       Endpoint changed. Please click "Fetch Models" to load models from the new endpoint before saving.
                     </AlertDescription>
                   </Alert>
@@ -1226,7 +1226,7 @@ export function ModelSettingsModal({
                   /* Show Ollama download link when not installed */
                   <div className="space-y-4">
                     <Alert className="border-warning bg-warning/10">
-                      <AlertDescription className="text-warning">
+                      <AlertDescription className="text-warning-text">
                         Ollama is not installed or not running. Please download and install Ollama to use local models.
                       </AlertDescription>
                     </Alert>
@@ -1279,8 +1279,8 @@ export function ModelSettingsModal({
                         {isDownloading('gemma3:1b') && getProgress('gemma3:1b') !== undefined && (
                           <div className="bg-card rounded-md border p-3">
                             <div className="flex items-center justify-between mb-2">
-                              <span className="text-sm font-medium text-info">Downloading gemma3:1b</span>
-                              <span className="text-sm font-semibold text-info">
+                              <span className="text-sm font-medium text-info-text">Downloading gemma3:1b</span>
+                              <span className="text-sm font-semibold text-info-text">
                                 {Math.round(getProgress('gemma3:1b')!)}%
                               </span>
                             </div>
@@ -1337,8 +1337,8 @@ export function ModelSettingsModal({
                           {modelIsDownloading && progress !== undefined && (
                             <div className="mt-3 pt-3 border-t border-border">
                               <div className="flex items-center justify-between mb-2">
-                                <span className="text-sm font-medium text-info">Downloading...</span>
-                                <span className="text-sm font-semibold text-info">{Math.round(progress)}%</span>
+                                <span className="text-sm font-medium text-info-text">Downloading...</span>
+                                <span className="text-sm font-semibold text-info-text">{Math.round(progress)}%</span>
                               </div>
                               <div className="w-full h-2 bg-muted rounded-full overflow-hidden">
                                 <div

--- a/frontend/src/components/ModelSettingsModal.tsx
+++ b/frontend/src/components/ModelSettingsModal.tsx
@@ -1095,7 +1095,7 @@ export function ModelSettingsModal({
                     variant="ghost"
                     size="icon"
                     onClick={() => setIsApiKeyLocked(!isApiKeyLocked)}
-                    className={isLockButtonVibrating ? 'animate-vibrate text-red-500' : ''}
+                    className={isLockButtonVibrating ? 'animate-vibrate text-destructive' : ''}
                     title={isApiKeyLocked ? 'Unlock to edit' : 'Lock to prevent editing'}
                   >
                     {isApiKeyLocked ? <Lock /> : <Unlock />}
@@ -1149,14 +1149,14 @@ export function ModelSettingsModal({
                       placeholder="http://localhost:11434"
                       className={cn(
                         "pr-10",
-                        endpointValidationState === 'invalid' && "border-red-500"
+                        endpointValidationState === 'invalid' && "border-destructive"
                       )}
                     />
                     {endpointValidationState === 'valid' && (
-                      <CheckCircle2 className="absolute right-3 top-1/2 -translate-y-1/2 h-5 w-5 text-green-500" />
+                      <CheckCircle2 className="absolute right-3 top-1/2 -translate-y-1/2 h-5 w-5 text-success" />
                     )}
                     {endpointValidationState === 'invalid' && (
-                      <XCircle className="absolute right-3 top-1/2 -translate-y-1/2 h-5 w-5 text-red-500" />
+                      <XCircle className="absolute right-3 top-1/2 -translate-y-1/2 h-5 w-5 text-destructive" />
                     )}
                   </div>
                   <Button
@@ -1181,8 +1181,8 @@ export function ModelSettingsModal({
                   </Button>
                 </div>
                 {ollamaEndpointChanged && !error && (
-                  <Alert className="mt-3 border-yellow-500 bg-yellow-50">
-                    <AlertDescription className="text-yellow-800">
+                  <Alert className="mt-3 border-warning bg-warning/10">
+                    <AlertDescription className="text-warning">
                       Endpoint changed. Please click "Fetch Models" to load models from the new endpoint before saving.
                     </AlertDescription>
                   </Alert>
@@ -1225,8 +1225,8 @@ export function ModelSettingsModal({
                 {ollamaNotInstalled ? (
                   /* Show Ollama download link when not installed */
                   <div className="space-y-4">
-                    <Alert className="border-orange-500 bg-orange-50">
-                      <AlertDescription className="text-orange-800">
+                    <Alert className="border-warning bg-warning/10">
+                      <AlertDescription className="text-warning">
                         Ollama is not installed or not running. Please download and install Ollama to use local models.
                       </AlertDescription>
                     </Alert>
@@ -1234,7 +1234,7 @@ export function ModelSettingsModal({
                       variant="default"
                       size="sm"
                       onClick={() => invoke('open_external_url', { url: 'https://ollama.com/download' })}
-                      className="w-full bg-blue-600 hover:bg-blue-700"
+                      className="w-full bg-info hover:bg-info/90"
                     >
                       <ExternalLink className="mr-2 h-4 w-4" />
                       Download Ollama
@@ -1277,16 +1277,16 @@ export function ModelSettingsModal({
 
                         {/* Show progress for gemma3:1b download */}
                         {isDownloading('gemma3:1b') && getProgress('gemma3:1b') !== undefined && (
-                          <div className="bg-white rounded-md border p-3">
+                          <div className="bg-card rounded-md border p-3">
                             <div className="flex items-center justify-between mb-2">
-                              <span className="text-sm font-medium text-blue-600">Downloading gemma3:1b</span>
-                              <span className="text-sm font-semibold text-blue-600">
+                              <span className="text-sm font-medium text-info">Downloading gemma3:1b</span>
+                              <span className="text-sm font-semibold text-info">
                                 {Math.round(getProgress('gemma3:1b')!)}%
                               </span>
                             </div>
-                            <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+                            <div className="w-full h-2 bg-muted rounded-full overflow-hidden">
                               <div
-                                className="h-full bg-gradient-to-r from-blue-500 to-blue-600 rounded-full transition-all duration-300"
+                                className="h-full bg-info rounded-full transition-all duration-300"
                                 style={{ width: `${getProgress('gemma3:1b')}%` }}
                               />
                             </div>
@@ -1317,7 +1317,7 @@ export function ModelSettingsModal({
                           className={cn(
                             'bg-card p-2 m-0 rounded-md border transition-colors',
                             modelConfig.model === model.name
-                              ? 'ring-1 ring-blue-500 border-blue-500 background-blue-100'
+                              ? 'ring-1 ring-info border-info bg-info/10'
                               : 'hover:bg-muted/50',
                             !modelIsDownloading && 'cursor-pointer'
                           )}
@@ -1335,14 +1335,14 @@ export function ModelSettingsModal({
 
                           {/* Progress bar for downloading models */}
                           {modelIsDownloading && progress !== undefined && (
-                            <div className="mt-3 pt-3 border-t border-gray-200">
+                            <div className="mt-3 pt-3 border-t border-border">
                               <div className="flex items-center justify-between mb-2">
-                                <span className="text-sm font-medium text-blue-600">Downloading...</span>
-                                <span className="text-sm font-semibold text-blue-600">{Math.round(progress)}%</span>
+                                <span className="text-sm font-medium text-info">Downloading...</span>
+                                <span className="text-sm font-semibold text-info">{Math.round(progress)}%</span>
                               </div>
-                              <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+                              <div className="w-full h-2 bg-muted rounded-full overflow-hidden">
                                 <div
-                                  className="h-full bg-gradient-to-r from-blue-500 to-blue-600 rounded-full transition-all duration-300"
+                                  className="h-full bg-info rounded-full transition-all duration-300"
                                   style={{ width: `${progress}%` }}
                                 />
                               </div>
@@ -1373,7 +1373,7 @@ export function ModelSettingsModal({
       </div>
 
       {/* Auto-generate summaries toggle */}
-      {/* <div className="mt-6 pt-6 border-t border-gray-200">
+      {/* <div className="mt-6 pt-6 border-t border-border">
         <div className="flex items-center justify-between">
           <div className="flex-1">
             <Label htmlFor="auto-generate" className="text-base font-medium">
@@ -1394,8 +1394,8 @@ export function ModelSettingsModal({
       <div className="mt-6 flex justify-end">
         <Button
           className={cn(
-            'px-4 text-sm font-medium text-white rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500',
-            isDoneDisabled ? 'bg-gray-400 cursor-not-allowed' : 'bg-blue-600 hover:bg-blue-700'
+            'px-4 text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-info',
+            isDoneDisabled ? 'bg-muted cursor-not-allowed text-muted-foreground' : 'bg-info hover:bg-info/90 text-info-foreground'
           )}
           onClick={handleSave}
           disabled={isDoneDisabled}

--- a/frontend/src/components/ParakeetModelManager.tsx
+++ b/frontend/src/components/ParakeetModelManager.tsx
@@ -332,8 +332,8 @@ export function ParakeetModelManager({
     return (
       <div className={`space-y-3 ${className}`}>
         <div className="animate-pulse space-y-3">
-          <div className="h-20 bg-gray-100 rounded-lg"></div>
-          <div className="h-20 bg-gray-100 rounded-lg"></div>
+          <div className="h-20 bg-muted rounded-lg"></div>
+          <div className="h-20 bg-muted rounded-lg"></div>
         </div>
       </div>
     );
@@ -341,9 +341,9 @@ export function ParakeetModelManager({
 
   if (error) {
     return (
-      <div className={`bg-red-50 border border-red-200 rounded-lg p-4 ${className}`}>
-        <p className="text-sm text-red-800">Failed to load models</p>
-        <p className="text-xs text-red-600 mt-1">{error}</p>
+      <div className={`bg-destructive/10 border border-destructive/30 rounded-lg p-4 ${className}`}>
+        <p className="text-sm text-destructive">Failed to load models</p>
+        <p className="text-xs text-destructive mt-1">{error}</p>
       </div>
     );
   }
@@ -403,7 +403,7 @@ export function ParakeetModelManager({
         <motion.div
           initial={{ opacity: 0, y: -5 }}
           animate={{ opacity: 1, y: 0 }}
-          className="text-xs text-gray-500 text-center pt-2"
+          className="text-xs text-muted-foreground text-center pt-2"
         >
           Using {getModelDisplayName(selectedModel)} for transcription
         </motion.div>
@@ -459,10 +459,10 @@ function ModelCard({
       className={`
         relative rounded-lg border-2 transition-all cursor-pointer
         ${isSelected && isAvailable
-          ? 'border-blue-500 bg-blue-50'
+          ? 'border-info bg-info/10'
           : isAvailable
-            ? 'border-gray-200 hover:border-gray-300 bg-white'
-            : 'border-gray-200 bg-gray-50'
+            ? 'border-border hover:border-border bg-card'
+            : 'border-border bg-muted/40'
         }
         ${isAvailable ? '' : 'cursor-default'}
       `}
@@ -472,7 +472,7 @@ function ModelCard({
     >
       {/* Recommended Badge */}
       {isRecommended && (
-        <div className="absolute -top-2 -right-2 bg-blue-600 text-white text-xs px-2 py-0.5 rounded-full font-medium">
+        <div className="absolute -top-2 -right-2 bg-info text-info-foreground text-xs px-2 py-0.5 rounded-full font-medium">
           Recommended
         </div>
       )}
@@ -483,12 +483,12 @@ function ModelCard({
             {/* Model Name */}
             <div className="flex items-center gap-2 mb-1">
               <span className="text-2xl">{icon}</span>
-              <h3 className="font-semibold text-gray-900">{displayName}</h3>
+              <h3 className="font-semibold text-foreground">{displayName}</h3>
               {isSelected && isAvailable && (
                 <motion.span
                   initial={{ scale: 0 }}
                   animate={{ scale: 1 }}
-                  className="bg-blue-600 text-white px-2 py-0.5 rounded-full text-xs font-medium flex items-center gap-1"
+                  className="bg-info text-info-foreground px-2 py-0.5 rounded-full text-xs font-medium flex items-center gap-1"
                 >
                   ✓
                 </motion.span>
@@ -496,15 +496,15 @@ function ModelCard({
             </div>
 
             {/* Tagline */}
-            <p className="text-sm text-gray-600 ml-9">{tagline}</p>
+            <p className="text-sm text-muted-foreground ml-9">{tagline}</p>
           </div>
 
           {/* Status/Action */}
           <div className="ml-4 flex items-center gap-2">
             {isAvailable && (
               <>
-                <div className="flex items-center gap-1.5 text-green-600">
-                  <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+                <div className="flex items-center gap-1.5 text-success">
+                  <div className="w-2 h-2 bg-success rounded-full"></div>
                   <span className="text-xs font-medium">Ready</span>
                 </div>
                 <AnimatePresence>
@@ -518,7 +518,7 @@ function ModelCard({
                         e.stopPropagation();
                         onDelete();
                       }}
-                      className="text-gray-400 hover:text-red-600 transition-colors p-1"
+                      className="text-muted-foreground hover:text-destructive transition-colors p-1"
                       title="Delete model to free up space"
                     >
                       <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -536,7 +536,7 @@ function ModelCard({
                   e.stopPropagation();
                   onDownload();
                 }}
-                className="bg-blue-600 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-blue-700 transition-colors"
+                className="bg-info text-info-foreground px-3 py-1.5 rounded-md text-sm font-medium hover:bg-info/90 transition-colors"
               >
                 Download
               </button>
@@ -548,7 +548,7 @@ function ModelCard({
                   e.stopPropagation();
                   onDownload();
                 }}
-                className="bg-red-600 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-red-700 transition-colors"
+                className="bg-destructive text-destructive-foreground px-3 py-1.5 rounded-md text-sm font-medium hover:bg-destructive/90 transition-colors"
               >
                 Retry
               </button>
@@ -561,7 +561,7 @@ function ModelCard({
                     e.stopPropagation();
                     onDelete();
                   }}
-                  className="bg-orange-600 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-orange-700 transition-colors"
+                  className="bg-warning text-warning-foreground px-3 py-1.5 rounded-md text-sm font-medium hover:bg-warning/90 transition-colors"
                 >
                   Delete
                 </button>
@@ -570,7 +570,7 @@ function ModelCard({
                     e.stopPropagation();
                     onDownload();
                   }}
-                  className="bg-blue-600 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-blue-700 transition-colors"
+                  className="bg-info text-info-foreground px-3 py-1.5 rounded-md text-sm font-medium hover:bg-info/90 transition-colors"
                 >
                   Re-download
                 </button>
@@ -585,33 +585,33 @@ function ModelCard({
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
-            className="mt-3 pt-3 border-t border-gray-200"
+            className="mt-3 pt-3 border-t border-border"
           >
             <div className="flex items-center justify-between mb-2">
               <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-blue-600">Downloading...</span>
-                <span className="text-sm font-semibold text-blue-600">{Math.round(downloadProgress)}%</span>
+                <span className="text-sm font-medium text-info">Downloading...</span>
+                <span className="text-sm font-semibold text-info">{Math.round(downloadProgress)}%</span>
               </div>
               <button
                 onClick={(e) => {
                   e.stopPropagation();
                   onCancel();
                 }}
-                className="text-xs text-gray-600 hover:text-red-600 font-medium transition-colors px-2 py-1 rounded hover:bg-red-50"
+                className="text-xs text-muted-foreground hover:text-destructive font-medium transition-colors px-2 py-1 rounded hover:bg-destructive/10"
                 title="Cancel download"
               >
                 Cancel
               </button>
             </div>
-            <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+            <div className="w-full h-2 bg-muted rounded-full overflow-hidden">
               <motion.div
-                className="h-full bg-gradient-to-r from-blue-500 to-blue-600 rounded-full"
+                className="h-full bg-info rounded-full"
                 initial={{ width: 0 }}
                 animate={{ width: `${downloadProgress}%` }}
                 transition={{ duration: 0.3, ease: 'easeOut' }}
               />
             </div>
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               {model.size_mb ? (
                 <>
                   {formatFileSize(model.size_mb * downloadProgress / 100)} / {formatFileSize(model.size_mb)}

--- a/frontend/src/components/ParakeetModelManager.tsx
+++ b/frontend/src/components/ParakeetModelManager.tsx
@@ -503,7 +503,7 @@ function ModelCard({
           <div className="ml-4 flex items-center gap-2">
             {isAvailable && (
               <>
-                <div className="flex items-center gap-1.5 text-success">
+                <div className="flex items-center gap-1.5 text-success-text">
                   <div className="w-2 h-2 bg-success rounded-full"></div>
                   <span className="text-xs font-medium">Ready</span>
                 </div>
@@ -589,8 +589,8 @@ function ModelCard({
           >
             <div className="flex items-center justify-between mb-2">
               <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-info">Downloading...</span>
-                <span className="text-sm font-semibold text-info">{Math.round(downloadProgress)}%</span>
+                <span className="text-sm font-medium text-info-text">Downloading...</span>
+                <span className="text-sm font-semibold text-info-text">{Math.round(downloadProgress)}%</span>
               </div>
               <button
                 onClick={(e) => {

--- a/frontend/src/components/PermissionWarning.tsx
+++ b/frontend/src/components/PermissionWarning.tsx
@@ -55,9 +55,9 @@ export function PermissionWarning({
     <div className="max-w-md mb-4 space-y-3">
       {/* Combined Permission Warning - Show when either permission is missing */}
       {(!hasMicrophone || !hasSystemAudio) && (
-        <Alert variant="destructive" className="border-amber-400 bg-amber-50">
-          <AlertTriangle className="h-5 w-5 text-amber-600" />
-          <AlertTitle className="text-amber-900 font-semibold">
+        <Alert variant="destructive" className="border-warning/30 bg-warning/10">
+          <AlertTriangle className="h-5 w-5 text-warning" />
+          <AlertTitle className="text-warning font-semibold">
             <div className="flex items-center gap-2">
               {!hasMicrophone && <Mic className="h-4 w-4" />}
               {!hasSystemAudio && <Speaker className="h-4 w-4" />}
@@ -69,7 +69,7 @@ export function PermissionWarning({
             {isMacOS && !hasMicrophone && (
               <button
                 onClick={openMicrophoneSettings}
-                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 rounded-md transition-colors"
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-warning-foreground bg-warning hover:bg-warning/90 rounded-md transition-colors"
               >
                 <Mic className="h-4 w-4" />
                 Open Microphone Settings
@@ -78,7 +78,7 @@ export function PermissionWarning({
             {isMacOS && !hasSystemAudio && (
               <button
                 onClick={openScreenRecordingSettings}
-                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-info-foreground bg-info hover:bg-info/90 rounded-md transition-colors"
               >
                 <Speaker className="h-4 w-4" />
                 Open Screen Recording Settings
@@ -87,13 +87,13 @@ export function PermissionWarning({
             <button
               onClick={onRecheck}
               disabled={isRechecking}
-              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-amber-900 bg-amber-100 hover:bg-amber-200 rounded-md transition-colors disabled:opacity-50"
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-warning bg-warning/15 hover:bg-warning/20 rounded-md transition-colors disabled:opacity-50"
             >
               <RefreshCw className={`h-4 w-4 ${isRechecking ? 'animate-spin' : ''}`} />
               Recheck
             </button>
           </div>
-          <AlertDescription className="text-amber-800 mt-2">
+          <AlertDescription className="text-warning mt-2">
             {/* Microphone Warning */}
             {!hasMicrophone && (
               <>

--- a/frontend/src/components/PermissionWarning.tsx
+++ b/frontend/src/components/PermissionWarning.tsx
@@ -56,8 +56,8 @@ export function PermissionWarning({
       {/* Combined Permission Warning - Show when either permission is missing */}
       {(!hasMicrophone || !hasSystemAudio) && (
         <Alert variant="destructive" className="border-warning/30 bg-warning/10">
-          <AlertTriangle className="h-5 w-5 text-warning" />
-          <AlertTitle className="text-warning font-semibold">
+          <AlertTriangle className="h-5 w-5 text-warning-text" />
+          <AlertTitle className="text-warning-text font-semibold">
             <div className="flex items-center gap-2">
               {!hasMicrophone && <Mic className="h-4 w-4" />}
               {!hasSystemAudio && <Speaker className="h-4 w-4" />}
@@ -87,13 +87,13 @@ export function PermissionWarning({
             <button
               onClick={onRecheck}
               disabled={isRechecking}
-              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-warning bg-warning/15 hover:bg-warning/20 rounded-md transition-colors disabled:opacity-50"
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-warning-text bg-warning/15 hover:bg-warning/20 rounded-md transition-colors disabled:opacity-50"
             >
               <RefreshCw className={`h-4 w-4 ${isRechecking ? 'animate-spin' : ''}`} />
               Recheck
             </button>
           </div>
-          <AlertDescription className="text-warning mt-2">
+          <AlertDescription className="text-warning-text mt-2">
             {/* Microphone Warning */}
             {!hasMicrophone && (
               <>

--- a/frontend/src/components/PreferenceSettings.tsx
+++ b/frontend/src/components/PreferenceSettings.tsx
@@ -2,11 +2,17 @@
 
 import { useEffect, useState, useRef } from "react"
 import { Switch } from "./ui/switch"
-import { FolderOpen } from "lucide-react"
+import { FolderOpen, Monitor, Moon, Sun } from "lucide-react"
 import { invoke } from "@tauri-apps/api/core"
 import Analytics from "@/lib/analytics"
 import AnalyticsConsentSwitch from "./AnalyticsConsentSwitch"
 import { useConfig, NotificationSettings } from "@/contexts/ConfigContext"
+
+const THEME_OPTIONS = [
+  { value: 'system', label: 'System', icon: Monitor },
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+] as const;
 
 export function PreferenceSettings() {
   const {
@@ -14,7 +20,9 @@ export function PreferenceSettings() {
     storageLocations,
     isLoadingPreferences,
     loadPreferences,
-    updateNotificationSettings
+    updateNotificationSettings,
+    themeMode,
+    setThemeMode
   } = useConfig();
 
   const [notificationsEnabled, setNotificationsEnabled] = useState<boolean | null>(null);
@@ -148,34 +156,60 @@ export function PreferenceSettings() {
 
   return (
     <div className="space-y-6">
+      {/* Appearance Section */}
+      <div className="bg-card text-card-foreground rounded-lg border border-border p-6 shadow-sm">
+        <div className="flex items-center justify-between gap-6">
+          <div>
+            <h3 className="text-lg font-semibold text-foreground mb-2">Appearance</h3>
+            <p className="text-sm text-muted-foreground">Choose how Meetily should render the interface</p>
+          </div>
+          <div className="inline-flex rounded-md border border-border bg-muted p-1">
+            {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setThemeMode(value)}
+                className={`flex items-center gap-2 rounded px-3 py-2 text-sm font-medium transition-colors ${themeMode === value
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+                  }`}
+              >
+                <Icon className="h-4 w-4" />
+                <span>{label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
       {/* Notifications Section */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+      <div className="bg-card text-card-foreground rounded-lg border border-border p-6 shadow-sm">
         <div className="flex items-center justify-between">
           <div>
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">Notifications</h3>
-            <p className="text-sm text-gray-600">Enable or disable notifications of start and end of meeting</p>
+            <h3 className="text-lg font-semibold text-foreground mb-2">Notifications</h3>
+            <p className="text-sm text-muted-foreground">Enable or disable notifications of start and end of meeting</p>
           </div>
           <Switch checked={notificationsEnabledValue} onCheckedChange={setNotificationsEnabled} />
         </div>
       </div>
 
       {/* Data Storage Locations Section */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">Data Storage Locations</h3>
-        <p className="text-sm text-gray-600 mb-6">
+      <div className="bg-card text-card-foreground rounded-lg border border-border p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-foreground mb-4">Data Storage Locations</h3>
+        <p className="text-sm text-muted-foreground mb-6">
           View and access where Meetily stores your data
         </p>
 
         <div className="space-y-4">
           {/* Database Location */}
-          {/* <div className="p-4 border rounded-lg bg-gray-50">
+          {/* <div className="p-4 border border-border rounded-lg bg-muted/40">
             <div className="font-medium mb-2">Database</div>
-            <div className="text-sm text-gray-600 mb-3 break-all font-mono text-xs">
+            <div className="text-sm text-muted-foreground mb-3 break-all font-mono text-xs">
               {storageLocations?.database || 'Loading...'}
             </div>
             <button
               onClick={() => handleOpenFolder('database')}
-              className="flex items-center gap-2 px-3 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-100 transition-colors"
+              className="flex items-center gap-2 px-3 py-2 text-sm border border-border rounded-md hover:bg-accent transition-colors"
             >
               <FolderOpen className="w-4 h-4" />
               Open Folder
@@ -183,14 +217,14 @@ export function PreferenceSettings() {
           </div> */}
 
           {/* Models Location */}
-          {/* <div className="p-4 border rounded-lg bg-gray-50">
+          {/* <div className="p-4 border border-border rounded-lg bg-muted/40">
             <div className="font-medium mb-2">Whisper Models</div>
-            <div className="text-sm text-gray-600 mb-3 break-all font-mono text-xs">
+            <div className="text-sm text-muted-foreground mb-3 break-all font-mono text-xs">
               {storageLocations?.models || 'Loading...'}
             </div>
             <button
               onClick={() => handleOpenFolder('models')}
-              className="flex items-center gap-2 px-3 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-100 transition-colors"
+              className="flex items-center gap-2 px-3 py-2 text-sm border border-border rounded-md hover:bg-accent transition-colors"
             >
               <FolderOpen className="w-4 h-4" />
               Open Folder
@@ -198,14 +232,14 @@ export function PreferenceSettings() {
           </div> */}
 
           {/* Recordings Location */}
-          <div className="p-4 border rounded-lg bg-gray-50">
+          <div className="p-4 border border-border rounded-lg bg-muted/40">
             <div className="font-medium mb-2">Meeting Recordings</div>
-            <div className="text-sm text-gray-600 mb-3 break-all font-mono text-xs">
+            <div className="text-sm text-muted-foreground mb-3 break-all font-mono text-xs">
               {storageLocations?.recordings || 'Loading...'}
             </div>
             <button
               onClick={() => handleOpenFolder('recordings')}
-              className="flex items-center gap-2 px-3 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-100 transition-colors"
+              className="flex items-center gap-2 px-3 py-2 text-sm border border-border rounded-md hover:bg-accent transition-colors"
             >
               <FolderOpen className="w-4 h-4" />
               Open Folder
@@ -213,15 +247,15 @@ export function PreferenceSettings() {
           </div>
         </div>
 
-        <div className="mt-4 p-3 bg-blue-50 rounded-md">
-          <p className="text-xs text-blue-800">
+        <div className="mt-4 p-3 bg-muted/40 border border-border rounded-md">
+          <p className="text-xs text-muted-foreground">
             <strong>Note:</strong> Database and models are stored together in your application data directory for unified management.
           </p>
         </div>
       </div>
 
       {/* Analytics Section */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+      <div className="bg-card text-card-foreground rounded-lg border border-border p-6 shadow-sm">
         <AnalyticsConsentSwitch />
       </div>
     </div>

--- a/frontend/src/components/PreferenceSettings.tsx
+++ b/frontend/src/components/PreferenceSettings.tsx
@@ -7,6 +7,7 @@ import { invoke } from "@tauri-apps/api/core"
 import Analytics from "@/lib/analytics"
 import AnalyticsConsentSwitch from "./AnalyticsConsentSwitch"
 import { useConfig, NotificationSettings } from "@/contexts/ConfigContext"
+import { cn } from "@/lib/utils"
 
 const THEME_OPTIONS = [
   { value: 'system', label: 'System', icon: Monitor },
@@ -29,6 +30,13 @@ export function PreferenceSettings() {
   const [isInitialLoad, setIsInitialLoad] = useState(true);
   const [previousNotificationsEnabled, setPreviousNotificationsEnabled] = useState<boolean | null>(null);
   const hasTrackedViewRef = useRef(false);
+
+  // themeMode is read from localStorage, so it differs between the server
+  // render ('system') and the first client render (the stored value). Gating
+  // the active-button highlight on mount keeps both renders neutral, avoiding
+  // a hydration mismatch that otherwise strands the highlight on System.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
 
   // Lazy load preferences on mount (only loads if not already cached)
   useEffect(() => {
@@ -141,46 +149,56 @@ export function PreferenceSettings() {
     }
   };
 
-  // Show loading only if we're actually loading and don't have cached data
-  if (isLoadingPreferences && !notificationSettings && !storageLocations) {
-    return <div className="max-w-2xl mx-auto p-6">Loading Preferences...</div>
-  }
-
-  // Show loading if notificationsEnabled hasn't been determined yet
-  if (notificationsEnabled === null && !isLoadingPreferences) {
-    return <div className="max-w-2xl mx-auto p-6">Loading Preferences...</div>
-  }
-
   // Ensure we have a boolean value for the Switch component
   const notificationsEnabledValue = notificationsEnabled ?? false;
 
-  return (
-    <div className="space-y-6">
-      {/* Appearance Section */}
-      <div className="bg-card text-card-foreground rounded-lg border border-border p-6 shadow-sm">
-        <div className="flex items-center justify-between gap-6">
-          <div>
-            <h3 className="text-lg font-semibold text-foreground mb-2">Appearance</h3>
-            <p className="text-sm text-muted-foreground">Choose how Meetily should render the interface</p>
-          </div>
-          <div className="inline-flex rounded-md border border-border bg-muted p-1">
-            {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
-              <button
-                key={value}
-                type="button"
-                onClick={() => setThemeMode(value)}
-                className={`flex items-center gap-2 rounded px-3 py-2 text-sm font-medium transition-colors ${themeMode === value
+  // The Appearance section needs no Tauri data, so it renders even while (or
+  // if) the notification/storage preferences fail to load.
+  const appearanceSection = (
+    <div className="bg-card text-card-foreground rounded-lg border border-border p-6 shadow-sm">
+      <div className="flex items-center justify-between gap-6">
+        <div>
+          <h3 className="text-lg font-semibold text-foreground mb-2">Appearance</h3>
+          <p className="text-sm text-muted-foreground">Choose how Meetily should render the interface</p>
+        </div>
+        <div className="inline-flex rounded-md border border-border bg-muted p-1">
+          {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setThemeMode(value)}
+              className={cn(
+                'flex items-center gap-2 rounded px-3 py-2 text-sm font-medium transition-colors',
+                mounted && themeMode === value
                   ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground'
-                  }`}
-              >
-                <Icon className="h-4 w-4" />
-                <span>{label}</span>
-              </button>
-            ))}
-          </div>
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              <Icon className="h-4 w-4" />
+              <span>{label}</span>
+            </button>
+          ))}
         </div>
       </div>
+    </div>
+  );
+
+  const preferencesPending =
+    (isLoadingPreferences && !notificationSettings && !storageLocations) ||
+    (notificationsEnabled === null && !isLoadingPreferences);
+
+  if (preferencesPending) {
+    return (
+      <div className="space-y-6">
+        {appearanceSection}
+        <div className="max-w-2xl mx-auto p-6">Loading Preferences...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {appearanceSection}
 
       {/* Notifications Section */}
       <div className="bg-card text-card-foreground rounded-lg border border-border p-6 shadow-sm">

--- a/frontend/src/components/RecordingControls.tsx
+++ b/frontend/src/components/RecordingControls.tsx
@@ -342,11 +342,11 @@ export const RecordingControls: React.FC<RecordingControlsProps> = ({
   return (
     <TooltipProvider>
       <div className="flex flex-col space-y-2">
-        <div className="flex items-center space-x-2 bg-white rounded-full shadow-lg px-4 py-2">
+        <div className="flex items-center space-x-2 bg-card rounded-full shadow-lg px-4 py-2">
           {isProcessing && !isParentProcessing ? (
             <div className="flex items-center space-x-2">
-              <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-gray-900"></div>
-              <span className="text-sm text-gray-600">Processing recording...</span>
+              <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-primary"></div>
+              <span className="text-sm text-muted-foreground">Processing recording...</span>
             </div>
           ) : (
             <>
@@ -354,32 +354,32 @@ export const RecordingControls: React.FC<RecordingControlsProps> = ({
                 <>
                   <button
                     onClick={handleStartRecording}
-                    className="w-10 h-10 flex items-center justify-center bg-red-500 rounded-full text-white hover:bg-red-600 transition-colors"
+                    className="w-10 h-10 flex items-center justify-center bg-destructive rounded-full text-destructive-foreground hover:bg-destructive/90 transition-colors"
                   >
                     <Mic size={16} />
                   </button>
 
-                  <div className="w-px h-6 bg-gray-200 mx-1" />
+                  <div className="w-px h-6 bg-muted mx-1" />
 
                   <div className="flex items-center space-x-1 mx-2">
-                    <div className="text-sm text-gray-600 min-w-[40px]">
+                    <div className="text-sm text-muted-foreground min-w-[40px]">
                       {formatTime(currentTime)}
                     </div>
                     <div
-                      className="relative w-24 h-1 bg-gray-200 rounded-full"
+                      className="relative w-24 h-1 bg-muted rounded-full"
                     >
                       <div
-                        className="absolute h-full bg-blue-500 rounded-full"
+                        className="absolute h-full bg-info rounded-full"
                         style={{ width: `${progress}%` }}
                       />
                     </div>
-                    <div className="text-sm text-gray-600 min-w-[40px]">
+                    <div className="text-sm text-muted-foreground min-w-[40px]">
                       {formatTime(duration)}
                     </div>
                   </div>
 
                   <button
-                    className="w-10 h-10 flex items-center justify-center bg-gray-300 rounded-full text-white cursor-not-allowed"
+                    className="w-10 h-10 flex items-center justify-center bg-muted rounded-full text-muted-foreground cursor-not-allowed"
                     disabled
                   >
                     <Play size={16} />
@@ -397,11 +397,11 @@ export const RecordingControls: React.FC<RecordingControlsProps> = ({
                             handleStartRecording();
                           }}
                           disabled={isStarting || isProcessing || isRecordingDisabled || isValidatingModel}
-                          className={`w-12 h-12 flex items-center justify-center ${isStarting || isProcessing || isValidatingModel ? 'bg-gray-400' : 'bg-red-500 hover:bg-red-600'
-                            } rounded-full text-white transition-colors relative`}
+                          className={`w-12 h-12 flex items-center justify-center ${isStarting || isProcessing || isValidatingModel ? 'bg-muted text-muted-foreground' : 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                            } rounded-full transition-colors relative`}
                         >
                           {isValidatingModel ? (
-                            <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
+                            <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-current"></div>
                           ) : (
                             <Mic size={20} />
                           )}
@@ -428,13 +428,13 @@ export const RecordingControls: React.FC<RecordingControlsProps> = ({
                             }}
                             disabled={isPausing || isResuming || isStopping}
                             className={`w-10 h-10 flex items-center justify-center ${isPausing || isResuming || isStopping
-                              ? 'bg-gray-200 border-2 border-gray-300 text-gray-400'
-                              : 'bg-white border-2 border-gray-300 text-gray-600 hover:border-gray-400 hover:bg-gray-50'
+                              ? 'bg-muted border-2 border-border text-muted-foreground'
+                              : 'bg-card border-2 border-border text-muted-foreground hover:border-border hover:bg-muted/40'
                               } rounded-full transition-colors relative`}
                           >
                             {isPaused ? <Play size={16} /> : <Pause size={16} />}
                             {(isPausing || isResuming) && (
-                              <div className="absolute -top-8 text-gray-600 font-medium text-xs">
+                              <div className="absolute -top-8 text-muted-foreground font-medium text-xs">
                                 {isPausing ? 'Pausing...' : 'Resuming...'}
                               </div>
                             )}
@@ -453,12 +453,12 @@ export const RecordingControls: React.FC<RecordingControlsProps> = ({
                               handleStopRecording();
                             }}
                             disabled={isStopping || isPausing || isResuming}
-                            className={`w-10 h-10 flex items-center justify-center ${isStopping || isPausing || isResuming ? 'bg-gray-400' : 'bg-red-500 hover:bg-red-600'
-                              } rounded-full text-white transition-colors relative`}
+                            className={`w-10 h-10 flex items-center justify-center ${isStopping || isPausing || isResuming ? 'bg-muted text-muted-foreground' : 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                              } rounded-full transition-colors relative`}
                           >
                             <Square size={16} />
                             {isStopping && (
-                              <div className="absolute -top-8 text-gray-600 font-medium text-xs">
+                              <div className="absolute -top-8 text-muted-foreground font-medium text-xs">
                                 Stopping...
                               </div>
                             )}
@@ -475,7 +475,7 @@ export const RecordingControls: React.FC<RecordingControlsProps> = ({
                     {barHeights.map((height, index) => (
                       <div
                         key={index}
-                        className={`w-1 rounded-full transition-all duration-200 ${isPaused ? 'bg-orange-500' : 'bg-red-500'
+                        className={`w-1 rounded-full transition-all duration-200 ${isPaused ? 'bg-warning' : 'bg-destructive'
                           }`}
                         style={{
                           height: isRecording && !isPaused ? height : '4px',
@@ -492,26 +492,26 @@ export const RecordingControls: React.FC<RecordingControlsProps> = ({
 
         {/* Show validation status only */}
         {isValidatingModel && (
-          <div className="text-xs text-gray-600 text-center mt-2">
+          <div className="text-xs text-muted-foreground text-center mt-2">
             Validating speech recognition...
           </div>
         )}
 
         {/* Device error alert */}
         {deviceError && (
-          <Alert variant="destructive" className="mt-4 border-red-300 bg-red-50">
-            <AlertCircle className="h-5 w-5 text-red-600" />
+          <Alert variant="destructive" className="mt-4 border-destructive/40 bg-destructive/10">
+            <AlertCircle className="h-5 w-5 text-destructive" />
             <button
               onClick={() => setDeviceError(null)}
-              className="absolute right-3 top-3 text-red-600 hover:text-red-800 transition-colors"
+              className="absolute right-3 top-3 text-destructive hover:text-destructive transition-colors"
               aria-label="Close alert"
             >
               <X className="h-4 w-4" />
             </button>
-            <AlertTitle className="text-red-800 font-semibold mb-2">
+            <AlertTitle className="text-destructive font-semibold mb-2">
               {deviceError.title}
             </AlertTitle>
-            <AlertDescription className="text-red-700">
+            <AlertDescription className="text-destructive">
               {deviceError.message.split('\n').map((line, i) => (
                 <div key={i} className={i > 0 ? 'ml-2' : ''}>
                   {line}
@@ -522,7 +522,7 @@ export const RecordingControls: React.FC<RecordingControlsProps> = ({
         )}
 
         {/* {showPlayback && recordingPath && (
-        <div className="text-sm text-gray-600 px-4">
+        <div className="text-sm text-muted-foreground px-4">
           Recording saved to: {recordingPath}
         </div>
       )} */}

--- a/frontend/src/components/RecordingSettings.tsx
+++ b/frontend/src/components/RecordingSettings.tsx
@@ -194,10 +194,10 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
           </div>
 
           <div className="p-4 border rounded-lg bg-info/10">
-            <div className="text-sm text-info">
+            <div className="text-sm text-info-text">
               <strong>File Format:</strong> {preferences.file_format.toUpperCase()} files
             </div>
-            <div className="text-xs text-info mt-1">
+            <div className="text-xs text-info-text mt-1">
               Recordings are saved with timestamp: recording_YYYYMMDD_HHMMSS.{preferences.file_format}
             </div>
           </div>
@@ -207,7 +207,7 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
       {/* Info when auto_save is disabled */}
       {!preferences.auto_save && (
         <div className="p-4 border rounded-lg bg-warning/10">
-          <div className="text-sm text-warning">
+          <div className="text-sm text-warning-text">
             Audio recording is disabled. Enable "Save Audio Recordings" to automatically save your meeting audio.
           </div>
         </div>

--- a/frontend/src/components/RecordingSettings.tsx
+++ b/frontend/src/components/RecordingSettings.tsx
@@ -146,8 +146,8 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
   if (loading) {
     return (
       <div className="animate-pulse">
-        <div className="h-4 bg-gray-200 rounded w-1/4 mb-4"></div>
-        <div className="h-8 bg-gray-200 rounded mb-4"></div>
+        <div className="h-4 bg-muted rounded w-1/4 mb-4"></div>
+        <div className="h-8 bg-muted rounded mb-4"></div>
       </div>
     );
   }
@@ -156,7 +156,7 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
     <div className="space-y-6">
       <div>
         <h3 className="text-lg font-semibold mb-4">Recording Settings</h3>
-        <p className="text-sm text-gray-600 mb-6">
+        <p className="text-sm text-muted-foreground mb-6">
           Configure how your audio recordings are saved during meetings.
         </p>
       </div>
@@ -165,7 +165,7 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
       <div className="flex items-center justify-between p-4 border rounded-lg">
         <div className="flex-1">
           <div className="font-medium">Save Audio Recordings</div>
-          <div className="text-sm text-gray-600">
+          <div className="text-sm text-muted-foreground">
             Automatically save audio files when recording stops
           </div>
         </div>
@@ -179,25 +179,25 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
       {/* Folder Location - Only shown when auto_save is enabled */}
       {preferences.auto_save && (
         <div className="space-y-4">
-          <div className="p-4 border rounded-lg bg-gray-50">
+          <div className="p-4 border rounded-lg bg-muted/40">
             <div className="font-medium mb-2">Save Location</div>
-            <div className="text-sm text-gray-600 mb-3 break-all">
+            <div className="text-sm text-muted-foreground mb-3 break-all">
               {preferences.save_folder || 'Default folder'}
             </div>
             <button
               onClick={handleOpenFolder}
-              className="flex items-center gap-2 px-3 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+              className="flex items-center gap-2 px-3 py-2 text-sm border border-border rounded-md hover:bg-muted/40 transition-colors"
             >
               <FolderOpen className="w-4 h-4" />
               Open Folder
             </button>
           </div>
 
-          <div className="p-4 border rounded-lg bg-blue-50">
-            <div className="text-sm text-blue-800">
+          <div className="p-4 border rounded-lg bg-info/10">
+            <div className="text-sm text-info">
               <strong>File Format:</strong> {preferences.file_format.toUpperCase()} files
             </div>
-            <div className="text-xs text-blue-600 mt-1">
+            <div className="text-xs text-info mt-1">
               Recordings are saved with timestamp: recording_YYYYMMDD_HHMMSS.{preferences.file_format}
             </div>
           </div>
@@ -206,8 +206,8 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
 
       {/* Info when auto_save is disabled */}
       {!preferences.auto_save && (
-        <div className="p-4 border rounded-lg bg-yellow-50">
-          <div className="text-sm text-yellow-800">
+        <div className="p-4 border rounded-lg bg-warning/10">
+          <div className="text-sm text-warning">
             Audio recording is disabled. Enable "Save Audio Recordings" to automatically save your meeting audio.
           </div>
         </div>
@@ -217,7 +217,7 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
       <div className="flex items-center justify-between p-4 border rounded-lg">
         <div className="flex-1">
           <div className="font-medium">Recording Start Notification</div>
-          <div className="text-sm text-gray-600">
+          <div className="text-sm text-muted-foreground">
             Show reminder to inform participants when recording starts
           </div>
         </div>
@@ -230,12 +230,12 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
       {/* Device Preferences */}
       <div className="space-y-4">
         <div className="border-t pt-6">
-          <h4 className="text-base font-medium text-gray-900 mb-4">Default Audio Devices</h4>
-          <p className="text-sm text-gray-600 mb-4">
+          <h4 className="text-base font-medium text-foreground mb-4">Default Audio Devices</h4>
+          <p className="text-sm text-muted-foreground mb-4">
             Set your preferred microphone and system audio devices for recording. These will be automatically selected when starting new recordings.
           </p>
 
-          <div className="border rounded-lg p-4 bg-gray-50">
+          <div className="border rounded-lg p-4 bg-muted/40">
             <DeviceSelection
               selectedDevices={{
                 micDevice: preferences.preferred_mic_device,

--- a/frontend/src/components/RecordingStatusBar.tsx
+++ b/frontend/src/components/RecordingStatusBar.tsx
@@ -39,7 +39,7 @@ export const RecordingStatusBar: React.FC<RecordingStatusBarProps> = ({ isPaused
       className="flex items-center gap-2 px-3 py-2 bg-muted/40 rounded-lg mb-2"
     >
       <div className={`w-2 h-2 rounded-full ${isPaused ? 'bg-warning' : 'bg-destructive animate-pulse'}`} />
-      <span className={`text-sm ${isPaused ? 'text-warning' : 'text-foreground'}`}>
+      <span className={`text-sm ${isPaused ? 'text-warning-text' : 'text-foreground'}`}>
         {isPaused ? 'Paused' : 'Recording'} • {formatDuration(displaySeconds)}
       </span>
     </motion.div>

--- a/frontend/src/components/RecordingStatusBar.tsx
+++ b/frontend/src/components/RecordingStatusBar.tsx
@@ -36,10 +36,10 @@ export const RecordingStatusBar: React.FC<RecordingStatusBarProps> = ({ isPaused
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -10 }}
       transition={{ duration: 0.2 }}
-      className="flex items-center gap-2 px-3 py-2 bg-gray-50 rounded-lg mb-2"
+      className="flex items-center gap-2 px-3 py-2 bg-muted/40 rounded-lg mb-2"
     >
-      <div className={`w-2 h-2 rounded-full ${isPaused ? 'bg-orange-500' : 'bg-red-500 animate-pulse'}`} />
-      <span className={`text-sm ${isPaused ? 'text-orange-700' : 'text-gray-700'}`}>
+      <div className={`w-2 h-2 rounded-full ${isPaused ? 'bg-warning' : 'bg-destructive animate-pulse'}`} />
+      <span className={`text-sm ${isPaused ? 'text-warning' : 'text-foreground'}`}>
         {isPaused ? 'Paused' : 'Recording'} • {formatDuration(displaySeconds)}
       </span>
     </motion.div>

--- a/frontend/src/components/Sidebar/index.tsx
+++ b/frontend/src/components/Sidebar/index.tsx
@@ -460,10 +460,11 @@ const Sidebar: React.FC = () => {
             <TooltipTrigger asChild>
               <button
                 onClick={() => router.push('/')}
-                className={`p-2 rounded-lg transition-colors duration-150 ${isHomePage ? 'bg-gray-100' : 'hover:bg-gray-100'
+                aria-label="Home"
+                className={`p-2 rounded-lg transition-colors duration-150 ${isHomePage ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
                   }`}
               >
-                <Home className="w-5 h-5 text-gray-600" />
+                <Home className="h-5 w-5" />
               </button>
             </TooltipTrigger>
             <TooltipContent side="right">
@@ -476,12 +477,13 @@ const Sidebar: React.FC = () => {
               <button
                 onClick={handleRecordingToggle}
                 disabled={isRecording}
-                className={`p-2 ${isRecording ? 'bg-red-500 cursor-not-allowed' : 'bg-red-500 hover:bg-red-600'} rounded-full transition-colors duration-150 shadow-sm`}
+                aria-label={isRecording ? 'Recording in progress' : 'Start Recording'}
+                className={`p-2 ${isRecording ? 'cursor-not-allowed bg-recording/50' : 'bg-recording hover:bg-recording/90'} rounded-full text-recording-foreground shadow-sm transition-colors duration-150`}
               >
                 {isRecording ? (
-                  <Square className="w-5 h-5 text-white" />
+                  <Square className="h-5 w-5" />
                 ) : (
-                  <Mic className="w-5 h-5 text-white" />
+                  <Mic className="h-5 w-5" />
                 )}
               </button>
             </TooltipTrigger>
@@ -495,9 +497,10 @@ const Sidebar: React.FC = () => {
               <TooltipTrigger asChild>
                 <button
                   onClick={() => openImportDialog()}
-                  className="p-2 rounded-lg transition-colors duration-150 hover:bg-blue-100 bg-blue-50"
+                  aria-label="Import Audio"
+                  className="rounded-lg bg-info/15 p-2 text-info transition-colors duration-150 hover:bg-info/25"
                 >
-                  <Upload className="w-5 h-5 text-blue-600" />
+                  <Upload className="h-5 w-5" />
                 </button>
               </TooltipTrigger>
               <TooltipContent side="right">
@@ -513,10 +516,11 @@ const Sidebar: React.FC = () => {
                   if (isCollapsed) toggleCollapse();
                   toggleFolder('meetings');
                 }}
-                className={`p-2 rounded-lg transition-colors duration-150 ${isMeetingPage ? 'bg-gray-100' : 'hover:bg-gray-100'
+                aria-label="Meeting Notes"
+                className={`p-2 rounded-lg transition-colors duration-150 ${isMeetingPage ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
                   }`}
               >
-                <NotebookPen className="w-5 h-5 text-gray-600" />
+                <NotebookPen className="h-5 w-5" />
               </button>
             </TooltipTrigger>
             <TooltipContent side="right">
@@ -528,10 +532,11 @@ const Sidebar: React.FC = () => {
             <TooltipTrigger asChild>
               <button
                 onClick={() => router.push('/settings')}
-                className={`p-2 rounded-lg transition-colors duration-150 ${isSettingsPage ? 'bg-gray-100' : 'hover:bg-gray-100'
+                aria-label="Settings"
+                className={`p-2 rounded-lg transition-colors duration-150 ${isSettingsPage ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
                   }`}
               >
-                <Settings className="w-5 h-5 text-gray-600" />
+                <Settings className="h-5 w-5" />
               </button>
             </TooltipTrigger>
             <TooltipContent side="right">
@@ -568,8 +573,8 @@ const Sidebar: React.FC = () => {
         <div
           className={`flex items-center transition-all duration-150 group ${item.type === 'folder' && depth === 0
             ? 'p-3 text-lg font-semibold h-10 mx-3 mt-3 rounded-lg'
-            : `px-3 py-2 my-0.5 rounded-md text-sm ${isActive ? 'bg-blue-100 text-blue-700 font-medium' :
-              hasTranscriptMatch ? 'bg-yellow-50' : 'hover:bg-gray-50'
+            : `px-3 py-2 my-0.5 rounded-md text-sm ${isActive ? 'bg-info/15 text-info font-medium' :
+              hasTranscriptMatch ? 'bg-warning/15' : 'hover:bg-accent'
             } cursor-pointer`
             }`}
           style={item.type === 'folder' && depth === 0 ? {} : { paddingLeft }}
@@ -594,25 +599,25 @@ const Sidebar: React.FC = () => {
               <span className={depth === 0 ? "" : "font-medium"}>{item.title}</span>
               <div className="ml-auto">
                 {isExpanded ? (
-                  <ChevronDown className="w-4 h-4 text-gray-500" />
+                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
                 ) : (
-                  <ChevronRight className="w-4 h-4 text-gray-500" />
+                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
                 )}
               </div>
               {searchQuery && item.id === 'meetings' && isSearching && (
-                <span className="ml-2 text-xs text-blue-500 animate-pulse">Searching...</span>
+                <span className="ml-2 text-xs text-info animate-pulse">Searching...</span>
               )}
             </>
           ) : (
             <div className="flex flex-col w-full">
               <div className="flex items-center w-full">
                 {isMeetingItem ? (
-                  <div className="flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-full mr-2 bg-gray-100">
-                    <File className="w-3.5 h-3.5 text-gray-600" />
+                  <div className="mr-2 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-muted">
+                    <File className="h-3.5 w-3.5 text-muted-foreground" />
                   </div>
                 ) : (
-                  <div className="flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-full mr-2 bg-blue-100">
-                    <Plus className="w-3.5 h-3.5 text-blue-600" />
+                  <div className="flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-full mr-2 bg-info/15">
+                    <Plus className="w-3.5 h-3.5 text-info" />
                   </div>
                 )}
                 <span className="flex-1 break-words">{item.title}</span>
@@ -623,7 +628,7 @@ const Sidebar: React.FC = () => {
                         e.stopPropagation();
                         handleEditStart(item.id, item.title);
                       }}
-                      className="hover:text-blue-600 p-1 rounded-md hover:bg-blue-50 flex-shrink-0"
+                      className="flex-shrink-0 rounded-md p-1 hover:bg-info/10 hover:text-info"
                       aria-label="Edit meeting title"
                     >
                       <Pencil className="w-4 h-4" />
@@ -633,7 +638,7 @@ const Sidebar: React.FC = () => {
                         e.stopPropagation();
                         setDeleteModalState({ isOpen: true, itemId: item.id });
                       }}
-                      className="hover:text-red-600 p-1 rounded-md hover:bg-red-50 flex-shrink-0"
+                      className="flex-shrink-0 rounded-md p-1 hover:bg-destructive/10 hover:text-destructive"
                       aria-label="Delete meeting"
                     >
                       <Trash2 className="w-4 h-4" />
@@ -644,8 +649,8 @@ const Sidebar: React.FC = () => {
 
               {/* Show transcript match snippet if available */}
               {hasTranscriptMatch && (
-                <div className="mt-1 ml-8 text-xs text-gray-500 bg-yellow-50 p-1.5 rounded border border-yellow-100 line-clamp-2">
-                  <span className="font-medium text-yellow-600">Match:</span> {matchingResult.matchContext}
+                <div className="mt-1 ml-8 line-clamp-2 rounded border border-warning/30 bg-warning/10 p-1.5 text-xs text-muted-foreground">
+                  <span className="font-medium text-warning">Match:</span> {matchingResult.matchContext}
                 </div>
               )}
             </div>
@@ -665,7 +670,8 @@ const Sidebar: React.FC = () => {
       {/* Floating collapse button */}
       <button
         onClick={toggleCollapse}
-        className="absolute -right-6 top-20 z-50 p-1 bg-white hover:bg-gray-100 rounded-full shadow-lg border"
+        aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        className="absolute -right-6 top-20 z-50 rounded-full border border-border bg-card p-1 text-card-foreground shadow-lg hover:bg-accent"
         style={{ transform: 'translateX(50%)' }}
       >
         {isCollapsed ? (
@@ -676,7 +682,8 @@ const Sidebar: React.FC = () => {
       </button>
 
       <div
-        className={`h-screen bg-white border-r shadow-sm flex flex-col transition-all duration-300 ${isCollapsed ? 'w-16' : 'w-64'
+        data-testid="app-sidebar"
+        className={`flex h-screen flex-col border-r border-border bg-card text-card-foreground shadow-sm transition-all duration-300 ${isCollapsed ? 'w-16' : 'w-64'
           }`}
       >
         {/*  Header with traffic light spacing */}
@@ -689,9 +696,6 @@ const Sidebar: React.FC = () => {
           <div className="flex-1">
             {!isCollapsed && (
               <div className="p-3">
-                {/* <span className="text-lg text-center border rounded-full bg-blue-50 border-white font-semibold text-gray-700 mb-2 block items-center">
-                  <span>Meetily</span>
-                </span> */}
                 <Logo isCollapsed={isCollapsed} />
 
                 <div className="relative mb-1">
@@ -725,7 +729,7 @@ const Sidebar: React.FC = () => {
             {!isCollapsed && (
               <div
                 onClick={() => router.push('/')}
-                className="p-3  text-lg font-semibold items-center hover:bg-gray-100 h-10   flex mx-3 mt-3 rounded-lg cursor-pointer"
+                className="mx-3 mt-3 flex h-10 cursor-pointer items-center rounded-lg p-3 text-lg font-semibold hover:bg-accent"
               >
                 <Home className="w-4 h-4 mr-2" />
                 <span>Home</span>
@@ -744,10 +748,10 @@ const Sidebar: React.FC = () => {
                     <div
                       className="flex items-center transition-all duration-150 p-3 text-lg font-semibold h-10 mx-3 mt-3 rounded-lg"
                     >
-                      <NotebookPen className="w-4 h-4 mr-2 text-gray-600" />
-                      <span className="text-gray-700">{item.title}</span>
+                      <NotebookPen className="mr-2 h-4 w-4 text-muted-foreground" />
+                      <span className="text-foreground">{item.title}</span>
                       {searchQuery && item.id === 'meetings' && isSearching && (
-                        <span className="ml-2 text-xs text-blue-500 animate-pulse">Searching...</span>
+                        <span className="ml-2 text-xs text-info animate-pulse">Searching...</span>
                       )}
                     </div>
                   </div>
@@ -773,11 +777,11 @@ const Sidebar: React.FC = () => {
         {/* Footer */}
         {!isCollapsed && (
 
-          <div className="flex-shrink-0 p-2 border-t border-gray-100">
+          <div className="flex-shrink-0 border-t border-border p-2">
             <button
               onClick={handleRecordingToggle}
               disabled={isRecording}
-              className={`w-full flex items-center justify-center px-3 py-2 text-sm font-medium text-white ${isRecording ? 'bg-red-300 cursor-not-allowed' : 'bg-red-500 hover:bg-red-600'} rounded-lg transition-colors shadow-sm`}
+              className={`flex w-full items-center justify-center rounded-lg px-3 py-2 text-sm font-medium text-recording-foreground shadow-sm transition-colors ${isRecording ? 'cursor-not-allowed bg-recording/50' : 'bg-recording hover:bg-recording/90'}`}
             >
               {isRecording ? (
                 <>
@@ -795,7 +799,7 @@ const Sidebar: React.FC = () => {
             {betaFeatures.importAndRetranscribe && (
               <button
                 onClick={() => openImportDialog()}
-                className="w-full flex items-center justify-center px-3 py-2 mt-1 text-sm font-medium text-gray-700 bg-blue-100 hover:bg-blue-200 rounded-lg transition-colors shadow-sm"
+                className="mt-1 flex w-full items-center justify-center rounded-lg bg-info px-3 py-2 text-sm font-medium text-info-foreground shadow-sm transition-colors hover:bg-info/90"
               >
                 <Upload className="w-4 h-4 mr-2" />
                 <span>Import Audio</span>
@@ -804,13 +808,13 @@ const Sidebar: React.FC = () => {
 
             <button
               onClick={() => router.push('/settings')}
-              className="w-full flex items-center justify-center px-3 py-1.5 mt-1 mb-1 text-sm font-medium text-gray-700 bg-gray-200 hover:bg-gray-300 rounded-lg transition-colors shadow-sm"
+              className="mb-1 mt-1 flex w-full items-center justify-center rounded-lg bg-muted px-3 py-1.5 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-accent"
             >
               <Settings className="w-4 h-4 mr-2" />
               <span>Settings</span>
             </button>
             <Info isCollapsed={isCollapsed} />
-            <div className="w-full flex items-center justify-center px-3 py-1 text-xs text-gray-400">
+            <div className="flex w-full items-center justify-center px-3 py-1 text-xs text-muted-foreground">
               v0.4.0
             </div>
           </div>
@@ -837,7 +841,7 @@ const Sidebar: React.FC = () => {
             <h3 className="text-lg font-semibold mb-4">Edit Meeting Title</h3>
             <div className="space-y-4">
               <div>
-                <label htmlFor="meeting-title" className="block text-sm font-medium text-gray-700 mb-2">
+                <label htmlFor="meeting-title" className="mb-2 block text-sm font-medium text-foreground">
                   Meeting Title
                 </label>
                 <input
@@ -852,7 +856,7 @@ const Sidebar: React.FC = () => {
                       handleEditCancel();
                     }
                   }}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-foreground placeholder:text-muted-foreground focus:border-transparent focus:outline-none focus:ring-2 focus:ring-ring"
                   placeholder="Enter meeting title"
                   autoFocus
                 />
@@ -862,13 +866,13 @@ const Sidebar: React.FC = () => {
           <DialogFooter>
             <button
               onClick={handleEditCancel}
-              className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md transition-colors"
+              className="rounded-md bg-muted px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
             >
               Cancel
             </button>
             <button
               onClick={handleEditConfirm}
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
             >
               Save
             </button>

--- a/frontend/src/components/Sidebar/index.tsx
+++ b/frontend/src/components/Sidebar/index.tsx
@@ -498,7 +498,7 @@ const Sidebar: React.FC = () => {
                 <button
                   onClick={() => openImportDialog()}
                   aria-label="Import Audio"
-                  className="rounded-lg bg-info/15 p-2 text-info transition-colors duration-150 hover:bg-info/25"
+                  className="rounded-lg bg-info/15 p-2 text-info-text transition-colors duration-150 hover:bg-info/25"
                 >
                   <Upload className="h-5 w-5" />
                 </button>
@@ -573,7 +573,7 @@ const Sidebar: React.FC = () => {
         <div
           className={`flex items-center transition-all duration-150 group ${item.type === 'folder' && depth === 0
             ? 'p-3 text-lg font-semibold h-10 mx-3 mt-3 rounded-lg'
-            : `px-3 py-2 my-0.5 rounded-md text-sm ${isActive ? 'bg-info/15 text-info font-medium' :
+            : `px-3 py-2 my-0.5 rounded-md text-sm ${isActive ? 'bg-info/15 text-info-text font-medium' :
               hasTranscriptMatch ? 'bg-warning/15' : 'hover:bg-accent'
             } cursor-pointer`
             }`}
@@ -605,7 +605,7 @@ const Sidebar: React.FC = () => {
                 )}
               </div>
               {searchQuery && item.id === 'meetings' && isSearching && (
-                <span className="ml-2 text-xs text-info animate-pulse">Searching...</span>
+                <span className="ml-2 text-xs text-info-text animate-pulse">Searching...</span>
               )}
             </>
           ) : (
@@ -617,7 +617,7 @@ const Sidebar: React.FC = () => {
                   </div>
                 ) : (
                   <div className="flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-full mr-2 bg-info/15">
-                    <Plus className="w-3.5 h-3.5 text-info" />
+                    <Plus className="w-3.5 h-3.5 text-info-text" />
                   </div>
                 )}
                 <span className="flex-1 break-words">{item.title}</span>
@@ -628,7 +628,7 @@ const Sidebar: React.FC = () => {
                         e.stopPropagation();
                         handleEditStart(item.id, item.title);
                       }}
-                      className="flex-shrink-0 rounded-md p-1 hover:bg-info/10 hover:text-info"
+                      className="flex-shrink-0 rounded-md p-1 hover:bg-info/10 hover:text-info-text"
                       aria-label="Edit meeting title"
                     >
                       <Pencil className="w-4 h-4" />
@@ -650,7 +650,7 @@ const Sidebar: React.FC = () => {
               {/* Show transcript match snippet if available */}
               {hasTranscriptMatch && (
                 <div className="mt-1 ml-8 line-clamp-2 rounded border border-warning/30 bg-warning/10 p-1.5 text-xs text-muted-foreground">
-                  <span className="font-medium text-warning">Match:</span> {matchingResult.matchContext}
+                  <span className="font-medium text-warning-text">Match:</span> {matchingResult.matchContext}
                 </div>
               )}
             </div>
@@ -751,7 +751,7 @@ const Sidebar: React.FC = () => {
                       <NotebookPen className="mr-2 h-4 w-4 text-muted-foreground" />
                       <span className="text-foreground">{item.title}</span>
                       {searchQuery && item.id === 'meetings' && isSearching && (
-                        <span className="ml-2 text-xs text-info animate-pulse">Searching...</span>
+                        <span className="ml-2 text-xs text-info-text animate-pulse">Searching...</span>
                       )}
                     </div>
                   </div>

--- a/frontend/src/components/SummaryLanguageSettings.tsx
+++ b/frontend/src/components/SummaryLanguageSettings.tsx
@@ -34,7 +34,7 @@ export function SummaryLanguageSettings() {
               key={code}
               className={`inline-flex items-center rounded-full border text-sm overflow-hidden ${
                 isPinned
-                  ? 'bg-info/10 border-info/30 text-info'
+                  ? 'bg-info/10 border-info/30 text-info-text'
                   : 'bg-muted border-border text-foreground'
               }`}
             >
@@ -45,12 +45,12 @@ export function SummaryLanguageSettings() {
                 title={isPinned ? 'Click to unset as default' : 'Click to set as default'}
                 onClick={() => togglePin(code)}
                 className={`flex items-center gap-1.5 pl-3 pr-2 py-1 hover:brightness-95 active:brightness-90 ${
-                  isPinned ? 'text-info' : 'text-foreground'
+                  isPinned ? 'text-info-text' : 'text-foreground'
                 }`}
               >
                 <Pin
                   size={14}
-                  className={isPinned ? 'text-info' : 'text-muted-foreground'}
+                  className={isPinned ? 'text-info-text' : 'text-muted-foreground'}
                   fill={isPinned ? 'currentColor' : 'none'}
                 />
                 {labelForCode(code)}
@@ -59,7 +59,7 @@ export function SummaryLanguageSettings() {
                 type="button"
                 aria-label={`Remove ${labelForCode(code)}`}
                 onClick={() => removeRecent(code)}
-                className={`pr-2.5 pl-0.5 py-1 leading-none ${isPinned ? 'text-info hover:text-info' : 'text-muted-foreground hover:text-foreground'}`}
+                className={`pr-2.5 pl-0.5 py-1 leading-none ${isPinned ? 'text-info-text hover:text-info-text' : 'text-muted-foreground hover:text-foreground'}`}
               >
                 ×
               </button>

--- a/frontend/src/components/SummaryLanguageSettings.tsx
+++ b/frontend/src/components/SummaryLanguageSettings.tsx
@@ -16,12 +16,12 @@ export function SummaryLanguageSettings() {
   };
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm relative">
+    <div className="bg-card rounded-lg border border-border p-6 shadow-sm relative">
       <div className="flex items-center gap-2 mb-2">
-        <Globe size={18} className="text-gray-500" />
-        <h3 className="text-lg font-semibold text-gray-900">Summary Language</h3>
+        <Globe size={18} className="text-muted-foreground" />
+        <h3 className="text-lg font-semibold text-foreground">Summary Language</h3>
       </div>
-      <p className="text-sm text-gray-600 mb-4">
+      <p className="text-sm text-muted-foreground mb-4">
         Pin one language as the default for new meetings. Unpinned languages remain as
         quick-switch options in the summary generator. Auto uses the dominant transcript language.
       </p>
@@ -34,8 +34,8 @@ export function SummaryLanguageSettings() {
               key={code}
               className={`inline-flex items-center rounded-full border text-sm overflow-hidden ${
                 isPinned
-                  ? 'bg-blue-50 border-blue-200 text-blue-800'
-                  : 'bg-gray-100 border-gray-200 text-gray-800'
+                  ? 'bg-info/10 border-info/30 text-info'
+                  : 'bg-muted border-border text-foreground'
               }`}
             >
               <button
@@ -45,12 +45,12 @@ export function SummaryLanguageSettings() {
                 title={isPinned ? 'Click to unset as default' : 'Click to set as default'}
                 onClick={() => togglePin(code)}
                 className={`flex items-center gap-1.5 pl-3 pr-2 py-1 hover:brightness-95 active:brightness-90 ${
-                  isPinned ? 'text-blue-800' : 'text-gray-800'
+                  isPinned ? 'text-info' : 'text-foreground'
                 }`}
               >
                 <Pin
                   size={14}
-                  className={isPinned ? 'text-blue-600' : 'text-gray-400'}
+                  className={isPinned ? 'text-info' : 'text-muted-foreground'}
                   fill={isPinned ? 'currentColor' : 'none'}
                 />
                 {labelForCode(code)}
@@ -59,7 +59,7 @@ export function SummaryLanguageSettings() {
                 type="button"
                 aria-label={`Remove ${labelForCode(code)}`}
                 onClick={() => removeRecent(code)}
-                className={`pr-2.5 pl-0.5 py-1 leading-none ${isPinned ? 'text-blue-400 hover:text-blue-700' : 'text-gray-400 hover:text-gray-700'}`}
+                className={`pr-2.5 pl-0.5 py-1 leading-none ${isPinned ? 'text-info hover:text-info' : 'text-muted-foreground hover:text-foreground'}`}
               >
                 ×
               </button>
@@ -72,7 +72,7 @@ export function SummaryLanguageSettings() {
             <button
               type="button"
               disabled={recents.length >= 5}
-              className="inline-flex items-center gap-1 rounded-full border border-dashed border-gray-300 px-3 py-1 text-sm text-gray-600 hover:border-gray-400 hover:text-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex items-center gap-1 rounded-full border border-dashed border-border px-3 py-1 text-sm text-muted-foreground hover:border-border hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
             >
               ＋ Add language
             </button>
@@ -91,7 +91,7 @@ export function SummaryLanguageSettings() {
         </Popover>
       </div>
 
-      <p className="text-xs text-gray-400 mt-3">
+      <p className="text-xs text-muted-foreground mt-3">
         {pinned
           ? `Default: ${labelForCode(pinned)} - click it again to unset. Max 5 quick-switch options.`
           : 'Click any language to set it as your default. Max 5 quick-switch options.'}

--- a/frontend/src/components/SummaryModelSettings.tsx
+++ b/frontend/src/components/SummaryModelSettings.tsx
@@ -18,7 +18,7 @@ export function SummaryModelSettings({ refetchTrigger }: SummaryModelSettingsPro
     model: 'llama3.2:latest',
     whisperModel: 'large-v3',
     apiKey: null,
-    ollamaEndpoint: null
+    ollamaEndpoint: null,
   });
 
   const { isAutoSummary, toggleIsAutoSummary } = useConfig();
@@ -124,11 +124,11 @@ export function SummaryModelSettings({ refetchTrigger }: SummaryModelSettingsPro
 
   return (
     <div className='flex flex-col gap-4'>
-      <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+      <div className="bg-card rounded-lg border border-border p-6 shadow-sm">
         <div className="flex items-center justify-between">
           <div>
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">Auto Summary</h3>
-            <p className="text-sm text-gray-600">Auto Generating summary after meeting completion(Stopping)</p>
+            <h3 className="text-lg font-semibold text-foreground mb-2">Auto Summary</h3>
+            <p className="text-sm text-muted-foreground">Auto Generating summary after meeting completion(Stopping)</p>
           </div>
           <Switch checked={isAutoSummary} onCheckedChange={toggleIsAutoSummary} />
         </div>
@@ -136,9 +136,9 @@ export function SummaryModelSettings({ refetchTrigger }: SummaryModelSettingsPro
 
       <SummaryLanguageSettings />
 
-      <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+      <div className="bg-card rounded-lg border border-border p-6 shadow-sm">
         <h3 className="text-lg font-semibold mb-4">Summary Model Configuration</h3>
-        <p className="text-sm text-gray-600 mb-6">
+        <p className="text-sm text-muted-foreground mb-6">
           Configure the AI model used for generating meeting summaries.
         </p>
 

--- a/frontend/src/components/ThemeScript.tsx
+++ b/frontend/src/components/ThemeScript.tsx
@@ -1,0 +1,27 @@
+import { THEME_STORAGE_KEY } from '@/lib/theme';
+
+const themeScript = `
+(() => {
+  let storedMode = null;
+
+  try {
+    storedMode = window.localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});
+  } catch {}
+
+  const mode =
+    storedMode === 'light' || storedMode === 'dark' || storedMode === 'system'
+      ? storedMode
+      : 'system';
+  const isDark =
+    mode === 'dark' ||
+    (mode === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  const root = document.documentElement;
+
+  root.classList.toggle('dark', isDark);
+  root.style.colorScheme = isDark ? 'dark' : 'light';
+})();
+`;
+
+export function ThemeScript() {
+  return <script dangerouslySetInnerHTML={{ __html: themeScript }} />;
+}

--- a/frontend/src/components/ThemeScript.tsx
+++ b/frontend/src/components/ThemeScript.tsx
@@ -1,24 +1,26 @@
-import { THEME_STORAGE_KEY } from '@/lib/theme';
+import {
+  applyEffectiveTheme,
+  parseThemeMode,
+  resolveEffectiveTheme,
+  THEME_STORAGE_KEY,
+} from '@/lib/theme';
 
+// The pre-hydration boot script is composed from the shared theme functions so
+// there is a single source of truth for mode parsing/resolution/application.
+// Only closure-free functions can be serialized here: anything referencing
+// module-scope identifiers would break once the bundle is minified.
 const themeScript = `
 (() => {
-  let storedMode = null;
+  const parse = ${parseThemeMode.toString()};
+  const resolve = ${resolveEffectiveTheme.toString()};
+  const apply = ${applyEffectiveTheme.toString()};
 
+  let storedMode = null;
   try {
     storedMode = window.localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});
   } catch {}
 
-  const mode =
-    storedMode === 'light' || storedMode === 'dark' || storedMode === 'system'
-      ? storedMode
-      : 'system';
-  const isDark =
-    mode === 'dark' ||
-    (mode === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
-  const root = document.documentElement;
-
-  root.classList.toggle('dark', isDark);
-  root.style.colorScheme = isDark ? 'dark' : 'light';
+  apply(resolve(parse(storedMode), window.matchMedia('(prefers-color-scheme: dark)').matches));
 })();
 `;
 

--- a/frontend/src/components/TranscriptRecovery/TranscriptRecovery.tsx
+++ b/frontend/src/components/TranscriptRecovery/TranscriptRecovery.tsx
@@ -155,11 +155,11 @@ export function TranscriptRecovery({
                       </div>
                       {meeting.folderPath ? (
                         <span title="Audio available">
-                          <CheckCircle2 className="w-4 h-4 text-green-500 flex-shrink-0" />
+                          <CheckCircle2 className="w-4 h-4 text-success flex-shrink-0" />
                         </span>
                       ) : (
                         <span title="No audio">
-                          <AlertCircle className="w-4 h-4 text-yellow-500 flex-shrink-0" />
+                          <AlertCircle className="w-4 h-4 text-warning flex-shrink-0" />
                         </span>
                       )}
                     </div>
@@ -187,12 +187,12 @@ export function TranscriptRecovery({
                         {selectedMeeting.transcriptCount} transcripts
                       </span>
                       {selectedMeeting.folderPath ? (
-                        <span className="flex items-center gap-1 text-green-600">
+                        <span className="flex items-center gap-1 text-success">
                           <CheckCircle2 className="w-4 h-4" />
                           Audio available
                         </span>
                       ) : (
-                        <span className="flex items-center gap-1 text-yellow-600">
+                        <span className="flex items-center gap-1 text-warning">
                           <AlertCircle className="w-4 h-4" />
                           No audio
                         </span>

--- a/frontend/src/components/TranscriptRecovery/TranscriptRecovery.tsx
+++ b/frontend/src/components/TranscriptRecovery/TranscriptRecovery.tsx
@@ -155,11 +155,11 @@ export function TranscriptRecovery({
                       </div>
                       {meeting.folderPath ? (
                         <span title="Audio available">
-                          <CheckCircle2 className="w-4 h-4 text-success flex-shrink-0" />
+                          <CheckCircle2 className="w-4 h-4 text-success-text flex-shrink-0" />
                         </span>
                       ) : (
                         <span title="No audio">
-                          <AlertCircle className="w-4 h-4 text-warning flex-shrink-0" />
+                          <AlertCircle className="w-4 h-4 text-warning-text flex-shrink-0" />
                         </span>
                       )}
                     </div>
@@ -187,12 +187,12 @@ export function TranscriptRecovery({
                         {selectedMeeting.transcriptCount} transcripts
                       </span>
                       {selectedMeeting.folderPath ? (
-                        <span className="flex items-center gap-1 text-success">
+                        <span className="flex items-center gap-1 text-success-text">
                           <CheckCircle2 className="w-4 h-4" />
                           Audio available
                         </span>
                       ) : (
-                        <span className="flex items-center gap-1 text-warning">
+                        <span className="flex items-center gap-1 text-warning-text">
                           <AlertCircle className="w-4 h-4" />
                           No audio
                         </span>

--- a/frontend/src/components/TranscriptSettings.tsx
+++ b/frontend/src/components/TranscriptSettings.tsx
@@ -99,11 +99,11 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
         <div>
             <div>
                 {/* <div className="flex justify-between items-center mb-4">
-                    <h3 className="text-lg font-semibold text-gray-900">Transcript Settings</h3>
+                    <h3 className="text-lg font-semibold text-foreground">Transcript Settings</h3>
                 </div> */}
                 <div className="space-y-4 pb-6">
                     <div>
-                        <Label className="block text-sm font-medium text-gray-700 mb-1">
+                        <Label className="block text-sm font-medium text-foreground mb-1">
                             Transcript Model
                         </Label>
                         <div className="flex space-x-2 mx-1">
@@ -117,7 +117,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                     }
                                 }}
                             >
-                                <SelectTrigger className='focus:ring-1 focus:ring-blue-500 focus:border-blue-500'>
+                                <SelectTrigger className='focus:ring-1 focus:ring-info focus:border-info'>
                                     <SelectValue placeholder="Select provider" />
                                 </SelectTrigger>
                                 <SelectContent>
@@ -138,7 +138,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                         setTranscriptModelConfig({ ...transcriptModelConfig, provider: uiProvider, model });
                                     }}
                                 >
-                                    <SelectTrigger className='focus:ring-1 focus:ring-blue-500 focus:border-blue-500'>
+                                    <SelectTrigger className='focus:ring-1 focus:ring-info focus:border-info'>
                                         <SelectValue placeholder="Select model" />
                                     </SelectTrigger>
                                     <SelectContent>
@@ -175,13 +175,13 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
 
                     {requiresApiKey && (
                         <div>
-                            <Label className="block text-sm font-medium text-gray-700 mb-1">
+                            <Label className="block text-sm font-medium text-foreground mb-1">
                                 API Key
                             </Label>
                             <div className="relative mx-1">
                                 <Input
                                     type={showApiKey ? "text" : "password"}
-                                    className={`pr-24 focus:ring-1 focus:ring-blue-500 focus:border-blue-500 ${isApiKeyLocked ? 'bg-gray-100 cursor-not-allowed' : ''
+                                    className={`pr-24 focus:ring-1 focus:ring-info focus:border-info ${isApiKeyLocked ? 'bg-muted cursor-not-allowed' : ''
                                         }`}
                                     value={apiKey || ''}
                                     onChange={(e) => setApiKey(e.target.value)}
@@ -192,7 +192,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 {isApiKeyLocked && (
                                     <div
                                         onClick={handleInputClick}
-                                        className="absolute inset-0 flex items-center justify-center bg-gray-100 bg-opacity-50 rounded-md cursor-not-allowed"
+                                        className="absolute inset-0 flex items-center justify-center bg-muted/50 rounded-md cursor-not-allowed"
                                     />
                                 )}
                                 <div className="absolute inset-y-0 right-0 pr-1 flex items-center">
@@ -201,7 +201,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                         variant="ghost"
                                         size="icon"
                                         onClick={() => setIsApiKeyLocked(!isApiKeyLocked)}
-                                        className={`transition-colors duration-200 ${isLockButtonVibrating ? 'animate-vibrate text-red-500' : ''
+                                        className={`transition-colors duration-200 ${isLockButtonVibrating ? 'animate-vibrate text-destructive' : ''
                                             }`}
                                         title={isApiKeyLocked ? "Unlock to edit" : "Lock to prevent editing"}
                                     >

--- a/frontend/src/components/TranscriptView.tsx
+++ b/frontend/src/components/TranscriptView.tsx
@@ -254,7 +254,7 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
       {/* Recording Status Bar - Sticky at top, always visible when recording */}
       <AnimatePresence>
         {isRecording && (
-          <div className="sticky top-4 z-10 bg-white pb-2">
+          <div className="sticky top-4 z-10 bg-card pb-2">
             <RecordingStatusBar isPaused={isPaused} />
           </div>
         )}
@@ -284,7 +284,7 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
             <div className="flex items-start gap-2">
               <Tooltip>
                 <TooltipTrigger>
-                  <span className="text-xs text-gray-400 mt-1 flex-shrink-0 min-w-[50px]">
+                  <span className="text-xs text-muted-foreground mt-1 flex-shrink-0 min-w-[50px]">
                     {transcript.audio_start_time !== undefined
                       ? formatRecordingTime(transcript.audio_start_time)
                       : transcript.timestamp}
@@ -292,7 +292,7 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
                 </TooltipTrigger>
                 <TooltipContent>
                   {transcript.duration !== undefined && (
-                    <span className="text-xs text-gray-400">
+                    <span className="text-xs text-muted-foreground">
                       {transcript.duration.toFixed(1)}s
                       {transcript.confidence !== undefined && (
                         <ConfidenceIndicator
@@ -307,12 +307,12 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
               <div className="flex-1">
                 {isStreaming ? (
                   // Streaming transcript - show in bubble (full width)
-                  <div className="bg-gray-100 border border-gray-200 rounded-lg px-3 py-2">
+                  <div className="bg-muted border border-border rounded-lg px-3 py-2">
                     <div className="relative">
-                      <p className="text-base text-gray-800 leading-relaxed" style={{ visibility: 'hidden' }}>
+                      <p className="text-base text-foreground leading-relaxed" style={{ visibility: 'hidden' }}>
                         {sizerText}
                       </p>
-                      <p className="text-base text-gray-800 leading-relaxed absolute top-0 left-0">
+                      <p className="text-base text-foreground leading-relaxed absolute top-0 left-0">
                         {displayText}
                       </p>
                     </div>
@@ -320,10 +320,10 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
                 ) : (
                   // Regular transcript - simple text
                   <div className="relative">
-                    <p className="text-base text-gray-800 leading-relaxed" style={{ visibility: 'hidden' }}>
+                    <p className="text-base text-foreground leading-relaxed" style={{ visibility: 'hidden' }}>
                       {sizerText}
                     </p>
-                    <p className="text-base text-gray-800 leading-relaxed absolute top-0 left-0">
+                    <p className="text-base text-foreground leading-relaxed absolute top-0 left-0">
                       {displayText}
                     </p>
                   </div>
@@ -340,9 +340,9 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          className="flex items-center gap-2 mt-4 text-gray-500"
+          className="flex items-center gap-2 mt-4 text-muted-foreground"
         >
-          <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse"></div>
+          <div className="w-2 h-2 bg-info rounded-full animate-pulse"></div>
           <span className="text-sm">Listening...</span>
         </motion.div>
       )}
@@ -352,17 +352,17 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
         <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
-          className="text-center text-gray-500 mt-8"
+          className="text-center text-muted-foreground mt-8"
         >
           {isRecording ? (
             <>
               <div className="flex items-center justify-center mb-3">
-                <div className={`w-3 h-3 rounded-full ${isPaused ? 'bg-orange-500' : 'bg-blue-500 animate-pulse'}`}></div>
+                <div className={`w-3 h-3 rounded-full ${isPaused ? 'bg-warning' : 'bg-info animate-pulse'}`}></div>
               </div>
-              <p className="text-sm text-gray-600">
+              <p className="text-sm text-muted-foreground">
                 {isPaused ? 'Recording paused' : 'Listening for speech...'}
               </p>
-              <p className="text-xs mt-1 text-gray-400">
+              <p className="text-xs mt-1 text-muted-foreground">
                 {isPaused
                   ? 'Click resume to continue recording'
                   : 'Speak to see live transcription'}

--- a/frontend/src/components/UpdateDialog.tsx
+++ b/frontend/src/components/UpdateDialog.tsx
@@ -189,17 +189,17 @@ export function UpdateDialog({ open, onOpenChange, updateInfo }: UpdateDialogPro
           <DialogTitle className="flex items-center gap-2">
             {isDownloading ? (
               <>
-                <Loader2 className="h-5 w-5 animate-spin text-blue-600" />
+                <Loader2 className="h-5 w-5 animate-spin text-info" />
                 Downloading Update
               </>
             ) : error ? (
               <>
-                <AlertCircle className="h-5 w-5 text-red-600" />
+                <AlertCircle className="h-5 w-5 text-destructive" />
                 Update Error
               </>
             ) : (
               <>
-                <Download className="h-5 w-5 text-blue-600" />
+                <Download className="h-5 w-5 text-info" />
                 Update Available
               </>
             )}
@@ -223,7 +223,7 @@ export function UpdateDialog({ open, onOpenChange, updateInfo }: UpdateDialogPro
                 </div>
                 <div className="flex justify-between text-sm">
                   <span className="text-muted-foreground">New Version:</span>
-                  <span className="font-medium text-blue-600">{updateInfo.version}</span>
+                  <span className="font-medium text-info">{updateInfo.version}</span>
                 </div>
                 {updateInfo.date && (
                   <div className="flex justify-between text-sm">
@@ -234,8 +234,8 @@ export function UpdateDialog({ open, onOpenChange, updateInfo }: UpdateDialogPro
               </div>
 
               {updateInfo.body && (
-                <div className="bg-gray-50 rounded-lg p-3 max-h-40 overflow-y-auto">
-                  <p className="text-sm text-gray-700 whitespace-pre-wrap">
+                <div className="bg-muted/40 rounded-lg p-3 max-h-40 overflow-y-auto">
+                  <p className="text-sm text-foreground whitespace-pre-wrap">
                     {updateInfo.body}
                   </p>
                 </div>
@@ -246,13 +246,13 @@ export function UpdateDialog({ open, onOpenChange, updateInfo }: UpdateDialogPro
           {isDownloading && progress && (
             <div className="space-y-2">
               <div className="relative">
-                <div className="w-full bg-gray-200 rounded-full h-3">
+                <div className="w-full bg-muted rounded-full h-3">
                   <div
-                    className="bg-blue-600 h-3 rounded-full transition-all duration-300 ease-out"
+                    className="bg-info h-3 rounded-full transition-all duration-300 ease-out"
                     style={{ width: `${Math.min(progress.percentage, 100)}%` }}
                   />
                 </div>
-                <div className="flex justify-between text-xs text-gray-600 mt-1">
+                <div className="flex justify-between text-xs text-muted-foreground mt-1">
                   <span>{Math.round(progress.percentage)}% complete</span>
                   {progress.total > 0 && (
                     <span>
@@ -268,8 +268,8 @@ export function UpdateDialog({ open, onOpenChange, updateInfo }: UpdateDialogPro
           )}
 
           {error && (
-            <div className="bg-red-50 border border-red-200 rounded-lg p-3">
-              <p className="text-sm text-red-800">{error}</p>
+            <div className="bg-destructive/10 border border-destructive/30 rounded-lg p-3">
+              <p className="text-sm text-destructive">{error}</p>
             </div>
           )}
         </div>
@@ -280,7 +280,7 @@ export function UpdateDialog({ open, onOpenChange, updateInfo }: UpdateDialogPro
               <Button variant="outline" onClick={() => handleOpenChange(false)}>
                 Later
               </Button>
-              <Button onClick={handleDownloadAndInstall} className="bg-blue-600 hover:bg-blue-700">
+              <Button onClick={handleDownloadAndInstall} className="bg-info hover:bg-info/90">
                 <Download className="h-4 w-4 mr-2" />
                 Download & Install
               </Button>

--- a/frontend/src/components/UpdateDialog.tsx
+++ b/frontend/src/components/UpdateDialog.tsx
@@ -189,7 +189,7 @@ export function UpdateDialog({ open, onOpenChange, updateInfo }: UpdateDialogPro
           <DialogTitle className="flex items-center gap-2">
             {isDownloading ? (
               <>
-                <Loader2 className="h-5 w-5 animate-spin text-info" />
+                <Loader2 className="h-5 w-5 animate-spin text-info-text" />
                 Downloading Update
               </>
             ) : error ? (
@@ -199,7 +199,7 @@ export function UpdateDialog({ open, onOpenChange, updateInfo }: UpdateDialogPro
               </>
             ) : (
               <>
-                <Download className="h-5 w-5 text-info" />
+                <Download className="h-5 w-5 text-info-text" />
                 Update Available
               </>
             )}
@@ -223,7 +223,7 @@ export function UpdateDialog({ open, onOpenChange, updateInfo }: UpdateDialogPro
                 </div>
                 <div className="flex justify-between text-sm">
                   <span className="text-muted-foreground">New Version:</span>
-                  <span className="font-medium text-info">{updateInfo.version}</span>
+                  <span className="font-medium text-info-text">{updateInfo.version}</span>
                 </div>
                 {updateInfo.date && (
                   <div className="flex justify-between text-sm">

--- a/frontend/src/components/UpdateNotification.tsx
+++ b/frontend/src/components/UpdateNotification.tsx
@@ -34,7 +34,7 @@ export function showUpdateNotification(updateInfo: UpdateInfo, onUpdateClick?: (
           e.stopPropagation();
           handleClick();
         }}
-        className="text-sm font-medium text-info hover:text-info underline"
+        className="text-sm font-medium text-info-text hover:text-info-text underline"
       >
         View Details
       </button>

--- a/frontend/src/components/UpdateNotification.tsx
+++ b/frontend/src/components/UpdateNotification.tsx
@@ -34,7 +34,7 @@ export function showUpdateNotification(updateInfo: UpdateInfo, onUpdateClick?: (
           e.stopPropagation();
           handleClick();
         }}
-        className="text-sm font-medium text-blue-600 hover:text-blue-700 underline"
+        className="text-sm font-medium text-info hover:text-info underline"
       >
         View Details
       </button>

--- a/frontend/src/components/VirtualizedTranscriptView.tsx
+++ b/frontend/src/components/VirtualizedTranscriptView.tsx
@@ -86,7 +86,7 @@ const TranscriptSegment = memo(function TranscriptSegment({
             <div className="flex items-start gap-2">
                 <Tooltip>
                     <TooltipTrigger>
-                        <span className="text-xs text-gray-400 mt-1 flex-shrink-0 min-w-[50px]">
+                        <span className="text-xs text-muted-foreground mt-1 flex-shrink-0 min-w-[50px]">
                             {formatRecordingTime(timestamp)}
                         </span>
                     </TooltipTrigger>
@@ -98,11 +98,11 @@ const TranscriptSegment = memo(function TranscriptSegment({
                 </Tooltip>
                 <div className="flex-1">
                     {isStreaming ? (
-                        <div className="bg-gray-100 border border-gray-200 rounded-lg px-3 py-2">
-                            <p className="text-base text-gray-800 leading-relaxed">{displayText}</p>
+                        <div className="bg-muted border border-border rounded-lg px-3 py-2">
+                            <p className="text-base text-foreground leading-relaxed">{displayText}</p>
                         </div>
                     ) : (
-                        <p className="text-base text-gray-800 leading-relaxed">{displayText}</p>
+                        <p className="text-base text-foreground leading-relaxed">{displayText}</p>
                     )}
                 </div>
             </div>
@@ -228,7 +228,7 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
             {/* Recording Status Bar - Sticky at top, always visible when recording */}
             <AnimatePresence>
                 {isRecording && (
-                    <div className="sticky top-0 z-10 bg-white pb-2">
+                    <div className="sticky top-0 z-10 bg-card pb-2">
                         <RecordingStatusBar isPaused={isPaused} />
                     </div>
                 )}
@@ -241,17 +241,17 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                 <motion.div
                     initial={{ opacity: 0 }}
                     animate={{ opacity: 1 }}
-                    className="text-center text-gray-500 mt-8"
+                    className="text-center text-muted-foreground mt-8"
                 >
                     {isRecording ? (
                         <>
                             <div className="flex items-center justify-center mb-3">
-                                <div className={`w-3 h-3 rounded-full ${isPaused ? 'bg-orange-500' : 'bg-blue-500 animate-pulse'}`}></div>
+                                <div className={`w-3 h-3 rounded-full ${isPaused ? 'bg-warning' : 'bg-info animate-pulse'}`}></div>
                             </div>
-                            <p className="text-sm text-gray-600">
+                            <p className="text-sm text-muted-foreground">
                                 {isPaused ? 'Recording paused' : 'Listening for speech...'}
                             </p>
-                            <p className="text-xs mt-1 text-gray-400">
+                            <p className="text-xs mt-1 text-muted-foreground">
                                 {isPaused ? 'Click resume to continue recording' : 'Speak to see live transcription'}
                             </p>
                         </>
@@ -306,12 +306,12 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                     {(hasMore || isLoadingMore) && !isRecording && segments.length > 0 && (
                         <div ref={loadMoreTriggerRef} className="flex justify-center items-center py-4 mt-2">
                             {isLoadingMore ? (
-                                <div className="flex items-center gap-2 text-gray-500">
-                                    <div className="w-4 h-4 border-2 border-gray-300 border-t-gray-600 rounded-full animate-spin" />
+                                <div className="flex items-center gap-2 text-muted-foreground">
+                                    <div className="w-4 h-4 border-2 border-border border-t-muted-foreground rounded-full animate-spin" />
                                     <span className="text-sm">Loading more...</span>
                                 </div>
                             ) : hasMore && totalCount > 0 ? (
-                                <span className="text-sm text-gray-400">
+                                <span className="text-sm text-muted-foreground">
                                     Showing {loadedCount} of {totalCount} segments
                                 </span>
                             ) : null}
@@ -324,9 +324,9 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                             initial={{ opacity: 0 }}
                             animate={{ opacity: 1 }}
                             exit={{ opacity: 0 }}
-                            className="flex items-center gap-2 mt-4 text-gray-500"
+                            className="flex items-center gap-2 mt-4 text-muted-foreground"
                         >
-                            <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse"></div>
+                            <div className="w-2 h-2 bg-info rounded-full animate-pulse"></div>
                             <span className="text-sm">Listening...</span>
                         </motion.div>
                     )}
@@ -362,12 +362,12 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                     {(hasMore || isLoadingMore) && !isRecording && segments.length > 0 && (
                         <div ref={loadMoreTriggerRef} className="flex justify-center items-center py-4 mt-2">
                             {isLoadingMore ? (
-                                <div className="flex items-center gap-2 text-gray-500">
-                                    <div className="w-4 h-4 border-2 border-gray-300 border-t-gray-600 rounded-full animate-spin" />
+                                <div className="flex items-center gap-2 text-muted-foreground">
+                                    <div className="w-4 h-4 border-2 border-border border-t-muted-foreground rounded-full animate-spin" />
                                     <span className="text-sm">Loading more...</span>
                                 </div>
                             ) : hasMore && totalCount > 0 ? (
-                                <span className="text-sm text-gray-400">
+                                <span className="text-sm text-muted-foreground">
                                     Showing {loadedCount} of {totalCount} segments
                                 </span>
                             ) : null}
@@ -380,9 +380,9 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                             initial={{ opacity: 0 }}
                             animate={{ opacity: 1 }}
                             exit={{ opacity: 0 }}
-                            className="flex items-center gap-2 mt-4 text-gray-500"
+                            className="flex items-center gap-2 mt-4 text-muted-foreground"
                         >
-                            <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse"></div>
+                            <div className="w-2 h-2 bg-info rounded-full animate-pulse"></div>
                             <span className="text-sm">Listening...</span>
                         </motion.div>
                     )}

--- a/frontend/src/components/WhisperModelManager.tsx
+++ b/frontend/src/components/WhisperModelManager.tsx
@@ -393,9 +393,9 @@ export function ModelManager({
     return (
       <div className={`space-y-3 ${className}`}>
         <div className="animate-pulse space-y-3">
-          <div className="h-20 bg-gray-100 rounded-lg"></div>
-          <div className="h-20 bg-gray-100 rounded-lg"></div>
-          <div className="h-20 bg-gray-100 rounded-lg"></div>
+          <div className="h-20 bg-muted rounded-lg"></div>
+          <div className="h-20 bg-muted rounded-lg"></div>
+          <div className="h-20 bg-muted rounded-lg"></div>
         </div>
       </div>
     );
@@ -403,9 +403,9 @@ export function ModelManager({
 
   if (error) {
     return (
-      <div className={`bg-red-50 border border-red-200 rounded-lg p-4 ${className}`}>
-        <p className="text-sm text-red-800">Failed to load models</p>
-        <p className="text-xs text-red-600 mt-1">{error}</p>
+      <div className={`bg-destructive/10 border border-destructive/30 rounded-lg p-4 ${className}`}>
+        <p className="text-sm text-destructive">Failed to load models</p>
+        <p className="text-xs text-destructive mt-1">{error}</p>
       </div>
     );
   }
@@ -480,7 +480,7 @@ export function ModelManager({
         <motion.div
           initial={{ opacity: 0, y: -5 }}
           animate={{ opacity: 1, y: 0 }}
-          className="text-xs text-gray-500 text-center pt-2"
+          className="text-xs text-muted-foreground text-center pt-2"
         >
           Using {getDisplayName(selectedModel)} for transcription
         </motion.div>
@@ -534,10 +534,10 @@ function ModelCard({
       className={`
         relative rounded-lg border-2 transition-all cursor-pointer
         ${isSelected && isAvailable
-          ? 'border-blue-500 bg-blue-50'
+          ? 'border-info bg-info/10'
           : isAvailable
-            ? 'border-gray-200 hover:border-gray-300 bg-white'
-            : 'border-gray-200 bg-gray-50'
+            ? 'border-border hover:border-border bg-card'
+            : 'border-border bg-muted/40'
         }
         ${isAvailable ? '' : 'cursor-default'}
       `}
@@ -547,7 +547,7 @@ function ModelCard({
     >
       {/* Recommended Badge */}
       {isRecommended && (
-        <div className="absolute -top-2 -right-2 bg-blue-600 text-white text-xs px-2 py-0.5 rounded-full font-medium">
+        <div className="absolute -top-2 -right-2 bg-info text-info-foreground text-xs px-2 py-0.5 rounded-full font-medium">
           Recommended
         </div>
       )}
@@ -558,24 +558,24 @@ function ModelCard({
             {/* Model Name and Tagline */}
             <div className="flex items-center gap-2 flex-wrap mb-2">
               <span className="text-2xl">{getModelIcon(model.accuracy)}</span>
-              <h3 className="font-semibold text-gray-900">{displayName}</h3>
-              <span className="text-sm text-gray-500">•</span>
-              <span className="text-sm text-gray-500">{getModelTagline(model.name, model.speed, model.accuracy)}</span>
+              <h3 className="font-semibold text-foreground">{displayName}</h3>
+              <span className="text-sm text-muted-foreground">•</span>
+              <span className="text-sm text-muted-foreground">{getModelTagline(model.name, model.speed, model.accuracy)}</span>
               {isSelected && isAvailable && (
                 <motion.span
                   initial={{ scale: 0 }}
                   animate={{ scale: 1 }}
-                  className="bg-blue-600 text-white px-2 py-0.5 rounded-full text-xs font-medium flex items-center gap-1"
+                  className="bg-info text-info-foreground px-2 py-0.5 rounded-full text-xs font-medium flex items-center gap-1"
                 >
                   ✓
                 </motion.span>
               )}
               {isQuantizedModel(model.name) && (
                 <span className={`px-2 py-0.5 rounded-full text-xs ${getModelPerformanceBadge(model.name).color === 'green'
-                  ? 'bg-green-100 text-green-700'
+                  ? 'bg-success/15 text-success'
                   : getModelPerformanceBadge(model.name).color === 'orange'
-                    ? 'bg-orange-100 text-orange-700'
-                    : 'bg-gray-100 text-gray-700'
+                    ? 'bg-warning/15 text-warning'
+                    : 'bg-muted text-foreground'
                   }`}>
                   {getModelPerformanceBadge(model.name).label}
                 </span>
@@ -583,7 +583,7 @@ function ModelCard({
             </div>
 
             {/* Model Specs */}
-            <div className="flex items-center space-x-4 text-sm text-gray-600 ml-9 mt-1.5">
+            <div className="flex items-center space-x-4 text-sm text-muted-foreground ml-9 mt-1.5">
               <span className="flex items-center space-x-1">
                 <span>📦</span>
                 <span>{formatFileSize(model.size_mb)}</span>
@@ -603,8 +603,8 @@ function ModelCard({
           <div className="ml-4 flex items-center gap-2">
             {isAvailable && (
               <>
-                <div className="flex items-center gap-1.5 text-green-600">
-                  <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+                <div className="flex items-center gap-1.5 text-success">
+                  <div className="w-2 h-2 bg-success rounded-full"></div>
                   <span className="text-xs font-medium">Ready</span>
                 </div>
                 <AnimatePresence>
@@ -618,7 +618,7 @@ function ModelCard({
                         e.stopPropagation();
                         onDelete();
                       }}
-                      className="text-gray-400 hover:text-red-600 transition-colors p-1"
+                      className="text-muted-foreground hover:text-destructive transition-colors p-1"
                       title="Delete model to free up space"
                     >
                       <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -636,7 +636,7 @@ function ModelCard({
                   e.stopPropagation();
                   onDownload();
                 }}
-                className="bg-blue-600 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-blue-700 transition-colors"
+                className="bg-info text-info-foreground px-3 py-1.5 rounded-md text-sm font-medium hover:bg-info/90 transition-colors"
               >
                 Download
               </button>
@@ -648,7 +648,7 @@ function ModelCard({
                   e.stopPropagation();
                   onDownload();
                 }}
-                className="bg-red-600 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-red-700 transition-colors"
+                className="bg-destructive text-destructive-foreground px-3 py-1.5 rounded-md text-sm font-medium hover:bg-destructive/90 transition-colors"
               >
                 Retry
               </button>
@@ -661,7 +661,7 @@ function ModelCard({
                     e.stopPropagation();
                     onDelete();
                   }}
-                  className="bg-orange-600 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-orange-700 transition-colors"
+                  className="bg-warning text-warning-foreground px-3 py-1.5 rounded-md text-sm font-medium hover:bg-warning/90 transition-colors"
                 >
                   Delete
                 </button>
@@ -670,7 +670,7 @@ function ModelCard({
                     e.stopPropagation();
                     onDownload();
                   }}
-                  className="bg-blue-600 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-blue-700 transition-colors"
+                  className="bg-info text-info-foreground px-3 py-1.5 rounded-md text-sm font-medium hover:bg-info/90 transition-colors"
                 >
                   Re-download
                 </button>
@@ -685,33 +685,33 @@ function ModelCard({
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
-            className="mt-3 pt-3 border-t border-gray-200"
+            className="mt-3 pt-3 border-t border-border"
           >
             <div className="flex items-center justify-between mb-2">
               <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-blue-600">Downloading...</span>
-                <span className="text-sm font-semibold text-blue-600">{Math.round(downloadProgress)}%</span>
+                <span className="text-sm font-medium text-info">Downloading...</span>
+                <span className="text-sm font-semibold text-info">{Math.round(downloadProgress)}%</span>
               </div>
               <button
                 onClick={(e) => {
                   e.stopPropagation();
                   onCancel();
                 }}
-                className="text-xs text-gray-600 hover:text-red-600 font-medium transition-colors px-2 py-1 rounded hover:bg-red-50"
+                className="text-xs text-muted-foreground hover:text-destructive font-medium transition-colors px-2 py-1 rounded hover:bg-destructive/10"
                 title="Cancel download"
               >
                 Cancel
               </button>
             </div>
-            <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+            <div className="w-full h-2 bg-muted rounded-full overflow-hidden">
               <motion.div
-                className="h-full bg-gradient-to-r from-blue-500 to-blue-600 rounded-full"
+                className="h-full bg-info rounded-full"
                 initial={{ width: 0 }}
                 animate={{ width: `${downloadProgress}%` }}
                 transition={{ duration: 0.3, ease: 'easeOut' }}
               />
             </div>
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               {model.size_mb ? (
                 <>
                   {formatFileSize(model.size_mb * downloadProgress / 100)} / {formatFileSize(model.size_mb)}

--- a/frontend/src/components/WhisperModelManager.tsx
+++ b/frontend/src/components/WhisperModelManager.tsx
@@ -572,9 +572,9 @@ function ModelCard({
               )}
               {isQuantizedModel(model.name) && (
                 <span className={`px-2 py-0.5 rounded-full text-xs ${getModelPerformanceBadge(model.name).color === 'green'
-                  ? 'bg-success/15 text-success'
+                  ? 'bg-success/15 text-success-text'
                   : getModelPerformanceBadge(model.name).color === 'orange'
-                    ? 'bg-warning/15 text-warning'
+                    ? 'bg-warning/15 text-warning-text'
                     : 'bg-muted text-foreground'
                   }`}>
                   {getModelPerformanceBadge(model.name).label}
@@ -603,7 +603,7 @@ function ModelCard({
           <div className="ml-4 flex items-center gap-2">
             {isAvailable && (
               <>
-                <div className="flex items-center gap-1.5 text-success">
+                <div className="flex items-center gap-1.5 text-success-text">
                   <div className="w-2 h-2 bg-success rounded-full"></div>
                   <span className="text-xs font-medium">Ready</span>
                 </div>
@@ -689,8 +689,8 @@ function ModelCard({
           >
             <div className="flex items-center justify-between mb-2">
               <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-info">Downloading...</span>
-                <span className="text-sm font-semibold text-info">{Math.round(downloadProgress)}%</span>
+                <span className="text-sm font-medium text-info-text">Downloading...</span>
+                <span className="text-sm font-semibold text-info-text">{Math.round(downloadProgress)}%</span>
               </div>
               <button
                 onClick={(e) => {

--- a/frontend/src/components/molecules/form-components/form-input-item.tsx
+++ b/frontend/src/components/molecules/form-components/form-input-item.tsx
@@ -91,7 +91,7 @@ export const FormInputItem = ({
                       accept={accept}
                       className={inputStyle}
                     />
-                    <div className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 cursor-pointer">
+                    <div className="absolute inset-y-0 right-0 pr-3 flex items-center text-muted-foreground cursor-pointer">
                       {showPassword ? (
                         <EyeOff
                           className="h-6 w-6"

--- a/frontend/src/components/molecules/form-components/form-select-item.tsx
+++ b/frontend/src/components/molecules/form-components/form-select-item.tsx
@@ -71,7 +71,7 @@ export const FormSelectItem = ({
                         <SelectItem
                           key={`${item}+${i}`}
                           value={item.value}
-                          className="hover:bg-slate-100 cursor-pointer"
+                          className="hover:bg-muted cursor-pointer"
                         >
                           {item.label}
                         </SelectItem>

--- a/frontend/src/components/onboarding/OnboardingContainer.tsx
+++ b/frontend/src/components/onboarding/OnboardingContainer.tsx
@@ -43,7 +43,7 @@ export function OnboardingContainer({
   };
 
   return (
-    <div className="fixed inset-0 bg-gray-50 flex items-center justify-center z-50 overflow-hidden">
+    <div className="fixed inset-0 bg-muted/40 flex items-center justify-center z-50 overflow-hidden">
       <div className={cn('w-full max-w-2xl h-full max-h-screen flex flex-col px-6 py-6', className)}>
         {/* Progress Indicator with Navigation - Fixed */}
         {step && !hideProgress && (
@@ -55,9 +55,9 @@ export function OnboardingContainer({
                   onClick={handlePrevious}
                   disabled={!canGoPrevious || step === 1}
                   className={cn(
-                    'pointer-events-auto w-8 h-8 rounded-full bg-white border border-gray-200 shadow-sm flex items-center justify-center transition-all duration-200',
+                    'pointer-events-auto w-8 h-8 rounded-full bg-card border border-border shadow-sm flex items-center justify-center transition-all duration-200',
                     canGoPrevious && step !== 1
-                      ? 'hover:bg-gray-50 hover:shadow-md hover:scale-110 text-gray-700'
+                      ? 'hover:bg-muted/40 hover:shadow-md hover:scale-110 text-foreground'
                       : 'opacity-0 cursor-not-allowed'
                   )}
                 >
@@ -68,9 +68,9 @@ export function OnboardingContainer({
                   onClick={handleNext}
                   disabled={!canGoNext || step === totalSteps}
                   className={cn(
-                    'pointer-events-auto w-8 h-8 rounded-full bg-white border border-gray-200 shadow-sm flex items-center justify-center transition-all duration-200',
+                    'pointer-events-auto w-8 h-8 rounded-full bg-card border border-border shadow-sm flex items-center justify-center transition-all duration-200',
                     canGoNext && step !== totalSteps
-                      ? 'hover:bg-gray-50 hover:shadow-md hover:scale-110 text-gray-700'
+                      ? 'hover:bg-muted/40 hover:shadow-md hover:scale-110 text-foreground'
                       : 'opacity-0 cursor-not-allowed'
                   )}
                 >
@@ -86,9 +86,9 @@ export function OnboardingContainer({
 
         {/* Header - Fixed */}
         <div className="mb-4 text-center space-y-3 flex-shrink-0">
-          <h1 className="text-4xl font-semibold text-gray-900 animate-fade-in-up">{title}</h1>
+          <h1 className="text-4xl font-semibold text-foreground animate-fade-in-up">{title}</h1>
           {description && (
-            <p className="text-base text-gray-600 max-w-md mx-auto animate-fade-in-up delay-75">
+            <p className="text-base text-muted-foreground max-w-md mx-auto animate-fade-in-up delay-75">
               {description}
             </p>
           )}

--- a/frontend/src/components/onboarding/shared/PermissionRow.tsx
+++ b/frontend/src/components/onboarding/shared/PermissionRow.tsx
@@ -40,7 +40,7 @@ export function PermissionRow({ icon, title, description, status, isPending = fa
           <div className="font-medium truncate text-foreground">{title}</div>
           <div className="text-sm text-muted-foreground">
             {isAuthorized ? (
-              <span className="text-success flex items-center gap-1">
+              <span className="text-success-text flex items-center gap-1">
                 <CheckCircle2 className="w-3.5 h-3.5" />
                 Access Granted
               </span>
@@ -72,7 +72,7 @@ export function PermissionRow({ icon, title, description, status, isPending = fa
         )}
         {isAuthorized && (
           <div className="flex size-8 items-center justify-center rounded-full bg-success/15">
-            <CheckCircle2 className="w-4 h-4 text-success" />
+            <CheckCircle2 className="w-4 h-4 text-success-text" />
           </div>
         )}
       </div>

--- a/frontend/src/components/onboarding/shared/PermissionRow.tsx
+++ b/frontend/src/components/onboarding/shared/PermissionRow.tsx
@@ -20,7 +20,7 @@ export function PermissionRow({ icon, title, description, status, isPending = fa
       className={cn(
         'flex items-center justify-between rounded-2xl border px-6 py-5',
         'transition-all duration-200',
-        isAuthorized ? 'border-gray-900 bg-gray-100' : isDenied ? 'border-red-300 bg-red-50' : 'bg-white border-neutral-200'
+        isAuthorized ? 'border-primary bg-muted' : isDenied ? 'border-destructive/40 bg-destructive/10' : 'bg-card border-border'
       )}
     >
       {/* Left side: Icon + Info */}
@@ -29,23 +29,23 @@ export function PermissionRow({ icon, title, description, status, isPending = fa
         <div
           className={cn(
             'flex size-10 items-center justify-center rounded-full flex-shrink-0',
-            isAuthorized ? 'bg-gray-200' : isDenied ? 'bg-red-100' : 'bg-neutral-50'
+            isAuthorized ? 'bg-muted' : isDenied ? 'bg-destructive/15' : 'bg-muted/40'
           )}
         >
-          <div className={cn(isAuthorized ? 'text-gray-900' : isDenied ? 'text-red-500' : 'text-neutral-500')}>{icon}</div>
+          <div className={cn(isAuthorized ? 'text-foreground' : isDenied ? 'text-destructive' : 'text-muted-foreground')}>{icon}</div>
         </div>
 
         {/* Title + Description */}
         <div className="min-w-0 flex-1">
-          <div className="font-medium truncate text-neutral-900">{title}</div>
+          <div className="font-medium truncate text-foreground">{title}</div>
           <div className="text-sm text-muted-foreground">
             {isAuthorized ? (
-              <span className="text-green-600 flex items-center gap-1">
+              <span className="text-success flex items-center gap-1">
                 <CheckCircle2 className="w-3.5 h-3.5" />
                 Access Granted
               </span>
             ) : isDenied ? (
-              <span className="text-red-500 flex items-center gap-1">
+              <span className="text-destructive flex items-center gap-1">
                 <XCircle className="w-3.5 h-3.5" />
                 Access Denied - Please grant in System Settings
               </span>
@@ -71,8 +71,8 @@ export function PermissionRow({ icon, title, description, status, isPending = fa
           </Button>
         )}
         {isAuthorized && (
-          <div className="flex size-8 items-center justify-center rounded-full bg-green-100">
-            <CheckCircle2 className="w-4 h-4 text-green-600" />
+          <div className="flex size-8 items-center justify-center rounded-full bg-success/15">
+            <CheckCircle2 className="w-4 h-4 text-success" />
           </div>
         )}
       </div>

--- a/frontend/src/components/onboarding/shared/ProgressIndicator.tsx
+++ b/frontend/src/components/onboarding/shared/ProgressIndicator.tsx
@@ -34,18 +34,18 @@ export function ProgressIndicator({ current, total, onStepClick }: ProgressIndic
                 disabled={!isClickable}
                 className={`relative flex items-center justify-center transition-all duration-300 ${
                   isCompleted
-                    ? 'w-7 h-7 bg-green-600 rounded-full'
+                    ? 'w-7 h-7 bg-success rounded-full'
                     : isActive
-                      ? 'w-8 h-8 bg-gray-900 rounded-full'
-                      : 'w-6 h-6 bg-gray-300 rounded-full'
+                      ? 'w-8 h-8 bg-primary rounded-full'
+                      : 'w-6 h-6 bg-muted-foreground/30 rounded-full'
                 } ${isClickable ? 'cursor-pointer hover:scale-110 hover:shadow-md' : 'cursor-default'}`}
               >
                 {isCompleted ? (
-                  <Check className="w-4 h-4 text-white" />
+                  <Check className="w-4 h-4 text-success-foreground" />
                 ) : (
                   <StepIcon
                     className={`transition-all duration-300 ${
-                      isActive ? 'w-4 h-4 text-white' : 'w-3 h-3 text-gray-600'
+                      isActive ? 'w-4 h-4 text-primary-foreground' : 'w-3 h-3 text-muted-foreground'
                     }`}
                   />
                 )}
@@ -55,7 +55,7 @@ export function ProgressIndicator({ current, total, onStepClick }: ProgressIndic
               {index < visibleSteps.length - 1 && (
                 <div
                   className={`h-0.5 w-6 transition-all duration-300 ${
-                    isCompleted ? 'bg-green-600' : 'bg-gray-300'
+                    isCompleted ? 'bg-success' : 'bg-muted-foreground/30'
                   }`}
                 />
               )}

--- a/frontend/src/components/onboarding/shared/StatusIndicator.tsx
+++ b/frontend/src/components/onboarding/shared/StatusIndicator.tsx
@@ -10,10 +10,10 @@ export function StatusIndicator({ status, size = 'md' }: StatusIndicatorProps) {
   };
 
   const statusColors = {
-    idle: 'bg-neutral-300',
-    checking: 'bg-yellow-400 animate-pulse',
-    success: 'bg-green-500',
-    error: 'bg-red-500',
+    idle: 'bg-muted-foreground/30',
+    checking: 'bg-warning animate-pulse',
+    success: 'bg-success',
+    error: 'bg-destructive',
   };
 
   return <span className={cn('rounded-full inline-block', sizeClasses[size], statusColors[status])} />;

--- a/frontend/src/components/onboarding/steps/DownloadProgressStep.tsx
+++ b/frontend/src/components/onboarding/steps/DownloadProgressStep.tsx
@@ -394,31 +394,31 @@ export function DownloadProgressStep() {
     modelSize: string,
     sizeUnit = 'MB'
   ) => (
-    <div className="bg-white rounded-xl border border-gray-200 p-5">
+    <div className="bg-card rounded-xl border border-border p-5">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-3">
-          <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center">
+          <div className="w-10 h-10 rounded-full bg-muted flex items-center justify-center">
             {icon}
           </div>
           <div>
-            <h3 className="font-medium text-gray-900">{title}</h3>
-            <p className="text-sm text-gray-500">{modelSize}</p>
+            <h3 className="font-medium text-foreground">{title}</h3>
+            <p className="text-sm text-muted-foreground">{modelSize}</p>
           </div>
         </div>
         <div>
           {state.status === 'waiting' && (
-            <span className="text-sm text-gray-500">Waiting...</span>
+            <span className="text-sm text-muted-foreground">Waiting...</span>
           )}
           {state.status === 'downloading' && (
-            <Loader2 className="w-5 h-5 text-gray-700 animate-spin" />
+            <Loader2 className="w-5 h-5 text-foreground animate-spin" />
           )}
           {state.status === 'completed' && (
-            <div className="w-6 h-6 rounded-full bg-green-100 flex items-center justify-center">
-              <Check className="w-4 h-4 text-green-600" />
+            <div className="w-6 h-6 rounded-full bg-success/15 flex items-center justify-center">
+              <Check className="w-4 h-4 text-success" />
             </div>
           )}
           {state.status === 'error' && (
-            <span className="text-sm text-red-500">Failed</span>
+            <span className="text-sm text-destructive">Failed</span>
           )}
         </div>
       </div>
@@ -426,23 +426,23 @@ export function DownloadProgressStep() {
       {/* Progress Bar */}
       {(state.status === 'downloading' || state.status === 'completed') && (
         <div className="space-y-2">
-          <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+          <div className="w-full h-2 bg-muted rounded-full overflow-hidden">
             <div
-              className="h-full bg-gradient-to-r from-gray-700 to-gray-900 rounded-full transition-all duration-300"
+              className="h-full bg-primary rounded-full transition-all duration-300"
               style={{ width: `${state.progress}%` }}
             />
           </div>
           <div className="flex items-center justify-between text-sm">
-            <span className="text-gray-600">
+            <span className="text-muted-foreground">
               {state.downloadedMb.toFixed(1)} {sizeUnit} / {state.totalMb.toFixed(1)} {sizeUnit}
             </span>
             <div className="flex items-center gap-2">
               {state.speedMbps > 0 && (
-                <span className="text-gray-500">
+                <span className="text-muted-foreground">
                   {state.speedMbps.toFixed(1)} {sizeUnit}/s
                 </span>
               )}
-              <span className="font-semibold text-gray-900">
+              <span className="font-semibold text-foreground">
                 {Math.round(state.progress)}%
               </span>
             </div>
@@ -451,13 +451,13 @@ export function DownloadProgressStep() {
       )}
 
       {state.status === 'error' && state.error && (
-        <div className="mt-2 p-3 bg-red-50 border border-red-200 rounded-md">
-          <p className="text-sm text-red-600 font-medium">Download Error</p>
-          <p className="text-xs text-red-500 mt-1">{state.error}</p>
+        <div className="mt-2 p-3 bg-destructive/10 border border-destructive/30 rounded-md">
+          <p className="text-sm text-destructive font-medium">Download Error</p>
+          <p className="text-xs text-destructive mt-1">{state.error}</p>
           {(title === 'Transcription Engine' || title === 'Summary Engine') && (
             <button
               onClick={title === 'Transcription Engine' ? handleRetryDownload : handleRetrySummaryDownload}
-              className="mt-3 w-full h-9 px-4 bg-gray-900 hover:bg-gray-800 text-white text-sm font-medium rounded-md transition-colors flex items-center justify-center gap-2"
+              className="mt-3 w-full h-9 px-4 bg-primary hover:bg-primary/90 text-primary-foreground text-sm font-medium rounded-md transition-colors flex items-center justify-center gap-2"
             >
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
@@ -483,14 +483,14 @@ export function DownloadProgressStep() {
         <div className="w-full max-w-lg space-y-4">
           {renderDownloadCard(
             'Transcription Engine',
-            <Mic className="w-5 h-5 text-gray-600" />,
+            <Mic className="w-5 h-5 text-muted-foreground" />,
             parakeetState,
             '~670 MB'
           )}
 
           {renderDownloadCard(
             'Summary Engine',
-            <Sparkles className="w-5 h-5 text-gray-600" />,
+            <Sparkles className="w-5 h-5 text-muted-foreground" />,
             summaryState,
             getSummaryModelSizeLabel(selectedSummaryModel || recommendedSummaryModel),
             'MiB'
@@ -505,13 +505,13 @@ export function DownloadProgressStep() {
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -10 }}
               transition={{ duration: 0.3, ease: 'easeOut' }}
-              className="w-full max-w-lg bg-gray-100 rounded-lg p-4 text-sm text-gray-800"
+              className="w-full max-w-lg bg-muted rounded-lg p-4 text-sm text-foreground"
             >
               <div className="flex items-start gap-3">
-                <Download className="w-5 h-5 text-gray-600 flex-shrink-0 mt-0.5" />
+                <Download className="w-5 h-5 text-muted-foreground flex-shrink-0 mt-0.5" />
                 <div>
                   <p className="font-medium">You can continue while this finishes</p>
-                  <p className="text-gray-700 mt-1">
+                  <p className="text-foreground mt-1">
                     Download will continue in the background.
                   </p>
                 </div>
@@ -525,7 +525,7 @@ export function DownloadProgressStep() {
           <Button
             onClick={handleContinue}
             disabled={!parakeetDownloaded || isCompleting}
-            className="w-full h-11 bg-gray-900 hover:bg-gray-800 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+            className="w-full h-11 bg-primary hover:bg-primary/90 text-primary-foreground disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {(isCompleting || !parakeetDownloaded) ? (
               <Loader2 className="w-4 h-4 mr-2 animate-spin" />

--- a/frontend/src/components/onboarding/steps/DownloadProgressStep.tsx
+++ b/frontend/src/components/onboarding/steps/DownloadProgressStep.tsx
@@ -414,7 +414,7 @@ export function DownloadProgressStep() {
           )}
           {state.status === 'completed' && (
             <div className="w-6 h-6 rounded-full bg-success/15 flex items-center justify-center">
-              <Check className="w-4 h-4 text-success" />
+              <Check className="w-4 h-4 text-success-text" />
             </div>
           )}
           {state.status === 'error' && (

--- a/frontend/src/components/onboarding/steps/PermissionsStep.tsx
+++ b/frontend/src/components/onboarding/steps/PermissionsStep.tsx
@@ -152,7 +152,7 @@ export function PermissionsStep() {
 
           <button
             onClick={handleSkip}
-            className="text-sm text-neutral-500 hover:text-neutral-700 transition-colors"
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
           >
             I'll do this later
           </button>

--- a/frontend/src/components/onboarding/steps/SetupOverviewStep.tsx
+++ b/frontend/src/components/onboarding/steps/SetupOverviewStep.tsx
@@ -52,7 +52,7 @@ export function SetupOverviewStep() {
     >
       <div className="flex flex-col items-center space-y-10">
         {/* Steps Card */}
-        <div className="w-full max-w-md bg-white rounded-lg border border-gray-200 p-4">
+        <div className="w-full max-w-md bg-card rounded-lg border border-border p-4">
           <div className="space-y-4">
             {steps.map((step, idx) => {
               return (
@@ -61,14 +61,14 @@ export function SetupOverviewStep() {
                   className={`flex items-start gap-4 p-1`}
                 >
                   <div className="flex-1 ml-1">
-                    <h3 className="font-medium text-gray-900 flex items-center gap-2">
+                    <h3 className="font-medium text-foreground flex items-center gap-2">
                         Step {step.number} :  {step.title}
 
                         {step.type === "summarization" && (
                             <TooltipProvider>
                             <Tooltip>
                                 <TooltipTrigger asChild>
-                                <button className="text-gray-400 hover:text-gray-600">
+                                <button className="text-muted-foreground hover:text-muted-foreground">
                                     <Info className="w-4 h-4" />
                                 </button>
                                 </TooltipTrigger>
@@ -92,7 +92,7 @@ export function SetupOverviewStep() {
         <div className="w-full max-w-xs space-y-4">
           <Button
             onClick={handleContinue}
-            className="w-full h-11 bg-gray-900 hover:bg-gray-800 text-white"
+            className="w-full h-11 bg-primary hover:bg-primary/90 text-primary-foreground"
           >
             Let's Go
           </Button>
@@ -101,7 +101,7 @@ export function SetupOverviewStep() {
               href="https://github.com/Zackriya-Solutions/meeting-minutes"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-xs text-gray-600 hover:underline"
+              className="text-xs text-muted-foreground hover:underline"
             >
               Report issues on GitHub
             </a>

--- a/frontend/src/components/onboarding/steps/WelcomeStep.tsx
+++ b/frontend/src/components/onboarding/steps/WelcomeStep.tsx
@@ -31,20 +31,20 @@ export function WelcomeStep() {
     >
       <div className="flex flex-col items-center space-y-10">
         {/* Divider */}
-        <div className="w-16 h-px bg-gray-300" />
+        <div className="w-16 h-px bg-muted-foreground/30" />
 
         {/* Features Card */}
-        <div className="w-full max-w-md bg-white rounded-lg border border-gray-200 shadow-sm p-6 space-y-4">
+        <div className="w-full max-w-md bg-card rounded-lg border border-border shadow-sm p-6 space-y-4">
           {features.map((feature, index) => {
             const Icon = feature.icon;
             return (
               <div key={index} className="flex items-start gap-3">
                 <div className="flex-shrink-0 mt-0.5">
-                  <div className="w-5 h-5 rounded-full bg-gray-100 flex items-center justify-center">
-                    <Icon className="w-3 h-3 text-gray-700" />
+                  <div className="w-5 h-5 rounded-full bg-muted flex items-center justify-center">
+                    <Icon className="w-3 h-3 text-foreground" />
                   </div>
                 </div>
-                <p className="text-sm text-gray-700 leading-relaxed">{feature.title}</p>
+                <p className="text-sm text-foreground leading-relaxed">{feature.title}</p>
               </div>
             );
           })}
@@ -54,11 +54,11 @@ export function WelcomeStep() {
         <div className="w-full max-w-xs space-y-3">
           <Button
             onClick={goNext}
-            className="w-full h-11 bg-gray-900 hover:bg-gray-800 text-white"
+            className="w-full h-11 bg-primary hover:bg-primary/90 text-primary-foreground"
           >
             Get Started
           </Button>
-          <p className="text-xs text-center text-gray-500">Takes less than 3 minutes</p>
+          <p className="text-xs text-center text-muted-foreground">Takes less than 3 minutes</p>
         </div>
       </div>
     </OnboardingContainer>

--- a/frontend/src/components/shared/DownloadProgressToast.tsx
+++ b/frontend/src/components/shared/DownloadProgressToast.tsx
@@ -67,7 +67,7 @@ function DownloadToastContent({
       <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${isComplete ? 'bg-success/15' : hasError ? 'bg-destructive/15' : isCancelled ? 'bg-muted' : 'bg-muted'
         }`}>
         {isComplete ? (
-          <Check className="w-4 h-4 text-success" />
+          <Check className="w-4 h-4 text-success-text" />
         ) : hasError ? (
           <X className="w-4 h-4 text-destructive" />
         ) : isCancelled ? (
@@ -88,7 +88,7 @@ function DownloadToastContent({
         {hasError ? (
           <p className="text-xs text-destructive">{download.error || 'Download failed'}</p>
         ) : isComplete ? (
-          <p className="text-xs text-success">Download complete</p>
+          <p className="text-xs text-success-text">Download complete</p>
         ) : isCancelled ? (
           <p className="text-xs text-muted-foreground">Download cancelled</p>
         ) : (

--- a/frontend/src/components/shared/DownloadProgressToast.tsx
+++ b/frontend/src/components/shared/DownloadProgressToast.tsx
@@ -61,48 +61,48 @@ function DownloadToastContent({
   const unitLabel = download.unitLabel ?? 'MB';
 
   return (
-    <div className="flex items-center gap-3 w-full max-w-sm bg-white rounded-lg shadow-lg border border-gray-200 p-3 relative">
+    <div className="flex items-center gap-3 w-full max-w-sm bg-card rounded-lg shadow-lg border border-border p-3 relative">
 
       {/* Icon */}
-      <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${isComplete ? 'bg-green-100' : hasError ? 'bg-red-100' : isCancelled ? 'bg-gray-100' : 'bg-gray-100'
+      <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${isComplete ? 'bg-success/15' : hasError ? 'bg-destructive/15' : isCancelled ? 'bg-muted' : 'bg-muted'
         }`}>
         {isComplete ? (
-          <Check className="w-4 h-4 text-green-600" />
+          <Check className="w-4 h-4 text-success" />
         ) : hasError ? (
-          <X className="w-4 h-4 text-red-600" />
+          <X className="w-4 h-4 text-destructive" />
         ) : isCancelled ? (
-          <X className="w-4 h-4 text-gray-600" />
+          <X className="w-4 h-4 text-muted-foreground" />
         ) : (
-          <ArrowBigDownDash className="size-5 text-gray-600 " />
+          <ArrowBigDownDash className="size-5 text-muted-foreground " />
         )}
       </div>
 
       {/* Content */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center justify-between gap-2 mb-1">
-          <p className="text-sm font-medium text-gray-900 truncate">
+          <p className="text-sm font-medium text-foreground truncate">
             {download.displayName}
           </p>
         </div>
 
         {hasError ? (
-          <p className="text-xs text-red-600">{download.error || 'Download failed'}</p>
+          <p className="text-xs text-destructive">{download.error || 'Download failed'}</p>
         ) : isComplete ? (
-          <p className="text-xs text-green-600">Download complete</p>
+          <p className="text-xs text-success">Download complete</p>
         ) : isCancelled ? (
-          <p className="text-xs text-gray-600">Download cancelled</p>
+          <p className="text-xs text-muted-foreground">Download cancelled</p>
         ) : (
           <>
             {/* Progress bar */}
-            <div className="w-full h-1.5 bg-gray-200 rounded-full overflow-hidden mb-1.5">
+            <div className="w-full h-1.5 bg-muted rounded-full overflow-hidden mb-1.5">
               <div
-                className="h-full bg-gray-900 rounded-full transition-all duration-300"
+                className="h-full bg-primary rounded-full transition-all duration-300"
                 style={{ width: `${download.progress}%` }}
               />
             </div>
 
             {/* Progress text */}
-            <div className="flex items-center justify-between text-xs text-gray-500">
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
               <span>
                 {download.downloadedMb.toFixed(1)} / {download.totalMb.toFixed(1)} {unitLabel}
               </span>
@@ -110,7 +110,7 @@ function DownloadToastContent({
                 {download.speedMbps > 0 && (
                   <span>{download.speedMbps.toFixed(1)} {unitLabel}/s</span>
                 )}
-                <span className="text-gray-900 font-medium">
+                <span className="text-foreground font-medium">
                   {Math.round(download.progress)}%
                 </span>
               </span>

--- a/frontend/src/components/ui/alert.tsx
+++ b/frontend/src/components/ui/alert.tsx
@@ -4,13 +4,20 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg~*]:pl-7",
   {
     variants: {
       variant: {
-        default: "bg-background text-foreground",
+        default:
+          "border-border bg-background text-foreground [&>svg]:text-foreground",
+        info:
+          "border-foreground/50 border-l-4 border-l-info-foreground bg-info/10 text-foreground [&>svg]:text-info-foreground dark:border-l-info dark:[&>svg]:text-info",
+        success:
+          "border-foreground/50 border-l-4 border-l-success-foreground bg-success/10 text-foreground [&>svg]:text-success-foreground dark:border-l-success dark:[&>svg]:text-success",
+        warning:
+          "border-foreground/50 border-l-4 border-l-warning-foreground bg-warning/10 text-foreground [&>svg]:text-warning-foreground dark:border-l-warning dark:[&>svg]:text-warning",
         destructive:
-          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+          "border-foreground/50 border-l-4 border-l-destructive bg-destructive/10 text-foreground [&>svg]:text-destructive",
       },
     },
     defaultVariants: {

--- a/frontend/src/components/ui/alert.tsx
+++ b/frontend/src/components/ui/alert.tsx
@@ -11,11 +11,11 @@ const alertVariants = cva(
         default:
           "border-border bg-background text-foreground [&>svg]:text-foreground",
         info:
-          "border-foreground/50 border-l-4 border-l-info-foreground bg-info/10 text-foreground [&>svg]:text-info-foreground dark:border-l-info dark:[&>svg]:text-info",
+          "border-foreground/50 border-l-4 border-l-info-foreground bg-info/10 text-foreground [&>svg]:text-info-foreground dark:border-l-info dark:[&>svg]:text-info-text",
         success:
-          "border-foreground/50 border-l-4 border-l-success-foreground bg-success/10 text-foreground [&>svg]:text-success-foreground dark:border-l-success dark:[&>svg]:text-success",
+          "border-foreground/50 border-l-4 border-l-success-foreground bg-success/10 text-foreground [&>svg]:text-success-foreground dark:border-l-success dark:[&>svg]:text-success-text",
         warning:
-          "border-foreground/50 border-l-4 border-l-warning-foreground bg-warning/10 text-foreground [&>svg]:text-warning-foreground dark:border-l-warning dark:[&>svg]:text-warning",
+          "border-foreground/50 border-l-4 border-l-warning-foreground bg-warning/10 text-foreground [&>svg]:text-warning-foreground dark:border-l-warning dark:[&>svg]:text-warning-text",
         destructive:
           "border-foreground/50 border-l-4 border-l-destructive bg-destructive/10 text-foreground [&>svg]:text-destructive",
       },
@@ -63,4 +63,4 @@ const AlertDescription = React.forwardRef<
 ))
 AlertDescription.displayName = "AlertDescription"
 
-export { Alert, AlertTitle, AlertDescription }
+export { Alert, AlertTitle, AlertDescription, alertVariants }

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -19,10 +19,13 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
-        green: "bg-green-600 text-white hover:bg-green-600",
-        blue: "bg-blue-500 text-white hover:bg-blue-600",
-        red: "bg-red-500 text-white hover:bg-red-600",
-        gray: "border bg-gray-100 border-input shadow-sm hover:bg-gray-200 hover:text-accent-foreground",
+        success:
+          "bg-success text-success-foreground hover:bg-success/90",
+        info: "bg-info text-info-foreground hover:bg-info/90",
+        recording:
+          "bg-recording text-recording-foreground hover:bg-recording/90",
+        muted:
+          "border border-input bg-muted text-foreground hover:bg-accent",
       },
       size: {
         default: "h-9 px-4 py-2",

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -15,7 +15,7 @@ const Command = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(
-      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      "flex h-full w-full flex-col overflow-hidden rounded-md border border-border bg-popover text-popover-foreground",
       className
     )}
     {...props}
@@ -39,12 +39,15 @@ const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
-  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+  <div
+    className="flex items-center border-b border-border px-3"
+    cmdk-input-wrapper=""
+  >
     <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-10 w-full rounded-md bg-popover py-3 text-sm text-popover-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-overlay/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-card p-6 text-card-foreground shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
       className
     )}
     {...props}
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
         className
       )}

--- a/frontend/src/components/ui/input-group.tsx
+++ b/frontend/src/components/ui/input-group.tsx
@@ -14,7 +14,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="input-group"
       role="group"
       className={cn(
-        "group/input-group border-input dark:bg-input/30 shadow-xs relative flex w-full items-center rounded-md border outline-none transition-[color,box-shadow]",
+        "group/input-group relative flex w-full items-center rounded-md border border-input bg-background text-foreground shadow-xs outline-none transition-[color,box-shadow]",
         "h-9 has-[>textarea]:h-auto",
 
         // Variants based on alignment.

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-base text-foreground shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         ref={ref}

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -21,7 +21,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
+        "z-50 w-72 rounded-md border border-border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/progress.tsx
+++ b/frontend/src/components/ui/progress.tsx
@@ -12,7 +12,7 @@ const Progress = React.forwardRef<
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
-      "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+      "relative h-2 w-full overflow-hidden rounded-full bg-muted",
       className
     )}
     {...props}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -21,7 +21,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-overlay/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -31,7 +31,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  "fixed z-50 gap-4 border-border bg-card p-6 text-card-foreground shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
   {
     variants: {
       side: {
@@ -108,7 +108,7 @@ const SheetTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold text-foreground", className)}
+    className={cn("text-lg font-semibold text-card-foreground", className)}
     {...props}
   />
 ))

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-info data-[state=unchecked]:bg-input",
       className
     )}
     {...props}

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[60px] w-full rounded-md border border-input bg-background px-3 py-2 text-base text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       ref={ref}

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -20,7 +20,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+        "z-50 overflow-hidden rounded-md border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
         className
       )}
       {...props}

--- a/frontend/src/contexts/ConfigContext.tsx
+++ b/frontend/src/contexts/ConfigContext.tsx
@@ -9,7 +9,7 @@ import Analytics from '@/lib/analytics';
 import { BetaFeatures, BetaFeatureKey, loadBetaFeatures, saveBetaFeatures } from '@/types/betaFeatures';
 import {
   applyEffectiveTheme,
-  parseThemeMode,
+  readStoredThemeMode,
   resolveEffectiveTheme,
   THEME_STORAGE_KEY,
   type ThemeMode,
@@ -73,7 +73,6 @@ interface ConfigContextType {
   toggleConfidenceIndicator: (checked: boolean) => void;
   themeMode: ThemeMode;
   setThemeMode: (mode: ThemeMode) => void;
-  isDarkTheme: boolean;
 
   // Beta features
   betaFeatures: BetaFeatures;
@@ -106,16 +105,6 @@ interface ConfigContextType {
 }
 
 const ConfigContext = createContext<ConfigContextType | undefined>(undefined);
-
-function getStoredThemeMode(): ThemeMode {
-  if (typeof window === 'undefined') return 'system';
-
-  try {
-    return parseThemeMode(window.localStorage.getItem(THEME_STORAGE_KEY));
-  } catch {
-    return 'system';
-  }
-}
 
 export function ConfigProvider({ children }: { children: ReactNode }) {
   // Model configuration state
@@ -175,12 +164,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     return true;
   });
 
-  const [themeMode, setThemeModeState] = useState<ThemeMode>(() => getStoredThemeMode());
-  const [isDarkTheme, setIsDarkTheme] = useState(
-    () =>
-      typeof document !== 'undefined' &&
-      document.documentElement.classList.contains('dark'),
-  );
+  const [themeMode, setThemeModeState] = useState<ThemeMode>(() => readStoredThemeMode());
 
   // Summary configs
   const [isAutoSummary, setisAutoSummary] = useState<boolean>(() => {
@@ -424,9 +408,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
 
     const media = window.matchMedia('(prefers-color-scheme: dark)');
     const applyTheme = () => {
-      const effectiveTheme = resolveEffectiveTheme(themeMode, media.matches);
-      applyEffectiveTheme(effectiveTheme);
-      setIsDarkTheme(effectiveTheme === 'dark');
+      applyEffectiveTheme(resolveEffectiveTheme(themeMode, media.matches));
     };
 
     applyTheme();
@@ -437,26 +419,35 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     return () => media.removeEventListener('change', applyTheme);
   }, [themeMode]);
 
+  const ownsNativeThemeRef = useRef(false);
+  const nativeThemeSeqRef = useRef(0);
+
   useEffect(() => {
-    let cancelled = false;
+    // 'system' is Tauri's default; skip the initial no-op IPC call until we've
+    // taken ownership by applying an explicit theme at least once. Ownership is
+    // claimed synchronously here (not after the async setTheme resolves) so a
+    // switch back to System while a previous explicit call is still in flight
+    // is never skipped — otherwise the stale call would strand native chrome
+    // on the old theme while the webview follows System.
+    if (!ownsNativeThemeRef.current && themeMode === 'system') return;
+    ownsNativeThemeRef.current = true;
+
+    const seq = ++nativeThemeSeqRef.current;
 
     const applyNativeTheme = async () => {
       try {
         const { setTheme } = await import('@tauri-apps/api/app');
-        if (cancelled) return;
+        // A newer theme change has superseded this one; don't issue a stale IPC.
+        if (seq !== nativeThemeSeqRef.current) return;
         await setTheme(themeMode === 'system' ? null : themeMode);
       } catch (error) {
-        if (process.env.NODE_ENV === 'development') {
-          console.debug('[ConfigContext] Tauri app theme sync skipped:', error);
-        }
+        // Surface in production too: a silent failure here leaves native
+        // window chrome permanently mismatched with the webview theme.
+        console.warn('[ConfigContext] Failed to sync native window theme:', error);
       }
     };
 
     applyNativeTheme();
-
-    return () => {
-      cancelled = true;
-    };
   }, [themeMode]);
 
   const toggleIsAutoSummary = useCallback((checked: boolean) => {
@@ -576,7 +567,6 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     toggleConfidenceIndicator,
     themeMode,
     setThemeMode,
-    isDarkTheme,
     betaFeatures,
     toggleBetaFeature,
     models,
@@ -601,7 +591,6 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     toggleConfidenceIndicator,
     themeMode,
     setThemeMode,
-    isDarkTheme,
     betaFeatures,
     toggleBetaFeature,
     models,

--- a/frontend/src/contexts/ConfigContext.tsx
+++ b/frontend/src/contexts/ConfigContext.tsx
@@ -7,6 +7,15 @@ import { configService, ModelConfig } from '@/services/configService';
 import { invoke } from '@tauri-apps/api/core';
 import Analytics from '@/lib/analytics';
 import { BetaFeatures, BetaFeatureKey, loadBetaFeatures, saveBetaFeatures } from '@/types/betaFeatures';
+import {
+  applyEffectiveTheme,
+  parseThemeMode,
+  resolveEffectiveTheme,
+  THEME_STORAGE_KEY,
+  type ThemeMode,
+} from '@/lib/theme';
+
+export type { ThemeMode } from '@/lib/theme';
 
 export interface OllamaModel {
   name: string;
@@ -62,6 +71,9 @@ interface ConfigContextType {
   // UI preferences
   showConfidenceIndicator: boolean;
   toggleConfidenceIndicator: (checked: boolean) => void;
+  themeMode: ThemeMode;
+  setThemeMode: (mode: ThemeMode) => void;
+  isDarkTheme: boolean;
 
   // Beta features
   betaFeatures: BetaFeatures;
@@ -95,6 +107,15 @@ interface ConfigContextType {
 
 const ConfigContext = createContext<ConfigContextType | undefined>(undefined);
 
+function getStoredThemeMode(): ThemeMode {
+  if (typeof window === 'undefined') return 'system';
+
+  try {
+    return parseThemeMode(window.localStorage.getItem(THEME_STORAGE_KEY));
+  } catch {
+    return 'system';
+  }
+}
 
 export function ConfigProvider({ children }: { children: ReactNode }) {
   // Model configuration state
@@ -102,7 +123,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     provider: 'ollama',
     model: 'llama3.2:latest',
     whisperModel: 'large-v3',
-    ollamaEndpoint: null
+    ollamaEndpoint: null,
   });
 
   // Transcript model configuration state
@@ -153,6 +174,13 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     }
     return true;
   });
+
+  const [themeMode, setThemeModeState] = useState<ThemeMode>(() => getStoredThemeMode());
+  const [isDarkTheme, setIsDarkTheme] = useState(
+    () =>
+      typeof document !== 'undefined' &&
+      document.documentElement.classList.contains('dark'),
+  );
 
   // Summary configs
   const [isAutoSummary, setisAutoSummary] = useState<boolean>(() => {
@@ -382,6 +410,55 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     window.dispatchEvent(new CustomEvent('confidenceIndicatorChanged', { detail: checked }));
   }, []);
 
+  const setThemeMode = useCallback((mode: ThemeMode) => {
+    setThemeModeState(mode);
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(THEME_STORAGE_KEY, mode);
+      } catch {}
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const applyTheme = () => {
+      const effectiveTheme = resolveEffectiveTheme(themeMode, media.matches);
+      applyEffectiveTheme(effectiveTheme);
+      setIsDarkTheme(effectiveTheme === 'dark');
+    };
+
+    applyTheme();
+
+    if (themeMode !== 'system') return;
+
+    media.addEventListener('change', applyTheme);
+    return () => media.removeEventListener('change', applyTheme);
+  }, [themeMode]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const applyNativeTheme = async () => {
+      try {
+        const { setTheme } = await import('@tauri-apps/api/app');
+        if (cancelled) return;
+        await setTheme(themeMode === 'system' ? null : themeMode);
+      } catch (error) {
+        if (process.env.NODE_ENV === 'development') {
+          console.debug('[ConfigContext] Tauri app theme sync skipped:', error);
+        }
+      }
+    };
+
+    applyNativeTheme();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [themeMode]);
+
   const toggleIsAutoSummary = useCallback((checked: boolean) => {
     setisAutoSummary(checked);
     if (typeof window !== 'undefined') {
@@ -497,6 +574,9 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     setSelectedLanguage: handleSetSelectedLanguage,
     showConfidenceIndicator,
     toggleConfidenceIndicator,
+    themeMode,
+    setThemeMode,
+    isDarkTheme,
     betaFeatures,
     toggleBetaFeature,
     models,
@@ -519,6 +599,9 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     handleSetSelectedLanguage,
     showConfidenceIndicator,
     toggleConfidenceIndicator,
+    themeMode,
+    setThemeMode,
+    isDarkTheme,
     betaFeatures,
     toggleBetaFeature,
     models,

--- a/frontend/src/hooks/useIsDarkTheme.ts
+++ b/frontend/src/hooks/useIsDarkTheme.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+function subscribe(onStoreChange: () => void): () => void {
+  const observer = new MutationObserver(onStoreChange);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['class'],
+  });
+  return () => observer.disconnect();
+}
+
+function getSnapshot(): boolean {
+  return document.documentElement.classList.contains('dark');
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+/**
+ * Effective theme derived from the root `dark` class — the single source of
+ * truth written by ThemeScript (pre-hydration) and ConfigContext (runtime).
+ * Scoped here instead of ConfigContext so OS-level theme flips only re-render
+ * the components that actually branch on the effective theme.
+ */
+export function useIsDarkTheme(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/frontend/src/lib/recordingNotification.tsx
+++ b/frontend/src/lib/recordingNotification.tsx
@@ -31,7 +31,7 @@ export async function showRecordingNotification(): Promise<void> {
                 onChange={(e) => {
                   dontShowAgain = e.target.checked;
                 }}
-                className="rounded border-border text-info focus:ring-info focus:ring-2"
+                className="rounded border-border text-info-text focus:ring-info focus:ring-2"
               />
               <span className="select-none text-foreground">Don't show this again</span>
             </label>

--- a/frontend/src/lib/recordingNotification.tsx
+++ b/frontend/src/lib/recordingNotification.tsx
@@ -22,18 +22,18 @@ export async function showRecordingNotification(): Promise<void> {
       const toastId = toast.info('🔴 Recording Started', {
         description: (
           <div className="space-y-3 min-w-[280px]">
-            <p className="text-sm font-medium text-gray-900">
+            <p className="text-sm font-medium text-foreground">
               Inform all participants this meeting is being recorded.
             </p>
-            <label className="flex items-center gap-2 text-xs cursor-pointer hover:bg-blue-100 p-2 rounded transition-colors">
+            <label className="flex items-center gap-2 text-xs cursor-pointer hover:bg-info/15 p-2 rounded transition-colors">
               <input
                 type="checkbox"
                 onChange={(e) => {
                   dontShowAgain = e.target.checked;
                 }}
-                className="rounded border-gray-300 text-blue-600 focus:ring-blue-500 focus:ring-2"
+                className="rounded border-border text-info focus:ring-info focus:ring-2"
               />
-              <span className="select-none text-gray-700">Don't show this again</span>
+              <span className="select-none text-foreground">Don't show this again</span>
             </label>
             <button
               onClick={async () => {
@@ -46,7 +46,7 @@ export async function showRecordingNotification(): Promise<void> {
                 Analytics.trackButtonClick('recording_notification_acknowledged', 'toast');
                 toast.dismiss(toastId);
               }}
-              className="w-full px-3 py-1.5 bg-gray-900 text-white text-xs rounded hover:bg-gray-800 transition-colors font-medium"
+              className="w-full px-3 py-1.5 bg-primary text-primary-foreground text-xs rounded hover:bg-primary/90 transition-colors font-medium"
             >
               I've Notified Participants
             </button>

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -1,0 +1,29 @@
+export type ThemeMode = 'light' | 'dark' | 'system';
+export type EffectiveTheme = 'light' | 'dark';
+
+export const THEME_STORAGE_KEY = 'themeMode';
+
+export function parseThemeMode(value: string | null | undefined): ThemeMode {
+  return value === 'light' || value === 'dark' || value === 'system'
+    ? value
+    : 'system';
+}
+
+export function resolveEffectiveTheme(
+  mode: ThemeMode,
+  prefersDark: boolean,
+): EffectiveTheme {
+  if (mode === 'system') {
+    return prefersDark ? 'dark' : 'light';
+  }
+
+  return mode;
+}
+
+export function applyEffectiveTheme(theme: EffectiveTheme) {
+  if (typeof document === 'undefined') return;
+
+  const root = document.documentElement;
+  root.classList.toggle('dark', theme === 'dark');
+  root.style.colorScheme = theme;
+}

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -9,6 +9,16 @@ export function parseThemeMode(value: string | null | undefined): ThemeMode {
     : 'system';
 }
 
+export function readStoredThemeMode(): ThemeMode {
+  if (typeof window === 'undefined') return 'system';
+
+  try {
+    return parseThemeMode(window.localStorage.getItem(THEME_STORAGE_KEY));
+  } catch {
+    return 'system';
+  }
+}
+
 export function resolveEffectiveTheme(
   mode: ThemeMode,
   prefersDark: boolean,

--- a/frontend/src/testing/E2EBootstrap.tsx
+++ b/frontend/src/testing/E2EBootstrap.tsx
@@ -2,9 +2,11 @@
 
 import { installTauriBrowserMocks } from './tauri-browser-mocks';
 
-if (process.env.NEXT_PUBLIC_E2E_TESTING === '1') {
-  installTauriBrowserMocks();
-}
+// Build-time exclusion happens in next.config.js (this module is replaced by
+// E2ENoop.tsx outside E2E builds); installTauriBrowserMocks additionally
+// guards on NEXT_PUBLIC_E2E_TESTING at runtime so the mocks can never
+// activate against a real Tauri shell.
+installTauriBrowserMocks();
 
 export function E2EBootstrap() {
   return null;

--- a/frontend/src/testing/E2EBootstrap.tsx
+++ b/frontend/src/testing/E2EBootstrap.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { installTauriBrowserMocks } from './tauri-browser-mocks';
+
+if (process.env.NEXT_PUBLIC_E2E_TESTING === '1') {
+  installTauriBrowserMocks();
+}
+
+export function E2EBootstrap() {
+  return null;
+}

--- a/frontend/src/testing/E2ENoop.tsx
+++ b/frontend/src/testing/E2ENoop.tsx
@@ -1,0 +1,7 @@
+// Production stand-in for E2EBootstrap: next.config.js swaps this module in
+// via NormalModuleReplacementPlugin whenever NEXT_PUBLIC_E2E_TESTING !== '1',
+// keeping the Tauri browser mocks (and @tauri-apps/api/mocks) out of the
+// production bundle entirely.
+export function E2EBootstrap() {
+  return null;
+}

--- a/frontend/src/testing/tauri-browser-mocks.noop.ts
+++ b/frontend/src/testing/tauri-browser-mocks.noop.ts
@@ -1,1 +1,0 @@
-export function installTauriBrowserMocks() {}

--- a/frontend/src/testing/tauri-browser-mocks.noop.ts
+++ b/frontend/src/testing/tauri-browser-mocks.noop.ts
@@ -1,0 +1,1 @@
+export function installTauriBrowserMocks() {}

--- a/frontend/src/testing/tauri-browser-mocks.ts
+++ b/frontend/src/testing/tauri-browser-mocks.ts
@@ -30,7 +30,6 @@ const newOnboardingStatus = {
 const browserStore = new Map<string, unknown>();
 
 const knownNoopCommands = new Set([
-  'plugin:app|set_app_theme',
   'set_audio_backend',
   'set_language_preference',
   'set_notification_settings',
@@ -62,6 +61,10 @@ const knownNoopCommands = new Set([
 ]);
 
 const commandFixtures: Record<string, unknown> = {
+  // Startup update check (useUpdateCheck fires ~2s after mount): keep it
+  // deterministic so long-lived E2E pages don't hit the fixture-missing throw.
+  'plugin:app|version': '0.0.0-e2e',
+  'plugin:updater|check': null,
   get_onboarding_status: completedOnboardingStatus,
   get_recording_state: { is_recording: false, is_paused: false },
   is_recording: false,
@@ -123,6 +126,14 @@ const commandFixtures: Record<string, unknown> = {
     preferred_system_device: null,
   },
   get_audio_devices: [],
+  get_audio_backend_info: [
+    {
+      id: 'screencapturekit',
+      name: 'ScreenCaptureKit',
+      description: 'Native macOS system audio capture.',
+    },
+  ],
+  get_current_audio_backend: 'screencapturekit',
   get_ollama_models: [],
   is_analytics_enabled: false,
   builtin_ai_list_models: [

--- a/frontend/src/testing/tauri-browser-mocks.ts
+++ b/frontend/src/testing/tauri-browser-mocks.ts
@@ -1,0 +1,266 @@
+import { mockIPC, mockWindows } from '@tauri-apps/api/mocks';
+
+const meeting = {
+  id: 'theme-test-meeting',
+  title: 'Theme Test Meeting',
+  created_at: '2026-06-20T09:00:00Z',
+  updated_at: '2026-06-20T09:30:00Z',
+  folder_path: '/tmp/theme-test-meeting',
+  transcripts: [],
+};
+
+const completedOnboardingStatus = {
+  version: '1.0',
+  completed: true,
+  current_step: 3,
+  model_status: {
+    parakeet: 'downloaded',
+    summary: 'downloaded',
+    selected_summary_model: 'qwen3.5:2b',
+  },
+  last_updated: '2026-06-20T09:30:00Z',
+};
+
+const newOnboardingStatus = {
+  ...completedOnboardingStatus,
+  completed: false,
+  current_step: 1,
+};
+
+const browserStore = new Map<string, unknown>();
+
+const knownNoopCommands = new Set([
+  'plugin:app|set_app_theme',
+  'set_audio_backend',
+  'set_language_preference',
+  'set_notification_settings',
+  'set_recording_preferences',
+  'start_analytics_session',
+  'start_audio_level_monitoring',
+  'start_import_audio_command',
+  'start_recording',
+  'start_recording_with_devices_and_meeting',
+  'start_retranscription_command',
+  'stop_audio_level_monitoring',
+  'stop_recording',
+  'track_analytics_disabled',
+  'track_analytics_enabled',
+  'track_analytics_transparency_viewed',
+  'track_custom_prompt_used',
+  'track_daily_active_user',
+  'track_event',
+  'track_feature_used',
+  'track_meeting_deleted',
+  'track_meeting_started',
+  'track_model_changed',
+  'track_recording_started',
+  'track_recording_stopped',
+  'track_settings_changed',
+  'track_summary_generation_completed',
+  'track_summary_regenerated',
+  'track_user_first_launch',
+]);
+
+const commandFixtures: Record<string, unknown> = {
+  get_onboarding_status: completedOnboardingStatus,
+  get_recording_state: { is_recording: false, is_paused: false },
+  is_recording: false,
+  api_get_meetings: [meeting],
+  api_get_meeting: meeting,
+  api_get_meeting_metadata: meeting,
+  api_get_meeting_transcripts: {
+    transcripts: [
+      {
+        id: 'theme-test-transcript',
+        text: 'We approved the dark theme.',
+        timestamp: '09:00:00',
+        audio_start_time: 0,
+        audio_end_time: 4.2,
+        duration: 4.2,
+        confidence: 0.98,
+      },
+    ],
+    has_more: false,
+    total_count: 1,
+  },
+  api_get_summary: {
+    status: 'completed',
+    meetingName: meeting.title,
+    meeting_id: meeting.id,
+    start: '2026-06-20T09:00:00Z',
+    end: '2026-06-20T09:30:00Z',
+    data: {
+      markdown: '# Theme Test Meeting\n## Decisions\nUse semantic tokens.',
+    },
+    error: null,
+  },
+  api_get_meeting_summary_language: {
+    language: null,
+    storage: 'metadata',
+  },
+  api_get_model_config: {
+    provider: 'builtin-ai',
+    model: 'qwen3.5:2b',
+    whisperModel: 'parakeet-tdt-0.6b-v3-int8',
+    ollamaEndpoint: null,
+  },
+  api_get_transcript_config: {
+    provider: 'parakeet',
+    model: 'parakeet-tdt-0.6b-v3-int8',
+    apiKey: null,
+  },
+  api_get_custom_openai_config: null,
+  api_get_api_key: null,
+  api_get_transcript_api_key: null,
+  api_get_auto_generate_setting: false,
+  api_list_templates: [],
+  get_notification_settings: null,
+  get_database_directory: '/tmp/Meetily',
+  whisper_get_models_directory: '/tmp/Meetily/models',
+  get_default_recordings_folder_path: '/tmp/Meetily Recordings',
+  get_recording_preferences: {
+    preferred_mic_device: null,
+    preferred_system_device: null,
+  },
+  get_audio_devices: [],
+  get_ollama_models: [],
+  is_analytics_enabled: false,
+  builtin_ai_list_models: [
+    {
+      name: 'qwen3.5:2b',
+      display_name: 'Qwen 3.5 2B (Balanced)',
+      status: { type: 'available' },
+      path: '/tmp/models/Qwen3.5-2B-Q4_K_M.gguf',
+      size_mb: 1221,
+      context_size: 32768,
+      description: 'Balanced local model for built-in summaries.',
+      gguf_file: 'Qwen3.5-2B-Q4_K_M.gguf',
+    },
+    {
+      name: 'qwen3.5:4b',
+      display_name: 'Qwen 3.5 4B (High Quality)',
+      status: { type: 'not_downloaded' },
+      path: '/tmp/models/Qwen3.5-4B-Q4_K_M.gguf',
+      size_mb: 2614,
+      context_size: 32768,
+      description: 'Higher-quality local model for built-in summaries.',
+      gguf_file: 'Qwen3.5-4B-Q4_K_M.gguf',
+    },
+  ],
+  builtin_ai_get_recommended_model: 'qwen3.5:2b',
+  builtin_ai_download_model: null,
+  check_first_launch: false,
+  check_default_legacy_database: null,
+  check_homebrew_database: null,
+  initialize_fresh_database: null,
+  import_and_initialize_database: null,
+  parakeet_init: null,
+  parakeet_has_available_models: true,
+  parakeet_download_model: null,
+  parakeet_retry_download: null,
+  parakeet_get_available_models: [
+    {
+      name: 'parakeet-tdt-0.6b-v3-int8',
+      path: '/tmp/models/parakeet-tdt-0.6b-v3-int8',
+      size_mb: 670,
+      speed: 'Ultra Fast (v3)',
+      status: 'Available',
+      description: 'Recommended local transcription model.',
+      quantization: 'Int8',
+    },
+  ],
+  save_onboarding_status_cmd: null,
+  complete_onboarding: null,
+  whisper_get_available_models: [],
+};
+
+let installed = false;
+
+function recordNativeThemePayload(payload: unknown) {
+  const target = window as typeof window & {
+    __e2eTauriThemeCalls?: unknown[];
+  };
+
+  target.__e2eTauriThemeCalls = target.__e2eTauriThemeCalls ?? [];
+  target.__e2eTauriThemeCalls.push(payload);
+}
+
+function getScenarioFixture(command: string) {
+  const scenario = new URLSearchParams(window.location.search).get('__e2e');
+
+  if (scenario === 'onboarding' && command === 'get_onboarding_status') {
+    return newOnboardingStatus;
+  }
+
+  if (scenario === 'empty-home' && command === 'api_get_meetings') {
+    return [];
+  }
+
+  return undefined;
+}
+
+export function installTauriBrowserMocks() {
+  if (
+    installed ||
+    typeof window === 'undefined' ||
+    process.env.NEXT_PUBLIC_E2E_TESTING !== '1'
+  ) {
+    return;
+  }
+
+  installed = true;
+  mockWindows('main');
+  mockIPC(
+    (command, payload) => {
+      const scenarioFixture = getScenarioFixture(command);
+      if (scenarioFixture !== undefined) return scenarioFixture;
+      if (command === 'plugin:store|load') return 1;
+      if (
+        command === 'plugin:store|has' ||
+        command === 'plugin:store|get' ||
+        command === 'plugin:store|set'
+      ) {
+        const key =
+          typeof payload === 'object' &&
+          payload !== null &&
+          'key' in payload &&
+          typeof payload.key === 'string'
+            ? payload.key
+            : '';
+
+        if (command === 'plugin:store|has') return browserStore.has(key);
+        if (command === 'plugin:store|get') {
+          return [browserStore.get(key), browserStore.has(key)];
+        }
+
+        const value =
+          typeof payload === 'object' &&
+          payload !== null &&
+          'value' in payload
+            ? payload.value
+            : undefined;
+        browserStore.set(key, value);
+        return null;
+      }
+      if (command === 'plugin:store|save') return null;
+      if (command === 'plugin:app|set_app_theme') {
+        recordNativeThemePayload(payload);
+        return null;
+      }
+      if (command === 'builtin_ai_is_model_ready') {
+        return (
+          typeof payload === 'object' &&
+          payload !== null &&
+          'modelName' in payload &&
+          payload.modelName === 'qwen3.5:2b'
+        );
+      }
+      if (command in commandFixtures) return commandFixtures[command];
+
+      if (knownNoopCommands.has(command)) return null;
+
+      throw new Error(`[E2E fixture missing] ${command}`);
+    },
+    { shouldMockEvents: true },
+  );
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -55,15 +55,22 @@ module.exports = {
   			},
       info: {
         DEFAULT: 'hsl(var(--info))',
-        foreground: 'hsl(var(--info-foreground))'
+        foreground: 'hsl(var(--info-foreground))',
+        text: 'hsl(var(--info-text))'
       },
       success: {
         DEFAULT: 'hsl(var(--success))',
-        foreground: 'hsl(var(--success-foreground))'
+        foreground: 'hsl(var(--success-foreground))',
+        text: 'hsl(var(--success-text))'
       },
       warning: {
         DEFAULT: 'hsl(var(--warning))',
-        foreground: 'hsl(var(--warning-foreground))'
+        foreground: 'hsl(var(--warning-foreground))',
+        text: 'hsl(var(--warning-text))'
+      },
+      'warning-strong': {
+        DEFAULT: 'hsl(var(--warning-strong))',
+        foreground: 'hsl(var(--warning-strong-foreground))'
       },
       recording: {
         DEFAULT: 'hsl(var(--recording))',

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -10,7 +10,12 @@ module.exports = {
   	extend: {
   		fontFamily: {
   			sans: [
-  				'var(--font-source-sans-3)'
+				'var(--font-source-sans-3, ui-sans-serif)',
+				'system-ui',
+				'-apple-system',
+				'BlinkMacSystemFont',
+				'Segoe UI',
+				'sans-serif'
   			]
   		},
   		colors: {
@@ -48,6 +53,26 @@ module.exports = {
   				DEFAULT: 'hsl(var(--destructive))',
   				foreground: 'hsl(var(--destructive-foreground))'
   			},
+      info: {
+        DEFAULT: 'hsl(var(--info))',
+        foreground: 'hsl(var(--info-foreground))'
+      },
+      success: {
+        DEFAULT: 'hsl(var(--success))',
+        foreground: 'hsl(var(--success-foreground))'
+      },
+      warning: {
+        DEFAULT: 'hsl(var(--warning))',
+        foreground: 'hsl(var(--warning-foreground))'
+      },
+      recording: {
+        DEFAULT: 'hsl(var(--recording))',
+        foreground: 'hsl(var(--recording-foreground))'
+      },
+      overlay: {
+        DEFAULT: 'hsl(var(--overlay))',
+        foreground: 'hsl(var(--overlay-foreground))'
+      },
   			chart: {
   				'1': 'hsl(var(--chart-1))',
   				'2': 'hsl(var(--chart-2))',

--- a/frontend/tests/fixture-contracts.spec.ts
+++ b/frontend/tests/fixture-contracts.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test } from './fixtures/tauri-fixtures';
+import type { Page } from '@playwright/test';
+
+function collectMissingFixtures(page: Page) {
+  const missingFixtures: string[] = [];
+
+  page.on('console', (message) => {
+    const text = message.text();
+    if (text.includes('[E2E fixture missing]')) {
+      missingFixtures.push(text);
+    }
+  });
+
+  page.on('pageerror', (error) => {
+    if (error.message.includes('[E2E fixture missing]')) {
+      missingFixtures.push(error.message);
+    }
+  });
+
+  return missingFixtures;
+}
+
+test('meeting fixtures render paginated transcripts and markdown summary', async ({
+  page,
+}) => {
+  const missingFixtures = collectMissingFixtures(page);
+
+  await page.goto('/meeting-details?id=theme-test-meeting');
+
+  await expect(
+    page.getByText('We approved the dark theme.', { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText('Use semantic tokens.', { exact: true })).toBeVisible();
+  expect(missingFixtures).toEqual([]);
+});
+
+test('onboarding fixtures keep the initial and download steps stable', async ({
+  page,
+}) => {
+  const missingFixtures = collectMissingFixtures(page);
+
+  await page.goto('/?__e2e=onboarding');
+
+  await expect(
+    page.getByRole('heading', { name: 'Welcome to Meetily' }),
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Get Started' }).click();
+  await expect(
+    page.getByRole('heading', { name: 'Setup Overview' }),
+  ).toBeVisible();
+  await page.getByRole('button', { name: "Let's Go" }).click();
+
+  await expect(
+    page.getByRole('heading', { name: 'Getting things ready' }),
+  ).toBeVisible();
+  await expect(page.getByText('Transcription Engine', { exact: true })).toBeVisible();
+  await expect(page.getByText('Summary Engine', { exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Continue' })).toBeEnabled();
+  expect(missingFixtures).toEqual([]);
+});
+
+test('built-in model fixtures expose ready and downloadable states', async ({
+  page,
+}) => {
+  const missingFixtures = collectMissingFixtures(page);
+
+  await page.goto('/settings');
+  await page.getByRole('tab', { name: 'Summary' }).click();
+
+  const readyModel = page
+    .getByText('Qwen 3.5 2B (Balanced)', { exact: true })
+    .locator('xpath=ancestor::div[contains(@class, "rounded-lg")][1]');
+  await expect(readyModel.getByText('Ready', { exact: true })).toBeVisible();
+
+  const downloadableModel = page
+    .getByText('Qwen 3.5 4B (High Quality)', { exact: true })
+    .locator('xpath=ancestor::div[contains(@class, "rounded-lg")][1]');
+  await expect(
+    downloadableModel.getByRole('button', { name: 'Download' }),
+  ).toBeVisible();
+
+  const readiness = await page.evaluate(async () => {
+    const invoke = (
+      window as typeof window & {
+        __TAURI_INTERNALS__: {
+          invoke: (command: string, payload?: Record<string, unknown>) => Promise<unknown>;
+        };
+      }
+    ).__TAURI_INTERNALS__.invoke;
+
+    return {
+      available: await invoke('builtin_ai_is_model_ready', {
+        modelName: 'qwen3.5:2b',
+      }),
+      unavailable: await invoke('builtin_ai_is_model_ready', {
+        modelName: 'qwen3.5:4b',
+      }),
+    };
+  });
+
+  expect(readiness).toEqual({
+    available: true,
+    unavailable: false,
+  });
+  expect(missingFixtures).toEqual([]);
+});
+
+test('unknown commands fail loudly instead of matching a prefix', async ({
+  page,
+}) => {
+  await page.goto('/');
+
+  const error = await page.evaluate(async () => {
+    const invoke = (
+      window as typeof window & {
+        __TAURI_INTERNALS__: {
+          invoke: (command: string) => Promise<unknown>;
+        };
+      }
+    ).__TAURI_INTERNALS__.invoke;
+
+    try {
+      await invoke('track_unexpected_theme_event');
+      return null;
+    } catch (caught) {
+      return String(caught);
+    }
+  });
+
+  expect(error).toContain('[E2E fixture missing] track_unexpected_theme_event');
+});

--- a/frontend/tests/fixtures/tauri-fixtures.ts
+++ b/frontend/tests/fixtures/tauri-fixtures.ts
@@ -1,15 +1,43 @@
 import { expect, test as base, type Page } from '@playwright/test';
 
+import { THEME_STORAGE_KEY } from '../../src/lib/theme';
+
 export const test = base;
-export { expect };
+export { expect, THEME_STORAGE_KEY };
 
 export async function setStoredTheme(
   page: Page,
   mode: 'light' | 'dark' | 'system',
 ) {
-  await page.addInitScript((value) => {
-    localStorage.setItem('themeMode', value);
-  }, mode);
+  await setRawStoredTheme(page, mode);
+}
+
+// Untyped variant for seeding invalid values in fallback tests.
+export async function setRawStoredTheme(page: Page, value: string) {
+  await page.addInitScript(
+    ([key, mode]) => {
+      localStorage.setItem(key, mode);
+    },
+    [THEME_STORAGE_KEY, value] as const,
+  );
+}
+
+export function lastNativeThemePayload(page: Page) {
+  return page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          __e2eTauriThemeCalls?: Array<{ theme?: string | null }>;
+        }
+      ).__e2eTauriThemeCalls?.at(-1)?.theme,
+  );
+}
+
+export async function expectLastNativeTheme(
+  page: Page,
+  theme: string | null | undefined,
+) {
+  await expect.poll(() => lastNativeThemePayload(page)).toBe(theme);
 }
 
 export async function expectNoHorizontalOverflow(page: Page) {

--- a/frontend/tests/fixtures/tauri-fixtures.ts
+++ b/frontend/tests/fixtures/tauri-fixtures.ts
@@ -1,0 +1,22 @@
+import { expect, test as base, type Page } from '@playwright/test';
+
+export const test = base;
+export { expect };
+
+export async function setStoredTheme(
+  page: Page,
+  mode: 'light' | 'dark' | 'system',
+) {
+  await page.addInitScript((value) => {
+    localStorage.setItem('themeMode', value);
+  }, mode);
+}
+
+export async function expectNoHorizontalOverflow(page: Page) {
+  const dimensions = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+
+  expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
+}

--- a/frontend/tests/theme-dark-surfaces.spec.ts
+++ b/frontend/tests/theme-dark-surfaces.spec.ts
@@ -1,0 +1,77 @@
+import {
+  expect,
+  expectNoHorizontalOverflow,
+  setStoredTheme,
+  test,
+} from './fixtures/tauri-fixtures';
+
+const routes = [
+  { path: '/', readyText: 'Welcome to meetily!' },
+  { path: '/settings', readyText: 'Settings' },
+  {
+    path: '/meeting-details?id=theme-test-meeting',
+    readyText: 'Theme Test Meeting',
+  },
+] as const;
+
+for (const route of routes) {
+  test(`dark theme avoids light app surfaces on ${route.path}`, async ({
+    page,
+  }) => {
+    await setStoredTheme(page, 'dark');
+
+    await page.goto(route.path);
+
+    await expect(page.locator('html')).toHaveClass(/dark/);
+    await expect(page.getByText(route.readyText).first()).toBeVisible();
+    await expectNoHorizontalOverflow(page);
+
+    const lightSurfaces = await page.evaluate(() => {
+      const appRoot = document.querySelector('main') ?? document.body;
+      const candidates = Array.from(
+        appRoot.querySelectorAll<HTMLElement>(
+          [
+            'aside',
+            'button',
+            'div',
+            'header',
+            'input',
+            'main',
+            'section',
+            'textarea',
+          ].join(','),
+        ),
+      );
+
+      return candidates
+        .filter((element) => {
+          const rect = element.getBoundingClientRect();
+          if (rect.width < 8 || rect.height < 8) return false;
+
+          const style = window.getComputedStyle(element);
+          if (style.visibility === 'hidden' || style.display === 'none') {
+            return false;
+          }
+
+          const match = style.backgroundColor.match(
+            /rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([0-9.]+))?\)/,
+          );
+          if (!match) return false;
+
+          const alpha = match[4] === undefined ? 1 : Number(match[4]);
+          if (alpha < 0.95) return false;
+
+          const [, red, green, blue] = match.map(Number);
+          return red >= 245 && green >= 245 && blue >= 245;
+        })
+        .slice(0, 10)
+        .map((element) => ({
+          className: element.className.toString(),
+          tagName: element.tagName,
+          text: element.textContent?.trim().slice(0, 80) ?? '',
+        }));
+    });
+
+    expect(lightSurfaces).toEqual([]);
+  });
+}

--- a/frontend/tests/theme-foundation.spec.ts
+++ b/frontend/tests/theme-foundation.spec.ts
@@ -1,0 +1,188 @@
+import { expect, test } from './fixtures/tauri-fixtures';
+
+test('applies stored dark mode before DOMContentLoaded', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('themeMode', 'dark');
+
+    const originalToggle = DOMTokenList.prototype.toggle;
+    DOMTokenList.prototype.toggle = function toggle(token, force) {
+      const result = originalToggle.call(this, token, force);
+      if (
+        token === 'dark' &&
+        force === true &&
+        this === document.documentElement?.classList
+      ) {
+        (
+          window as typeof window & {
+            __darkAppliedBeforeBody?: boolean;
+          }
+        ).__darkAppliedBeforeBody = document.body === null;
+      }
+      return result;
+    };
+  });
+
+  await page.goto('/settings');
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              __darkAppliedBeforeBody?: boolean;
+            }
+          ).__darkAppliedBeforeBody,
+      ),
+    )
+    .toBe(true);
+  await expect(page.locator('html')).toHaveClass(/dark/);
+});
+
+test('system mode follows the browser color scheme', async ({ page }) => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await page.addInitScript(() => localStorage.setItem('themeMode', 'system'));
+  await page.goto('/settings');
+  await expect(page.locator('html')).toHaveClass(/dark/);
+
+  await page.emulateMedia({ colorScheme: 'light' });
+  await expect(page.locator('html')).not.toHaveClass(/dark/);
+});
+
+test('clicking Dark persists the theme across reloads', async ({ page }) => {
+  await page.goto('/settings');
+
+  await page.getByRole('button', { name: 'Dark', exact: true }).click();
+
+  await expect(page.locator('html')).toHaveClass(/dark/);
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem('themeMode')))
+    .toBe('dark');
+
+  await page.reload();
+
+  await expect(page.locator('html')).toHaveClass(/dark/);
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem('themeMode')))
+    .toBe('dark');
+});
+
+test('syncs native Tauri theme payloads', async ({ page }) => {
+  await page.addInitScript(() => localStorage.removeItem('themeMode'));
+
+  await page.goto('/settings');
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              __e2eTauriThemeCalls?: Array<{ theme?: string | null }>;
+            }
+          ).__e2eTauriThemeCalls?.at(-1)?.theme,
+      ),
+    )
+    .toBe(null);
+
+  await page.getByRole('button', { name: 'Light', exact: true }).click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              __e2eTauriThemeCalls?: Array<{ theme?: string | null }>;
+            }
+          ).__e2eTauriThemeCalls?.at(-1)?.theme,
+      ),
+    )
+    .toBe('light');
+
+  await page.getByRole('button', { name: 'Dark', exact: true }).click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              __e2eTauriThemeCalls?: Array<{ theme?: string | null }>;
+            }
+          ).__e2eTauriThemeCalls?.at(-1)?.theme,
+      ),
+    )
+    .toBe('dark');
+
+  await page.getByRole('button', { name: 'System', exact: true }).click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              __e2eTauriThemeCalls?: Array<{ theme?: string | null }>;
+            }
+          ).__e2eTauriThemeCalls?.at(-1)?.theme,
+      ),
+    )
+    .toBe(null);
+});
+
+test('invalid stored theme falls back to the dark system theme', async ({
+  page,
+}) => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await page.addInitScript(() => localStorage.setItem('themeMode', 'sepia'));
+
+  await page.goto('/settings');
+
+  await expect(page.locator('html')).toHaveClass(/dark/);
+});
+
+test('unavailable theme storage falls back to system without blocking render', async ({
+  page,
+}) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await page.addInitScript(() => {
+    const originalGetItem = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key) {
+      if (key === 'themeMode') {
+        throw new DOMException('Theme storage unavailable', 'SecurityError');
+      }
+      return originalGetItem.call(this, key);
+    };
+  });
+
+  await page.goto('/settings');
+
+  await expect(page.getByRole('heading', { name: 'Appearance' })).toBeVisible();
+  await expect(page.locator('html')).toHaveClass(/dark/);
+  expect(pageErrors).toEqual([]);
+});
+
+test('selected theme still applies when theme storage writes fail', async ({
+  page,
+}) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await page.emulateMedia({ colorScheme: 'light' });
+  await page.addInitScript(() => {
+    const originalSetItem = Storage.prototype.setItem;
+    Storage.prototype.setItem = function setItem(key, value) {
+      if (key === 'themeMode') {
+        throw new DOMException('Theme storage unavailable', 'SecurityError');
+      }
+      return originalSetItem.call(this, key, value);
+    };
+  });
+
+  await page.goto('/settings');
+  await page.getByRole('button', { name: 'Dark', exact: true }).click();
+
+  await expect(page.locator('html')).toHaveClass(/dark/);
+  expect(pageErrors).toEqual([]);
+});

--- a/frontend/tests/theme-foundation.spec.ts
+++ b/frontend/tests/theme-foundation.spec.ts
@@ -1,9 +1,16 @@
-import { expect, test } from './fixtures/tauri-fixtures';
+import {
+  expect,
+  expectLastNativeTheme,
+  lastNativeThemePayload,
+  setRawStoredTheme,
+  setStoredTheme,
+  test,
+  THEME_STORAGE_KEY,
+} from './fixtures/tauri-fixtures';
 
 test('applies stored dark mode before DOMContentLoaded', async ({ page }) => {
+  await setStoredTheme(page, 'dark');
   await page.addInitScript(() => {
-    localStorage.setItem('themeMode', 'dark');
-
     const originalToggle = DOMTokenList.prototype.toggle;
     DOMTokenList.prototype.toggle = function toggle(token, force) {
       const result = originalToggle.call(this, token, force);
@@ -12,11 +19,16 @@ test('applies stored dark mode before DOMContentLoaded', async ({ page }) => {
         force === true &&
         this === document.documentElement?.classList
       ) {
-        (
-          window as typeof window & {
-            __darkAppliedBeforeBody?: boolean;
-          }
-        ).__darkAppliedBeforeBody = document.body === null;
+        const state = window as typeof window & {
+          __darkAppliedBeforeBody?: boolean;
+        };
+        // Latch on the FIRST dark application — the pre-hydration boot script.
+        // ConfigContext re-applies the class after hydration (when <body>
+        // exists); without this guard that later call overwrites the flag to
+        // false and the assertion races (and loses) under parallel load.
+        if (state.__darkAppliedBeforeBody === undefined) {
+          state.__darkAppliedBeforeBody = document.body === null;
+        }
       }
       return result;
     };
@@ -39,9 +51,41 @@ test('applies stored dark mode before DOMContentLoaded', async ({ page }) => {
   await expect(page.locator('html')).toHaveClass(/dark/);
 });
 
+test('appearance highlight matches the stored theme without hydration errors', async ({
+  page,
+}) => {
+  const errors: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(message.text());
+  });
+  page.on('pageerror', (error) => errors.push(error.message));
+
+  await setStoredTheme(page, 'dark');
+  await page.goto('/settings');
+
+  // The stored theme owns the highlight; System must not be stranded active.
+  await expect(page.getByRole('button', { name: 'Dark' })).toHaveClass(
+    /bg-background/,
+  );
+  await expect(page.getByRole('button', { name: 'System' })).not.toHaveClass(
+    /bg-background/,
+  );
+
+  // Let the ~2s startup update check fire so a missing updater fixture would
+  // surface as a console error.
+  await page.waitForTimeout(2600);
+
+  const relevant = errors.filter(
+    (text) => /did not match/.test(text) || /E2E fixture missing/.test(text),
+  );
+  expect(relevant, `unexpected console errors:\n${relevant.join('\n')}`).toEqual(
+    [],
+  );
+});
+
 test('system mode follows the browser color scheme', async ({ page }) => {
   await page.emulateMedia({ colorScheme: 'dark' });
-  await page.addInitScript(() => localStorage.setItem('themeMode', 'system'));
+  await setStoredTheme(page, 'system');
   await page.goto('/settings');
   await expect(page.locator('html')).toHaveClass(/dark/);
 
@@ -56,83 +100,49 @@ test('clicking Dark persists the theme across reloads', async ({ page }) => {
 
   await expect(page.locator('html')).toHaveClass(/dark/);
   await expect
-    .poll(() => page.evaluate(() => localStorage.getItem('themeMode')))
+    .poll(() =>
+      page.evaluate((key) => localStorage.getItem(key), THEME_STORAGE_KEY),
+    )
     .toBe('dark');
 
   await page.reload();
 
   await expect(page.locator('html')).toHaveClass(/dark/);
   await expect
-    .poll(() => page.evaluate(() => localStorage.getItem('themeMode')))
+    .poll(() =>
+      page.evaluate((key) => localStorage.getItem(key), THEME_STORAGE_KEY),
+    )
     .toBe('dark');
 });
 
 test('syncs native Tauri theme payloads', async ({ page }) => {
-  await page.addInitScript(() => localStorage.removeItem('themeMode'));
+  await page.addInitScript(
+    (key) => localStorage.removeItem(key),
+    THEME_STORAGE_KEY,
+  );
 
   await page.goto('/settings');
+  await expect(page.getByRole('heading', { name: 'Appearance' })).toBeVisible();
 
-  await expect
-    .poll(() =>
-      page.evaluate(
-        () =>
-          (
-            window as typeof window & {
-              __e2eTauriThemeCalls?: Array<{ theme?: string | null }>;
-            }
-          ).__e2eTauriThemeCalls?.at(-1)?.theme,
-      ),
-    )
-    .toBe(null);
+  // The default 'system' mode is Tauri's native default, so startup issues no
+  // redundant set_app_theme call.
+  expect(await lastNativeThemePayload(page)).toBeUndefined();
 
   await page.getByRole('button', { name: 'Light', exact: true }).click();
-  await expect
-    .poll(() =>
-      page.evaluate(
-        () =>
-          (
-            window as typeof window & {
-              __e2eTauriThemeCalls?: Array<{ theme?: string | null }>;
-            }
-          ).__e2eTauriThemeCalls?.at(-1)?.theme,
-      ),
-    )
-    .toBe('light');
+  await expectLastNativeTheme(page, 'light');
 
   await page.getByRole('button', { name: 'Dark', exact: true }).click();
-  await expect
-    .poll(() =>
-      page.evaluate(
-        () =>
-          (
-            window as typeof window & {
-              __e2eTauriThemeCalls?: Array<{ theme?: string | null }>;
-            }
-          ).__e2eTauriThemeCalls?.at(-1)?.theme,
-      ),
-    )
-    .toBe('dark');
+  await expectLastNativeTheme(page, 'dark');
 
   await page.getByRole('button', { name: 'System', exact: true }).click();
-  await expect
-    .poll(() =>
-      page.evaluate(
-        () =>
-          (
-            window as typeof window & {
-              __e2eTauriThemeCalls?: Array<{ theme?: string | null }>;
-            }
-          ).__e2eTauriThemeCalls?.at(-1)?.theme,
-      ),
-    )
-    .toBe(null);
+  await expectLastNativeTheme(page, null);
 });
 
 test('invalid stored theme falls back to the dark system theme', async ({
   page,
 }) => {
   await page.emulateMedia({ colorScheme: 'dark' });
-  await page.addInitScript(() => localStorage.setItem('themeMode', 'sepia'));
+  await setRawStoredTheme(page, 'sepia');
 
   await page.goto('/settings');
 
@@ -146,15 +156,15 @@ test('unavailable theme storage falls back to system without blocking render', a
   page.on('pageerror', (error) => pageErrors.push(error.message));
 
   await page.emulateMedia({ colorScheme: 'dark' });
-  await page.addInitScript(() => {
+  await page.addInitScript((themeKey) => {
     const originalGetItem = Storage.prototype.getItem;
     Storage.prototype.getItem = function getItem(key) {
-      if (key === 'themeMode') {
+      if (key === themeKey) {
         throw new DOMException('Theme storage unavailable', 'SecurityError');
       }
       return originalGetItem.call(this, key);
     };
-  });
+  }, THEME_STORAGE_KEY);
 
   await page.goto('/settings');
 
@@ -170,15 +180,15 @@ test('selected theme still applies when theme storage writes fail', async ({
   page.on('pageerror', (error) => pageErrors.push(error.message));
 
   await page.emulateMedia({ colorScheme: 'light' });
-  await page.addInitScript(() => {
+  await page.addInitScript((themeKey) => {
     const originalSetItem = Storage.prototype.setItem;
     Storage.prototype.setItem = function setItem(key, value) {
-      if (key === 'themeMode') {
+      if (key === themeKey) {
         throw new DOMException('Theme storage unavailable', 'SecurityError');
       }
       return originalSetItem.call(this, key, value);
     };
-  });
+  }, THEME_STORAGE_KEY);
 
   await page.goto('/settings');
   await page.getByRole('button', { name: 'Dark', exact: true }).click();

--- a/frontend/tests/theme-primitives.spec.ts
+++ b/frontend/tests/theme-primitives.spec.ts
@@ -1,0 +1,269 @@
+import { expect, test } from './fixtures/tauri-fixtures';
+import type { Page } from '@playwright/test';
+
+import { Alert } from '../src/components/ui/alert';
+
+type RGB = [number, number, number];
+type RGBA = [number, number, number, number];
+type ThemeMode = 'light' | 'dark';
+type AlertStatus = 'info' | 'success' | 'warning' | 'destructive';
+
+const solidStatuses = ['info', 'success', 'warning', 'destructive', 'recording'] as const;
+const alertStatuses: AlertStatus[] = [
+  'info',
+  'success',
+  'warning',
+  'destructive',
+];
+
+function getAlertClassName(variant: AlertStatus) {
+  const alertRender = Alert as unknown as {
+    render: (
+      props: { variant: AlertStatus },
+      ref: null,
+    ) => { props: { className: string } };
+  };
+
+  return alertRender.render({ variant }, null).props.className;
+}
+
+function luminance([red, green, blue]: RGB) {
+  const channels = [red, green, blue].map((channel) => {
+    const value = channel / 255;
+    return value <= 0.03928
+      ? value / 12.92
+      : Math.pow((value + 0.055) / 1.055, 2.4);
+  });
+
+  return (
+    0.2126 * channels[0] +
+    0.7152 * channels[1] +
+    0.0722 * channels[2]
+  );
+}
+
+function contrastRatio(first: RGB, second: RGB) {
+  const lighter = Math.max(luminance(first), luminance(second));
+  const darker = Math.min(luminance(first), luminance(second));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function parseColor(value: string): RGBA {
+  const channels = value.match(/[\d.]+/g)?.map(Number) ?? [];
+  if (channels.length < 3) {
+    throw new Error(`Unable to parse color: ${value}`);
+  }
+
+  return [
+    channels[0],
+    channels[1],
+    channels[2],
+    channels.length > 3 ? channels[3] : 1,
+  ];
+}
+
+function compositeColor(foreground: RGBA, background: RGB): RGB {
+  const [red, green, blue, alpha] = foreground;
+  return [
+    Math.round(red * alpha + background[0] * (1 - alpha)),
+    Math.round(green * alpha + background[1] * (1 - alpha)),
+    Math.round(blue * alpha + background[2] * (1 - alpha)),
+  ];
+}
+
+async function openSettings(page: Page, mode: ThemeMode) {
+  await page.addInitScript((value) => {
+    localStorage.setItem('themeMode', value);
+  }, mode);
+  await page.goto('/settings');
+}
+
+for (const mode of ['light', 'dark'] as const) {
+  test(`solid status tokens meet text contrast in ${mode} mode`, async ({
+    page,
+  }) => {
+    await openSettings(page, mode);
+
+    const pairs = await page.evaluate((statuses) => {
+      const probe = document.createElement('div');
+      document.body.appendChild(probe);
+
+      const readToken = (token: string) => {
+        probe.style.color = `hsl(var(--${token}))`;
+        const color = getComputedStyle(probe).color.match(/\d+/g);
+        return color?.slice(0, 3).map(Number) ?? [];
+      };
+
+      const result = statuses.map((status) => ({
+        status,
+        background: readToken(status),
+        foreground: readToken(`${status}-foreground`),
+      }));
+
+      probe.remove();
+      return result;
+    }, solidStatuses);
+
+    for (const pair of pairs) {
+      expect(pair.background, `${pair.status} background token`).toHaveLength(3);
+      expect(pair.foreground, `${pair.status} foreground token`).toHaveLength(3);
+      expect(
+        contrastRatio(pair.background as RGB, pair.foreground as RGB),
+        `${pair.status} foreground contrast in ${mode} mode`,
+      ).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  test(`alert variants meet non-text contrast in ${mode} mode`, async ({
+    page,
+  }) => {
+    await openSettings(page, mode);
+
+    const variants = alertStatuses.map((status) => ({
+      status,
+      className: getAlertClassName(status),
+    }));
+
+    const measurements = await page.evaluate((alertVariants) => {
+      const container = document.createElement('section');
+      document.body.appendChild(container);
+
+      const bodyBackground = getComputedStyle(document.body).backgroundColor;
+
+      return alertVariants.map(({ status, className }) => {
+        const alert = document.createElement('div');
+        alert.dataset.alertStatus = status;
+        alert.className = className;
+
+        const icon = document.createElementNS(
+          'http://www.w3.org/2000/svg',
+          'svg',
+        );
+        icon.dataset.alertIcon = status;
+        alert.appendChild(icon);
+        container.appendChild(alert);
+
+        const alertStyle = getComputedStyle(alert);
+        return {
+          status,
+          bodyBackground,
+          alertBackground: alertStyle.backgroundColor,
+          boundaryColor: alertStyle.borderTopColor,
+          stripeColor: alertStyle.borderLeftColor,
+          stripeWidth: alertStyle.borderLeftWidth,
+          iconColor: getComputedStyle(icon).color,
+        };
+      });
+    }, variants);
+
+    for (const measurement of measurements) {
+      const bodyBackground = parseColor(measurement.bodyBackground);
+      const bodyRgb = bodyBackground.slice(0, 3) as RGB;
+      const alertBackground = compositeColor(
+        parseColor(measurement.alertBackground),
+        bodyRgb,
+      );
+      const iconColor = compositeColor(
+        parseColor(measurement.iconColor),
+        alertBackground,
+      );
+      const boundaryColor = compositeColor(
+        parseColor(measurement.boundaryColor),
+        bodyRgb,
+      );
+      const stripeColor = compositeColor(
+        parseColor(measurement.stripeColor),
+        bodyRgb,
+      );
+
+      expect(
+        contrastRatio(iconColor, alertBackground),
+        `${measurement.status} icon contrast in ${mode} mode`,
+      ).toBeGreaterThanOrEqual(3);
+      expect(
+        contrastRatio(boundaryColor, bodyRgb),
+        `${measurement.status} boundary contrast in ${mode} mode`,
+      ).toBeGreaterThanOrEqual(3);
+      expect(measurement.stripeWidth).toBe('4px');
+      expect(
+        contrastRatio(stripeColor, bodyRgb),
+        `${measurement.status} stripe contrast in ${mode} mode`,
+      ).toBeGreaterThanOrEqual(3);
+    }
+  });
+}
+
+test('cards, dialogs, and popovers are elevated above the dark page background', async ({
+  page,
+}) => {
+  await openSettings(page, 'dark');
+
+  const pageBackground = await page.locator('body').evaluate(
+    (element) => getComputedStyle(element).backgroundColor,
+  );
+  const appearanceCard = page
+    .getByRole('heading', { name: 'Appearance' })
+    .locator('..')
+    .locator('..')
+    .locator('..');
+
+  await expect(appearanceCard).not.toHaveCSS('background-color', pageBackground);
+  await expect(appearanceCard).toHaveCSS(
+    'border-top-color',
+    'rgb(38, 38, 38)',
+  );
+
+  await page.getByRole('tab', { name: 'Summary' }).click();
+  await page.locator('button[role="combobox"]').first().click();
+  const popover = page.getByRole('listbox');
+
+  await expect(popover).toBeVisible();
+  await expect(popover).not.toHaveCSS('background-color', pageBackground);
+  await expect(popover).toHaveCSS('border-top-color', 'rgb(38, 38, 38)');
+
+  await page.keyboard.press('Escape');
+  await page.locator('button[title="About Meetily"]').click();
+  const dialog = page.getByRole('dialog').filter({
+    hasText: 'What makes Meetily different',
+  });
+
+  await expect(dialog).toBeVisible();
+  await expect(dialog).not.toHaveCSS('background-color', pageBackground);
+  await expect(dialog).toHaveCSS('color', 'rgb(250, 250, 250)');
+});
+
+test('destructive text remains readable on dark semantic surfaces', async ({
+  page,
+}) => {
+  await openSettings(page, 'dark');
+
+  const measurements = await page.evaluate(() => {
+    const bodyBackground = getComputedStyle(document.body).backgroundColor;
+    const probe = document.createElement('div');
+    probe.className = 'bg-card text-destructive';
+    probe.textContent = 'Destructive status text';
+    document.body.appendChild(probe);
+
+    const style = getComputedStyle(probe);
+    const result = {
+      bodyBackground,
+      cardBackground: style.backgroundColor,
+      destructiveText: style.color,
+    };
+
+    probe.remove();
+    return result;
+  });
+
+  const bodyRgb = parseColor(measurements.bodyBackground).slice(0, 3) as RGB;
+  const cardRgb = compositeColor(parseColor(measurements.cardBackground), bodyRgb);
+  const destructiveRgb = compositeColor(
+    parseColor(measurements.destructiveText),
+    cardRgb,
+  );
+
+  expect(
+    contrastRatio(destructiveRgb, cardRgb),
+    'destructive text contrast on dark card',
+  ).toBeGreaterThanOrEqual(4.5);
+});

--- a/frontend/tests/theme-primitives.spec.ts
+++ b/frontend/tests/theme-primitives.spec.ts
@@ -1,7 +1,7 @@
-import { expect, test } from './fixtures/tauri-fixtures';
+import { expect, setStoredTheme, test } from './fixtures/tauri-fixtures';
 import type { Page } from '@playwright/test';
 
-import { Alert } from '../src/components/ui/alert';
+import { alertVariants } from '../src/components/ui/alert';
 
 type RGB = [number, number, number];
 type RGBA = [number, number, number, number];
@@ -17,14 +17,7 @@ const alertStatuses: AlertStatus[] = [
 ];
 
 function getAlertClassName(variant: AlertStatus) {
-  const alertRender = Alert as unknown as {
-    render: (
-      props: { variant: AlertStatus },
-      ref: null,
-    ) => { props: { className: string } };
-  };
-
-  return alertRender.render({ variant }, null).props.className;
+  return alertVariants({ variant });
 }
 
 function luminance([red, green, blue]: RGB) {
@@ -72,9 +65,7 @@ function compositeColor(foreground: RGBA, background: RGB): RGB {
 }
 
 async function openSettings(page: Page, mode: ThemeMode) {
-  await page.addInitScript((value) => {
-    localStorage.setItem('themeMode', value);
-  }, mode);
+  await setStoredTheme(page, mode);
   await page.goto('/settings');
 }
 
@@ -110,6 +101,42 @@ for (const mode of ['light', 'dark'] as const) {
       expect(
         contrastRatio(pair.background as RGB, pair.foreground as RGB),
         `${pair.status} foreground contrast in ${mode} mode`,
+      ).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  test(`status text tokens meet text contrast on the page background in ${mode} mode`, async ({
+    page,
+  }) => {
+    await openSettings(page, mode);
+
+    const measurements = await page.evaluate((statuses) => {
+      const probe = document.createElement('div');
+      document.body.appendChild(probe);
+
+      const readToken = (token: string) => {
+        probe.style.color = `hsl(var(--${token}))`;
+        const color = getComputedStyle(probe).color.match(/\d+/g);
+        return color?.slice(0, 3).map(Number) ?? [];
+      };
+
+      const result = statuses.map((status) => ({
+        status,
+        text: readToken(`${status}-text`),
+      }));
+      const background = getComputedStyle(document.body).backgroundColor;
+
+      probe.remove();
+      return { result, background };
+    }, ['info', 'success', 'warning'] as const);
+
+    const backgroundRgb = parseColor(measurements.background).slice(0, 3) as RGB;
+
+    for (const { status, text } of measurements.result) {
+      expect(text, `${status}-text token`).toHaveLength(3);
+      expect(
+        contrastRatio(text as RGB, backgroundRgb),
+        `${status}-text contrast on page background in ${mode} mode`,
       ).toBeGreaterThanOrEqual(4.5);
     }
   });

--- a/frontend/tests/theme-shell.spec.ts
+++ b/frontend/tests/theme-shell.spec.ts
@@ -1,6 +1,7 @@
 import {
   expect,
   expectNoHorizontalOverflow,
+  setStoredTheme,
   test,
 } from './fixtures/tauri-fixtures';
 
@@ -8,9 +9,7 @@ for (const mode of ['light', 'dark'] as const) {
   test(`home shell renders semantic surfaces in ${mode} mode`, async ({
     page,
   }) => {
-    await page.addInitScript((value) => {
-      localStorage.setItem('themeMode', value);
-    }, mode);
+    await setStoredTheme(page, mode);
 
     await page.goto('/');
     const toggle = page.getByRole('button', { name: 'Expand sidebar' });

--- a/frontend/tests/theme-shell.spec.ts
+++ b/frontend/tests/theme-shell.spec.ts
@@ -1,0 +1,40 @@
+import {
+  expect,
+  expectNoHorizontalOverflow,
+  test,
+} from './fixtures/tauri-fixtures';
+
+for (const mode of ['light', 'dark'] as const) {
+  test(`home shell renders semantic surfaces in ${mode} mode`, async ({
+    page,
+  }) => {
+    await page.addInitScript((value) => {
+      localStorage.setItem('themeMode', value);
+    }, mode);
+
+    await page.goto('/');
+    const toggle = page.getByRole('button', { name: 'Expand sidebar' });
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+
+    await expect(page.getByText('Theme Test Meeting', { exact: true })).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Start Recording' }),
+    ).toBeVisible();
+    await expect(
+      page.getByPlaceholder('Search meeting content...'),
+    ).toBeVisible();
+
+    const sidebar = page.getByTestId('app-sidebar');
+    await expect(sidebar).toHaveCSS(
+      'background-color',
+      mode === 'dark' ? 'rgb(18, 18, 18)' : 'rgb(255, 255, 255)',
+    );
+    await expect(sidebar).toHaveCSS(
+      'border-right-color',
+      mode === 'dark' ? 'rgb(38, 38, 38)' : 'rgb(229, 229, 229)',
+    );
+
+    await expectNoHorizontalOverflow(page);
+  });
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -25,6 +25,7 @@
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": [
     "node_modules",
-    "src-tauri"
+    "src-tauri",
+    "tests"
   ]
 }

--- a/frontend/tsconfig.tests.json
+++ b/frontend/tsconfig.tests.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "next-env.d.ts",
+    "tests/**/*.spec.ts",
+    "tests/fixtures/**/*.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
+  "exclude": ["node_modules", "src-tauri"]
+}


### PR DESCRIPTION
## Summary

Fixes #554. Adds a persisted tri-state appearance preference — **System / Light / Dark** — for the Tauri app.

- Defaults to System and follows live `prefers-color-scheme`; applies the effective theme **before hydration** to avoid a light flash.
- Syncs the native window chrome via `setTheme(null | "light" | "dark")` and removes the forced `"theme": "Light"` config.
- Converts the app shell, settings, dialogs, editor, transcript, summary, and onboarding surfaces to **semantic theme tokens**, with a static audit that fails on hard-coded light-only colors.
- **Accessibility:** status *fill* tokens pass WCAG AA as text on light surfaces — added accessible `text-{status}-text` tokens (dark ink in light mode, light in dark) and remapped ~130 usages, with a Playwright contrast guard.

## Validation

Theme audit, `tsc`, `next build`, `cargo check`, and the Playwright theme suite (25/25) pass; 18 light/dark screenshots across home / settings / details with no overflow or console errors. Existing **pnpm 8** build workflows are unaffected — `pnpm@8 install` still succeeds and overrides stay in `package.json`.
