### PR TITLE
feat: add Persian (Farsi) language support

### DIFF
--- a/frontend/src-tauri/src/summary/language_detection.rs
+++ b/frontend/src-tauri/src/summary/language_detection.rs
@@ -133,6 +133,7 @@ fn summary_code_from_whatlang(lang: Lang) -> Option<&'static str> {
         Lang::Nld => Some("nl"),
         Lang::Pol => Some("pl"),
         Lang::Ara => Some("ar"),
+        Lang::Pes => Some("fa"),
         Lang::Hin => Some("hi"),
         Lang::Tam => Some("ta"),
         Lang::Tur => Some("tr"),

--- a/frontend/src-tauri/src/summary/processor.rs
+++ b/frontend/src-tauri/src/summary/processor.rs
@@ -101,6 +101,7 @@ pub(crate) fn language_name_from_code(code: &str) -> Option<&'static str> {
         "nl" => Some("Dutch"),
         "pl" => Some("Polish"),
         "ar" => Some("Arabic"),
+        "fa" => Some("Persian"),
         "hi" => Some("Hindi"),
         "ta" => Some("Tamil"),
         "tr" => Some("Turkish"),

--- a/frontend/src/components/LanguageSelection.tsx
+++ b/frontend/src/components/LanguageSelection.tsx
@@ -27,7 +27,6 @@ const LANGUAGES: Language[] = [
   { code: 'ca', name: 'Catalan' },
   { code: 'nl', name: 'Dutch' },
   { code: 'ar', name: 'Arabic' },
-  { code: 'fa', name: 'Persian' },
   { code: 'sv', name: 'Swedish' },
   { code: 'it', name: 'Italian' },
   { code: 'id', name: 'Indonesian' },

--- a/frontend/src/components/LanguageSelection.tsx
+++ b/frontend/src/components/LanguageSelection.tsx
@@ -27,6 +27,7 @@ const LANGUAGES: Language[] = [
   { code: 'ca', name: 'Catalan' },
   { code: 'nl', name: 'Dutch' },
   { code: 'ar', name: 'Arabic' },
+  { code: 'fa', name: 'Persian' },
   { code: 'sv', name: 'Swedish' },
   { code: 'it', name: 'Italian' },
   { code: 'id', name: 'Indonesian' },

--- a/frontend/src/constants/languages.ts
+++ b/frontend/src/constants/languages.ts
@@ -16,6 +16,7 @@ export const LANGUAGES = [
   { code: 'ca', name: 'Catalan' },
   { code: 'nl', name: 'Dutch' },
   { code: 'ar', name: 'Arabic' },
+  { code: 'fa', name: 'Persian' },
   { code: 'sv', name: 'Swedish' },
   { code: 'it', name: 'Italian' },
   { code: 'id', name: 'Indonesian' },

--- a/frontend/src/lib/summary-languages.ts
+++ b/frontend/src/lib/summary-languages.ts
@@ -23,6 +23,7 @@ export const LANGUAGE_OPTIONS: LanguageOption[] = [
   { code: 'nl', label: 'Dutch' },
   { code: 'pl', label: 'Polish' },
   { code: 'ar', label: 'Arabic' },
+  { code: 'fa', label: 'Persian' },
   { code: 'hi', label: 'Hindi' },
   { code: 'ta', label: 'Tamil' },
   { code: 'tr', label: 'Turkish' },


### PR DESCRIPTION
﻿## Description

Adds Persian (fa) to the transcription and summary language options.

**Transcription**: adds `fa` to the shared `constants/languages.ts` list used by the import/retranscribe dialogs, so Whisper transcribes Persian natively instead of falling back to the auto-translate default. The Settings picker (`LanguageSelection.tsx`) already listed Persian; this PR also removes a duplicate Persian entry there so the dropdown does not render it twice. The engine passes the language code straight to whisper.cpp and all downloadable models are multilingual, so no engine or model changes are needed.

**Summary**: maps `fa` to Persian in `language_name_from_code` so the summary translation pass and the summary-language validator accept it, adds Persian to `LANGUAGE_OPTIONS`, and maps whatlang `Lang::Pes` to `fa` so a Persian transcript auto-selects a Persian summary.

Net change: 4 insertions, 1 deletion.

## Related Issue

None yet; happy to open one if maintainers prefer.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] All tests pass

Manual testing: built and installed the Windows NSIS bundle (CPU and Vulkan) from this branch and verified that Persian appears and is selectable in the transcription language pickers, that recording Persian speech with the large-v3 model produces a Persian transcript rather than an English translation, and that the summary language picker offers Persian and produces a summary written in Persian (local GGUF model via llama-helper).

## Documentation

- [ ] Documentation updated
- [x] No documentation needed

## Checklist

- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code (none needed; data-only additions)
- [ ] Updated README if needed (not applicable)
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)

Not applicable; the change adds entries to existing dropdowns.

## Additional Notes

The five call sites were chosen so that Persian works end to end: transcription picker, retranscribe/import picker, summary language validator, summary picker, and automatic language detection of the transcript.
