### PR TITLE
fix(parakeet): thread language through all transcription paths

### DIFF
--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -582,7 +582,7 @@ async fn run_import<R: Runtime>(
         let (text, conf) = if use_parakeet {
             let engine = parakeet_engine.as_ref().unwrap();
             let text = engine
-                .transcribe_audio(segment.samples.clone())
+                .transcribe_audio(segment.samples.clone(), language.clone())
                 .await
                 .map_err(|e| anyhow!("Parakeet transcription failed on segment {}: {}", i, e))?;
             (text, 0.9f32)

--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -371,7 +371,7 @@ async fn run_retranscription<R: Runtime>(
         let (text, conf) = if use_parakeet {
             let engine = parakeet_engine.as_ref().unwrap();
             let text = engine
-                .transcribe_audio(segment.samples.clone())
+                .transcribe_audio(segment.samples.clone(), language.clone())
                 .await
                 .map_err(|e| anyhow!("Parakeet transcription failed on segment {}: {}", i, e))?;
             (text, 0.9f32)

--- a/frontend/src-tauri/src/audio/transcription/parakeet_provider.rs
+++ b/frontend/src-tauri/src/audio/transcription/parakeet_provider.rs
@@ -4,7 +4,6 @@
 
 use super::provider::{TranscriptionError, TranscriptionProvider, TranscriptResult};
 use async_trait::async_trait;
-use log::warn;
 use std::sync::Arc;
 
 /// Parakeet transcription provider (wraps ParakeetEngine)
@@ -25,15 +24,9 @@ impl TranscriptionProvider for ParakeetProvider {
         audio: Vec<f32>,
         language: Option<String>,
     ) -> std::result::Result<TranscriptResult, TranscriptionError> {
-        // Log language preference warning if set (Parakeet doesn't support it yet)
-        if let Some(ref lang) = language {
-            warn!(
-                "Parakeet doesn't support language preference '{}' yet - transcribing in default language",
-                lang
-            );
-        }
-
-        match self.engine.transcribe_audio(audio).await {
+        // Parakeet can't lock to a specific language; the engine logs this once
+        // when a concrete language is requested (issue #581).
+        match self.engine.transcribe_audio(audio, language).await {
             Ok(text) => Ok(TranscriptResult {
                 text: text.trim().to_string(),
                 confidence: None, // Parakeet doesn't provide confidence scores

--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -486,7 +486,12 @@ async fn transcribe_chunk_with_provider<R: Runtime>(
             }
         }
         TranscriptionEngine::Parakeet(parakeet_engine) => {
-            match parakeet_engine.transcribe_audio(speech_samples).await {
+            // Parakeet only supports automatic language detection. Passing the
+            // global language preference here would leak a stale/specific
+            // language (e.g. one set while using Whisper, then switched to
+            // Parakeet) that Parakeet can't honor, so we explicitly transcribe
+            // in auto mode (issue #581).
+            match parakeet_engine.transcribe_audio(speech_samples, None).await {
                 Ok(text) => {
                     let cleaned_text = text.trim().to_string();
                     if cleaned_text.is_empty() {

--- a/frontend/src-tauri/src/parakeet_engine/commands.rs
+++ b/frontend/src-tauri/src/parakeet_engine/commands.rs
@@ -352,7 +352,7 @@ pub async fn parakeet_transcribe_audio(audio_data: Vec<f32>) -> Result<String, S
 
     if let Some(engine) = engine {
         engine
-            .transcribe_audio(audio_data)
+            .transcribe_audio(audio_data, crate::get_language_preference_internal())
             .await
             .map_err(|e| format!("Parakeet transcription failed: {}", e))
     } else {

--- a/frontend/src-tauri/src/parakeet_engine/parakeet_engine.rs
+++ b/frontend/src-tauri/src/parakeet_engine/parakeet_engine.rs
@@ -450,8 +450,36 @@ impl ParakeetEngine {
         self.current_model.read().await.is_some()
     }
 
-    /// Transcribe audio samples using the loaded Parakeet model
-    pub async fn transcribe_audio(&self, audio_data: Vec<f32>) -> Result<String> {
+    /// Transcribe audio samples using the loaded Parakeet model.
+    ///
+    /// `language` is accepted for parity with the Whisper and provider-based
+    /// transcription paths (issue #581). The Parakeet model performs automatic
+    /// language detection and has no per-call language input, so a specific
+    /// language cannot be forced here. When a concrete language is requested we
+    /// emit a one-time warning so the behaviour is transparent; use the Whisper
+    /// engine if you need to lock the transcription language.
+    pub async fn transcribe_audio(
+        &self,
+        audio_data: Vec<f32>,
+        language: Option<String>,
+    ) -> Result<String> {
+        // Warn once (not per chunk) when the user selected a concrete language
+        // that Parakeet can't honor, so the logs stay readable.
+        match language.as_deref() {
+            None | Some("auto") | Some("auto-translate") => {}
+            Some(lang) => {
+                static LANGUAGE_WARNING: std::sync::Once = std::sync::Once::new();
+                let lang = lang.to_string();
+                LANGUAGE_WARNING.call_once(move || {
+                    log::warn!(
+                        "Parakeet auto-detects language and cannot lock to '{}'. \
+                         Switch to the Whisper engine to force a fixed transcription language (issue #581).",
+                        lang
+                    );
+                });
+            }
+        }
+
         let mut model_guard = self.current_model.write().await;
         let model = model_guard
             .as_mut()


### PR DESCRIPTION
## description

parakeet transcription dropped the language argument that the whisper and provider paths already honored. this threads a language argument through every parakeet transcription path so behavior stays consistent.

parakeet engine transcribe_audio now takes a language argument for parity. the import retranscription provider and command paths pass it through. the parakeet tdt model cannot lock a language so it warns one time instead of per chunk rather than failing silently. the live worker passes none so a stale global preference cannot leak into parakeet.

the frontend already blocks choosing a specific language for parakeet in settings import and retranscribe so no ui change was needed.

## related issue

fixes #581

## type of change

* [x] bug fix

## testing

* [ ] manual testing performed

full crate compile needs xcode for the cidre dependency so end to end verification is still pending. the whisper.cpp build succeeds through cmake and cargo compiles every dependency up to the app crate. the changed warn once logic was verified in isolation.

## documentation

* [x] no documentation needed
