### PR TITLE
Fix: Typo in macOS custom templates path (Meetily → meetily) in README (Auto-Generated)

### DIFF
--- a/frontend/src-tauri/templates/README.md
+++ b/frontend/src-tauri/templates/README.md
@@ -47,9 +47,9 @@ Each template JSON file follows this schema:
 
 Users can add custom templates to the application data directory:
 
-- **macOS**: `~/Library/Application Support/Meetily/templates/`
-- **Windows**: `%APPDATA%\Meetily\templates\`
-- **Linux**: `~/.config/Meetily/templates/`
+- **macOS**: `~/Library/Application Support/meetily/templates/`
+- **Windows**: `%APPDATA%\meetily\templates\`
+- **Linux**: `~/.config/meetily/templates/`
 
 Custom templates override built-in templates with the same filename.
 


### PR DESCRIPTION
This PR automatically resolves #458 based on the issue description. 

**Intent:** TYPO_CORRECTION
**Instructions:** Correct the path in the README documentation from 'Meetily' to 'meetily'.

*Generated by DevRel Agent using GPT-4o-mini via GitHub Models.*