### PR TITLE
feat: Add manual transcription language selection (Fixes #581)

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -68,6 +68,19 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
+useEffect(() => {
+    const hydrateLanguagePreference = async () => {
+      try {
+        const savedLanguage = localStorage.getItem("meetily_transcription_language");
+        if (savedLanguage) {
+          await invoke("set_language_preference", { language: savedLanguage });
+        }
+      } catch (error) {
+        console.error("Failed to hydrate language preference on startup:", error);
+      }
+    };
+    hydrateLanguagePreference();
+  }, []);
   const [showOnboarding, setShowOnboarding] = useState(false)
   const [onboardingCompleted, setOnboardingCompleted] = useState(false)
 

--- a/frontend/src/components/TranscriptSettings.tsx
+++ b/frontend/src/components/TranscriptSettings.tsx
@@ -38,6 +38,22 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
             setApiKey(null);
         }
     }, [transcriptModelConfig.provider]);
+const [transcriptionLanguage, setTranscriptionLanguage] = useState<string>("auto");
+
+    useEffect(() => {
+        const savedLanguage = localStorage.getItem("meetily_transcription_language") || "auto";
+        setTranscriptionLanguage(savedLanguage);
+    }, []);
+
+    const handleLanguageChange = async (newLanguage: string) => {
+        setTranscriptionLanguage(newLanguage);
+        localStorage.setItem("meetily_transcription_language", newLanguage);
+        try {
+            await invoke("set_language_preference", { language: newLanguage });
+        } catch (error) {
+            console.error("Failed to set language preference:", error);
+        }
+    };
 
     const fetchApiKey = async (provider: string) => {
         try {
@@ -97,6 +113,28 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
 
     return (
         <div>
+            <div className="flex flex-col space-y-3 p-4 border rounded-lg bg-card mb-4">
+                <div>
+                    <h3 className="text-lg font-medium leading-none mb-2">Transcription Language</h3>
+                    <p className="text-sm text-muted-foreground">
+                        Lock the language to disable per-segment auto-detection.
+                    </p>
+                </div>
+                
+                <Select value={transcriptionLanguage} onValueChange={handleLanguageChange}>
+                    <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Select a language" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="auto">Auto-Detect (Default)</SelectItem>
+                        <SelectItem value="auto-translate">Auto-Translate to English</SelectItem>
+                        <SelectItem value="en">English</SelectItem>
+                        <SelectItem value="ru">Russian</SelectItem>
+                        <SelectItem value="hi">Hindi</SelectItem>
+                        <SelectItem value="es">Spanish</SelectItem>
+                    </SelectContent>
+                </Select>
+            </div>
             <div>
                 {/* <div className="flex justify-between items-center mb-4">
                     <h3 className="text-lg font-semibold text-gray-900">Transcript Settings</h3>

--- a/frontend/src/components/TranscriptSettings.tsx
+++ b/frontend/src/components/TranscriptSettings.tsx
@@ -10,263 +10,261 @@ import { ParakeetModelManager } from './ParakeetModelManager';
 
 
 export interface TranscriptModelProps {
-    provider: 'localWhisper' | 'parakeet' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
-    model: string;
-    apiKey?: string | null;
+    provider: 'localWhisper' | 'parakeet' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
+    model: string;
+    apiKey?: string | null;
 }
 
 export interface TranscriptSettingsProps {
-    transcriptModelConfig: TranscriptModelProps;
-    setTranscriptModelConfig: (config: TranscriptModelProps) => void;
-    onModelSelect?: () => void;
+    transcriptModelConfig: TranscriptModelProps;
+    setTranscriptModelConfig: (config: TranscriptModelProps) => void;
+    onModelSelect?: () => void;
 }
 
 export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelConfig, onModelSelect }: TranscriptSettingsProps) {
-    const [apiKey, setApiKey] = useState<string | null>(transcriptModelConfig.apiKey || null);
-    const [showApiKey, setShowApiKey] = useState<boolean>(false);
-    const [isApiKeyLocked, setIsApiKeyLocked] = useState<boolean>(true);
-    const [isLockButtonVibrating, setIsLockButtonVibrating] = useState<boolean>(false);
-    const [uiProvider, setUiProvider] = useState<TranscriptModelProps['provider']>(transcriptModelConfig.provider);
+    const [apiKey, setApiKey] = useState<string | null>(transcriptModelConfig.apiKey || null);
+    const [showApiKey, setShowApiKey] = useState<boolean>(false);
+    const [isApiKeyLocked, setIsApiKeyLocked] = useState<boolean>(true);
+    const [isLockButtonVibrating, setIsLockButtonVibrating] = useState<boolean>(false);
+    const [uiProvider, setUiProvider] = useState<TranscriptModelProps['provider']>(transcriptModelConfig.provider);
 
-    // Sync uiProvider when backend config changes (e.g., after model selection or initial load)
-    useEffect(() => {
-        setUiProvider(transcriptModelConfig.provider);
-    }, [transcriptModelConfig.provider]);
+    // Sync uiProvider when backend config changes (e.g., after model selection or initial load)
+    useEffect(() => {
+        setUiProvider(transcriptModelConfig.provider);
+    }, [transcriptModelConfig.provider]);
 
-    useEffect(() => {
-        if (transcriptModelConfig.provider === 'localWhisper' || transcriptModelConfig.provider === 'parakeet') {
-            setApiKey(null);
-        }
-    }, [transcriptModelConfig.provider]);
+    useEffect(() => {
+        if (transcriptModelConfig.provider === 'localWhisper' || transcriptModelConfig.provider === 'parakeet') {
+            setApiKey(null);
+        }
+    }, [transcriptModelConfig.provider]);
 const [transcriptionLanguage, setTranscriptionLanguage] = useState<string>("auto");
 
-    useEffect(() => {
-        const savedLanguage = localStorage.getItem("meetily_transcription_language") || "auto";
-        setTranscriptionLanguage(savedLanguage);
-    }, []);
+    useEffect(() => {
+        const savedLanguage = localStorage.getItem("meetily_transcription_language") || "auto";
+        setTranscriptionLanguage(savedLanguage);
+    }, []);
 
-    const handleLanguageChange = async (newLanguage: string) => {
-        setTranscriptionLanguage(newLanguage);
-        localStorage.setItem("meetily_transcription_language", newLanguage);
-        try {
-            await invoke("set_language_preference", { language: newLanguage });
-        } catch (error) {
-            console.error("Failed to set language preference:", error);
-        }
-    };
+    const handleLanguageChange = async (newLanguage: string) => {
+        setTranscriptionLanguage(newLanguage);
+        localStorage.setItem("meetily_transcription_language", newLanguage);
+        try {
+            await invoke("set_language_preference", { language: newLanguage });
+        } catch (error) {
+            console.error("Failed to set language preference:", error);
+        }
+    };
 
-    const fetchApiKey = async (provider: string) => {
-        try {
+    const fetchApiKey = async (provider: string) => {
+        try {
 
-            const data = await invoke('api_get_transcript_api_key', { provider }) as string;
+            const data = await invoke('api_get_transcript_api_key', { provider }) as string;
 
-            setApiKey(data || '');
-        } catch (err) {
-            console.error('Error fetching API key:', err);
-            setApiKey(null);
-        }
-    };
-    const modelOptions = {
-        localWhisper: [], // Model selection handled by ModelManager component
-        parakeet: [], // Model selection handled by ParakeetModelManager component
-        deepgram: ['nova-2-phonecall'],
-        elevenLabs: ['eleven_multilingual_v2'],
-        groq: ['llama-3.3-70b-versatile'],
-        openai: ['gpt-4o'],
-    };
-    const requiresApiKey = transcriptModelConfig.provider === 'deepgram' || transcriptModelConfig.provider === 'elevenLabs' || transcriptModelConfig.provider === 'openai' || transcriptModelConfig.provider === 'groq';
+            setApiKey(data || '');
+        } catch (err) {
+            console.error('Error fetching API key:', err);
+            setApiKey(null);
+        }
+    };
+    const modelOptions = {
+        localWhisper: [], // Model selection handled by ModelManager component
+        parakeet: [], // Model selection handled by ParakeetModelManager component
+        deepgram: ['nova-2-phonecall'],
+        elevenLabs: ['eleven_multilingual_v2'],
+        groq: ['llama-3.3-70b-versatile'],
+        openai: ['gpt-4o'],
+    };
+    const requiresApiKey = transcriptModelConfig.provider === 'deepgram' || transcriptModelConfig.provider === 'elevenLabs' || transcriptModelConfig.provider === 'openai' || transcriptModelConfig.provider === 'groq';
 
-    const handleInputClick = () => {
-        if (isApiKeyLocked) {
-            setIsLockButtonVibrating(true);
-            setTimeout(() => setIsLockButtonVibrating(false), 500);
-        }
-    };
+    const handleInputClick = () => {
+        if (isApiKeyLocked) {
+            setIsLockButtonVibrating(true);
+            setTimeout(() => setIsLockButtonVibrating(false), 500);
+        }
+    };
 
-    const handleWhisperModelSelect = (modelName: string) => {
-        // Always update config when model is selected, regardless of current provider
-        // This ensures the model is set when user switches back
-        setTranscriptModelConfig({
-            ...transcriptModelConfig,
-            provider: 'localWhisper', // Ensure provider is set correctly
-            model: modelName
-        });
-        // Close modal after selection
-        if (onModelSelect) {
-            onModelSelect();
-        }
-    };
+    const handleWhisperModelSelect = (modelName: string) => {
+        // Always update config when model is selected, regardless of current provider
+        // This ensures the model is set when user switches back
+        setTranscriptModelConfig({
+            ...transcriptModelConfig,
+            provider: 'localWhisper', // Ensure provider is set correctly
+            model: modelName
+        });
+        // Close modal after selection
+        if (onModelSelect) {
+            onModelSelect();
+        }
+    };
 
-    const handleParakeetModelSelect = (modelName: string) => {
-        // Always update config when model is selected, regardless of current provider
-        // This ensures the model is set when user switches back
-        setTranscriptModelConfig({
-            ...transcriptModelConfig,
-            provider: 'parakeet', // Ensure provider is set correctly
-            model: modelName
-        });
-        // Close modal after selection
-        if (onModelSelect) {
-            onModelSelect();
-        }
-    };
+    const handleParakeetModelSelect = (modelName: string) => {
+        // Always update config when model is selected, regardless of current provider
+        // This ensures the model is set when user switches back
+        setTranscriptModelConfig({
+            ...transcriptModelConfig,
+            provider: 'parakeet', // Ensure provider is set correctly
+            model: modelName
+        });
+        // Close modal after selection
+        if (onModelSelect) {
+            onModelSelect();
+        }
+    };
 
-    return (
-        <div>
-            <div className="flex flex-col space-y-3 p-4 border rounded-lg bg-card mb-4">
-                <div>
-                    <h3 className="text-lg font-medium leading-none mb-2">Transcription Language</h3>
-                    <p className="text-sm text-muted-foreground">
-                        Lock the language to disable per-segment auto-detection.
-                    </p>
-                </div>
-                
-                <Select value={transcriptionLanguage} onValueChange={handleLanguageChange}>
-                    <SelectTrigger className="w-full">
-                        <SelectValue placeholder="Select a language" />
-                    </SelectTrigger>
-                    <SelectContent>
-                        <SelectItem value="auto">Auto-Detect (Default)</SelectItem>
-                        <SelectItem value="auto-translate">Auto-Translate to English</SelectItem>
-                        <SelectItem value="en">English</SelectItem>
-                        <SelectItem value="ru">Russian</SelectItem>
-                        <SelectItem value="hi">Hindi</SelectItem>
-                        <SelectItem value="es">Spanish</SelectItem>
-                    </SelectContent>
-                </Select>
-            </div>
-            <div>
-                {/* <div className="flex justify-between items-center mb-4">
-                    <h3 className="text-lg font-semibold text-gray-900">Transcript Settings</h3>
-                </div> */}
-                <div className="space-y-4 pb-6">
-                    <div>
-                        <Label className="block text-sm font-medium text-gray-700 mb-1">
-                            Transcript Model
-                        </Label>
-                        <div className="flex space-x-2 mx-1">
-                            <Select
-                                value={uiProvider}
-                                onValueChange={(value) => {
-                                    const provider = value as TranscriptModelProps['provider'];
-                                    setUiProvider(provider);
-                                    if (provider !== 'localWhisper' && provider !== 'parakeet') {
-                                        fetchApiKey(provider);
-                                    }
-                                }}
-                            >
-                                <SelectTrigger className='focus:ring-1 focus:ring-blue-500 focus:border-blue-500'>
-                                    <SelectValue placeholder="Select provider" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectItem value="parakeet">⚡ Parakeet (Recommended - Real-time / Accurate)</SelectItem>
-                                    <SelectItem value="localWhisper">🏠 Local Whisper (High Accuracy)</SelectItem>
-                                    {/* <SelectItem value="deepgram">☁️ Deepgram (Backup)</SelectItem>
-                                    <SelectItem value="elevenLabs">☁️ ElevenLabs</SelectItem>
-                                    <SelectItem value="groq">☁️ Groq</SelectItem>
-                                    <SelectItem value="openai">☁️ OpenAI</SelectItem> */}
-                                </SelectContent>
-                            </Select>
-
-                            {uiProvider !== 'localWhisper' && uiProvider !== 'parakeet' && (
-                                <Select
-                                    value={transcriptModelConfig.model}
-                                    onValueChange={(value) => {
-                                        const model = value as TranscriptModelProps['model'];
-                                        setTranscriptModelConfig({ ...transcriptModelConfig, provider: uiProvider, model });
-                                    }}
-                                >
-                                    <SelectTrigger className='focus:ring-1 focus:ring-blue-500 focus:border-blue-500'>
-                                        <SelectValue placeholder="Select model" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {modelOptions[uiProvider].map((model) => (
-                                            <SelectItem key={model} value={model}>{model}</SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                            )}
-
-                        </div>
+    return (
+        <div>
+            <div className="flex flex-col space-y-3 p-4 border rounded-lg bg-card mb-4">
+                <div>
+                    <h3 className="text-lg font-medium leading-none mb-2">Transcription Language</h3>
+                    <p className="text-sm text-muted-foreground">
+                        Lock the language to disable per-segment auto-detection.
+                    </p>
+                </div>
+                
+                {uiProvider === 'parakeet' ? (
+                    <div className="p-3 text-sm text-yellow-600 bg-yellow-50 rounded-md border border-yellow-200">
+                        Parakeet model auto-detects language. Manual language locking is currently not supported for Parakeet.
                     </div>
+                ) : (
+                    <Select value={transcriptionLanguage} onValueChange={handleLanguageChange}>
+                        <SelectTrigger className="w-full">
+                            <SelectValue placeholder="Select a language" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="auto">Auto-Detect (Default)</SelectItem>
+                            <SelectItem value="auto-translate">Auto-Translate to English</SelectItem>
+                            <SelectItem value="en">English</SelectItem>
+                            <SelectItem value="ru">Russian</SelectItem>
+                            <SelectItem value="hi">Hindi</SelectItem>
+                            <SelectItem value="es">Spanish</SelectItem>
+                        </SelectContent>
+                    </Select>
+                )}
+            </div>
+            <div>
+                {/* <div className="flex justify-between items-center mb-4">
+                    <h3 className="text-lg font-semibold text-gray-900">Transcript Settings</h3>
+                </div> */}
+                <div className="space-y-4 pb-6">
+                    <div>
+                        <Label className="block text-sm font-medium text-gray-700 mb-1">
+                            Transcript Model
+                        </Label>
+                        <div className="flex space-x-2 mx-1">
+                            <Select
+                                value={uiProvider}
+                                onValueChange={(value) => {
+                                    const provider = value as TranscriptModelProps['provider'];
+                                    setUiProvider(provider);
+                                    if (provider !== 'localWhisper' && provider !== 'parakeet') {
+                                        fetchApiKey(provider);
+                                    }
+                                }}
+                            >
+                                <SelectTrigger className='focus:ring-1 focus:ring-blue-500 focus:border-blue-500'>
+                                    <SelectValue placeholder="Select provider" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="parakeet">⚡ Parakeet (Recommended - Real-time / Accurate)</SelectItem>
+                                    <SelectItem value="localWhisper">🏠 Local Whisper (High Accuracy)</SelectItem>
+                                    {/* <SelectItem value="deepgram">☁️ Deepgram (Backup)</SelectItem>
+                                    <SelectItem value="elevenLabs">☁️ ElevenLabs</SelectItem>
+                                    <SelectItem value="groq">☁️ Groq</SelectItem>
+                                    <SelectItem value="openai">☁️ OpenAI</SelectItem> */}
+                                </SelectContent>
+                            </Select>
 
-                    {uiProvider === 'localWhisper' && (
-                        <div className="mt-6">
-                            <ModelManager
-                                selectedModel={transcriptModelConfig.provider === 'localWhisper' ? transcriptModelConfig.model : undefined}
-                                onModelSelect={handleWhisperModelSelect}
-                                autoSave={true}
-                            />
-                        </div>
-                    )}
+                            {uiProvider !== 'localWhisper' && uiProvider !== 'parakeet' && (
+                                <Select
+                                    value={transcriptModelConfig.model}
+                                    onValueChange={(value) => {
+                                        const model = value as TranscriptModelProps['model'];
+                                        setTranscriptModelConfig({ ...transcriptModelConfig, provider: uiProvider, model });
+                                    }}
+                                >
+                                    <SelectTrigger className='focus:ring-1 focus:ring-blue-500 focus:border-blue-500'>
+                                        <SelectValue placeholder="Select model" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {modelOptions[uiProvider].map((model) => (
+                                            <SelectItem key={model} value={model}>{model}</SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            )}
 
-                    {uiProvider === 'parakeet' && (
-                        <div className="mt-6">
-                            <ParakeetModelManager
-                                selectedModel={transcriptModelConfig.provider === 'parakeet' ? transcriptModelConfig.model : undefined}
-                                onModelSelect={handleParakeetModelSelect}
-                                autoSave={true}
-                            />
-                        </div>
-                    )}
+                        </div>
+                    </div>
+
+                    {uiProvider === 'localWhisper' && (
+                        <div className="mt-6">
+                            <ModelManager
+                                selectedModel={transcriptModelConfig.provider === 'localWhisper' ? transcriptModelConfig.model : undefined}
+                                onModelSelect={handleWhisperModelSelect}
+                                autoSave={true}
+                            />
+                        </div>
+                    )}
+
+                    {uiProvider === 'parakeet' && (
+                        <div className="mt-6">
+                            <ParakeetModelManager
+                                selectedModel={transcriptModelConfig.provider === 'parakeet' ? transcriptModelConfig.model : undefined}
+                                onModelSelect={handleParakeetModelSelect}
+                                autoSave={true}
+                            />
+                        </div>
+                    )}
 
 
-                    {requiresApiKey && (
-                        <div>
-                            <Label className="block text-sm font-medium text-gray-700 mb-1">
-                                API Key
-                            </Label>
-                            <div className="relative mx-1">
-                                <Input
-                                    type={showApiKey ? "text" : "password"}
-                                    className={`pr-24 focus:ring-1 focus:ring-blue-500 focus:border-blue-500 ${isApiKeyLocked ? 'bg-gray-100 cursor-not-allowed' : ''
-                                        }`}
-                                    value={apiKey || ''}
-                                    onChange={(e) => setApiKey(e.target.value)}
-                                    disabled={isApiKeyLocked}
-                                    onClick={handleInputClick}
-                                    placeholder="Enter your API key"
-                                />
-                                {isApiKeyLocked && (
-                                    <div
-                                        onClick={handleInputClick}
-                                        className="absolute inset-0 flex items-center justify-center bg-gray-100 bg-opacity-50 rounded-md cursor-not-allowed"
-                                    />
-                                )}
-                                <div className="absolute inset-y-0 right-0 pr-1 flex items-center">
-                                    <Button
-                                        type="button"
-                                        variant="ghost"
-                                        size="icon"
-                                        onClick={() => setIsApiKeyLocked(!isApiKeyLocked)}
-                                        className={`transition-colors duration-200 ${isLockButtonVibrating ? 'animate-vibrate text-red-500' : ''
-                                            }`}
-                                        title={isApiKeyLocked ? "Unlock to edit" : "Lock to prevent editing"}
-                                    >
-                                        {isApiKeyLocked ? <Lock className="h-4 w-4" /> : <Unlock className="h-4 w-4" />}
-                                    </Button>
-                                    <Button
-                                        type="button"
-                                        variant="ghost"
-                                        size="icon"
-                                        onClick={() => setShowApiKey(!showApiKey)}
-                                    >
-                                        {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                                    </Button>
-                                </div>
-                            </div>
-                        </div>
-                    )}
-                </div>
-            </div>
-        </div >
-    )
+                    {requiresApiKey && (
+                        <div>
+                            <Label className="block text-sm font-medium text-gray-700 mb-1">
+                                API Key
+                            </Label>
+                            <div className="relative mx-1">
+                                <Input
+                                    type={showApiKey ? "text" : "password"}
+                                    className={`pr-24 focus:ring-1 focus:ring-blue-500 focus:border-blue-500 ${isApiKeyLocked ? 'bg-gray-100 cursor-not-allowed' : ''
+                                        }`}
+                                    value={apiKey || ''}
+                                    onChange={(e) => setApiKey(e.target.value)}
+                                    disabled={isApiKeyLocked}
+                                    onClick={handleInputClick}
+                                    placeholder="Enter your API key"
+                                />
+                                {isApiKeyLocked && (
+                                    <div
+                                        onClick={handleInputClick}
+                                        className="absolute inset-0 flex items-center justify-center bg-gray-100 bg-opacity-50 rounded-md cursor-not-allowed"
+                                    />
+                                )}
+                                <div className="absolute inset-y-0 right-0 pr-1 flex items-center">
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        onClick={() => setIsApiKeyLocked(!isApiKeyLocked)}
+                                        className={`transition-colors duration-200 ${isLockButtonVibrating ? 'animate-vibrate text-red-500' : ''
+                                            }`}
+                                        title={isApiKeyLocked ? "Unlock to edit" : "Lock to prevent editing"}
+                                    >
+                                        {isApiKeyLocked ? <Lock className="h-4 w-4" /> : <Unlock className="h-4 w-4" />}
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        onClick={() => setShowApiKey(!showApiKey)}
+                                    >
+                                        {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                                    </Button>
+                                </div>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div >
+    )
 }
-
-
-
-
-
-
-
-


### PR DESCRIPTION
### Description
Added a manual transcription language selection dropdown in the Settings UI to prevent Whisper from continuously auto-detecting and hallucinating (switching languages mid-sentence). Additionally, gated this UI element for the Parakeet model to accurately reflect its auto-detect-only behavior.

### Key Implementation Details:
* Added a language selection dropdown in `TranscriptSettings.tsx`.
* **[UPDATE] Added UI gating to hide the language dropdown and display a warning when Parakeet is the selected provider, ensuring consistency with backend limitations.**
* Handled state persistence via frontend `localStorage`.
* Implemented backend hydration on app startup in `layout.tsx` using the existing `set_language_preference` command.
* Zero backend changes: Did not modify any Rust code, as `whisper_engine.rs` already successfully pattern matches fixed language strings (like "en", "hi") alongside "auto".

### Related Issue
Fixes #581

### Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

### Testing
- [x] Manual testing performed
* Verified that the language preference saves to `localStorage` and persists across app restarts.
* Confirmed that the backend memory is hydrated correctly upon launching the app.
* **[UPDATE] Verified that selecting the Parakeet provider correctly hides the language dropdown and shows the appropriate warning UI.**