### PR TITLE
feat(transcription): add first-class Deepgram provider (nova + Flux)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,6 +1508,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,6 +3679,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -7240,6 +7247,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7512,6 +7533,26 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "typeid"

--- a/frontend/build-gpu.sh
+++ b/frontend/build-gpu.sh
@@ -108,7 +108,7 @@ fi
 # Note: llama-cpp-2 does NOT support coreml, only metal/cuda/vulkan
 # So for macOS Apple Silicon (which returns 'coreml' for Whisper), use 'metal' for llama-helper
 HELPER_FEATURES=""
-if [ -n "$TAURI_GPU_FEATURE" ]; then
+if [ -n "$TAURI_GPU_FEATURE" ] && [ "$TAURI_GPU_FEATURE" != "none" ]; then
     LLAMA_FEATURE="$TAURI_GPU_FEATURE"
     if [ "$LLAMA_FEATURE" = "coreml" ]; then
         LLAMA_FEATURE="metal"

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -100,6 +100,7 @@ nnnoiseless = "0.5"
 # NOTE: whisper-rs is declared in platform-specific sections below (macOS/Windows/Linux)
 # to ensure correct GPU features are enabled per platform
 futures-util = "0.3"
+tokio-tungstenite = { version = "0.21", features = ["native-tls"] }
 silero_rs = { git = "https://github.com/emotechlab/silero-rs", rev = "26a6460", package = "silero" }
 
 # Parakeet (ONNX-based fast transcription) dependencies

--- a/frontend/src-tauri/migrations/20260101000000_add_deepgram_options.sql
+++ b/frontend/src-tauri/migrations/20260101000000_add_deepgram_options.sql
@@ -1,0 +1,6 @@
+-- Deepgram provider-specific knobs surfaced in Transcription settings.
+-- deepgramKeyterm: newline/comma-separated keyterm-prompting phrases (nova-3) /
+--                  keyword boosts (nova-2).
+-- deepgramDiarize: 1/0 toggle for speaker diarization (defaults to on when NULL).
+ALTER TABLE transcript_settings ADD COLUMN deepgramKeyterm TEXT;
+ALTER TABLE transcript_settings ADD COLUMN deepgramDiarize INTEGER;

--- a/frontend/src-tauri/migrations/20260108000000_add_deepgram_mip_opt_out.sql
+++ b/frontend/src-tauri/migrations/20260108000000_add_deepgram_mip_opt_out.sql
@@ -1,0 +1,4 @@
+-- deepgramMipOptOut: 1/0 toggle for Deepgram's Model Improvement Program opt-out
+-- (sends mip_opt_out=true). Meetily is privacy-first, so the effective default is
+-- ON (opt out) when the column is NULL.
+ALTER TABLE transcript_settings ADD COLUMN deepgramMipOptOut INTEGER;

--- a/frontend/src-tauri/migrations/20260108000001_add_deepgram_language.sql
+++ b/frontend/src-tauri/migrations/20260108000001_add_deepgram_language.sql
@@ -1,0 +1,8 @@
+-- deepgramLanguage: Deepgram-specific language mode, decoupled from the shared
+-- global language preference (which is Whisper/Parakeet-oriented). Values:
+--   'multi'  -> language=multi (nova-3 code-switching)
+--   'detect' -> detect_language=true (auto-detect one language)
+--   ISO code -> language=<code>
+-- NULL/'' falls back to the nova-3 default (multi). Kept separate so Deepgram-only
+-- values never leak into the Whisper/Parakeet language path.
+ALTER TABLE transcript_settings ADD COLUMN deepgramLanguage TEXT;

--- a/frontend/src-tauri/src/api/api.rs
+++ b/frontend/src-tauri/src/api/api.rs
@@ -714,6 +714,43 @@ pub async fn api_get_transcript_api_key<R: Runtime>(
 }
 
 #[tauri::command]
+pub async fn api_get_deepgram_options<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    _auth_token: Option<String>,
+) -> Result<serde_json::Value, String> {
+    let pool = state.db_manager.pool();
+    match SettingsRepository::get_deepgram_options(pool).await {
+        Ok((keyterm, diarize)) => Ok(serde_json::json!({
+            "keyterm": keyterm.unwrap_or_default(),
+            "diarize": diarize.map(|d| d != 0).unwrap_or(true),
+        })),
+        Err(e) => {
+            log_error!("Failed to get Deepgram options: {}", e);
+            Err(e.to_string())
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn api_save_deepgram_options<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    keyterm: Option<String>,
+    diarize: bool,
+    _auth_token: Option<String>,
+) -> Result<serde_json::Value, String> {
+    let pool = state.db_manager.pool();
+    if let Err(e) =
+        SettingsRepository::save_deepgram_options(pool, keyterm.as_deref(), diarize).await
+    {
+        log_error!("Failed to save Deepgram options: {}", e);
+        return Err(e.to_string());
+    }
+    Ok(serde_json::json!({ "status": "success", "message": "Deepgram options saved successfully" }))
+}
+
+#[tauri::command]
 pub async fn api_delete_api_key<R: Runtime>(
     _app: AppHandle<R>,
     state: tauri::State<'_, AppState>,

--- a/frontend/src-tauri/src/api/api.rs
+++ b/frontend/src-tauri/src/api/api.rs
@@ -721,9 +721,13 @@ pub async fn api_get_deepgram_options<R: Runtime>(
 ) -> Result<serde_json::Value, String> {
     let pool = state.db_manager.pool();
     match SettingsRepository::get_deepgram_options(pool).await {
-        Ok((keyterm, diarize)) => Ok(serde_json::json!({
-            "keyterm": keyterm.unwrap_or_default(),
-            "diarize": diarize.map(|d| d != 0).unwrap_or(true),
+        Ok(opts) => Ok(serde_json::json!({
+            "keyterm": opts.keyterm.unwrap_or_default(),
+            "diarize": opts.diarize.map(|d| d != 0).unwrap_or(true),
+            // Privacy-first default: opt OUT of Deepgram's model-improvement program when unset.
+            "mipOptOut": opts.mip_opt_out.map(|m| m != 0).unwrap_or(true),
+            // Deepgram-specific language; empty string means "use nova-3 default (multi)".
+            "language": opts.language.unwrap_or_default(),
         })),
         Err(e) => {
             log_error!("Failed to get Deepgram options: {}", e);
@@ -738,11 +742,19 @@ pub async fn api_save_deepgram_options<R: Runtime>(
     state: tauri::State<'_, AppState>,
     keyterm: Option<String>,
     diarize: bool,
+    #[allow(non_snake_case)] mipOptOut: bool,
+    language: Option<String>,
     _auth_token: Option<String>,
 ) -> Result<serde_json::Value, String> {
     let pool = state.db_manager.pool();
-    if let Err(e) =
-        SettingsRepository::save_deepgram_options(pool, keyterm.as_deref(), diarize).await
+    if let Err(e) = SettingsRepository::save_deepgram_options(
+        pool,
+        keyterm.as_deref(),
+        diarize,
+        mipOptOut,
+        language.as_deref().filter(|l| !l.is_empty()),
+    )
+    .await
     {
         log_error!("Failed to save Deepgram options: {}", e);
         return Err(e.to_string());

--- a/frontend/src-tauri/src/audio/deepgram.rs
+++ b/frontend/src-tauri/src/audio/deepgram.rs
@@ -66,6 +66,14 @@ pub struct DeepgramOptions {
     pub model: String,
     pub keyterms: Vec<String>,
     pub diarize: bool,
+    /// Opt out of Deepgram's Model Improvement Program (sends `mip_opt_out=true`).
+    /// Defaults to true: Meetily is privacy-first, so audio is not retained for
+    /// model training unless the user explicitly opts back in.
+    pub mip_opt_out: bool,
+    /// Deepgram-specific language mode (`multi`, `detect`, or an ISO code). Kept
+    /// separate from the shared global language pref so Deepgram-only values never
+    /// leak into the Whisper/Parakeet path. None -> fall back to the caller's hint.
+    pub language: Option<String>,
 }
 
 impl Default for DeepgramOptions {
@@ -74,6 +82,8 @@ impl Default for DeepgramOptions {
             model: crate::config::DEFAULT_DEEPGRAM_REALTIME_MODEL.to_string(),
             keyterms: Vec::new(),
             diarize: true,
+            mip_opt_out: true,
+            language: None,
         }
     }
 }
@@ -108,7 +118,7 @@ struct Alternative {
     words: Vec<DeepgramWord>,
 }
 
-// Deepgram splits utterances by speaker when diarize=true, so each utterance is
+// Deepgram splits utterances by speaker when diarization is on, so each utterance is
 // already a single-speaker turn. meetily's transcript model has no diarization
 // speaker field (its `speaker` column is audio-source: mic/system), so the
 // numeric speaker id is intentionally not carried — diarization manifests as
@@ -360,9 +370,18 @@ impl DeepgramClient {
             ("paragraphs".to_string(), "true".to_string()),
         ];
         if self.options.diarize {
-            query.push(("diarize".to_string(), "true".to_string()));
+            // Deepgram's current diarizer. `diarize_model` is mutually exclusive with
+            // `diarize`/`diarize_version` (sending both -> HTTP 400), so emit ONLY
+            // diarize_model=latest here, never diarize=true. Verified live against
+            // api.deepgram.com (both prerecorded and streaming return 200/101).
+            query.push(("diarize_model".to_string(), "latest".to_string()));
         }
-        apply_language(&mut query, language.as_deref(), model);
+        if self.options.mip_opt_out {
+            query.push(("mip_opt_out".to_string(), "true".to_string()));
+        }
+        // Deepgram-specific language wins; fall back to the caller's hint if unset.
+        let lang = self.options.language.as_deref().or(language.as_deref());
+        apply_language(&mut query, lang, model);
         apply_keyterms(&mut query, &self.options.keyterms);
         query
     }
@@ -430,13 +449,17 @@ pub async fn configured_options<R: Runtime>(app: &AppHandle<R>) -> Result<Deepgr
         }
     }
 
-    let (keyterm, diarize) = SettingsRepository::get_deepgram_options(pool)
+    let row = SettingsRepository::get_deepgram_options(pool)
         .await
-        .unwrap_or((None, None));
-    options.keyterms = parse_keyterms(keyterm.as_deref());
-    if let Some(diarize) = diarize {
+        .unwrap_or_default();
+    options.keyterms = parse_keyterms(row.keyterm.as_deref());
+    if let Some(diarize) = row.diarize {
         options.diarize = diarize != 0;
     }
+    if let Some(mip_opt_out) = row.mip_opt_out {
+        options.mip_opt_out = mip_opt_out != 0;
+    }
+    options.language = row.language.filter(|l| !l.trim().is_empty());
 
     Ok(options)
 }
@@ -816,9 +839,16 @@ fn build_realtime_url(options: &DeepgramOptions, language: Option<String>) -> St
         ("endpointing".to_string(), "300".to_string()),
     ];
     if options.diarize {
-        query.push(("diarize".to_string(), "true".to_string()));
+        // diarize_model=latest replaces diarize=true (400 if both sent). See
+        // prerecorded_query; verified live that streaming accepts it (101 handshake).
+        query.push(("diarize_model".to_string(), "latest".to_string()));
     }
-    apply_language(&mut query, language.as_deref(), &options.model);
+    if options.mip_opt_out {
+        query.push(("mip_opt_out".to_string(), "true".to_string()));
+    }
+    // Deepgram-specific language wins; fall back to the caller's hint if unset.
+    let lang = options.language.as_deref().or(language.as_deref());
+    apply_language(&mut query, lang, &options.model);
     apply_keyterms(&mut query, &options.keyterms);
     encode_ws_url(LISTEN_WS_URL, &query)
 }
@@ -904,41 +934,37 @@ fn emit_transcript_update<R: Runtime>(
 // HELPERS
 // ============================================================================
 
-/// Apply a language hint. Deepgram nova-3 supports `multi` for code-switching;
-/// when the user leaves language on auto we default nova-3 to `multi` and leave
-/// other models to their own default.
+/// Map the stored language preference to Deepgram query params. Three distinct modes:
+///   `detect`    -> `detect_language=true`  (auto-detect a single language)
+///   `multi`     -> `language=multi`        (nova-3 code-switching across 10 languages)
+///   ISO code    -> `language=<code>`       (explicit selection, e.g. `es`)
+/// When unset/auto, nova-3 defaults to `multi` (its code-switching default) and other
+/// models fall back to Deepgram's own default. Previously `detect` was silently dropped
+/// and auto collapsed to `multi`, so single-language detection was unreachable.
 fn apply_language(query: &mut Vec<(String, String)>, language: Option<&str>, model: &str) {
-    let hint = language
-        .map(str::trim)
-        .filter(|l| !l.is_empty() && *l != "auto" && *l != "auto-translate" && *l != "detect");
-
-    match hint {
-        Some(lang) => query.push(("language".to_string(), lang.to_string())),
-        None if model.starts_with("nova-3") => {
-            query.push(("language".to_string(), "multi".to_string()))
+    match language.map(str::trim).unwrap_or("") {
+        "detect" => query.push(("detect_language".to_string(), "true".to_string())),
+        "multi" => query.push(("language".to_string(), "multi".to_string())),
+        "" | "auto" | "auto-translate" => {
+            if model.starts_with("nova-3") {
+                query.push(("language".to_string(), "multi".to_string()));
+            }
         }
-        None => {}
+        lang => query.push(("language".to_string(), lang.to_string())),
     }
 }
 
-/// keyterm prompting is supported by nova-3 and Flux (both use `keyterm`); nova-2
-/// uses `keywords`. Route each term to the correct parameter for the model.
+/// keyterm prompting. The only supported models (nova-3 and Flux) both use the
+/// `keyterm` parameter, so every term routes there. (nova-2's `keywords` param was
+/// dropped along with nova-2 model support.)
 fn apply_keyterms(query: &mut Vec<(String, String)>, keyterms: &[String]) {
     if keyterms.is_empty() {
         return;
     }
-    let param = if query
-        .iter()
-        .any(|(k, v)| k == "model" && (v.starts_with("nova-3") || v.starts_with("flux")))
-    {
-        "keyterm"
-    } else {
-        "keywords"
-    };
     for term in keyterms {
         let term = term.trim();
         if !term.is_empty() {
-            query.push((param.to_string(), term.to_string()));
+            query.push(("keyterm".to_string(), term.to_string()));
         }
     }
 }
@@ -1162,14 +1188,6 @@ mod tests {
     }
 
     #[test]
-    fn nova2_keyterms_use_keywords_param() {
-        let mut query = vec![("model".to_string(), "nova-2".to_string())];
-        apply_keyterms(&mut query, &["Meetily".to_string()]);
-        assert!(query.iter().any(|(k, _)| k == "keywords"));
-        assert!(!query.iter().any(|(k, _)| k == "keyterm"));
-    }
-
-    #[test]
     fn language_defaults_to_multi_for_nova3_only() {
         let mut q1 = vec![];
         apply_language(&mut q1, None, "nova-3");
@@ -1182,6 +1200,15 @@ mod tests {
         let mut q3 = vec![];
         apply_language(&mut q3, Some("en"), "nova-3");
         assert_eq!(q3, vec![("language".to_string(), "en".to_string())]);
+
+        // `detect` -> single-language auto-detect; `multi` -> code-switching (any model).
+        let mut q4 = vec![];
+        apply_language(&mut q4, Some("detect"), "nova-3");
+        assert_eq!(q4, vec![("detect_language".to_string(), "true".to_string())]);
+
+        let mut q5 = vec![];
+        apply_language(&mut q5, Some("multi"), "nova-2");
+        assert_eq!(q5, vec![("language".to_string(), "multi".to_string())]);
     }
 
     #[test]
@@ -1200,20 +1227,61 @@ mod tests {
             model: "nova-3".to_string(),
             keyterms: vec!["Meetily".to_string()],
             diarize: true,
+            mip_opt_out: true,
+            language: None,
         };
         let url = build_realtime_url(&options, Some("en".to_string()));
         assert!(url.starts_with("wss://api.deepgram.com/v1/listen?"));
         assert!(url.contains("encoding=linear16"));
         assert!(url.contains("model=nova-3"));
-        assert!(url.contains("diarize=true"));
+        assert!(url.contains("diarize_model=latest"));
+        assert!(!url.contains("diarize=true")); // diarize_model replaces diarize (400 if both)
+        assert!(url.contains("mip_opt_out=true")); // privacy-first: opt out by default
         assert!(url.contains("interim_results=false"));
         assert!(url.contains("keyterm=Meetily"));
         assert!(url.contains("language=en"));
     }
 
     #[test]
+    fn prerecorded_query_emits_diarize_model_and_mip_opt_out() {
+        let client = DeepgramClient::new(
+            "k".to_string(),
+            DeepgramOptions {
+                model: "nova-3".to_string(),
+                keyterms: vec![],
+                diarize: true,
+                mip_opt_out: true,
+                language: None,
+            },
+        );
+        let q = client.prerecorded_query(Some("es".to_string()));
+        let has = |k: &str, v: &str| q.iter().any(|(a, b)| a == k && b == v);
+        assert!(has("diarize_model", "latest"));
+        assert!(!q.iter().any(|(k, _)| k == "diarize")); // never diarize=true (400 if both)
+        assert!(has("mip_opt_out", "true"));
+        assert!(has("smart_format", "true"));
+        assert!(has("language", "es")); // caller hint used when options.language is unset
+    }
+
+    #[test]
+    fn deepgram_specific_language_overrides_caller_hint() {
+        let opts = DeepgramOptions {
+            model: "nova-3".to_string(),
+            keyterms: vec![],
+            diarize: false,
+            mip_opt_out: false,
+            language: Some("multi".to_string()),
+        };
+        // Even when the caller passes a global hint ("es"), the Deepgram-specific
+        // language ("multi") wins, so global values never override the provider setting.
+        let url = build_realtime_url(&opts, Some("es".to_string()));
+        assert!(url.contains("language=multi"));
+        assert!(!url.contains("language=es"));
+    }
+
+    #[test]
     fn language_auto_is_treated_as_no_hint() {
-        // "auto"/"detect" sentinels are filtered; nova-3 then falls back to multi.
+        // "auto" is treated as no explicit hint; nova-3 then falls back to multi.
         let mut q = vec![];
         apply_language(&mut q, Some("auto"), "nova-3");
         assert_eq!(q, vec![("language".to_string(), "multi".to_string())]);
@@ -1225,10 +1293,13 @@ mod tests {
             model: "nova-3".to_string(),
             keyterms: vec!["Acme Corp".to_string()],
             diarize: false,
+            mip_opt_out: false,
+            language: None,
         };
         let url = build_realtime_url(&options, None);
         assert!(url.contains("keyterm=Acme%20Corp"));
         assert!(!url.contains("diarize="));
+        assert!(!url.contains("mip_opt_out")); // off -> param omitted
     }
 
     // Contract tests: lock the Deepgram wire shape we verified live so a
@@ -1385,6 +1456,8 @@ mod tests {
             model: "flux-general-multi".to_string(),
             keyterms: vec!["Meetily".to_string()],
             diarize: true, // ignored by Flux
+            mip_opt_out: false,
+            language: None,
         };
         let url = build_flux_url(&opts, Some("en".to_string()));
         assert!(url.starts_with("wss://api.deepgram.com/v2/listen?"));
@@ -1403,6 +1476,8 @@ mod tests {
             model: "flux-general-en".to_string(),
             keyterms: vec![],
             diarize: false,
+            mip_opt_out: false,
+            language: None,
         };
         let url = build_flux_url(&opts, Some("en".to_string()));
         assert!(!url.contains("language_hint"));
@@ -1417,6 +1492,8 @@ mod tests {
                 model: "flux-general-en".to_string(),
                 keyterms: vec!["Meetily".to_string()],
                 diarize: true,
+                mip_opt_out: false,
+                language: None,
             },
         );
         let q = flux.prerecorded_query(None);

--- a/frontend/src-tauri/src/audio/deepgram.rs
+++ b/frontend/src-tauri/src/audio/deepgram.rs
@@ -1,0 +1,1429 @@
+// audio/deepgram.rs
+//
+// First-class Deepgram transcription provider.
+//
+// Deepgram is a streaming-first cloud ASR: live recording uses the realtime
+// WebSocket API (low-latency interim + final results), while imported files and
+// retranscription use the prerecorded REST API. This does NOT map onto the
+// batch `TranscriptionProvider` trait (chunk -> Vec<f32> -> text), so Deepgram
+// is wired in as its own streaming path and the trait-based engine is bypassed
+// for this provider.
+//
+// Wire contract (verified live against api.deepgram.com, nova-3):
+//   - Auth header is `Authorization: Token <key>` (NOT `Bearer`).
+//   - Prerecorded: a single synchronous POST of the audio bytes; the response
+//     carries `results.utterances[]` (speaker-segmented turns) and
+//     `results.channels[0].alternatives[0].{transcript,words}`. No polling.
+//   - Realtime: params are passed as WS query string (not a config frame). Each
+//     `Results` message carries `is_final`/`speech_final` and a smart-formatted
+//     `channel.alternatives[0].transcript` plus word-level timing.
+
+use anyhow::{anyhow, Context, Result};
+use futures_util::{SinkExt, StreamExt};
+use log::{error, info, warn};
+use serde::Deserialize;
+use std::path::Path;
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, Ordering},
+    Arc,
+};
+use std::time::Duration;
+use tauri::{AppHandle, Emitter, Manager, Runtime};
+use tokio::sync::{mpsc, Mutex};
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{client::IntoClientRequest, http::HeaderValue, Message},
+};
+
+use crate::api::TranscriptSegment;
+use crate::database::repositories::setting::SettingsRepository;
+use crate::state::AppState;
+
+use super::recording_state::AudioChunk;
+use super::transcription::TranscriptUpdate;
+
+pub const PROVIDER: &str = "deepgram";
+const LISTEN_REST_URL: &str = "https://api.deepgram.com/v1/listen";
+const LISTEN_WS_URL: &str = "wss://api.deepgram.com/v1/listen";
+// Flux uses a separate v2 realtime endpoint with turn-based events.
+const FLUX_WS_URL: &str = "wss://api.deepgram.com/v2/listen";
+const PCM_SAMPLE_RATE: u32 = 16_000;
+/// Deepgram closes an idle realtime socket after ~10s; send KeepAlive well under that.
+const KEEPALIVE_SECS: u64 = 5;
+
+static REALTIME_SEQUENCE_COUNTER: AtomicU64 = AtomicU64::new(0);
+static REALTIME_SPEECH_DETECTED_EMITTED: AtomicBool = AtomicBool::new(false);
+
+// ============================================================================
+// OPTIONS
+// ============================================================================
+
+/// Provider-specific knobs surfaced in Settings (model + keyterm prompting +
+/// diarization). These are what make Deepgram worth wiring first-class rather
+/// than flattening to a generic "text out" contract.
+#[derive(Debug, Clone)]
+pub struct DeepgramOptions {
+    pub model: String,
+    pub keyterms: Vec<String>,
+    pub diarize: bool,
+}
+
+impl Default for DeepgramOptions {
+    fn default() -> Self {
+        Self {
+            model: crate::config::DEFAULT_DEEPGRAM_REALTIME_MODEL.to_string(),
+            keyterms: Vec::new(),
+            diarize: true,
+        }
+    }
+}
+
+// ============================================================================
+// RESPONSE TYPES
+// ============================================================================
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeepgramWord {
+    #[serde(default)]
+    pub word: String,
+    #[serde(default)]
+    pub punctuated_word: Option<String>,
+    #[serde(default)]
+    pub start: f64,
+    #[serde(default)]
+    pub end: f64,
+    #[serde(default)]
+    pub confidence: Option<f32>,
+    #[serde(default)]
+    pub speaker: Option<i64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct Alternative {
+    #[serde(default)]
+    transcript: String,
+    #[serde(default)]
+    confidence: Option<f32>,
+    #[serde(default)]
+    words: Vec<DeepgramWord>,
+}
+
+// Deepgram splits utterances by speaker when diarize=true, so each utterance is
+// already a single-speaker turn. meetily's transcript model has no diarization
+// speaker field (its `speaker` column is audio-source: mic/system), so the
+// numeric speaker id is intentionally not carried — diarization manifests as
+// speaker-split segmentation, consistent with the existing Whisper/Parakeet behavior.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Utterance {
+    #[serde(default)]
+    pub start: f64,
+    #[serde(default)]
+    pub end: f64,
+    #[serde(default)]
+    pub transcript: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Channel {
+    #[serde(default)]
+    alternatives: Vec<Alternative>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PrerecordedResults {
+    #[serde(default)]
+    channels: Vec<Channel>,
+    #[serde(default)]
+    utterances: Vec<Utterance>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PrerecordedMetadata {
+    #[serde(default)]
+    duration: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PrerecordedResponse {
+    results: PrerecordedResults,
+    #[serde(default)]
+    metadata: Option<PrerecordedMetadata>,
+}
+
+/// Result of a prerecorded transcription, normalized for segment mapping.
+#[derive(Debug, Clone)]
+pub struct DeepgramTranscript {
+    pub text: String,
+    pub utterances: Vec<Utterance>,
+    pub words: Vec<DeepgramWord>,
+    pub duration_seconds: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RealtimeChannel {
+    #[serde(default)]
+    alternatives: Vec<Alternative>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RealtimeMessage {
+    #[serde(default, rename = "type")]
+    msg_type: Option<String>,
+    #[serde(default)]
+    channel: Option<RealtimeChannel>,
+    #[serde(default)]
+    is_final: bool,
+    #[serde(default)]
+    start: f64,
+    #[serde(default)]
+    duration: f64,
+    // A `type: "Error"` message carries these; both are optional in the schema.
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+/// Flux (`/v2/listen`) turn-based message. The finalized turn transcript arrives
+/// on `event == "EndOfTurn"` (natively punctuated); Update/StartOfTurn/Eager/
+/// TurnResumed are interim. `audio_window_start/end` are stream-relative seconds.
+#[derive(Debug, Deserialize)]
+struct FluxTurnInfo {
+    #[serde(default, rename = "type")]
+    msg_type: Option<String>,
+    #[serde(default)]
+    event: Option<String>,
+    #[serde(default)]
+    transcript: String,
+    #[serde(default)]
+    audio_window_start: f64,
+    #[serde(default)]
+    audio_window_end: f64,
+    #[serde(default)]
+    words: Vec<DeepgramWord>,
+    // Present on a `type: "Error"` control message.
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+/// A finalized segment reduced from either protocol, in stream-relative ms.
+struct FinalSeg {
+    transcript: String,
+    start_ms: f64,
+    end_ms: f64,
+    confidence: f32,
+}
+
+/// Reduce a nova `Results` message to a finalized segment (None for interim/other).
+fn nova_result_to_final(m: RealtimeMessage) -> Option<FinalSeg> {
+    if m.msg_type.as_deref() != Some("Results") || !m.is_final {
+        return None;
+    }
+    let alternative = m.channel.and_then(|c| c.alternatives.into_iter().next())?;
+    let transcript = alternative.transcript.trim();
+    if transcript.is_empty() {
+        return None;
+    }
+    let confidence = alternative
+        .confidence
+        .unwrap_or_else(|| average_confidence(alternative.words.iter().filter_map(|w| w.confidence)));
+    Some(FinalSeg {
+        transcript: transcript.to_string(),
+        start_ms: m.start * 1000.0,
+        end_ms: (m.start + m.duration) * 1000.0,
+        confidence,
+    })
+}
+
+/// Reduce a Flux `TurnInfo` to a finalized segment (only on `EndOfTurn`).
+fn flux_turn_to_final(m: &FluxTurnInfo) -> Option<FinalSeg> {
+    if m.event.as_deref() != Some("EndOfTurn") {
+        return None;
+    }
+    let transcript = m.transcript.trim();
+    if transcript.is_empty() {
+        return None;
+    }
+    Some(FinalSeg {
+        transcript: transcript.to_string(),
+        start_ms: m.audio_window_start * 1000.0,
+        end_ms: m.audio_window_end * 1000.0,
+        confidence: average_confidence(m.words.iter().filter_map(|w| w.confidence)),
+    })
+}
+
+/// Maps realtime-stream time onto original recording time. The pipeline feeds a
+/// continuous mixed stream while carrying each chunk's recording-relative
+/// timestamp, so realtime word times (stream-relative) are remapped back.
+#[derive(Debug, Clone)]
+pub struct AudioTimeMapEntry {
+    pub stream_start_ms: f64,
+    pub stream_end_ms: f64,
+    pub original_start_ms: f64,
+    pub original_end_ms: f64,
+}
+
+// ============================================================================
+// CLIENT (prerecorded REST)
+// ============================================================================
+
+#[derive(Debug, Clone)]
+pub struct DeepgramClient {
+    api_key: String,
+    http: reqwest::Client,
+    options: DeepgramOptions,
+}
+
+impl DeepgramClient {
+    pub fn new(api_key: String, options: DeepgramOptions) -> Self {
+        Self {
+            api_key,
+            http: reqwest::Client::new(),
+            options,
+        }
+    }
+
+    /// Transcribe a local file via the prerecorded REST API. This is a single
+    /// synchronous request (no upload -> create -> poll -> fetch cycle),
+    /// so progress is coarse: submit, then parse.
+    pub async fn transcribe_file_with_progress<F, C>(
+        &self,
+        path: &Path,
+        language: Option<String>,
+        _client_reference_id: &str,
+        mut progress: F,
+        mut should_cancel: C,
+    ) -> Result<DeepgramTranscript>
+    where
+        F: FnMut(u32, &str),
+        C: FnMut() -> bool,
+    {
+        ensure_not_cancelled(&mut should_cancel)?;
+        progress(10, "Reading audio file...");
+        let bytes = tokio::fs::read(path)
+            .await
+            .with_context(|| format!("Failed to read audio file: {}", path.display()))?;
+
+        ensure_not_cancelled(&mut should_cancel)?;
+        progress(25, "Uploading audio to Deepgram...");
+
+        let query = self.prerecorded_query(language);
+        let content_type = mime_for_path(path);
+        let response = self
+            .http
+            .post(LISTEN_REST_URL)
+            .query(&query)
+            .header("Authorization", format!("Token {}", self.api_key))
+            .header("Content-Type", content_type)
+            .body(bytes)
+            .send()
+            .await
+            .context("Failed to submit audio to Deepgram")?;
+
+        let response = ensure_success(response, "prerecorded transcription").await?;
+
+        ensure_not_cancelled(&mut should_cancel)?;
+        progress(85, "Parsing Deepgram transcript...");
+        let payload: PrerecordedResponse = response
+            .json()
+            .await
+            .context("Failed to parse Deepgram prerecorded response")?;
+
+        let (text, words) = payload
+            .results
+            .channels
+            .into_iter()
+            .next()
+            .and_then(|channel| channel.alternatives.into_iter().next())
+            .map(|alt| (alt.transcript, alt.words))
+            .unwrap_or_default();
+
+        Ok(DeepgramTranscript {
+            text,
+            utterances: payload.results.utterances,
+            words,
+            duration_seconds: payload.metadata.and_then(|m| m.duration),
+        })
+    }
+
+    /// Query parameters for the prerecorded endpoint. `smart_format` and
+    /// `punctuate` give readable transcripts; `utterances` yields speaker turns.
+    fn prerecorded_query(&self, language: Option<String>) -> Vec<(String, String)> {
+        let model = self.prerecorded_model();
+        let mut query = vec![
+            ("model".to_string(), model.to_string()),
+            ("smart_format".to_string(), "true".to_string()),
+            ("punctuate".to_string(), "true".to_string()),
+            ("utterances".to_string(), "true".to_string()),
+            ("paragraphs".to_string(), "true".to_string()),
+        ];
+        if self.options.diarize {
+            query.push(("diarize".to_string(), "true".to_string()));
+        }
+        apply_language(&mut query, language.as_deref(), model);
+        apply_keyterms(&mut query, &self.options.keyterms);
+        query
+    }
+
+    /// The model to use for prerecorded (file) transcription. Flux is a
+    /// realtime-only API with no `/v1/listen` prerecorded support, so imported
+    /// audio / retranscription falls back to the default nova async model.
+    fn prerecorded_model(&self) -> &str {
+        if is_flux_model(&self.options.model) {
+            crate::config::DEFAULT_DEEPGRAM_ASYNC_MODEL
+        } else {
+            &self.options.model
+        }
+    }
+}
+
+// ============================================================================
+// CONFIG READERS
+// ============================================================================
+
+pub async fn configured_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<String> {
+    let app_state = app
+        .try_state::<AppState>()
+        .ok_or_else(|| anyhow!("App state not available"))?;
+
+    let stored_key =
+        SettingsRepository::get_transcript_api_key(app_state.db_manager.pool(), PROVIDER)
+            .await
+            .context("Failed to read Deepgram API key from settings")?;
+
+    let key = stored_key
+        .filter(|key| !key.trim().is_empty())
+        .or_else(|| std::env::var("DEEPGRAM_API_KEY").ok())
+        .unwrap_or_default();
+
+    if key.trim().is_empty() {
+        return Err(anyhow!(
+            "Deepgram API key is not configured. Add it in Transcription settings or set DEEPGRAM_API_KEY."
+        ));
+    }
+
+    Ok(key)
+}
+
+pub async fn validate_configured_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+    configured_api_key(app)
+        .await
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+/// Reads the persisted Deepgram options: model (from transcript config) plus
+/// keyterms/diarize (from the dedicated Deepgram settings columns).
+pub async fn configured_options<R: Runtime>(app: &AppHandle<R>) -> Result<DeepgramOptions> {
+    let app_state = app
+        .try_state::<AppState>()
+        .ok_or_else(|| anyhow!("App state not available"))?;
+    let pool = app_state.db_manager.pool();
+
+    let mut options = DeepgramOptions::default();
+
+    if let Ok(Some(config)) = SettingsRepository::get_transcript_config(pool).await {
+        if config.provider == PROVIDER && !config.model.trim().is_empty() {
+            options.model = config.model;
+        }
+    }
+
+    let (keyterm, diarize) = SettingsRepository::get_deepgram_options(pool)
+        .await
+        .unwrap_or((None, None));
+    options.keyterms = parse_keyterms(keyterm.as_deref());
+    if let Some(diarize) = diarize {
+        options.diarize = diarize != 0;
+    }
+
+    Ok(options)
+}
+
+pub async fn client_from_config<R: Runtime>(app: &AppHandle<R>) -> Result<DeepgramClient> {
+    let api_key = configured_api_key(app).await?;
+    let options = configured_options(app).await?;
+    Ok(DeepgramClient::new(api_key, options))
+}
+
+// ============================================================================
+// SEGMENT MAPPING (prerecorded)
+// ============================================================================
+
+/// Convert a prerecorded transcript to segments. Prefers `utterances` (already
+/// speaker-segmented turns); falls back to word grouping, then to a single
+/// segment covering the whole file.
+pub fn transcript_to_segments(
+    transcript: &DeepgramTranscript,
+    fallback_duration_seconds: f64,
+) -> Vec<TranscriptSegment> {
+    if !transcript.utterances.is_empty() {
+        let tuples = utterances_to_tuples(&transcript.utterances);
+        let segments = super::common::create_transcript_segments(&tuples);
+        if !segments.is_empty() {
+            return segments;
+        }
+    }
+
+    let mut segments = super::common::create_transcript_segments(&words_to_tuples(&transcript.words));
+    if segments.is_empty() && !transcript.text.trim().is_empty() {
+        // Prefer Deepgram's own reported duration; fall back to the caller's.
+        let total_duration = transcript.duration_seconds.unwrap_or(fallback_duration_seconds);
+        segments.push(TranscriptSegment {
+            id: format!("transcript-{}", uuid::Uuid::new_v4()),
+            text: transcript.text.trim().to_string(),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            audio_start_time: Some(0.0),
+            audio_end_time: Some(total_duration),
+            duration: Some(total_duration),
+        });
+    }
+    segments
+}
+
+fn utterances_to_tuples(utterances: &[Utterance]) -> Vec<(String, f64, f64)> {
+    let mut tuples = Vec::new();
+    for utterance in utterances {
+        push_tuple(
+            &mut tuples,
+            utterance.transcript.clone(),
+            utterance.start * 1000.0,
+            utterance.end * 1000.0,
+        );
+    }
+    tuples
+}
+
+/// Group word-level output into segments on speaker change, long pause, or a
+/// long sentence-terminated run, so transcript rows stay a readable size.
+fn words_to_tuples(words: &[DeepgramWord]) -> Vec<(String, f64, f64)> {
+    let mut segments = Vec::new();
+    let mut current_text = String::new();
+    let mut current_start_ms = 0.0;
+    let mut current_end_ms = 0.0;
+    let mut current_speaker: Option<i64> = None;
+
+    for word in words {
+        let display = word.punctuated_word.as_deref().unwrap_or(&word.word);
+        if display.is_empty() {
+            continue;
+        }
+
+        let word_start_ms = word.start * 1000.0;
+        let word_end_ms = (word.end * 1000.0).max(word_start_ms);
+        let speaker_changed = current_speaker.is_some() && word.speaker != current_speaker;
+        let long_gap = !current_text.is_empty() && word_start_ms - current_end_ms > 1500.0;
+        let long_segment =
+            word_start_ms - current_start_ms > 30_000.0 && ends_sentence(&current_text);
+
+        if !current_text.is_empty() && (speaker_changed || long_gap || long_segment) {
+            push_tuple(
+                &mut segments,
+                std::mem::take(&mut current_text),
+                current_start_ms,
+                current_end_ms,
+            );
+            current_speaker = None;
+        }
+
+        if current_text.is_empty() {
+            current_start_ms = word_start_ms;
+            current_speaker = word.speaker;
+        } else {
+            current_text.push(' ');
+        }
+
+        current_text.push_str(display);
+        current_end_ms = word_end_ms;
+    }
+
+    push_tuple(&mut segments, current_text, current_start_ms, current_end_ms);
+    segments
+}
+
+// ============================================================================
+// REALTIME (WebSocket)
+// ============================================================================
+
+pub async fn run_realtime_transcription<R: Runtime>(
+    app: AppHandle<R>,
+    transcription_receiver: mpsc::UnboundedReceiver<AudioChunk>,
+) -> Result<(), String> {
+    REALTIME_SPEECH_DETECTED_EMITTED.store(false, Ordering::SeqCst);
+
+    let api_key = configured_api_key(&app).await.map_err(|e| e.to_string())?;
+    let options = configured_options(&app).await.map_err(|e| e.to_string())?;
+    let language = crate::get_language_preference_internal();
+
+    // Flux is a distinct realtime API: /v2/listen with turn-based `TurnInfo` events
+    // and its own model-selected language handling. nova uses /v1/listen `Results`.
+    let flux = is_flux_model(&options.model);
+    let url = if flux {
+        build_flux_url(&options, language)
+    } else {
+        build_realtime_url(&options, language)
+    };
+    let mut request = url
+        .into_client_request()
+        .map_err(|e| format!("Failed to build Deepgram WebSocket request: {}", e))?;
+    // Deepgram uses the "Token" scheme, not "Bearer".
+    let auth_header = HeaderValue::from_str(&format!("Token {}", api_key))
+        .map_err(|e| format!("Failed to build Deepgram auth header: {}", e))?;
+    request.headers_mut().insert("Authorization", auth_header);
+
+    info!("Connecting to Deepgram realtime transcription ({})", options.model);
+    let writer_flux = flux;
+    let reader_flux = flux;
+    let (ws_stream, _) = connect_async(request)
+        .await
+        .map_err(|e| format!("Failed to connect to Deepgram realtime API: {}", e))?;
+    let (mut write, mut read) = ws_stream.split();
+
+    let time_map = Arc::new(Mutex::new(Vec::<AudioTimeMapEntry>::new()));
+    let stream_cursor_ms = Arc::new(Mutex::new(0.0f64));
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    let writer_time_map = time_map.clone();
+    let writer_cursor = stream_cursor_ms.clone();
+    let writer_shutdown = shutdown.clone();
+    let writer_handle = tokio::spawn(async move {
+        let mut receiver = transcription_receiver;
+        let mut keepalive = tokio::time::interval(Duration::from_secs(KEEPALIVE_SECS));
+        let mut shutdown_interval = tokio::time::interval(Duration::from_millis(250));
+
+        loop {
+            tokio::select! {
+                _ = shutdown_interval.tick() => {
+                    if writer_shutdown.load(Ordering::SeqCst) {
+                        break;
+                    }
+                }
+                _ = keepalive.tick() => {
+                    // nova closes an idle socket after ~10s; Flux manages turns itself
+                    // and does not accept the KeepAlive control frame.
+                    if !writer_flux {
+                        let msg = serde_json::json!({ "type": "KeepAlive" }).to_string();
+                        if let Err(e) = write.send(Message::Text(msg)).await {
+                            return Err(anyhow!("Failed to send Deepgram KeepAlive: {}", e));
+                        }
+                    }
+                }
+                maybe_chunk = receiver.recv() => {
+                    let Some(chunk) = maybe_chunk else {
+                        break;
+                    };
+
+                    if chunk.data.is_empty() {
+                        continue;
+                    }
+
+                    let original_start_ms = chunk.timestamp * 1000.0;
+                    let original_duration_ms =
+                        chunk.data.len() as f64 / chunk.sample_rate as f64 * 1000.0;
+                    let original_end_ms = original_start_ms + original_duration_ms;
+
+                    let pcm_samples = if chunk.sample_rate != PCM_SAMPLE_RATE {
+                        super::audio_processing::resample_audio(&chunk.data, chunk.sample_rate, PCM_SAMPLE_RATE)
+                    } else {
+                        chunk.data
+                    };
+
+                    if pcm_samples.is_empty() {
+                        continue;
+                    }
+
+                    let duration_ms = pcm_samples.len() as f64 / PCM_SAMPLE_RATE as f64 * 1000.0;
+                    {
+                        let mut cursor = writer_cursor.lock().await;
+                        let entry = AudioTimeMapEntry {
+                            stream_start_ms: *cursor,
+                            stream_end_ms: *cursor + duration_ms,
+                            original_start_ms,
+                            original_end_ms,
+                        };
+                        *cursor += duration_ms;
+                        writer_time_map.lock().await.push(entry);
+                    }
+
+                    let bytes = f32_to_pcm16le(&pcm_samples);
+                    if let Err(e) = write.send(Message::Binary(bytes)).await {
+                        return Err(anyhow!("Failed to send audio to Deepgram realtime API: {}", e));
+                    }
+                }
+            }
+        }
+
+        // nova: flush pending audio and finalize via CloseStream. Flux: just drop
+        // the write half (closing the socket ends the turn); it has no CloseStream.
+        if !writer_flux {
+            let close = serde_json::json!({ "type": "CloseStream" }).to_string();
+            let _ = write.send(Message::Text(close)).await;
+        }
+        Ok::<(), anyhow::Error>(())
+    });
+
+    let reader_time_map = time_map.clone();
+    let reader_shutdown = shutdown.clone();
+    let reader_app = app.clone();
+    let reader_handle = tokio::spawn(async move {
+        while let Some(message) = read.next().await {
+            let message = match message {
+                Ok(message) => message,
+                Err(e) => {
+                    reader_shutdown.store(true, Ordering::SeqCst);
+                    return Err(anyhow!("Deepgram realtime WebSocket error: {}", e));
+                }
+            };
+
+            match message {
+                Message::Text(text) => {
+                    // Parse per protocol and reduce to an optional finalized segment
+                    // (interim/Metadata/StartOfTurn/Update/etc. produce None). Both
+                    // report a `type:"Error"` control message on failure.
+                    let final_seg = if reader_flux {
+                        match serde_json::from_str::<FluxTurnInfo>(&text) {
+                            Ok(m) => {
+                                if m.msg_type.as_deref() == Some("Error") {
+                                    let err = m
+                                        .description
+                                        .or(m.message)
+                                        .unwrap_or_else(|| "unknown error".to_string());
+                                    reader_shutdown.store(true, Ordering::SeqCst);
+                                    return Err(anyhow!("Deepgram Flux realtime error: {}", err));
+                                }
+                                flux_turn_to_final(&m)
+                            }
+                            Err(e) => {
+                                warn!("Failed to parse Deepgram Flux response: {} ({})", e, text);
+                                None
+                            }
+                        }
+                    } else {
+                        match serde_json::from_str::<RealtimeMessage>(&text) {
+                            Ok(m) => {
+                                if m.msg_type.as_deref() == Some("Error") {
+                                    let err = m
+                                        .description
+                                        .or(m.message)
+                                        .unwrap_or_else(|| "unknown error".to_string());
+                                    reader_shutdown.store(true, Ordering::SeqCst);
+                                    return Err(anyhow!("Deepgram realtime error: {}", err));
+                                }
+                                nova_result_to_final(m)
+                            }
+                            Err(e) => {
+                                warn!("Failed to parse Deepgram realtime response: {} ({})", e, text);
+                                None
+                            }
+                        }
+                    };
+
+                    if let Some(seg) = final_seg {
+                        let entries = reader_time_map.lock().await.clone();
+                        let start_ms = map_stream_ms_to_original(&entries, seg.start_ms);
+                        let end_ms =
+                            map_stream_ms_to_original(&entries, seg.end_ms).max(start_ms);
+                        emit_speech_detected(&reader_app);
+                        emit_transcript_update(
+                            &reader_app,
+                            seg.transcript,
+                            start_ms,
+                            end_ms,
+                            seg.confidence,
+                            false,
+                        );
+                    }
+                }
+                Message::Close(_) => break,
+                _ => {}
+            }
+        }
+
+        reader_shutdown.store(true, Ordering::SeqCst);
+        Ok::<(), anyhow::Error>(())
+    });
+
+    let writer_result = writer_handle
+        .await
+        .map_err(|e| format!("Deepgram realtime writer task failed: {}", e))?;
+    // On any error we return Err; the transcription worker owns the single
+    // `transcription-error` emit, so we do not emit here (avoids double events).
+    if let Err(e) = writer_result {
+        shutdown.store(true, Ordering::SeqCst);
+        return Err(e.to_string());
+    }
+
+    let mut reader_handle = reader_handle;
+    match tokio::time::timeout(Duration::from_secs(30), &mut reader_handle).await {
+        Ok(join_result) => {
+            let reader_result =
+                join_result.map_err(|e| format!("Deepgram realtime reader task failed: {}", e))?;
+            if let Err(e) = reader_result {
+                return Err(e.to_string());
+            }
+        }
+        Err(_) => {
+            reader_handle.abort();
+            warn!("Timed out waiting for Deepgram realtime final response");
+        }
+    }
+
+    info!("Deepgram realtime transcription task completed");
+    Ok(())
+}
+
+pub fn map_stream_ms_to_original(entries: &[AudioTimeMapEntry], stream_ms: f64) -> f64 {
+    if entries.is_empty() {
+        return stream_ms;
+    }
+
+    if let Some(entry) = entries
+        .iter()
+        .find(|entry| stream_ms >= entry.stream_start_ms && stream_ms <= entry.stream_end_ms)
+    {
+        let stream_duration = (entry.stream_end_ms - entry.stream_start_ms).max(1.0);
+        let original_duration = (entry.original_end_ms - entry.original_start_ms).max(0.0);
+        let offset_ratio = ((stream_ms - entry.stream_start_ms) / stream_duration).clamp(0.0, 1.0);
+        return entry.original_start_ms + original_duration * offset_ratio;
+    }
+
+    if stream_ms < entries[0].stream_start_ms {
+        return entries[0].original_start_ms;
+    }
+
+    let last = entries.last().expect("entries is not empty");
+    last.original_end_ms + (stream_ms - last.stream_end_ms).max(0.0)
+}
+
+/// True for Flux models (`flux-general-en`, `flux-general-multi`), which use the
+/// separate v2 turn-based realtime API rather than the nova `/v1/listen` path.
+fn is_flux_model(model: &str) -> bool {
+    model.starts_with("flux")
+}
+
+fn build_realtime_url(options: &DeepgramOptions, language: Option<String>) -> String {
+    let mut query: Vec<(String, String)> = vec![
+        ("encoding".to_string(), "linear16".to_string()),
+        ("sample_rate".to_string(), PCM_SAMPLE_RATE.to_string()),
+        ("channels".to_string(), "1".to_string()),
+        ("model".to_string(), options.model.clone()),
+        ("smart_format".to_string(), "true".to_string()),
+        ("punctuate".to_string(), "true".to_string()),
+        // Finals only: the transcript UI buffers by sequence id with no
+        // partial-replace path, so interim results would duplicate segments.
+        ("interim_results".to_string(), "false".to_string()),
+        ("endpointing".to_string(), "300".to_string()),
+    ];
+    if options.diarize {
+        query.push(("diarize".to_string(), "true".to_string()));
+    }
+    apply_language(&mut query, language.as_deref(), &options.model);
+    apply_keyterms(&mut query, &options.keyterms);
+    encode_ws_url(LISTEN_WS_URL, &query)
+}
+
+/// Build the Flux v2 realtime URL. Flux does its own turn detection and
+/// formatting, so it takes none of the nova knobs (smart_format/punctuate/
+/// diarize/endpointing/language). The multilingual model accepts `language_hint`;
+/// language is otherwise selected by the model name, not a `language` param.
+fn build_flux_url(options: &DeepgramOptions, language: Option<String>) -> String {
+    let mut query: Vec<(String, String)> = vec![
+        ("model".to_string(), options.model.clone()),
+        ("encoding".to_string(), "linear16".to_string()),
+        ("sample_rate".to_string(), PCM_SAMPLE_RATE.to_string()),
+    ];
+    if options.model.ends_with("multi") {
+        if let Some(hint) = language.as_deref().map(str::trim).filter(|l| {
+            !l.is_empty() && *l != "auto" && *l != "auto-translate" && *l != "detect"
+        }) {
+            query.push(("language_hint".to_string(), hint.to_string()));
+        }
+    }
+    apply_keyterms(&mut query, &options.keyterms);
+    encode_ws_url(FLUX_WS_URL, &query)
+}
+
+fn encode_ws_url(base: &str, query: &[(String, String)]) -> String {
+    let encoded = query
+        .iter()
+        .map(|(k, v)| format!("{}={}", k, urlencode(v)))
+        .collect::<Vec<_>>()
+        .join("&");
+    format!("{}?{}", base, encoded)
+}
+
+// ============================================================================
+// EMITTERS (shared with the local-engine worker event contract)
+// ============================================================================
+
+fn emit_speech_detected<R: Runtime>(app: &AppHandle<R>) {
+    if REALTIME_SPEECH_DETECTED_EMITTED
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        let _ = app.emit(
+            "speech-detected",
+            serde_json::json!({ "message": "Speech activity detected" }),
+        );
+    }
+}
+
+fn emit_transcript_update<R: Runtime>(
+    app: &AppHandle<R>,
+    text: String,
+    start_ms: f64,
+    end_ms: f64,
+    confidence: f32,
+    is_partial: bool,
+) {
+    let sequence_id = REALTIME_SEQUENCE_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let audio_start_time = start_ms / 1000.0;
+    let audio_end_time = end_ms.max(start_ms) / 1000.0;
+    let duration = (audio_end_time - audio_start_time).max(0.0);
+
+    let update = TranscriptUpdate {
+        text,
+        timestamp: chrono::Local::now().format("%H:%M:%S").to_string(),
+        source: "Audio".to_string(),
+        sequence_id,
+        chunk_start_time: audio_start_time,
+        is_partial,
+        confidence,
+        audio_start_time,
+        audio_end_time,
+        duration,
+    };
+
+    if let Err(e) = app.emit("transcript-update", &update) {
+        error!("Failed to emit Deepgram transcript update: {}", e);
+    }
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/// Apply a language hint. Deepgram nova-3 supports `multi` for code-switching;
+/// when the user leaves language on auto we default nova-3 to `multi` and leave
+/// other models to their own default.
+fn apply_language(query: &mut Vec<(String, String)>, language: Option<&str>, model: &str) {
+    let hint = language
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && *l != "auto" && *l != "auto-translate" && *l != "detect");
+
+    match hint {
+        Some(lang) => query.push(("language".to_string(), lang.to_string())),
+        None if model.starts_with("nova-3") => {
+            query.push(("language".to_string(), "multi".to_string()))
+        }
+        None => {}
+    }
+}
+
+/// keyterm prompting is supported by nova-3 and Flux (both use `keyterm`); nova-2
+/// uses `keywords`. Route each term to the correct parameter for the model.
+fn apply_keyterms(query: &mut Vec<(String, String)>, keyterms: &[String]) {
+    if keyterms.is_empty() {
+        return;
+    }
+    let param = if query
+        .iter()
+        .any(|(k, v)| k == "model" && (v.starts_with("nova-3") || v.starts_with("flux")))
+    {
+        "keyterm"
+    } else {
+        "keywords"
+    };
+    for term in keyterms {
+        let term = term.trim();
+        if !term.is_empty() {
+            query.push((param.to_string(), term.to_string()));
+        }
+    }
+}
+
+/// Split a stored keyterm blob (newline- or comma-separated) into terms.
+pub fn parse_keyterms(raw: Option<&str>) -> Vec<String> {
+    raw.map(|raw| {
+        raw.split(['\n', ','])
+            .map(str::trim)
+            .filter(|term| !term.is_empty())
+            .map(str::to_string)
+            .collect()
+    })
+    .unwrap_or_default()
+}
+
+fn mime_for_path(path: &Path) -> &'static str {
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("wav") => "audio/wav",
+        Some("mp3") => "audio/mpeg",
+        Some("m4a" | "mp4") => "audio/mp4",
+        Some("flac") => "audio/flac",
+        Some("ogg" | "opus") => "audio/ogg",
+        Some("webm") => "audio/webm",
+        _ => "application/octet-stream",
+    }
+}
+
+fn f32_to_pcm16le(samples: &[f32]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(samples.len() * 2);
+    for sample in samples {
+        let clamped = sample.clamp(-1.0, 1.0);
+        let pcm = (clamped * i16::MAX as f32) as i16;
+        bytes.extend_from_slice(&pcm.to_le_bytes());
+    }
+    bytes
+}
+
+async fn ensure_success(response: reqwest::Response, action: &str) -> Result<reqwest::Response> {
+    if response.status().is_success() {
+        return Ok(response);
+    }
+
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    Err(anyhow!(
+        "Deepgram {} failed (HTTP {}): {}",
+        action,
+        status,
+        truncate_for_error(&body)
+    ))
+}
+
+fn ensure_not_cancelled<C>(should_cancel: &mut C) -> Result<()>
+where
+    C: FnMut() -> bool,
+{
+    if should_cancel() {
+        Err(anyhow!("Operation cancelled"))
+    } else {
+        Ok(())
+    }
+}
+
+fn push_tuple(segments: &mut Vec<(String, f64, f64)>, text: String, start_ms: f64, end_ms: f64) {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    segments.push((trimmed.to_string(), start_ms, end_ms.max(start_ms)));
+}
+
+fn average_confidence(values: impl Iterator<Item = f32>) -> f32 {
+    let mut sum = 0.0;
+    let mut count = 0usize;
+    for value in values {
+        sum += value;
+        count += 1;
+    }
+    if count == 0 {
+        0.85
+    } else {
+        sum / count as f32
+    }
+}
+
+fn ends_sentence(text: &str) -> bool {
+    text.trim_end()
+        .chars()
+        .last()
+        .map(|c| matches!(c, '.' | '!' | '?' | '\n'))
+        .unwrap_or(false)
+}
+
+fn truncate_for_error(text: &str) -> String {
+    const MAX_LEN: usize = 500;
+    if text.len() <= MAX_LEN {
+        return text.to_string();
+    }
+    let mut end = MAX_LEN;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &text[..end])
+}
+
+/// Minimal percent-encoding for query values (keyterms may contain spaces).
+fn urlencode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char)
+            }
+            _ => out.push_str(&format!("%{:02X}", byte)),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn word(w: &str, start: f64, end: f64, speaker: Option<i64>) -> DeepgramWord {
+        DeepgramWord {
+            word: w.to_string(),
+            punctuated_word: Some(w.to_string()),
+            start,
+            end,
+            confidence: Some(0.9),
+            speaker,
+        }
+    }
+
+    #[test]
+    fn utterances_map_to_one_segment_each() {
+        let transcript = DeepgramTranscript {
+            text: "ignored".to_string(),
+            utterances: vec![
+                Utterance {
+                    start: 0.0,
+                    end: 1.5,
+                    transcript: "Hello there.".to_string(),
+                },
+                Utterance {
+                    start: 2.0,
+                    end: 3.0,
+                    transcript: "General Kenobi.".to_string(),
+                },
+            ],
+            words: vec![],
+            duration_seconds: Some(3.0),
+        };
+        let segments = transcript_to_segments(&transcript, 3.0);
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].text, "Hello there.");
+        assert_eq!(segments[1].text, "General Kenobi.");
+        assert_eq!(segments[0].audio_start_time, Some(0.0));
+        assert_eq!(segments[1].audio_start_time, Some(2.0));
+    }
+
+    #[test]
+    fn words_split_on_speaker_change() {
+        let words = vec![
+            word("Hello", 0.0, 0.4, Some(0)),
+            word("world.", 0.4, 0.9, Some(0)),
+            word("Reply", 1.0, 1.4, Some(1)),
+        ];
+        let tuples = words_to_tuples(&words);
+        assert_eq!(tuples.len(), 2);
+        assert_eq!(tuples[0].0, "Hello world.");
+        assert_eq!(tuples[1].0, "Reply");
+    }
+
+    #[test]
+    fn falls_back_to_single_segment_when_only_text() {
+        let transcript = DeepgramTranscript {
+            text: "Whole thing.".to_string(),
+            utterances: vec![],
+            words: vec![],
+            duration_seconds: Some(5.0),
+        };
+        let segments = transcript_to_segments(&transcript, 5.0);
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].text, "Whole thing.");
+        assert_eq!(segments[0].audio_end_time, Some(5.0));
+    }
+
+    #[test]
+    fn maps_stream_time_to_original_chunk_time() {
+        let entries = vec![
+            AudioTimeMapEntry {
+                stream_start_ms: 0.0,
+                stream_end_ms: 1000.0,
+                original_start_ms: 5000.0,
+                original_end_ms: 6000.0,
+            },
+            AudioTimeMapEntry {
+                stream_start_ms: 1000.0,
+                stream_end_ms: 2000.0,
+                original_start_ms: 9000.0,
+                original_end_ms: 10_000.0,
+            },
+        ];
+        assert_eq!(map_stream_ms_to_original(&entries, 500.0), 5500.0);
+        assert_eq!(map_stream_ms_to_original(&entries, 1500.0), 9500.0);
+    }
+
+    #[test]
+    fn nova3_keyterms_use_keyterm_param() {
+        let mut query = vec![("model".to_string(), "nova-3".to_string())];
+        apply_keyterms(&mut query, &["Meetily".to_string(), "Deepgram".to_string()]);
+        let keyterms: Vec<_> = query.iter().filter(|(k, _)| k == "keyterm").collect();
+        assert_eq!(keyterms.len(), 2);
+    }
+
+    #[test]
+    fn nova2_keyterms_use_keywords_param() {
+        let mut query = vec![("model".to_string(), "nova-2".to_string())];
+        apply_keyterms(&mut query, &["Meetily".to_string()]);
+        assert!(query.iter().any(|(k, _)| k == "keywords"));
+        assert!(!query.iter().any(|(k, _)| k == "keyterm"));
+    }
+
+    #[test]
+    fn language_defaults_to_multi_for_nova3_only() {
+        let mut q1 = vec![];
+        apply_language(&mut q1, None, "nova-3");
+        assert_eq!(q1, vec![("language".to_string(), "multi".to_string())]);
+
+        let mut q2 = vec![];
+        apply_language(&mut q2, None, "nova-2");
+        assert!(q2.is_empty());
+
+        let mut q3 = vec![];
+        apply_language(&mut q3, Some("en"), "nova-3");
+        assert_eq!(q3, vec![("language".to_string(), "en".to_string())]);
+    }
+
+    #[test]
+    fn parse_keyterms_splits_on_commas_and_newlines() {
+        assert_eq!(
+            parse_keyterms(Some("Meetily, Deepgram\nNova")),
+            vec!["Meetily", "Deepgram", "Nova"]
+        );
+        assert!(parse_keyterms(None).is_empty());
+        assert!(parse_keyterms(Some("  ,\n ")).is_empty());
+    }
+
+    #[test]
+    fn realtime_url_contains_expected_params() {
+        let options = DeepgramOptions {
+            model: "nova-3".to_string(),
+            keyterms: vec!["Meetily".to_string()],
+            diarize: true,
+        };
+        let url = build_realtime_url(&options, Some("en".to_string()));
+        assert!(url.starts_with("wss://api.deepgram.com/v1/listen?"));
+        assert!(url.contains("encoding=linear16"));
+        assert!(url.contains("model=nova-3"));
+        assert!(url.contains("diarize=true"));
+        assert!(url.contains("interim_results=false"));
+        assert!(url.contains("keyterm=Meetily"));
+        assert!(url.contains("language=en"));
+    }
+
+    #[test]
+    fn language_auto_is_treated_as_no_hint() {
+        // "auto"/"detect" sentinels are filtered; nova-3 then falls back to multi.
+        let mut q = vec![];
+        apply_language(&mut q, Some("auto"), "nova-3");
+        assert_eq!(q, vec![("language".to_string(), "multi".to_string())]);
+    }
+
+    #[test]
+    fn keyterm_with_spaces_is_percent_encoded_in_url() {
+        let options = DeepgramOptions {
+            model: "nova-3".to_string(),
+            keyterms: vec!["Acme Corp".to_string()],
+            diarize: false,
+        };
+        let url = build_realtime_url(&options, None);
+        assert!(url.contains("keyterm=Acme%20Corp"));
+        assert!(!url.contains("diarize="));
+    }
+
+    // Contract tests: lock the Deepgram wire shape we verified live so a
+    // response-schema change is caught here rather than at runtime.
+    #[test]
+    fn parses_prerecorded_utterances_into_segments() {
+        let json = r#"{
+            "metadata": { "duration": 3.5 },
+            "results": {
+                "channels": [ { "alternatives": [ {
+                    "transcript": "Hello there. General Kenobi.",
+                    "confidence": 0.98,
+                    "words": [ { "word": "hello", "punctuated_word": "Hello.",
+                        "start": 0.0, "end": 0.8, "confidence": 0.95, "speaker": 0 } ]
+                } ] } ],
+                "utterances": [
+                    { "start": 0.0, "end": 1.5, "confidence": 0.97,
+                      "transcript": "Hello there.", "speaker": 0 },
+                    { "start": 2.0, "end": 3.0, "confidence": 0.96,
+                      "transcript": "General Kenobi.", "speaker": 1 }
+                ]
+            }
+        }"#;
+        let payload: PrerecordedResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.metadata.and_then(|m| m.duration), Some(3.5));
+        let transcript = DeepgramTranscript {
+            text: payload.results.channels[0].alternatives[0].transcript.clone(),
+            utterances: payload.results.utterances,
+            words: payload.results.channels[0].alternatives[0].words.clone(),
+            duration_seconds: Some(3.5),
+        };
+        let segments = transcript_to_segments(&transcript, 3.5);
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].text, "Hello there.");
+        assert_eq!(segments[1].audio_start_time, Some(2.0));
+    }
+
+    #[test]
+    fn parses_realtime_results_message() {
+        let json = r#"{
+            "type": "Results",
+            "channel_index": [0, 1],
+            "duration": 1.02,
+            "start": 4.5,
+            "is_final": true,
+            "speech_final": true,
+            "channel": { "alternatives": [ {
+                "transcript": "This is a meeting.",
+                "confidence": 0.99,
+                "words": [ { "word": "this", "punctuated_word": "This",
+                    "start": 4.5, "end": 4.7, "confidence": 0.99, "speaker": 0 } ]
+            } ] }
+        }"#;
+        let msg: RealtimeMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.msg_type.as_deref(), Some("Results"));
+        assert!(msg.is_final);
+        assert_eq!(msg.start, 4.5);
+        let alt = msg.channel.unwrap().alternatives.into_iter().next().unwrap();
+        assert_eq!(alt.transcript, "This is a meeting.");
+        assert_eq!(alt.confidence, Some(0.99));
+    }
+
+    #[test]
+    fn parses_realtime_error_message() {
+        let json = r#"{ "type": "Error", "description": "bad audio", "message": "detail" }"#;
+        let msg: RealtimeMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.msg_type.as_deref(), Some("Error"));
+        assert_eq!(msg.description.as_deref(), Some("bad audio"));
+    }
+
+    #[test]
+    fn nova_result_reduction_finals_only() {
+        let mk = |is_final: bool| RealtimeMessage {
+            msg_type: Some("Results".to_string()),
+            channel: Some(RealtimeChannel {
+                alternatives: vec![Alternative {
+                    transcript: "Hi there.".to_string(),
+                    confidence: Some(0.9),
+                    words: vec![],
+                }],
+            }),
+            is_final,
+            start: 1.0,
+            duration: 0.5,
+            description: None,
+            message: None,
+        };
+        assert!(nova_result_to_final(mk(false)).is_none());
+        let seg = nova_result_to_final(mk(true)).unwrap();
+        assert_eq!(seg.transcript, "Hi there.");
+        assert_eq!(seg.start_ms, 1000.0);
+        assert_eq!(seg.end_ms, 1500.0);
+    }
+
+    // --- Flux (v2) contract + reduction ---
+
+    #[test]
+    fn flux_reduction_only_on_end_of_turn() {
+        let mk = |event: &str, transcript: &str| FluxTurnInfo {
+            msg_type: Some("TurnInfo".to_string()),
+            event: Some(event.to_string()),
+            transcript: transcript.to_string(),
+            audio_window_start: 0.0,
+            audio_window_end: 8.32,
+            words: vec![DeepgramWord {
+                word: "Hello".to_string(),
+                punctuated_word: None,
+                start: 0.0,
+                end: 0.48,
+                confidence: Some(1.0),
+                speaker: None,
+            }],
+            description: None,
+            message: None,
+        };
+        assert!(flux_turn_to_final(&mk("Update", "Hello")).is_none());
+        assert!(flux_turn_to_final(&mk("StartOfTurn", "Hello")).is_none());
+        assert!(flux_turn_to_final(&mk("EndOfTurn", "   ")).is_none());
+        let seg = flux_turn_to_final(&mk("EndOfTurn", "Hello. This is a test.")).unwrap();
+        assert_eq!(seg.transcript, "Hello. This is a test.");
+        assert_eq!(seg.start_ms, 0.0);
+        assert_eq!(seg.end_ms, 8320.0);
+    }
+
+    #[test]
+    fn parses_real_flux_turninfo_shape() {
+        // Shape captured live from wss://api.deepgram.com/v2/listen (flux-general-multi).
+        let json = r#"{
+            "type": "TurnInfo", "request_id": "abc", "event": "EndOfTurn",
+            "turn_index": 0, "audio_window_start": 0.0, "audio_window_end": 8.32,
+            "transcript": "Hello. This is a flux test.",
+            "words": [ { "word": "Hello.", "confidence": 1.0, "start": 0.0, "end": 0.48, "language": "en" } ],
+            "languages": ["en"], "languages_hinted": ["en"],
+            "end_of_turn_confidence": 0.83, "sequence_id": 12
+        }"#;
+        let m: FluxTurnInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(m.msg_type.as_deref(), Some("TurnInfo"));
+        assert_eq!(m.event.as_deref(), Some("EndOfTurn"));
+        let seg = flux_turn_to_final(&m).unwrap();
+        assert_eq!(seg.transcript, "Hello. This is a flux test.");
+    }
+
+    #[test]
+    fn is_flux_model_detects_flux() {
+        assert!(is_flux_model("flux-general-en"));
+        assert!(is_flux_model("flux-general-multi"));
+        assert!(!is_flux_model("nova-3"));
+        assert!(!is_flux_model("nova-2"));
+    }
+
+    #[test]
+    fn flux_url_uses_v2_and_omits_nova_knobs() {
+        let opts = DeepgramOptions {
+            model: "flux-general-multi".to_string(),
+            keyterms: vec!["Meetily".to_string()],
+            diarize: true, // ignored by Flux
+        };
+        let url = build_flux_url(&opts, Some("en".to_string()));
+        assert!(url.starts_with("wss://api.deepgram.com/v2/listen?"));
+        assert!(url.contains("model=flux-general-multi"));
+        assert!(url.contains("language_hint=en")); // multi model biases via hint
+        assert!(url.contains("keyterm=Meetily")); // Flux uses keyterm, not keywords
+        assert!(!url.contains("smart_format"));
+        assert!(!url.contains("diarize"));
+        assert!(!url.contains("endpointing"));
+        assert!(!url.contains("language=")); // no language tag; model selects language
+    }
+
+    #[test]
+    fn flux_en_url_omits_language_hint() {
+        let opts = DeepgramOptions {
+            model: "flux-general-en".to_string(),
+            keyterms: vec![],
+            diarize: false,
+        };
+        let url = build_flux_url(&opts, Some("en".to_string()));
+        assert!(!url.contains("language_hint"));
+    }
+
+    #[test]
+    fn prerecorded_falls_back_to_nova_for_flux() {
+        // Flux is realtime-only; file transcription must use a nova model.
+        let flux = DeepgramClient::new(
+            "k".to_string(),
+            DeepgramOptions {
+                model: "flux-general-en".to_string(),
+                keyterms: vec!["Meetily".to_string()],
+                diarize: true,
+            },
+        );
+        let q = flux.prerecorded_query(None);
+        let model = &q.iter().find(|(k, _)| k == "model").unwrap().1;
+        assert_eq!(model, crate::config::DEFAULT_DEEPGRAM_ASYNC_MODEL);
+        assert!(!is_flux_model(model));
+        // keyterm still routes correctly for the nova fallback model.
+        assert!(q.iter().any(|(k, _)| k == "keyterm"));
+    }
+}

--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -266,6 +266,7 @@ pub async fn start_import<R: Runtime>(
     IMPORT_CANCELLED.store(false, Ordering::SeqCst);
 
     let use_parakeet = provider.as_deref() == Some("parakeet");
+    let use_deepgram = provider.as_deref() == Some(super::deepgram::PROVIDER);
     let result = run_import(
         app.clone(),
         source_path,
@@ -276,8 +277,11 @@ pub async fn start_import<R: Runtime>(
     )
     .await;
 
-    // Unload the engine after the batch job (success, failure, or cancellation)
-    super::common::unload_engine_after_batch(use_parakeet).await;
+    // Unload the engine after the batch job (success, failure, or cancellation).
+    // Deepgram is cloud-based with no local engine to unload.
+    if !use_deepgram {
+        super::common::unload_engine_after_batch(use_parakeet).await;
+    }
 
     // Guard will automatically clear flag on drop
     // No need for manual: IMPORT_IN_PROGRESS.store(false, Ordering::SeqCst);
@@ -330,6 +334,7 @@ async fn run_import<R: Runtime>(
 
     // Determine which provider to use (default to whisper)
     let use_parakeet = provider.as_deref() == Some("parakeet");
+    let use_deepgram = provider.as_deref() == Some(super::deepgram::PROVIDER);
 
     emit_progress(&app, "copying", 5, "Creating meeting folder...");
 
@@ -368,6 +373,85 @@ async fn run_import<R: Runtime>(
         // Cleanup: remove the meeting folder
         let _ = std::fs::remove_dir_all(&meeting_folder);
         return Err(anyhow!("Import cancelled"));
+    }
+
+    if use_deepgram {
+        emit_progress(&app, "transcribing", 15, "Preparing Deepgram transcription...");
+        let duration_seconds = match extract_duration_from_metadata(&dest_path) {
+            Ok(duration) => duration,
+            Err(e) => {
+                warn!("Deepgram import metadata duration failed: {}, decoding duration", e);
+                let decoded = tokio::task::spawn_blocking({
+                    let path = dest_path.clone();
+                    move || decode_audio_file(&path)
+                })
+                .await
+                .map_err(|e| anyhow!("Decode task join error: {}", e))??;
+                decoded.duration_seconds
+            }
+        };
+
+        let client = super::deepgram::client_from_config(&app).await?;
+        let app_for_progress = app.clone();
+        let client_reference_id = format!("import:{}", title);
+        let transcript = client
+            .transcribe_file_with_progress(
+                &dest_path,
+                language.clone(),
+                &client_reference_id,
+                move |provider_progress, message| {
+                    let overall_progress = 15 + ((provider_progress as f32 * 0.70) as u32);
+                    emit_progress(&app_for_progress, "transcribing", overall_progress.min(85), message);
+                },
+                || IMPORT_CANCELLED.load(Ordering::SeqCst),
+            )
+            .await?;
+
+        if IMPORT_CANCELLED.load(Ordering::SeqCst) {
+            let _ = std::fs::remove_dir_all(&meeting_folder);
+            return Err(anyhow!("Import cancelled"));
+        }
+
+        emit_progress(&app, "saving", 85, "Creating meeting...");
+        let segments = super::deepgram::transcript_to_segments(&transcript, duration_seconds);
+
+        let app_state = app
+            .try_state::<AppState>()
+            .ok_or_else(|| anyhow!("App state not available"))?;
+
+        let meeting_id = create_meeting_with_transcripts(
+            app_state.db_manager.pool(),
+            &title,
+            &segments,
+            meeting_folder.to_string_lossy().to_string(),
+        )
+        .await?;
+
+        emit_progress(&app, "saving", 90, "Writing transcript files...");
+
+        if let Err(e) = write_transcripts_json(&meeting_folder, &segments) {
+            warn!("Failed to write transcripts.json: {}", e);
+        }
+
+        if let Err(e) = write_import_metadata(
+            &meeting_folder,
+            &meeting_id,
+            &title,
+            duration_seconds,
+            &dest_filename,
+            "import",
+        ) {
+            warn!("Failed to write metadata.json: {}", e);
+        }
+
+        emit_progress(&app, "complete", 100, "Import complete");
+
+        return Ok(ImportResult {
+            meeting_id,
+            title,
+            segments_count: segments.len(),
+            duration_seconds,
+        });
     }
 
     emit_progress(&app, "decoding", 15, "Decoding audio file...");

--- a/frontend/src-tauri/src/audio/mod.rs
+++ b/frontend/src-tauri/src/audio/mod.rs
@@ -4,6 +4,7 @@ pub mod decoder;
 pub mod encode;
 pub mod ffmpeg;
 pub mod vad;
+pub mod deepgram;
 
 // Modularized device management
 pub mod devices;

--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -13,6 +13,12 @@ use super::recording_state::{AudioChunk, AudioError, RecordingState, DeviceType}
 use super::audio_processing::{audio_to_mono, LoudnessNormalizer, NoiseSuppressionProcessor, HighPassFilter};
 use super::vad::{ContinuousVadProcessor};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TranscriptionPipelineMode {
+    VadSpeechOnly,
+    ContinuousMixed,
+}
+
 /// Ring buffer for synchronized audio mixing
 /// Accumulates samples from mic and system streams until we have aligned windows
 struct AudioMixerRingBuffer {
@@ -694,6 +700,8 @@ pub struct AudioPipeline {
     mixer: ProfessionalAudioMixer,
     // Recording sender for pre-mixed audio
     recording_sender_for_mixed: Option<mpsc::UnboundedSender<AudioChunk>>,
+    transcription_mode: TranscriptionPipelineMode,
+    mixed_transcription_next_timestamp: Option<f64>,
 }
 
 impl AudioPipeline {
@@ -707,6 +715,7 @@ impl AudioPipeline {
         mic_device_kind: super::device_detection::InputDeviceKind,
         system_device_name: String,
         system_device_kind: super::device_detection::InputDeviceKind,
+        send_continuous_transcription: bool,
     ) -> Self {
         // Log device characteristics for adaptive buffering
         info!("🎛️ AudioPipeline initializing with device characteristics:");
@@ -760,6 +769,12 @@ impl AudioPipeline {
             ring_buffer,
             mixer,
             recording_sender_for_mixed: None,  // Will be set by manager
+            transcription_mode: if send_continuous_transcription {
+                TranscriptionPipelineMode::ContinuousMixed
+            } else {
+                TranscriptionPipelineMode::VadSpeechOnly
+            },
+            mixed_transcription_next_timestamp: None,
         }
     }
 
@@ -831,37 +846,62 @@ impl AudioPipeline {
                             // Previous 2x gain was causing excessive limiting/distortion
                             let mixed_with_gain = mixed_clean;
 
-                            // STEP 3: Send mixed audio for transcription (VAD + Whisper)
-                            match self.vad_processor.process_audio(&mixed_with_gain) {
-                                Ok(speech_segments) => {
-                                    for segment in speech_segments {
-                                        let duration_ms = segment.end_timestamp_ms - segment.start_timestamp_ms;
+                            // STEP 3: Send mixed audio for transcription.
+                            // Local engines still receive VAD speech segments, while a
+                            // realtime cloud provider receives a continuous stream to keep
+                            // its endpointing / turn detection stable.
+                            if self.transcription_mode == TranscriptionPipelineMode::ContinuousMixed {
+                                let duration = mixed_with_gain.len() as f64 / self.sample_rate as f64;
+                                let timestamp = self
+                                    .mixed_transcription_next_timestamp
+                                    .unwrap_or(chunk.timestamp);
+                                self.mixed_transcription_next_timestamp = Some(timestamp + duration);
 
-                                        if segment.samples.len() >= 800 {  // Minimum 50ms at 16kHz - matches Parakeet capability
-                                            info!("📤 Sending VAD segment: {:.1}ms, {} samples",
-                                                  duration_ms, segment.samples.len());
+                                let transcription_chunk = AudioChunk {
+                                    data: mixed_with_gain.clone(),
+                                    sample_rate: self.sample_rate,
+                                    timestamp,
+                                    chunk_id: self.chunk_id_counter,
+                                    device_type: DeviceType::Microphone,
+                                };
 
-                                            let transcription_chunk = AudioChunk {
-                                                data: segment.samples,
-                                                sample_rate: 16000,
-                                                timestamp: segment.start_timestamp_ms / 1000.0,
-                                                chunk_id: self.chunk_id_counter,
-                                                device_type: DeviceType::Microphone,  // Mixed audio
-                                            };
+                                if let Err(e) = self.transcription_sender.send(transcription_chunk) {
+                                    warn!("Failed to send mixed continuous transcription chunk: {}", e);
+                                } else {
+                                    self.chunk_id_counter += 1;
+                                }
+                            } else {
+                                match self.vad_processor.process_audio(&mixed_with_gain) {
+                                    Ok(speech_segments) => {
+                                        for segment in speech_segments {
+                                            let duration_ms = segment.end_timestamp_ms - segment.start_timestamp_ms;
 
-                                            if let Err(e) = self.transcription_sender.send(transcription_chunk) {
-                                                warn!("Failed to send VAD segment: {}", e);
+                                            if segment.samples.len() >= 800 {  // Minimum 50ms at 16kHz - matches Parakeet capability
+                                                info!("📤 Sending VAD segment: {:.1}ms, {} samples",
+                                                      duration_ms, segment.samples.len());
+
+                                                let transcription_chunk = AudioChunk {
+                                                    data: segment.samples,
+                                                    sample_rate: 16000,
+                                                    timestamp: segment.start_timestamp_ms / 1000.0,
+                                                    chunk_id: self.chunk_id_counter,
+                                                    device_type: DeviceType::Microphone,  // Mixed audio
+                                                };
+
+                                                if let Err(e) = self.transcription_sender.send(transcription_chunk) {
+                                                    warn!("Failed to send VAD segment: {}", e);
+                                                } else {
+                                                    self.chunk_id_counter += 1;
+                                                }
                                             } else {
-                                                self.chunk_id_counter += 1;
+                                                debug!("⏭️ Dropping short VAD segment: {:.1}ms ({} samples < 800)",
+                                                       duration_ms, segment.samples.len());
                                             }
-                                        } else {
-                                            debug!("⏭️ Dropping short VAD segment: {:.1}ms ({} samples < 800)",
-                                                   duration_ms, segment.samples.len());
                                         }
                                     }
-                                }
-                                Err(e) => {
-                                    warn!("⚠️ VAD error: {}", e);
+                                    Err(e) => {
+                                        warn!("⚠️ VAD error: {}", e);
+                                    }
                                 }
                             }
 
@@ -891,7 +931,9 @@ impl AudioPipeline {
         }
 
         // Flush any remaining VAD segments
-        self.flush_remaining_audio()?;
+        if self.transcription_mode == TranscriptionPipelineMode::VadSpeechOnly {
+            self.flush_remaining_audio()?;
+        }
 
         info!("VAD-driven audio pipeline ended");
         Ok(())
@@ -966,6 +1008,7 @@ impl AudioPipelineManager {
         mic_device_kind: super::device_detection::InputDeviceKind,
         system_device_name: String,
         system_device_kind: super::device_detection::InputDeviceKind,
+        send_continuous_transcription: bool,
     ) -> Result<()> {
         // Log device information for adaptive buffering
         info!("🎙️ Starting pipeline with device info:");
@@ -989,6 +1032,7 @@ impl AudioPipelineManager {
             mic_device_kind,
             system_device_name,
             system_device_kind,
+            send_continuous_transcription,
         );
 
         // CRITICAL FIX: Connect recording sender to receive pre-mixed audio

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -105,6 +105,7 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
         return Err(validation_error);
     }
     info!("✅ Transcription model validation passed");
+    let send_continuous_transcription = transcription::is_deepgram_transcription_provider(&app).await;
 
     // Async-first approach - no more blocking operations!
     info!("🚀 Starting async recording initialization");
@@ -234,7 +235,12 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
 
     // Start recording with resolved devices (replaces start_recording_with_defaults_and_auto_save call)
     let transcription_receiver = manager
-        .start_recording(microphone_device, system_device, auto_save)
+        .start_recording(
+            microphone_device,
+            system_device,
+            auto_save,
+            send_continuous_transcription,
+        )
         .await
         .map_err(|e| format!("Failed to start recording: {}", e))?;
 
@@ -351,6 +357,7 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
         return Err(validation_error);
     }
     info!("✅ Transcription model validation passed");
+    let send_continuous_transcription = transcription::is_deepgram_transcription_provider(&app).await;
 
     // Parse devices
     let mic_device = if let Some(ref name) = mic_device_name {
@@ -405,7 +412,12 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
 
     // Start recording with specified devices and auto_save setting
     let transcription_receiver = manager
-        .start_recording(mic_device, system_device, auto_save)
+        .start_recording(
+            mic_device,
+            system_device,
+            auto_save,
+            send_continuous_transcription,
+        )
         .await
         .map_err(|e| format!("Failed to start recording: {}", e))?;
 

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -98,7 +98,10 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
         // (download progress is already shown in top-right toast)
         let _ = app.emit("transcription-error", serde_json::json!({
             "error": validation_error,
-            "userMessage": "Recording cannot start: Transcription model is still downloading. Please wait for the download to complete.",
+            // Surface the actual reason (missing API key, model still downloading, unsupported
+            // provider, ...). validation_error is already user-facing per provider, e.g. Deepgram
+            // returns "Deepgram API key is not configured. Add it in Transcription settings...".
+            "userMessage": format!("Recording cannot start: {}", validation_error),
             "actionable": false
         }));
 
@@ -350,7 +353,10 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
         // (download progress is already shown in top-right toast)
         let _ = app.emit("transcription-error", serde_json::json!({
             "error": validation_error,
-            "userMessage": "Recording cannot start: Transcription model is still downloading. Please wait for the download to complete.",
+            // Surface the actual reason (missing API key, model still downloading, unsupported
+            // provider, ...). validation_error is already user-facing per provider, e.g. Deepgram
+            // returns "Deepgram API key is not configured. Add it in Transcription settings...".
+            "userMessage": format!("Recording cannot start: {}", validation_error),
             "actionable": false
         }));
 

--- a/frontend/src-tauri/src/audio/recording_manager.rs
+++ b/frontend/src-tauri/src/audio/recording_manager.rs
@@ -65,6 +65,7 @@ impl RecordingManager {
         microphone_device: Option<Arc<AudioDevice>>,
         system_device: Option<Arc<AudioDevice>>,
         auto_save: bool,
+        send_continuous_transcription: bool,
     ) -> Result<mpsc::UnboundedReceiver<AudioChunk>> {
         info!("Starting recording manager (auto_save: {})", auto_save);
 
@@ -116,6 +117,7 @@ impl RecordingManager {
             mic_kind,
             sys_name,
             sys_kind,
+            send_continuous_transcription,
         )?;
 
         // Give the pipeline a moment to fully initialize before starting streams
@@ -186,7 +188,7 @@ impl RecordingManager {
             }
 
             // Start recording with selected devices and auto_save setting
-            self.start_recording(microphone_device, system_device, auto_save).await
+            self.start_recording(microphone_device, system_device, auto_save, false).await
         }
 
         #[cfg(not(target_os = "macos"))]
@@ -221,7 +223,7 @@ impl RecordingManager {
                 return Err(anyhow::anyhow!("No microphone device available"));
             }
 
-            self.start_recording(microphone_device, system_device, auto_save).await
+            self.start_recording(microphone_device, system_device, auto_save, false).await
         }
     }
 

--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -102,10 +102,14 @@ pub async fn start_retranscription<R: Runtime>(
     RETRANSCRIPTION_CANCELLED.store(false, Ordering::SeqCst);
 
     let use_parakeet = provider.as_deref() == Some("parakeet");
+    let use_deepgram = provider.as_deref() == Some(super::deepgram::PROVIDER);
     let result = run_retranscription(app.clone(), meeting_id.clone(), meeting_folder_path, language, model, provider).await;
 
-    // Unload the engine after the batch job (success, failure, or cancellation)
-    super::common::unload_engine_after_batch(use_parakeet).await;
+    // Unload the engine after the batch job (success, failure, or cancellation).
+    // Deepgram is cloud-based with no local engine to unload.
+    if !use_deepgram {
+        super::common::unload_engine_after_batch(use_parakeet).await;
+    }
 
     // Guard will automatically clear flag on drop
     // No need for manual: RETRANSCRIPTION_IN_PROGRESS.store(false, Ordering::SeqCst);
@@ -182,11 +186,125 @@ async fn run_retranscription<R: Runtime>(
 
     // Determine which provider to use (default to whisper)
     let use_parakeet = provider.as_deref() == Some("parakeet");
+    let use_deepgram = provider.as_deref() == Some(super::deepgram::PROVIDER);
 
     info!(
         "Starting retranscription for meeting {} with language {:?}, model {:?}, provider {:?}",
         meeting_id, language, model, provider
     );
+
+    if use_deepgram {
+        emit_progress(&app, &meeting_id, "transcribing", 5, "Preparing Deepgram transcription...");
+        let duration_seconds = match super::import::validate_audio_file(&audio_path) {
+            Ok(info) => info.duration_seconds,
+            Err(e) => {
+                warn!("Deepgram retranscription metadata duration failed: {}, decoding duration", e);
+                let decoded = tokio::task::spawn_blocking({
+                    let path = audio_path.clone();
+                    move || decode_audio_file(&path)
+                })
+                .await
+                .map_err(|e| anyhow!("Decode task panicked: {}", e))??;
+                decoded.duration_seconds
+            }
+        };
+
+        let client = super::deepgram::client_from_config(&app).await?;
+        let app_for_progress = app.clone();
+        let meeting_id_for_progress = meeting_id.clone();
+        let client_reference_id = format!("retranscription:{}", meeting_id);
+        let transcript = client
+            .transcribe_file_with_progress(
+                &audio_path,
+                language.clone(),
+                &client_reference_id,
+                move |provider_progress, message| {
+                    let overall_progress = 5 + ((provider_progress as f32 * 0.75) as u32);
+                    emit_progress(
+                        &app_for_progress,
+                        &meeting_id_for_progress,
+                        "transcribing",
+                        overall_progress.min(80),
+                        message,
+                    );
+                },
+                || RETRANSCRIPTION_CANCELLED.load(Ordering::SeqCst),
+            )
+            .await?;
+
+        if RETRANSCRIPTION_CANCELLED.load(Ordering::SeqCst) {
+            return Err(anyhow!("Retranscription cancelled"));
+        }
+
+        emit_progress(&app, &meeting_id, "saving", 80, "Saving transcripts...");
+        let segments = super::deepgram::transcript_to_segments(&transcript, duration_seconds);
+
+        let app_state = app
+            .try_state::<AppState>()
+            .ok_or_else(|| anyhow!("App state not available"))?;
+
+        let pool = app_state.db_manager.pool();
+        let mut conn = pool.acquire().await.map_err(|e| anyhow!("DB error: {}", e))?;
+        let mut tx = sqlx::Connection::begin(&mut *conn)
+            .await
+            .map_err(|e| anyhow!("Failed to start transaction: {}", e))?;
+
+        sqlx::query("DELETE FROM transcripts WHERE meeting_id = ?")
+            .bind(&meeting_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| anyhow!("Failed to delete existing transcripts: {}", e))?;
+
+        for segment in &segments {
+            sqlx::query(
+                "INSERT INTO transcripts (id, meeting_id, transcript, timestamp, audio_start_time, audio_end_time, duration)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)"
+            )
+            .bind(&segment.id)
+            .bind(&meeting_id)
+            .bind(&segment.text)
+            .bind(&segment.timestamp)
+            .bind(segment.audio_start_time)
+            .bind(segment.audio_end_time)
+            .bind(segment.duration)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| anyhow!("Failed to insert transcript: {}", e))?;
+        }
+
+        tx.commit().await
+            .map_err(|e| anyhow!("Failed to commit transaction: {}", e))?;
+
+        emit_progress(&app, &meeting_id, "saving", 90, "Writing transcript files...");
+
+        if let Err(e) = write_transcripts_json(&folder_path, &segments) {
+            warn!("Failed to write transcripts.json: {}", e);
+        }
+
+        let audio_filename = audio_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("audio.mp4")
+            .to_string();
+
+        if let Err(e) = write_retranscription_metadata(
+            &folder_path,
+            &meeting_id,
+            duration_seconds,
+            &audio_filename,
+        ) {
+            warn!("Failed to update metadata.json: {}", e);
+        }
+
+        emit_progress(&app, &meeting_id, "complete", 100, "Retranscription complete");
+
+        return Ok(RetranscriptionResult {
+            meeting_id,
+            segments_count: segments.len(),
+            duration_seconds,
+            language,
+        });
+    }
 
     // Emit progress: decoding
     emit_progress(&app, &meeting_id, "decoding", 5, "Decoding audio file...");

--- a/frontend/src-tauri/src/audio/transcription/engine.rs
+++ b/frontend/src-tauri/src/audio/transcription/engine.rs
@@ -135,10 +135,23 @@ pub async fn validate_transcription_model_ready<R: Runtime>(app: &AppHandle<R>) 
                 }
             }
         }
+        "deepgram" => {
+            info!("🔍 Validating Deepgram API key...");
+            match crate::audio::deepgram::validate_configured_api_key(app).await {
+                Ok(()) => {
+                    info!("✅ Deepgram API key is configured");
+                    Ok(())
+                }
+                Err(e) => {
+                    warn!("❌ Deepgram validation failed: {}", e);
+                    Err(e)
+                }
+            }
+        }
         other => {
             warn!("❌ Unsupported transcription provider for local recording: {}", other);
             Err(format!(
-                "Provider '{}' is not supported for local transcription. Please select 'localWhisper' or 'parakeet'.",
+                "Provider '{}' is not supported for recording. Please select 'localWhisper', 'parakeet', or 'deepgram'.",
                 other
             ))
         }
@@ -212,10 +225,28 @@ pub async fn get_or_init_transcription_engine<R: Runtime>(
                 }
             }
         }
+        "deepgram" => {
+            Err("Deepgram realtime transcription is handled by the Deepgram streaming worker".to_string())
+        }
         "localWhisper" | _ => {
             info!("🎤 Initializing Whisper transcription engine");
             let whisper_engine = get_or_init_whisper(app).await?;
             Ok(TranscriptionEngine::Whisper(whisper_engine))
+        }
+    }
+}
+
+/// Returns true when the configured transcription provider is Deepgram, which
+/// streams via WebSocket instead of the batch trait-based engine. Used both to
+/// route the transcription worker and to switch the audio pipeline into
+/// continuous (non-VAD) mode so realtime endpointing stays stable.
+pub async fn is_deepgram_transcription_provider<R: Runtime>(app: &AppHandle<R>) -> bool {
+    match crate::api::api::api_get_transcript_config(app.clone(), app.clone().state(), None).await {
+        Ok(Some(config)) => config.provider == crate::audio::deepgram::PROVIDER,
+        Ok(None) => false,
+        Err(e) => {
+            warn!("⚠️ Failed to read transcript config while checking Deepgram provider: {}", e);
+            false
         }
     }
 }

--- a/frontend/src-tauri/src/audio/transcription/mod.rs
+++ b/frontend/src-tauri/src/audio/transcription/mod.rs
@@ -16,7 +16,8 @@ pub use engine::{
     TranscriptionEngine,
     validate_transcription_model_ready,
     get_or_init_transcription_engine,
-    get_or_init_whisper
+    get_or_init_whisper,
+    is_deepgram_transcription_provider
 };
 pub use worker::{
     start_transcription_task,

--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -49,6 +49,24 @@ pub fn start_transcription_task<R: Runtime>(
     tokio::spawn(async move {
         info!("🚀 Starting optimized parallel transcription task - guaranteeing zero chunk loss");
 
+        if super::engine::is_deepgram_transcription_provider(&app).await {
+            info!("☁️ Starting Deepgram realtime transcription task");
+            if let Err(e) = crate::audio::deepgram::run_realtime_transcription(
+                app.clone(),
+                transcription_receiver,
+            )
+            .await
+            {
+                error!("Deepgram realtime transcription failed: {}", e);
+                let _ = app.emit("transcription-error", serde_json::json!({
+                    "error": e,
+                    "userMessage": "Deepgram transcription failed. Check your API key and network connection.",
+                    "actionable": true
+                }));
+            }
+            return;
+        }
+
         // Initialize transcription engine (Whisper or Parakeet based on config)
         let transcription_engine = match super::engine::get_or_init_transcription_engine(&app).await {
             Ok(engine) => engine,

--- a/frontend/src-tauri/src/config.rs
+++ b/frontend/src-tauri/src/config.rs
@@ -11,6 +11,13 @@ pub const DEFAULT_WHISPER_MODEL: &str = "large-v3-turbo";
 /// This is the quantized version optimized for speed.
 pub const DEFAULT_PARAKEET_MODEL: &str = "parakeet-tdt-0.6b-v3-int8";
 
+/// Default Deepgram model for realtime cloud transcription (live recording).
+/// nova-3 is Deepgram's most accurate general model and enables keyterm prompting.
+pub const DEFAULT_DEEPGRAM_REALTIME_MODEL: &str = "nova-3";
+
+/// Default Deepgram model for prerecorded transcription (import / retranscription).
+pub const DEFAULT_DEEPGRAM_ASYNC_MODEL: &str = "nova-3";
+
 /// Whisper model catalog with metadata for all supported models.
 /// Used by both WhisperEngine::discover_models() and discover_models_standalone().
 ///

--- a/frontend/src-tauri/src/database/models.rs
+++ b/frontend/src-tauri/src/database/models.rs
@@ -127,4 +127,10 @@ pub struct TranscriptSetting {
     #[sqlx(rename = "openaiApiKey")]
     #[serde(rename = "openaiApiKey")]
     pub openai_api_key: Option<String>,
+    #[sqlx(rename = "deepgramKeyterm")]
+    #[serde(rename = "deepgramKeyterm")]
+    pub deepgram_keyterm: Option<String>,
+    #[sqlx(rename = "deepgramDiarize")]
+    #[serde(rename = "deepgramDiarize")]
+    pub deepgram_diarize: Option<i64>,
 }

--- a/frontend/src-tauri/src/database/models.rs
+++ b/frontend/src-tauri/src/database/models.rs
@@ -133,4 +133,10 @@ pub struct TranscriptSetting {
     #[sqlx(rename = "deepgramDiarize")]
     #[serde(rename = "deepgramDiarize")]
     pub deepgram_diarize: Option<i64>,
+    #[sqlx(rename = "deepgramMipOptOut")]
+    #[serde(rename = "deepgramMipOptOut")]
+    pub deepgram_mip_opt_out: Option<i64>,
+    #[sqlx(rename = "deepgramLanguage")]
+    #[serde(rename = "deepgramLanguage")]
+    pub deepgram_language: Option<String>,
 }

--- a/frontend/src-tauri/src/database/repositories/setting.rs
+++ b/frontend/src-tauri/src/database/repositories/setting.rs
@@ -231,6 +231,42 @@ impl SettingsRepository {
         Ok(api_key)
     }
 
+    /// Read Deepgram provider knobs (keyterm blob, diarize flag). Returns
+    /// (None, None) when no settings row exists yet.
+    pub async fn get_deepgram_options(
+        pool: &SqlitePool,
+    ) -> std::result::Result<(Option<String>, Option<i64>), sqlx::Error> {
+        let row: Option<(Option<String>, Option<i64>)> = sqlx::query_as(
+            "SELECT deepgramKeyterm, deepgramDiarize FROM transcript_settings WHERE id = '1' LIMIT 1",
+        )
+        .fetch_optional(pool)
+        .await?;
+        Ok(row.unwrap_or((None, None)))
+    }
+
+    /// Persist Deepgram provider knobs without disturbing provider/model/api-key.
+    pub async fn save_deepgram_options(
+        pool: &SqlitePool,
+        keyterm: Option<&str>,
+        diarize: bool,
+    ) -> std::result::Result<(), sqlx::Error> {
+        sqlx::query(
+            r#"
+            INSERT INTO transcript_settings (id, provider, model, deepgramKeyterm, deepgramDiarize)
+            VALUES ('1', 'parakeet', $3, $1, $2)
+            ON CONFLICT(id) DO UPDATE SET
+                deepgramKeyterm = $1,
+                deepgramDiarize = $2
+            "#,
+        )
+        .bind(keyterm)
+        .bind(if diarize { 1_i64 } else { 0_i64 })
+        .bind(crate::config::DEFAULT_PARAKEET_MODEL)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+
     pub async fn delete_api_key(
         pool: &SqlitePool,
         provider: &str,

--- a/frontend/src-tauri/src/database/repositories/setting.rs
+++ b/frontend/src-tauri/src/database/repositories/setting.rs
@@ -2,6 +2,16 @@ use crate::database::models::{Setting, TranscriptSetting};
 use crate::summary::CustomOpenAIConfig;
 use sqlx::SqlitePool;
 
+/// Deepgram provider knobs read from the dedicated `transcript_settings` columns.
+/// `diarize`/`mip_opt_out` are stored as 1/0 integers (None = column never set).
+#[derive(Debug, Default, Clone)]
+pub struct DeepgramOptionsRow {
+    pub keyterm: Option<String>,
+    pub diarize: Option<i64>,
+    pub mip_opt_out: Option<i64>,
+    pub language: Option<String>,
+}
+
 #[derive(serde::Deserialize, Debug)]
 pub struct SaveModelConfigRequest {
     pub provider: String,
@@ -231,17 +241,20 @@ impl SettingsRepository {
         Ok(api_key)
     }
 
-    /// Read Deepgram provider knobs (keyterm blob, diarize flag). Returns
-    /// (None, None) when no settings row exists yet.
+    /// Read Deepgram provider knobs. All fields are None/absent when no settings
+    /// row exists yet. `language` is Deepgram-specific and deliberately separate
+    /// from the shared global language preference (which is Whisper/Parakeet-oriented),
+    /// so Deepgram-only values like `multi`/`detect` never reach the Whisper path.
     pub async fn get_deepgram_options(
         pool: &SqlitePool,
-    ) -> std::result::Result<(Option<String>, Option<i64>), sqlx::Error> {
-        let row: Option<(Option<String>, Option<i64>)> = sqlx::query_as(
-            "SELECT deepgramKeyterm, deepgramDiarize FROM transcript_settings WHERE id = '1' LIMIT 1",
+    ) -> std::result::Result<DeepgramOptionsRow, sqlx::Error> {
+        let row: Option<(Option<String>, Option<i64>, Option<i64>, Option<String>)> = sqlx::query_as(
+            "SELECT deepgramKeyterm, deepgramDiarize, deepgramMipOptOut, deepgramLanguage FROM transcript_settings WHERE id = '1' LIMIT 1",
         )
         .fetch_optional(pool)
         .await?;
-        Ok(row.unwrap_or((None, None)))
+        let (keyterm, diarize, mip_opt_out, language) = row.unwrap_or((None, None, None, None));
+        Ok(DeepgramOptionsRow { keyterm, diarize, mip_opt_out, language })
     }
 
     /// Persist Deepgram provider knobs without disturbing provider/model/api-key.
@@ -249,18 +262,24 @@ impl SettingsRepository {
         pool: &SqlitePool,
         keyterm: Option<&str>,
         diarize: bool,
+        mip_opt_out: bool,
+        language: Option<&str>,
     ) -> std::result::Result<(), sqlx::Error> {
         sqlx::query(
             r#"
-            INSERT INTO transcript_settings (id, provider, model, deepgramKeyterm, deepgramDiarize)
-            VALUES ('1', 'parakeet', $3, $1, $2)
+            INSERT INTO transcript_settings (id, provider, model, deepgramKeyterm, deepgramDiarize, deepgramMipOptOut, deepgramLanguage)
+            VALUES ('1', 'parakeet', $5, $1, $2, $3, $4)
             ON CONFLICT(id) DO UPDATE SET
                 deepgramKeyterm = $1,
-                deepgramDiarize = $2
+                deepgramDiarize = $2,
+                deepgramMipOptOut = $3,
+                deepgramLanguage = $4
             "#,
         )
         .bind(keyterm)
         .bind(if diarize { 1_i64 } else { 0_i64 })
+        .bind(if mip_opt_out { 1_i64 } else { 0_i64 })
+        .bind(language)
         .bind(crate::config::DEFAULT_PARAKEET_MODEL)
         .execute(pool)
         .await?;

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -643,6 +643,8 @@ pub fn run() {
             api::api_get_transcript_config,
             api::api_save_transcript_config,
             api::api_get_transcript_api_key,
+            api::api_get_deepgram_options,
+            api::api_save_deepgram_options,
             api::api_delete_meeting,
             api::api_get_meeting,
             api::api_get_meeting_metadata,

--- a/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
+++ b/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
@@ -395,7 +395,7 @@ export function ImportAudioDialog({
                                   key={`${model.provider}:${model.name}`}
                                   value={`${model.provider}:${model.name}`}
                                 >
-                                  {model.displayName} ({Math.round(model.size_mb)} MB)
+                                  {model.displayName}{model.size_mb > 0 ? ` (${Math.round(model.size_mb)} MB)` : ''}
                                 </SelectItem>
                               ))}
                             </SelectContent>

--- a/frontend/src/components/LanguageSelection.tsx
+++ b/frontend/src/components/LanguageSelection.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { Globe } from 'lucide-react';
 import Analytics from '@/lib/analytics';
 import { toast } from 'sonner';
-import { useConfig } from '@/contexts/ConfigContext';
 
 export interface Language {
   code: string;
@@ -128,24 +127,98 @@ export function LanguageSelection({
   provider = 'localWhisper'
 }: LanguageSelectionProps) {
   const [saving, setSaving] = useState(false);
-  const { setSelectedLanguage } = useConfig();
 
   // Parakeet only supports auto-detection (doesn't support manual language selection)
   const isParakeet = provider === 'parakeet';
+  const isDeepgram = provider === 'deepgram';
+  // Deepgram exposes three distinct language modes (no Whisper-style "translate to English"):
+  //   multi  -> language=multi (nova-3 code-switching across 10 languages)
+  //   detect -> detect_language=true (auto-detect a single language)
+  //   <code> -> explicit language selection
+  // nova-3 language set (primary code per language; regional variants collapsed to
+  // the base code, except the ones Deepgram treats as distinct: Swiss German and the
+  // three Chinese scripts). `multi` = code-switching; `detect` = single-language auto-detect.
+  const DEEPGRAM_LANGUAGES: Language[] = [
+    { code: 'multi', name: 'Multilingual (code-switching)' },
+    { code: 'detect', name: 'Auto-detect (single language)' },
+    { code: 'ar', name: 'Arabic' },
+    { code: 'be', name: 'Belarusian' },
+    { code: 'bn', name: 'Bengali' },
+    { code: 'bs', name: 'Bosnian' },
+    { code: 'bg', name: 'Bulgarian' },
+    { code: 'ca', name: 'Catalan' },
+    { code: 'zh-HK', name: 'Chinese (Cantonese, Traditional)' },
+    { code: 'zh', name: 'Chinese (Mandarin, Simplified)' },
+    { code: 'zh-TW', name: 'Chinese (Mandarin, Traditional)' },
+    { code: 'hr', name: 'Croatian' },
+    { code: 'cs', name: 'Czech' },
+    { code: 'da', name: 'Danish' },
+    { code: 'nl', name: 'Dutch' },
+    { code: 'en', name: 'English' },
+    { code: 'et', name: 'Estonian' },
+    { code: 'fi', name: 'Finnish' },
+    { code: 'nl-BE', name: 'Flemish' },
+    { code: 'fr', name: 'French' },
+    { code: 'de', name: 'German' },
+    { code: 'de-CH', name: 'German (Switzerland)' },
+    { code: 'el', name: 'Greek' },
+    { code: 'gu', name: 'Gujarati' },
+    { code: 'he', name: 'Hebrew' },
+    { code: 'hi', name: 'Hindi' },
+    { code: 'hu', name: 'Hungarian' },
+    { code: 'id', name: 'Indonesian' },
+    { code: 'it', name: 'Italian' },
+    { code: 'ja', name: 'Japanese' },
+    { code: 'kn', name: 'Kannada' },
+    { code: 'ko', name: 'Korean' },
+    { code: 'lv', name: 'Latvian' },
+    { code: 'lt', name: 'Lithuanian' },
+    { code: 'mk', name: 'Macedonian' },
+    { code: 'ms', name: 'Malay' },
+    { code: 'mr', name: 'Marathi' },
+    { code: 'no', name: 'Norwegian' },
+    { code: 'fa', name: 'Persian' },
+    { code: 'pl', name: 'Polish' },
+    { code: 'pt', name: 'Portuguese' },
+    { code: 'ro', name: 'Romanian' },
+    { code: 'ru', name: 'Russian' },
+    { code: 'sr', name: 'Serbian' },
+    { code: 'sk', name: 'Slovak' },
+    { code: 'sl', name: 'Slovenian' },
+    { code: 'es', name: 'Spanish' },
+    { code: 'sv', name: 'Swedish' },
+    { code: 'tl', name: 'Tagalog' },
+    { code: 'ta', name: 'Tamil' },
+    { code: 'te', name: 'Telugu' },
+    { code: 'th', name: 'Thai' },
+    { code: 'tr', name: 'Turkish' },
+    { code: 'uk', name: 'Ukrainian' },
+    { code: 'ur', name: 'Urdu' },
+    { code: 'vi', name: 'Vietnamese' },
+  ];
   const availableLanguages = isParakeet
     ? LANGUAGES.filter(lang => lang.code === 'auto' || lang.code === 'auto-translate')
-    : LANGUAGES;
+    : isDeepgram
+      ? DEEPGRAM_LANGUAGES
+      : LANGUAGES;
+  // When Deepgram is active but the stored preference is a Whisper-ism (auto / auto-translate /
+  // empty), display `multi`, which is what the backend maps those to for nova-3.
+  const effectiveSelected = isDeepgram && ['auto', 'auto-translate', ''].includes(selectedLanguage)
+    ? 'multi'
+    : selectedLanguage;
 
   const handleLanguageChange = async (languageCode: string) => {
     setSaving(true);
     try {
-      // Save language preference to localStorage and sync to backend
-      setSelectedLanguage(languageCode);
+      // The parent owns persistence (global pref for Whisper/Parakeet, or the
+      // Deepgram-specific setting) via onLanguageChange. This component no longer
+      // writes the shared global pref directly, so provider-specific values
+      // (e.g. Deepgram's `multi`/`detect`) never leak across providers.
       onLanguageChange(languageCode);
       console.log('Language preference saved:', languageCode);
 
       // Track language selection analytics
-      const selectedLang = LANGUAGES.find(lang => lang.code === languageCode);
+      const selectedLang = availableLanguages.find(lang => lang.code === languageCode);
       await Analytics.track('language_selected', {
         language_code: languageCode,
         language_name: selectedLang?.name || 'Unknown',
@@ -169,8 +242,8 @@ export function LanguageSelection({
   };
 
   // Find the selected language name for display
-  const selectedLanguageName = LANGUAGES.find(
-    lang => lang.code === selectedLanguage
+  const selectedLanguageName = availableLanguages.find(
+    lang => lang.code === effectiveSelected
   )?.name || 'Auto Detect (Original Language)';
 
   return (
@@ -184,7 +257,7 @@ export function LanguageSelection({
 
       <div className="space-y-2">
         <select
-          value={selectedLanguage}
+          value={effectiveSelected}
           onChange={(e) => handleLanguageChange(e.target.value)}
           disabled={disabled || saving}
           className="w-full px-3 py-2 text-sm bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-50 disabled:text-gray-500"
@@ -192,7 +265,7 @@ export function LanguageSelection({
           {availableLanguages.map((language) => (
             <option key={language.code} value={language.code}>
               {language.name}
-              {language.code !== 'auto' && language.code !== 'auto-translate' && ` (${language.code})`}
+              {!isDeepgram && !['auto', 'auto-translate', 'detect', 'multi'].includes(language.code) && ` (${language.code})`}
             </option>
           ))}
         </select>
@@ -202,6 +275,14 @@ export function LanguageSelection({
           <div className="p-2 bg-amber-50 border border-amber-200 rounded text-amber-800">
             <p className="font-medium">ℹ️ Parakeet Language Support</p>
             <p className="mt-1 text-xs">Parakeet currently only supports automatic language detection. Manual language selection is not available. Use Whisper if you need to specify a particular language.</p>
+          </div>
+        )}
+
+        {/* Deepgram language modes */}
+        {isDeepgram && (
+          <div className="p-2 bg-blue-50 border border-blue-200 rounded text-blue-800 text-xs">
+            <p className="font-medium">Deepgram language modes</p>
+            <p className="mt-1"><strong>Multilingual</strong>: nova-3 code-switching across English, Spanish, French, German, Hindi, Russian, Portuguese, Japanese, Italian, and Dutch. <strong>Auto-detect</strong>: picks one language for the whole recording. Or choose a specific language for best accuracy.</p>
           </div>
         )}
 

--- a/frontend/src/components/MeetingDetails/RetranscribeDialog.tsx
+++ b/frontend/src/components/MeetingDetails/RetranscribeDialog.tsx
@@ -349,7 +349,7 @@ export function RetranscribeDialog({
                 <SelectContent>
                   {availableModels.map((model) => (
                     <SelectItem key={`${model.provider}:${model.name}`} value={`${model.provider}:${model.name}`}>
-                      {model.displayName} ({Math.round(model.size_mb)} MB)
+                      {model.displayName}{model.size_mb > 0 ? ` (${Math.round(model.size_mb)} MB)` : ''}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/frontend/src/components/TranscriptSettings.tsx
+++ b/frontend/src/components/TranscriptSettings.tsx
@@ -7,6 +7,8 @@ import { Label } from './ui/label';
 import { Eye, EyeOff, Lock, Unlock } from 'lucide-react';
 import { ModelManager } from './WhisperModelManager';
 import { ParakeetModelManager } from './ParakeetModelManager';
+import { Textarea } from './ui/textarea';
+import { Switch } from './ui/switch';
 
 
 export interface TranscriptModelProps {
@@ -27,11 +29,27 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
     const [isApiKeyLocked, setIsApiKeyLocked] = useState<boolean>(true);
     const [isLockButtonVibrating, setIsLockButtonVibrating] = useState<boolean>(false);
     const [uiProvider, setUiProvider] = useState<TranscriptModelProps['provider']>(transcriptModelConfig.provider);
+    const [deepgramKeyterm, setDeepgramKeyterm] = useState<string>('');
+    const [deepgramDiarize, setDeepgramDiarize] = useState<boolean>(true);
 
     // Sync uiProvider when backend config changes (e.g., after model selection or initial load)
     useEffect(() => {
         setUiProvider(transcriptModelConfig.provider);
     }, [transcriptModelConfig.provider]);
+
+    // Load Deepgram-specific knobs when the Deepgram provider is active.
+    useEffect(() => {
+        if (uiProvider !== 'deepgram') return;
+        (async () => {
+            try {
+                const opts = await invoke('api_get_deepgram_options') as { keyterm: string; diarize: boolean };
+                setDeepgramKeyterm(opts.keyterm || '');
+                setDeepgramDiarize(opts.diarize ?? true);
+            } catch (err) {
+                console.error('Failed to load Deepgram options:', err);
+            }
+        })();
+    }, [uiProvider]);
 
     useEffect(() => {
         if (transcriptModelConfig.provider === 'localWhisper' || transcriptModelConfig.provider === 'parakeet') {
@@ -53,12 +71,28 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
     const modelOptions = {
         localWhisper: [], // Model selection handled by ModelManager component
         parakeet: [], // Model selection handled by ParakeetModelManager component
-        deepgram: ['nova-2-phonecall'],
+        deepgram: ['nova-3', 'nova-2', 'flux-general-en', 'flux-general-multi'],
         elevenLabs: ['eleven_multilingual_v2'],
         groq: ['llama-3.3-70b-versatile'],
         openai: ['gpt-4o'],
     };
-    const requiresApiKey = transcriptModelConfig.provider === 'deepgram' || transcriptModelConfig.provider === 'elevenLabs' || transcriptModelConfig.provider === 'openai' || transcriptModelConfig.provider === 'groq';
+    const requiresApiKey = uiProvider === 'deepgram' || uiProvider === 'elevenLabs' || uiProvider === 'openai' || uiProvider === 'groq';
+
+    const saveCloudConfig = async (provider: TranscriptModelProps['provider'], model: string, key: string | null) => {
+        try {
+            await invoke('api_save_transcript_config', { provider, model, apiKey: key || null });
+        } catch (error) {
+            console.error('Failed to save transcript provider:', error);
+        }
+    };
+
+    const saveDeepgramOptions = async (keyterm: string, diarize: boolean) => {
+        try {
+            await invoke('api_save_deepgram_options', { keyterm: keyterm || null, diarize });
+        } catch (error) {
+            console.error('Failed to save Deepgram options:', error);
+        }
+    };
 
     const handleInputClick = () => {
         if (isApiKeyLocked) {
@@ -114,6 +148,9 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                     setUiProvider(provider);
                                     if (provider !== 'localWhisper' && provider !== 'parakeet') {
                                         fetchApiKey(provider);
+                                        const model = modelOptions[provider][0];
+                                        setTranscriptModelConfig({ ...transcriptModelConfig, provider, model });
+                                        saveCloudConfig(provider, model, apiKey);
                                     }
                                 }}
                             >
@@ -123,8 +160,8 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 <SelectContent>
                                     <SelectItem value="parakeet">⚡ Parakeet (Recommended - Real-time / Accurate)</SelectItem>
                                     <SelectItem value="localWhisper">🏠 Local Whisper (High Accuracy)</SelectItem>
-                                    {/* <SelectItem value="deepgram">☁️ Deepgram (Backup)</SelectItem>
-                                    <SelectItem value="elevenLabs">☁️ ElevenLabs</SelectItem>
+                                    <SelectItem value="deepgram">☁️ Deepgram (Realtime + Diarization)</SelectItem>
+                                    {/* <SelectItem value="elevenLabs">☁️ ElevenLabs</SelectItem>
                                     <SelectItem value="groq">☁️ Groq</SelectItem>
                                     <SelectItem value="openai">☁️ OpenAI</SelectItem> */}
                                 </SelectContent>
@@ -136,6 +173,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                     onValueChange={(value) => {
                                         const model = value as TranscriptModelProps['model'];
                                         setTranscriptModelConfig({ ...transcriptModelConfig, provider: uiProvider, model });
+                                        saveCloudConfig(uiProvider, model, apiKey);
                                     }}
                                 >
                                     <SelectTrigger className='focus:ring-1 focus:ring-blue-500 focus:border-blue-500'>
@@ -185,6 +223,13 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                         }`}
                                     value={apiKey || ''}
                                     onChange={(e) => setApiKey(e.target.value)}
+                                    onBlur={() => {
+                                        if (requiresApiKey) {
+                                            const model = transcriptModelConfig.model || modelOptions[uiProvider][0];
+                                            saveCloudConfig(uiProvider, model, apiKey);
+                                            setTranscriptModelConfig({ ...transcriptModelConfig, provider: uiProvider, model, apiKey });
+                                        }
+                                    }}
                                     disabled={isApiKeyLocked}
                                     onClick={handleInputClick}
                                     placeholder="Enter your API key"
@@ -217,6 +262,38 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                     </Button>
                                 </div>
                             </div>
+                        </div>
+                    )}
+
+                    {uiProvider === 'deepgram' && (
+                        <div className="space-y-3">
+                            <div>
+                                <Label className="block text-sm font-medium text-gray-700 mb-1">
+                                    Keyterms (one per line)
+                                </Label>
+                                <Textarea
+                                    className="mx-1 focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                                    value={deepgramKeyterm}
+                                    rows={3}
+                                    placeholder="Product names, acronyms, or jargon to boost recognition (nova-3 keyterm prompting)"
+                                    onChange={(e) => setDeepgramKeyterm(e.target.value)}
+                                    onBlur={() => saveDeepgramOptions(deepgramKeyterm, deepgramDiarize)}
+                                />
+                            </div>
+                            {!transcriptModelConfig.model?.startsWith('flux') && (
+                                <div className="flex items-center justify-between mx-1">
+                                    <Label className="text-sm font-medium text-gray-700">
+                                        Speaker diarization
+                                    </Label>
+                                    <Switch
+                                        checked={deepgramDiarize}
+                                        onCheckedChange={(checked) => {
+                                            setDeepgramDiarize(checked);
+                                            saveDeepgramOptions(deepgramKeyterm, checked);
+                                        }}
+                                    />
+                                </div>
+                            )}
                         </div>
                     )}
                 </div>

--- a/frontend/src/components/TranscriptSettings.tsx
+++ b/frontend/src/components/TranscriptSettings.tsx
@@ -9,6 +9,7 @@ import { ModelManager } from './WhisperModelManager';
 import { ParakeetModelManager } from './ParakeetModelManager';
 import { Textarea } from './ui/textarea';
 import { Switch } from './ui/switch';
+import { LanguageSelection } from './LanguageSelection';
 
 
 export interface TranscriptModelProps {
@@ -31,6 +32,9 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
     const [uiProvider, setUiProvider] = useState<TranscriptModelProps['provider']>(transcriptModelConfig.provider);
     const [deepgramKeyterm, setDeepgramKeyterm] = useState<string>('');
     const [deepgramDiarize, setDeepgramDiarize] = useState<boolean>(true);
+    const [deepgramMipOptOut, setDeepgramMipOptOut] = useState<boolean>(true);
+    // Deepgram-specific language, kept separate from the global (Whisper/Parakeet) pref.
+    const [deepgramLanguage, setDeepgramLanguage] = useState<string>('');
 
     // Sync uiProvider when backend config changes (e.g., after model selection or initial load)
     useEffect(() => {
@@ -42,9 +46,11 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
         if (uiProvider !== 'deepgram') return;
         (async () => {
             try {
-                const opts = await invoke('api_get_deepgram_options') as { keyterm: string; diarize: boolean };
+                const opts = await invoke('api_get_deepgram_options') as { keyterm: string; diarize: boolean; mipOptOut: boolean; language: string };
                 setDeepgramKeyterm(opts.keyterm || '');
                 setDeepgramDiarize(opts.diarize ?? true);
+                setDeepgramMipOptOut(opts.mipOptOut ?? true);
+                setDeepgramLanguage(opts.language || '');
             } catch (err) {
                 console.error('Failed to load Deepgram options:', err);
             }
@@ -71,12 +77,20 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
     const modelOptions = {
         localWhisper: [], // Model selection handled by ModelManager component
         parakeet: [], // Model selection handled by ParakeetModelManager component
-        deepgram: ['nova-3', 'nova-2', 'flux-general-en', 'flux-general-multi'],
+        deepgram: ['nova-3', 'flux-general-en', 'flux-general-multi'],
         elevenLabs: ['eleven_multilingual_v2'],
         groq: ['llama-3.3-70b-versatile'],
         openai: ['gpt-4o'],
     };
     const requiresApiKey = uiProvider === 'deepgram' || uiProvider === 'elevenLabs' || uiProvider === 'openai' || uiProvider === 'groq';
+    // Flux models pick their language via the model itself and ignore nova-only knobs
+    // (language selection, diarization), so those controls are hidden for Flux.
+    const isFluxModel = transcriptModelConfig.model?.startsWith('flux') ?? false;
+
+    const persistDeepgramLanguage = (code: string) => {
+        setDeepgramLanguage(code);
+        saveDeepgramOptions(deepgramKeyterm, deepgramDiarize, deepgramMipOptOut, code);
+    };
 
     const saveCloudConfig = async (provider: TranscriptModelProps['provider'], model: string, key: string | null) => {
         try {
@@ -86,9 +100,9 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
         }
     };
 
-    const saveDeepgramOptions = async (keyterm: string, diarize: boolean) => {
+    const saveDeepgramOptions = async (keyterm: string, diarize: boolean, mipOptOut: boolean, language: string) => {
         try {
-            await invoke('api_save_deepgram_options', { keyterm: keyterm || null, diarize });
+            await invoke('api_save_deepgram_options', { keyterm: keyterm || null, diarize, mipOptOut, language: language || null });
         } catch (error) {
             console.error('Failed to save Deepgram options:', error);
         }
@@ -267,6 +281,30 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
 
                     {uiProvider === 'deepgram' && (
                         <div className="space-y-3">
+                            <p className="text-xs text-gray-500 mx-1">
+                                Need an API key?{' '}
+                                <a
+                                    href="https://console.deepgram.com/"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="text-blue-600 hover:underline"
+                                >
+                                    Create a free Deepgram account
+                                </a>
+                                {' '}to get one.
+                            </p>
+                            {/* Language selection is a nova-3 knob. Flux models pick their
+                                language via the model itself (flux-general-en / -multi). */}
+                            {!isFluxModel && (
+                                <div className="mx-1">
+                                    <LanguageSelection
+                                        provider="deepgram"
+                                        selectedLanguage={deepgramLanguage}
+                                        onLanguageChange={persistDeepgramLanguage}
+                                        disabled={false}
+                                    />
+                                </div>
+                            )}
                             <div>
                                 <Label className="block text-sm font-medium text-gray-700 mb-1">
                                     Keyterms (one per line)
@@ -277,10 +315,10 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                     rows={3}
                                     placeholder="Product names, acronyms, or jargon to boost recognition (nova-3 keyterm prompting)"
                                     onChange={(e) => setDeepgramKeyterm(e.target.value)}
-                                    onBlur={() => saveDeepgramOptions(deepgramKeyterm, deepgramDiarize)}
+                                    onBlur={() => saveDeepgramOptions(deepgramKeyterm, deepgramDiarize, deepgramMipOptOut, deepgramLanguage)}
                                 />
                             </div>
-                            {!transcriptModelConfig.model?.startsWith('flux') && (
+                            {!isFluxModel && (
                                 <div className="flex items-center justify-between mx-1">
                                     <Label className="text-sm font-medium text-gray-700">
                                         Speaker diarization
@@ -289,11 +327,28 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                         checked={deepgramDiarize}
                                         onCheckedChange={(checked) => {
                                             setDeepgramDiarize(checked);
-                                            saveDeepgramOptions(deepgramKeyterm, checked);
+                                            saveDeepgramOptions(deepgramKeyterm, checked, deepgramMipOptOut, deepgramLanguage);
                                         }}
                                     />
                                 </div>
                             )}
+                            <div className="flex items-center justify-between mx-1">
+                                <div className="pr-3">
+                                    <Label className="text-sm font-medium text-gray-700">
+                                        Opt out of model improvement
+                                    </Label>
+                                    <p className="text-xs text-gray-500 mt-0.5">
+                                        Sends mip_opt_out=true so Deepgram does not retain your audio for model training. On by default.
+                                    </p>
+                                </div>
+                                <Switch
+                                    checked={deepgramMipOptOut}
+                                    onCheckedChange={(checked) => {
+                                        setDeepgramMipOptOut(checked);
+                                        saveDeepgramOptions(deepgramKeyterm, deepgramDiarize, checked, deepgramLanguage);
+                                    }}
+                                />
+                            </div>
                         </div>
                     )}
                 </div>

--- a/frontend/src/constants/modelDefaults.ts
+++ b/frontend/src/constants/modelDefaults.ts
@@ -16,10 +16,22 @@ export const DEFAULT_WHISPER_MODEL = 'large-v3-turbo';
 export const DEFAULT_PARAKEET_MODEL = 'parakeet-tdt-0.6b-v3-int8';
 
 /**
+ * Default Deepgram model for realtime cloud transcription (live recording).
+ * nova-3 is Deepgram's most accurate general model and enables keyterm prompting.
+ */
+export const DEFAULT_DEEPGRAM_REALTIME_MODEL = 'nova-3';
+
+/**
+ * Default Deepgram model for imported audio and retranscription.
+ */
+export const DEFAULT_DEEPGRAM_ASYNC_MODEL = 'nova-3';
+
+/**
  * Model defaults by provider type
  */
 export const MODEL_DEFAULTS = {
   whisper: DEFAULT_WHISPER_MODEL,
   localWhisper: DEFAULT_WHISPER_MODEL,
   parakeet: DEFAULT_PARAKEET_MODEL,
+  deepgram: DEFAULT_DEEPGRAM_REALTIME_MODEL,
 } as const;

--- a/frontend/src/hooks/useTranscriptionModels.ts
+++ b/frontend/src/hooks/useTranscriptionModels.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { DEFAULT_DEEPGRAM_ASYNC_MODEL } from '@/constants/modelDefaults';
 
 export interface RawModelInfo {
   name: string;
@@ -8,7 +9,7 @@ export interface RawModelInfo {
 }
 
 export interface ModelOption {
-  provider: 'whisper' | 'parakeet';
+  provider: 'whisper' | 'parakeet' | 'deepgram';
   name: string;
   displayName: string;
   size_mb: number;
@@ -77,6 +78,15 @@ export function useTranscriptionModels(transcriptModelConfig: TranscriptModelCon
       console.error('Failed to fetch Parakeet models:', err);
     }
 
+    // Deepgram is a cloud provider (no local model download); offer it for
+    // prerecorded import / retranscription.
+    allModels.push({
+      provider: 'deepgram',
+      name: DEFAULT_DEEPGRAM_ASYNC_MODEL,
+      displayName: `☁️ Deepgram: ${DEFAULT_DEEPGRAM_ASYNC_MODEL}`,
+      size_mb: 0,
+    });
+
     setAvailableModels(allModels);
 
     // Set default model based on user's saved configuration
@@ -88,7 +98,8 @@ export function useTranscriptionModels(transcriptModelConfig: TranscriptModelCon
     const configuredMatch = allModels.find(
       (m) =>
         (configuredProvider === 'localWhisper' && m.provider === 'whisper' && m.name === configuredModel) ||
-        (configuredProvider === 'parakeet' && m.provider === 'parakeet' && m.name === configuredModel)
+        (configuredProvider === 'parakeet' && m.provider === 'parakeet' && m.name === configuredModel) ||
+        (configuredProvider === 'deepgram' && m.provider === 'deepgram')
     );
 
     // Only set default model if user hasn't manually selected one


### PR DESCRIPTION
## Summary

Adds **Deepgram** as a first-class transcription provider:

- **Realtime WebSocket streaming** for live recording (low-latency finalized results, speaker diarization, keyterm prompting).
- **Deepgram Flux** realtime support (`flux-general-en` / `flux-general-multi`) via the v2 turn-based API (`TurnInfo`/`EndOfTurn` events, native turn detection + formatting, multilingual code-switching).
- **Prerecorded REST** for imported audio and retranscription (single synchronous request; speaker-segmented utterances).
- Provider-specific knobs surfaced in Settings: **model** (nova-3 / nova-2 / flux-general-en / flux-general-multi), **keyterm prompting**, and a **diarization** toggle (nova models).
- API keys persist through the existing transcript settings (`deepgramApiKey` column already present); Deepgram can also read `DEEPGRAM_API_KEY` from the environment.

Deepgram is streaming-first, so it does not map onto the batch `TranscriptionProvider` trait (chunk → `Vec<f32>` → text). It is wired in as its own streaming path and the trait-based engine is bypassed for the `deepgram` provider. A generic "POST-a-WAV" contract would flatten Deepgram to batch-only "text out" and throw away the low-latency streaming + provider-specific features (keyterm prompting, diarization, Flux turn detection) that are the reason to use it for meetings.

## What's included

Backend (`frontend/src-tauri`):
- `src/audio/deepgram.rs` — the provider: realtime WS client, prerecorded REST client, segment mapping, stream→recording time mapping, config readers, unit tests.
- Wired into `transcription/engine.rs` (validate key, route provider, `is_deepgram_transcription_provider`), `transcription/worker.rs` (realtime task), `import.rs` + `retranscription.rs` (prerecorded path), `pipeline.rs` + `recording_manager.rs` + `recording_commands.rs` (continuous-stream mode so realtime endpointing stays stable), `config.rs` (default models).
- `migrations/20260101000000_add_deepgram_options.sql` — `deepgramKeyterm` + `deepgramDiarize` columns; `SettingsRepository::{get,save}_deepgram_options`; `api_{get,save}_deepgram_options` Tauri commands.

Frontend:
- `TranscriptSettings.tsx` — enable the Deepgram provider, model picker (nova-3/nova-2/flux-general-en/flux-general-multi), keyterm textarea + diarization switch (nova), persistence.
- `useTranscriptionModels.ts` — offer Deepgram in the import/retranscribe model pickers.
- `constants/modelDefaults.ts` — Deepgram default-model constants (kept in sync with `config.rs`).

## Wire contract notes (verified live against api.deepgram.com)

- Auth header is `Authorization: Token <key>` (not `Bearer`).
- Prerecorded is a single synchronous POST (no upload → poll cycle); `results.utterances[]` gives speaker-segmented turns.
- nova realtime params are passed as WS query string; each `Results` message with `is_final` carries a smart-formatted transcript + word timing.
- Flux realtime is a distinct v2 endpoint whose raw `TurnInfo` shape (`event` string + top-level `transcript`/`words`/`audio_window_*`) differs from both published docs examples — confirmed by the live probe.
- keyterm prompting routes to `keyterm` for nova-3 and Flux, `keywords` for nova-2.

## Live verification

Exercised both real Deepgram paths with a synthesized speech sample (nova-3, smart_format, diarize, keyterm=Meetily,Deepgram):

- **Prerecorded REST** → HTTP 200; `results.utterances[]` (6 speaker turns) + `alternatives[0].words[]` with `{start,end,confidence,speaker,punctuated_word}`; `metadata.duration` present. Transcript returned correctly.
- **Realtime WS (nova-3)** → connected; 20 `Results` messages; final stitched transcript matched the input verbatim.
- **Realtime WS (Flux, flux-general-multi)** → connected to `/v2/listen`; received `Connected` + `TurnInfo` events (`StartOfTurn`/`Update`/`EndOfTurn`); the `EndOfTurn` transcript matched the input. This confirmed the real `TurnInfo` shape (which differs from the published docs examples).

## Testing

- `cargo check --tests` — clean (no new warnings).
- `cargo test --lib deepgram::` — 21 passed, 0 failed. Covers utterance/word → segment mapping, stream→recording time map, keyterm routing (nova-3/Flux `keyterm` vs nova-2 `keywords`), language defaulting, nova + Flux URL construction, nova/Flux final-segment reduction, prerecorded Flux→nova fallback, and wire-contract deserialization of real prerecorded / nova-realtime / Flux-`TurnInfo` / error JSON.
- `tsc --noEmit` — clean for all changed files (one unrelated pre-existing `bun:test` error in `tests/lib/blocknote-markdown.test.ts`, not in the `next build` graph).

## Models & scope

- **nova-3** (default) / **nova-2** — `/v1/listen`; nova-3 uses `language=multi` on auto, keyterm via `keyterm` (nova-2 via `keywords`).
- **flux-general-en** / **flux-general-multi** — `/v2/listen` turn-based realtime; the multi model biases via repeatable `language_hint` (auto-detect otherwise). Flux is realtime-only, so imported/retranscribed files transparently fall back to the default nova async model.
- Realtime emits finalized results only (nova `is_final`, Flux `EndOfTurn`). The transcript UI buffers by `sequence_id` with no partial-replace path, so nova `interim_results` is disabled to avoid duplicated segments; low latency comes from `endpointing` (nova) / native turn detection (Flux).

## Type of Change
- [x] New feature (first-class Deepgram transcription provider)
