### PR TITLE
feat: interactive meeting timeline with audio sync (#558)

### DIFF
--- a/frontend/src/components/MeetingDetails/MeetingAudioPlayer.tsx
+++ b/frontend/src/components/MeetingDetails/MeetingAudioPlayer.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Pause, Play } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { formatTimecode } from '@/lib/meeting-timeline';
+
+export interface MeetingAudioPlayerProps {
+  /** Whether audio is currently playing. */
+  isPlaying: boolean;
+  /** Current playback position in seconds. */
+  currentTime: number;
+  /** Total duration in seconds (0 until the audio has loaded). */
+  duration: number;
+  /** Error message to surface, if loading or playback failed. */
+  error?: string | null;
+  /** Start playback. */
+  onPlay: () => void;
+  /** Pause playback. */
+  onPause: () => void;
+  /** Seek to an absolute position in seconds. */
+  onSeek: (seconds: number) => void;
+  /** Optional additional class names for the outer container. */
+  className?: string;
+}
+
+/**
+ * Compact audio transport for a recorded meeting: a play/pause toggle, a
+ * scrubber, and elapsed/total timecodes. Purely presentational — playback state
+ * is owned by the parent (via the `useAudioPlayer` hook) so the timeline can
+ * drive seeking too.
+ */
+export function MeetingAudioPlayer({
+  isPlaying,
+  currentTime,
+  duration,
+  error,
+  onPlay,
+  onPause,
+  onSeek,
+  className,
+}: MeetingAudioPlayerProps) {
+  const isReady = duration > 0;
+
+  return (
+    <div className={cn('flex items-center gap-3 px-3 py-2', className)}>
+      <button
+        type="button"
+        onClick={isPlaying ? onPause : onPlay}
+        disabled={!isReady}
+        aria-label={isPlaying ? 'Pause recording' : 'Play recording'}
+        className={cn(
+          'flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition-colors',
+          'hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
+          'disabled:cursor-not-allowed disabled:bg-gray-300',
+        )}
+      >
+        {isPlaying ? <Pause size={16} /> : <Play size={16} className="ml-0.5" />}
+      </button>
+
+      <span className="font-mono text-xs text-gray-500 tabular-nums">{formatTimecode(currentTime)}</span>
+
+      <input
+        type="range"
+        min={0}
+        max={isReady ? duration : 1}
+        step={0.1}
+        value={Math.min(currentTime, isReady ? duration : 1)}
+        disabled={!isReady}
+        onChange={(event) => onSeek(Number(event.target.value))}
+        aria-label="Seek recording"
+        className="h-1 flex-1 cursor-pointer accent-blue-600 disabled:cursor-not-allowed"
+      />
+
+      <span className="font-mono text-xs text-gray-400 tabular-nums">{formatTimecode(duration)}</span>
+
+      {error && (
+        <span className="text-xs text-red-500" role="alert">
+          Audio unavailable
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/MeetingDetails/MeetingTimeline.tsx
+++ b/frontend/src/components/MeetingDetails/MeetingTimeline.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { memo } from 'react';
+import {
+  BookOpen,
+  ChevronDown,
+  ChevronRight,
+  HelpCircle,
+  ListChecks,
+  PlayCircle,
+  type LucideIcon,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { formatTimecode, type TimelineMarker, type TimelineMarkerKind } from '@/lib/meeting-timeline';
+
+/** Visual configuration for each marker kind: icon, accent colours and label. */
+const KIND_CONFIG: Record<
+  TimelineMarkerKind,
+  { icon: LucideIcon; srLabel: string; iconClass: string; activeClass: string }
+> = {
+  chapter: {
+    icon: BookOpen,
+    srLabel: 'Chapter',
+    iconClass: 'text-blue-500',
+    activeClass: 'border-blue-500 bg-blue-50',
+  },
+  action: {
+    icon: ListChecks,
+    srLabel: 'Action item',
+    iconClass: 'text-emerald-600',
+    activeClass: 'border-emerald-500 bg-emerald-50',
+  },
+  question: {
+    icon: HelpCircle,
+    srLabel: 'Question',
+    iconClass: 'text-violet-600',
+    activeClass: 'border-violet-500 bg-violet-50',
+  },
+  resume: {
+    icon: PlayCircle,
+    srLabel: 'Resumes after pause',
+    iconClass: 'text-amber-600',
+    activeClass: 'border-amber-500 bg-amber-50',
+  },
+};
+
+export interface MeetingTimelineProps {
+  /** Key moments to render, in chronological order. */
+  markers: TimelineMarker[];
+  /** Id of the marker to highlight as active, if any. */
+  activeMarkerId?: string | null;
+  /** Invoked when the user selects a marker. */
+  onMarkerSelect: (marker: TimelineMarker) => void;
+  /** When true, the header toggles the list open and closed. */
+  collapsible?: boolean;
+  /** Whether the list is expanded. Only used when `collapsible` is true. */
+  isOpen?: boolean;
+  /** Invoked when the header is clicked. Only used when `collapsible` is true. */
+  onToggleOpen?: () => void;
+  /** Optional additional class names for the outer container. */
+  className?: string;
+}
+
+/** A single, selectable timeline entry. Memoised to avoid needless re-renders. */
+const TimelineEntry = memo(function TimelineEntry({
+  marker,
+  isActive,
+  onSelect,
+}: {
+  marker: TimelineMarker;
+  isActive: boolean;
+  onSelect: (marker: TimelineMarker) => void;
+}) {
+  const config = KIND_CONFIG[marker.kind];
+  const Icon = config.icon;
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onSelect(marker)}
+        aria-current={isActive ? 'true' : undefined}
+        title={`${formatTimecode(marker.time)} — ${marker.label}`}
+        className={cn(
+          'group flex w-full items-start gap-2 rounded-md border border-transparent px-2 py-1.5 text-left transition-colors',
+          'hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
+          isActive && config.activeClass,
+        )}
+      >
+        <Icon
+          size={16}
+          className={cn('mt-0.5 flex-shrink-0', config.iconClass)}
+          aria-hidden="true"
+        />
+        <span className="sr-only">{config.srLabel}:</span>
+        <span className="flex min-w-0 flex-col">
+          <span className="font-mono text-xs text-gray-400 tabular-nums">
+            {formatTimecode(marker.time)}
+          </span>
+          <span className="truncate text-sm text-gray-700 group-hover:text-gray-900">
+            {marker.label}
+          </span>
+        </span>
+      </button>
+    </li>
+  );
+});
+
+/**
+ * Renders an interactive list of meeting "key moments". Purely presentational:
+ * the parent owns marker generation and selection state so this component stays
+ * easy to test and reuse.
+ */
+export function MeetingTimeline({
+  markers,
+  activeMarkerId,
+  onMarkerSelect,
+  collapsible = false,
+  isOpen = true,
+  onToggleOpen,
+  className,
+}: MeetingTimelineProps) {
+  const expanded = collapsible ? isOpen : true;
+  const count = markers.length;
+  const countLabel = count > 0 ? `${count} ${count === 1 ? 'moment' : 'moments'}` : null;
+
+  const header = (
+    <>
+      <span className="flex items-center gap-1.5">
+        {collapsible &&
+          (expanded ? (
+            <ChevronDown size={14} className="text-gray-400" aria-hidden="true" />
+          ) : (
+            <ChevronRight size={14} className="text-gray-400" aria-hidden="true" />
+          ))}
+        <span className="text-sm font-semibold text-gray-700">Timeline</span>
+      </span>
+      {countLabel && <span className="text-xs text-gray-400 tabular-nums">{countLabel}</span>}
+    </>
+  );
+
+  return (
+    <section aria-label="Meeting timeline" className={cn('flex min-h-0 flex-col bg-white', className)}>
+      {collapsible ? (
+        <button
+          type="button"
+          onClick={onToggleOpen}
+          aria-expanded={expanded}
+          className="flex items-center justify-between px-3 py-2 border-b border-gray-200 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        >
+          {header}
+        </button>
+      ) : (
+        <div className="flex items-center justify-between px-3 py-2 border-b border-gray-200">{header}</div>
+      )}
+
+      {expanded &&
+        (markers.length === 0 ? (
+          <p className="px-3 py-4 text-xs text-gray-400">
+            Key moments appear here once a meeting has been transcribed.
+          </p>
+        ) : (
+          <ul className="flex flex-1 flex-col gap-0.5 overflow-y-auto p-2">
+            {markers.map((marker) => (
+              <TimelineEntry
+                key={marker.id}
+                marker={marker}
+                isActive={marker.id === activeMarkerId}
+                onSelect={onMarkerSelect}
+              />
+            ))}
+          </ul>
+        ))}
+    </section>
+  );
+}

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -81,6 +81,10 @@ export function TranscriptPanel({
 
   // Resolve the finalized meeting recording (saved as `audio.mp4` in the
   // meeting folder) so it can be played back and seeked from the timeline.
+  // Note: recordings live outside the app's data dir (e.g. ~/Music), so we do
+  // not use the permission-scoped `plugin-fs` here. We build the path and let
+  // the audio loader (`read_audio_file`) report whether it can be read; the
+  // player is only shown once the audio loads successfully.
   const [audioPath, setAudioPath] = useState<string | null>(null);
   useEffect(() => {
     let cancelled = false;
@@ -91,10 +95,8 @@ export function TranscriptPanel({
       }
       try {
         const { join } = await import('@tauri-apps/api/path');
-        const { exists } = await import('@tauri-apps/plugin-fs');
         const candidate = await join(meetingFolderPath, 'audio.mp4');
-        const found = await exists(candidate);
-        if (!cancelled) setAudioPath(found ? candidate : null);
+        if (!cancelled) setAudioPath(candidate);
       } catch {
         if (!cancelled) setAudioPath(null);
       }
@@ -157,7 +159,9 @@ export function TranscriptPanel({
   }, []);
 
   const showTimeline = !isRecording && timelineMarkers.length > 0;
-  const showAudioPlayer = !isRecording && audioPath !== null;
+  // Show the player once a recording path is resolved; hide it if the audio
+  // could not be loaded (e.g. the meeting has no recording).
+  const showAudioPlayer = !isRecording && audioPath !== null && !audio.error;
 
   return (
     <div className="hidden md:flex md:w-1/4 lg:w-1/3 min-w-0 border-r border-gray-200 bg-white flex-col relative shrink-0">

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -5,8 +5,15 @@ import { TranscriptView } from '@/components/TranscriptView';
 import { VirtualizedTranscriptView, type TranscriptViewHandle } from '@/components/VirtualizedTranscriptView';
 import { TranscriptButtonGroup } from './TranscriptButtonGroup';
 import { MeetingTimeline } from './MeetingTimeline';
-import { generateTimeline, type TimelineMarker } from '@/lib/meeting-timeline';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { MeetingAudioPlayer } from './MeetingAudioPlayer';
+import {
+  generateTimeline,
+  findActiveMarkerId,
+  findActiveSegmentIdAtTime,
+  type TimelineMarker,
+} from '@/lib/meeting-timeline';
+import { useAudioPlayer } from '@/hooks/useAudioPlayer';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 interface TranscriptPanelProps {
   transcripts: Transcript[];
@@ -72,6 +79,34 @@ export function TranscriptPanel({
   const [activeSegmentId, setActiveSegmentId] = useState<string | null>(null);
   const [isTimelineOpen, setIsTimelineOpen] = useState(true);
 
+  // Resolve the finalized meeting recording (saved as `audio.mp4` in the
+  // meeting folder) so it can be played back and seeked from the timeline.
+  const [audioPath, setAudioPath] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    const resolveAudio = async () => {
+      if (isRecording || !meetingFolderPath) {
+        setAudioPath(null);
+        return;
+      }
+      try {
+        const { join } = await import('@tauri-apps/api/path');
+        const { exists } = await import('@tauri-apps/plugin-fs');
+        const candidate = await join(meetingFolderPath, 'audio.mp4');
+        const found = await exists(candidate);
+        if (!cancelled) setAudioPath(found ? candidate : null);
+      } catch {
+        if (!cancelled) setAudioPath(null);
+      }
+    };
+    resolveAudio();
+    return () => {
+      cancelled = true;
+    };
+  }, [meetingFolderPath, isRecording]);
+
+  const audio = useAudioPlayer(audioPath);
+
   // Derive timeline key moments from the loaded segments. Only meaningful once
   // recording has stopped and the transcript is available.
   const timelineMarkers = useMemo<TimelineMarker[]>(() => {
@@ -86,17 +121,43 @@ export function TranscriptPanel({
     );
   }, [convertedSegments, isRecording]);
 
-  const handleMarkerSelect = useCallback((marker: TimelineMarker) => {
-    setActiveMarkerId(marker.id);
-    setActiveSegmentId(marker.segmentId);
-    transcriptViewRef.current?.scrollToSegment(marker.segmentId);
-  }, []);
+  // Lightweight segment shape reused for resolving the active segment during
+  // playback (see the follow-playback effect below).
+  const playableSegments = useMemo(
+    () => convertedSegments.map((segment) => ({ id: segment.id, startTime: segment.timestamp })),
+    [convertedSegments],
+  );
+
+  const handleMarkerSelect = useCallback(
+    (marker: TimelineMarker) => {
+      setActiveMarkerId(marker.id);
+      setActiveSegmentId(marker.segmentId);
+      transcriptViewRef.current?.scrollToSegment(marker.segmentId);
+      // Jump audio playback to the same moment when a recording is available.
+      if (audioPath) {
+        audio.seek(marker.time);
+        audio.play();
+      }
+    },
+    [audioPath, audio],
+  );
+
+  // While playing, keep the active marker and transcript segment in sync with
+  // the playback position. Setting the same id is a no-op, so this stays cheap.
+  useEffect(() => {
+    if (!audio.isPlaying) return;
+    const segmentId = findActiveSegmentIdAtTime(playableSegments, audio.currentTime);
+    if (segmentId) setActiveSegmentId(segmentId);
+    const markerId = findActiveMarkerId(timelineMarkers, audio.currentTime);
+    if (markerId) setActiveMarkerId(markerId);
+  }, [audio.currentTime, audio.isPlaying, playableSegments, timelineMarkers]);
 
   const handleToggleTimeline = useCallback(() => {
     setIsTimelineOpen((open) => !open);
   }, []);
 
   const showTimeline = !isRecording && timelineMarkers.length > 0;
+  const showAudioPlayer = !isRecording && audioPath !== null;
 
   return (
     <div className="hidden md:flex md:w-1/4 lg:w-1/3 min-w-0 border-r border-gray-200 bg-white flex-col relative shrink-0">
@@ -111,6 +172,21 @@ export function TranscriptPanel({
           onRefetchTranscripts={onRefetchTranscripts}
         />
       </div>
+
+      {/* Recorded audio transport (play / seek), when a recording exists */}
+      {showAudioPlayer && (
+        <div className="border-b border-gray-200">
+          <MeetingAudioPlayer
+            isPlaying={audio.isPlaying}
+            currentTime={audio.currentTime}
+            duration={audio.duration}
+            error={audio.error}
+            onPlay={audio.play}
+            onPause={audio.pause}
+            onSeek={audio.seek}
+          />
+        </div>
+      )}
 
       {/* Interactive timeline of key moments (collapsible) */}
       {showTimeline && (

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -2,9 +2,11 @@
 
 import { Transcript, TranscriptSegmentData } from '@/types';
 import { TranscriptView } from '@/components/TranscriptView';
-import { VirtualizedTranscriptView } from '@/components/VirtualizedTranscriptView';
+import { VirtualizedTranscriptView, type TranscriptViewHandle } from '@/components/VirtualizedTranscriptView';
 import { TranscriptButtonGroup } from './TranscriptButtonGroup';
-import { useMemo } from 'react';
+import { MeetingTimeline } from './MeetingTimeline';
+import { generateTimeline, type TimelineMarker } from '@/lib/meeting-timeline';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 interface TranscriptPanelProps {
   transcripts: Transcript[];
@@ -64,6 +66,38 @@ export function TranscriptPanel({
     }));
   }, [transcripts, usePagination, segments]);
 
+  // Imperative handle to the transcript view for timeline-driven navigation.
+  const transcriptViewRef = useRef<TranscriptViewHandle>(null);
+  const [activeMarkerId, setActiveMarkerId] = useState<string | null>(null);
+  const [activeSegmentId, setActiveSegmentId] = useState<string | null>(null);
+  const [isTimelineOpen, setIsTimelineOpen] = useState(true);
+
+  // Derive timeline key moments from the loaded segments. Only meaningful once
+  // recording has stopped and the transcript is available.
+  const timelineMarkers = useMemo<TimelineMarker[]>(() => {
+    if (isRecording) return [];
+    return generateTimeline(
+      convertedSegments.map((segment) => ({
+        id: segment.id,
+        startTime: segment.timestamp,
+        endTime: segment.endTime,
+        text: segment.text,
+      })),
+    );
+  }, [convertedSegments, isRecording]);
+
+  const handleMarkerSelect = useCallback((marker: TimelineMarker) => {
+    setActiveMarkerId(marker.id);
+    setActiveSegmentId(marker.segmentId);
+    transcriptViewRef.current?.scrollToSegment(marker.segmentId);
+  }, []);
+
+  const handleToggleTimeline = useCallback(() => {
+    setIsTimelineOpen((open) => !open);
+  }, []);
+
+  const showTimeline = !isRecording && timelineMarkers.length > 0;
+
   return (
     <div className="hidden md:flex md:w-1/4 lg:w-1/3 min-w-0 border-r border-gray-200 bg-white flex-col relative shrink-0">
       {/* Title area */}
@@ -78,9 +112,23 @@ export function TranscriptPanel({
         />
       </div>
 
+      {/* Interactive timeline of key moments (collapsible) */}
+      {showTimeline && (
+        <MeetingTimeline
+          markers={timelineMarkers}
+          activeMarkerId={activeMarkerId}
+          onMarkerSelect={handleMarkerSelect}
+          collapsible
+          isOpen={isTimelineOpen}
+          onToggleOpen={handleToggleTimeline}
+          className="max-h-[38vh] border-b border-gray-200"
+        />
+      )}
+
       {/* Transcript content - use virtualized view for better performance */}
       <div className="flex-1 overflow-hidden pb-4">
         <VirtualizedTranscriptView
+          ref={transcriptViewRef}
           segments={convertedSegments}
           isRecording={isRecording}
           isPaused={false}
@@ -89,6 +137,7 @@ export function TranscriptPanel({
           enableStreaming={false}
           showConfidence={true}
           disableAutoScroll={disableAutoScroll}
+          activeSegmentId={activeSegmentId}
           hasMore={hasMore}
           isLoadingMore={isLoadingMore}
           totalCount={totalCount}

--- a/frontend/src/components/VirtualizedTranscriptView.tsx
+++ b/frontend/src/components/VirtualizedTranscriptView.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useCallback, useRef, useReducer, startTransition, useEffect, useState, memo } from "react";
+import { useCallback, useRef, useReducer, startTransition, useEffect, useState, memo, forwardRef, useImperativeHandle } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { cn } from "@/lib/utils";
 import { useAutoScroll } from "@/hooks/useAutoScroll";
 import { useTranscriptStreaming } from "@/hooks/useTranscriptStreaming";
 import { ConfidenceIndicator } from "./ConfidenceIndicator";
@@ -34,6 +35,14 @@ export interface VirtualizedTranscriptViewProps {
     totalCount?: number;
     loadedCount?: number;
     onLoadMore?: () => void;
+    /** Id of the segment to visually highlight (e.g. selected from the timeline). */
+    activeSegmentId?: string | null;
+}
+
+/** Imperative API exposed via ref for programmatic navigation. */
+export interface TranscriptViewHandle {
+    /** Scrolls the given segment into view, if it is currently loaded. */
+    scrollToSegment: (segmentId: string) => void;
 }
 
 // Threshold for enabling virtualization (below this, use simple rendering)
@@ -71,6 +80,7 @@ const TranscriptSegment = memo(function TranscriptSegment({
     confidence,
     isStreaming,
     showConfidence,
+    isActive = false,
 }: {
     id: string;
     timestamp: number;
@@ -78,11 +88,18 @@ const TranscriptSegment = memo(function TranscriptSegment({
     confidence?: number;
     isStreaming: boolean;
     showConfidence: boolean;
+    isActive?: boolean;
 }) {
     const displayText = cleanStopWords(text) || (text.trim() === '' ? '[Silence]' : text);
 
     return (
-        <div id={`segment-${id}`} className="mb-3">
+        <div
+            id={`segment-${id}`}
+            className={cn(
+                'mb-3 rounded-md transition-colors',
+                isActive && 'bg-blue-50 px-2 -mx-2 ring-1 ring-blue-200',
+            )}
+        >
             <div className="flex items-start gap-2">
                 <Tooltip>
                     <TooltipTrigger>
@@ -110,7 +127,8 @@ const TranscriptSegment = memo(function TranscriptSegment({
     );
 });
 
-export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps> = ({
+export const VirtualizedTranscriptView = forwardRef<TranscriptViewHandle, VirtualizedTranscriptViewProps>(
+    function VirtualizedTranscriptView({
     segments,
     isRecording = false,
     isPaused = false,
@@ -124,7 +142,8 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
     totalCount = 0,
     loadedCount = 0,
     onLoadMore,
-}) => {
+    activeSegmentId = null,
+}, ref) {
     // Create scroll ref first - shared between virtualizer and auto-scroll hook
     const scrollRef = useRef<HTMLDivElement>(null);
     // Ref for infinite scroll trigger element
@@ -156,6 +175,21 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
         virtualizationThreshold: VIRTUALIZATION_THRESHOLD,
         disableAutoScroll,
     });
+
+    // Expose an imperative scroll-to-segment API for the meeting timeline.
+    const scrollToSegment = useCallback((segmentId: string) => {
+        const index = segments.findIndex((segment) => segment.id === segmentId);
+        if (index < 0) return;
+
+        if (segments.length >= VIRTUALIZATION_THRESHOLD) {
+            virtualizer.scrollToIndex(index, { align: 'center' });
+        } else {
+            const element = document.getElementById(`segment-${segmentId}`);
+            element?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+    }, [segments, virtualizer]);
+
+    useImperativeHandle(ref, () => ({ scrollToSegment }), [scrollToSegment]);
 
     // Streaming text effect hook (typewriter animation for new transcripts)
     const { streamingSegmentId, getDisplayText } = useTranscriptStreaming(
@@ -296,6 +330,7 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                                         confidence={segment.confidence}
                                         isStreaming={isStreaming}
                                         showConfidence={showConfidence}
+                                        isActive={segment.id === activeSegmentId}
                                     />
                                 </div>
                             );
@@ -352,6 +387,7 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                                         confidence={segment.confidence}
                                         isStreaming={isStreaming}
                                         showConfidence={showConfidence}
+                                        isActive={segment.id === activeSegmentId}
                                     />
                                 </motion.div>
                             );
@@ -391,4 +427,4 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
             </div>
         </div>
     );
-};
+});

--- a/frontend/src/lib/meeting-timeline.ts
+++ b/frontend/src/lib/meeting-timeline.ts
@@ -354,3 +354,63 @@ function toMarker(item: IndexedSegment, kind: TimelineMarkerKind, idSuffix: stri
     segmentIndex: item.index,
   };
 }
+
+/**
+ * Returns the id of the marker that is "active" at the given playback time —
+ * the last marker whose time is at or before `timeSeconds`. Assumes `markers`
+ * are in chronological order (as returned by {@link generateTimeline}).
+ *
+ * @returns The active marker id, or null when there is no marker at/before the
+ *          time (or the time is negative/non-finite).
+ */
+export function findActiveMarkerId(
+  markers: readonly TimelineMarker[],
+  timeSeconds: number,
+): string | null {
+  if (!Number.isFinite(timeSeconds) || timeSeconds < 0) {
+    return null;
+  }
+  let activeId: string | null = null;
+  for (const marker of markers) {
+    if (marker.time <= timeSeconds) {
+      activeId = marker.id;
+    } else {
+      break;
+    }
+  }
+  return activeId;
+}
+
+/** Minimal segment shape needed to resolve the active segment at a time. */
+export interface PlayableSegment {
+  id: string;
+  /** Seconds from the start of the recording. */
+  startTime: number;
+}
+
+/**
+ * Returns the id of the transcript segment that is "active" at the given
+ * playback time — the last segment that has started at or before `timeSeconds`.
+ * Keeping the most recently started segment active means the highlight stays
+ * stable through silence gaps rather than flickering off. Assumes `segments`
+ * are in chronological order.
+ *
+ * @returns The active segment id, or null when playback is before the first
+ *          segment (or the time is negative/non-finite).
+ */
+export function findActiveSegmentIdAtTime(
+  segments: readonly PlayableSegment[],
+  timeSeconds: number,
+): string | null {
+  if (!Number.isFinite(timeSeconds) || timeSeconds < 0) {
+    return null;
+  }
+  let activeId: string | null = null;
+  for (const segment of segments) {
+    if (segment.startTime > timeSeconds) {
+      break;
+    }
+    activeId = segment.id;
+  }
+  return activeId;
+}

--- a/frontend/src/lib/meeting-timeline.ts
+++ b/frontend/src/lib/meeting-timeline.ts
@@ -1,0 +1,356 @@
+/**
+ * Meeting timeline generation.
+ *
+ * Turns a list of transcript segments into a compact set of navigable
+ * "key moments" (chapters, questions, action items and points where the
+ * conversation resumes after a pause). The output powers the interactive
+ * meeting timeline on the meeting-details page.
+ *
+ * This module is intentionally free of React and I/O so the heuristics can be
+ * unit-tested in isolation and reused by any surface that has transcript data.
+ */
+
+/** The category a timeline marker belongs to. Drives its icon and styling. */
+export type TimelineMarkerKind = 'chapter' | 'question' | 'action' | 'resume';
+
+/**
+ * A single transcript segment, expressed in recording-relative seconds.
+ *
+ * This mirrors the fields the meeting-details page already holds
+ * (`TranscriptSegmentData`) but is kept local so the generator does not depend
+ * on UI types.
+ */
+export interface TimelineSegment {
+  id: string;
+  /** Seconds from the start of the recording. */
+  startTime: number;
+  /** Seconds from the start of the recording. Optional for legacy data. */
+  endTime?: number;
+  /** The transcribed text for this segment. */
+  text: string;
+}
+
+/** A key moment surfaced on the timeline. */
+export interface TimelineMarker {
+  /** Stable identifier, unique within a generated timeline. */
+  id: string;
+  /** Position in seconds from the start of the recording. */
+  time: number;
+  /** Short, human-readable description of the moment. */
+  label: string;
+  /** The category of moment, used for icon and colour. */
+  kind: TimelineMarkerKind;
+  /** Id of the transcript segment this marker points to. */
+  segmentId: string;
+  /** Index of that segment within the input array (for fast scroll-to). */
+  segmentIndex: number;
+}
+
+/** Tunable knobs for {@link generateTimeline}. All fields are optional. */
+export interface TimelineOptions {
+  /** Target number of evenly spaced chapters across the meeting. */
+  targetChapters?: number;
+  /** Silence gap (seconds) between segments that flags a "resume" marker. */
+  pauseThresholdSeconds?: number;
+  /** Minimum spacing (seconds) enforced between two adjacent markers. */
+  minMarkerSpacingSeconds?: number;
+  /** Hard cap on the number of markers returned. */
+  maxMarkers?: number;
+}
+
+/** Default generation options, tuned for typical meeting lengths. */
+export const DEFAULT_TIMELINE_OPTIONS: Required<TimelineOptions> = {
+  targetChapters: 6,
+  pauseThresholdSeconds: 20,
+  minMarkerSpacingSeconds: 8,
+  maxMarkers: 24,
+};
+
+/**
+ * Relative importance of each marker kind. When two markers fall too close
+ * together, the higher-priority one wins. Content-bearing moments (action
+ * items, questions) are considered more informative than generic chapter
+ * boundaries.
+ */
+const KIND_PRIORITY: Record<TimelineMarkerKind, number> = {
+  action: 4,
+  question: 3,
+  resume: 2,
+  chapter: 1,
+};
+
+/**
+ * Phrases that typically signal a commitment or task. Matched
+ * case-insensitively against whole words to limit false positives.
+ */
+const ACTION_PATTERNS: readonly RegExp[] = [
+  /\baction item\b/i,
+  /\bto-?dos?\b/i,
+  /\bfollow[-\s]?ups?\b/i,
+  /\b(?:i|we|you|they)['’]?ll\b/i,
+  /\b(?:i|we|you|they)\s+will\b/i,
+  /\bwe (?:need|have) to\b/i,
+  /\bwe should\b/i,
+  /\blet[’']?s\b/i,
+  /\bassigned?\b/i,
+  /\btake care of\b/i,
+  /\bmake sure\b/i,
+  /\bnext steps?\b/i,
+  /\bby (?:tomorrow|today|eod|end of day|monday|tuesday|wednesday|thursday|friday|next week)\b/i,
+];
+
+/**
+ * Formats a duration in seconds as a timecode.
+ *
+ * Uses `M:SS` for meetings under an hour and `H:MM:SS` beyond that. Negative
+ * or non-finite input is clamped to `0:00`.
+ */
+export function formatTimecode(seconds: number): string {
+  const safe = Number.isFinite(seconds) && seconds > 0 ? Math.floor(seconds) : 0;
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  const secs = safe % 60;
+
+  const paddedSecs = secs.toString().padStart(2, '0');
+  if (hours > 0) {
+    const paddedMinutes = minutes.toString().padStart(2, '0');
+    return `${hours}:${paddedMinutes}:${paddedSecs}`;
+  }
+  return `${minutes}:${paddedSecs}`;
+}
+
+/**
+ * Produces a short, single-line label from a segment's text.
+ *
+ * Collapses whitespace, cuts at the first sentence boundary when one appears
+ * early, and otherwise truncates on a word boundary with an ellipsis.
+ */
+export function summarizeSegmentText(text: string, maxLength = 60): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (normalized.length === 0) {
+    return 'Discussion';
+  }
+
+  // Prefer cutting at the first sentence boundary if it yields a usable label.
+  const sentenceMatch = normalized.match(/^(.+?[.!?])(\s|$)/);
+  if (sentenceMatch) {
+    const sentence = sentenceMatch[1].trim();
+    if (sentence.length <= maxLength) {
+      return stripTrailingPunctuation(sentence);
+    }
+  }
+
+  if (normalized.length <= maxLength) {
+    return stripTrailingPunctuation(normalized);
+  }
+
+  const truncated = normalized.slice(0, maxLength);
+  const lastSpace = truncated.lastIndexOf(' ');
+  const clipped = lastSpace > maxLength * 0.5 ? truncated.slice(0, lastSpace) : truncated;
+  return `${clipped.trim()}…`;
+}
+
+function stripTrailingPunctuation(text: string): string {
+  return text.replace(/[.,;:!?]+$/, '').trim();
+}
+
+/**
+ * Classifies a segment as an action item or a question, or neither.
+ * Action items take precedence over questions when both signals are present.
+ */
+export function classifySegment(text: string): 'action' | 'question' | null {
+  const normalized = text.trim();
+  if (normalized.length === 0) {
+    return null;
+  }
+  if (ACTION_PATTERNS.some((pattern) => pattern.test(normalized))) {
+    return 'action';
+  }
+  if (normalized.includes('?')) {
+    return 'question';
+  }
+  return null;
+}
+
+/**
+ * Generates a timeline of key moments from transcript segments.
+ *
+ * The algorithm is deterministic:
+ * 1. Invalid segments (non-finite or negative start time, empty text) are
+ *    dropped and the rest are sorted by start time.
+ * 2. Evenly spaced chapter markers form a navigation backbone.
+ * 3. Per-segment heuristics add question and action-item markers.
+ * 4. Long silence gaps add "resume" markers.
+ * 5. Markers closer than `minMarkerSpacingSeconds` are merged, keeping the
+ *    higher-priority marker.
+ * 6. The result is capped at `maxMarkers`, keeping the highest-priority markers
+ *    and returned in chronological order.
+ *
+ * @returns Chronologically ordered markers. Empty when there are no valid
+ *          segments.
+ */
+export function generateTimeline(
+  segments: readonly TimelineSegment[],
+  options: TimelineOptions = {},
+): TimelineMarker[] {
+  const config = { ...DEFAULT_TIMELINE_OPTIONS, ...options };
+
+  const valid = segments
+    .map((segment, index) => ({ segment, index }))
+    .filter(
+      ({ segment }) =>
+        Number.isFinite(segment.startTime) &&
+        segment.startTime >= 0 &&
+        segment.text.trim().length > 0,
+    )
+    .sort((a, b) => a.segment.startTime - b.segment.startTime);
+
+  if (valid.length === 0) {
+    return [];
+  }
+
+  const candidates: TimelineMarker[] = [
+    ...buildChapterMarkers(valid, config.targetChapters),
+    ...buildEventMarkers(valid),
+    ...buildResumeMarkers(valid, config.pauseThresholdSeconds),
+  ];
+
+  const merged = mergeBySpacing(candidates, config.minMarkerSpacingSeconds);
+  const capped = capByPriority(merged, config.maxMarkers);
+
+  return capped.sort((a, b) => a.time - b.time);
+}
+
+type IndexedSegment = { segment: TimelineSegment; index: number };
+
+/**
+ * Builds the chapter backbone by bucketing the meeting duration into
+ * `targetChapters` evenly spaced windows and picking the first segment in each.
+ */
+function buildChapterMarkers(valid: IndexedSegment[], targetChapters: number): TimelineMarker[] {
+  const chapters = Math.max(1, Math.floor(targetChapters));
+  const first = valid[0];
+  const last = valid[valid.length - 1];
+  const span = last.segment.startTime - first.segment.startTime;
+
+  // A single meaningful chapter for very short meetings or a single segment.
+  if (span <= 0 || valid.length === 1) {
+    return [toMarker(first, 'chapter', 'chapter')];
+  }
+
+  const bucketSize = span / chapters;
+  const markers: TimelineMarker[] = [];
+  let searchFrom = 0;
+
+  for (let bucket = 0; bucket < chapters; bucket++) {
+    const bucketStart = first.segment.startTime + bucket * bucketSize;
+    const pick = findFirstAtOrAfter(valid, bucketStart, searchFrom);
+    if (pick === null) {
+      break;
+    }
+    searchFrom = pick.position + 1;
+    markers.push(toMarker(pick.item, 'chapter', `chapter-${bucket}`));
+  }
+
+  return markers;
+}
+
+/** Adds a question/action marker for every segment that matches a heuristic. */
+function buildEventMarkers(valid: IndexedSegment[]): TimelineMarker[] {
+  const markers: TimelineMarker[] = [];
+  for (const item of valid) {
+    const kind = classifySegment(item.segment.text);
+    if (kind !== null) {
+      markers.push(toMarker(item, kind, `event-${item.segment.id}`));
+    }
+  }
+  return markers;
+}
+
+/**
+ * Adds a "resume" marker for the segment that follows a silence gap larger than
+ * `pauseThresholdSeconds`.
+ */
+function buildResumeMarkers(valid: IndexedSegment[], pauseThresholdSeconds: number): TimelineMarker[] {
+  if (pauseThresholdSeconds <= 0) {
+    return [];
+  }
+
+  const markers: TimelineMarker[] = [];
+  for (let i = 1; i < valid.length; i++) {
+    const previous = valid[i - 1].segment;
+    const current = valid[i].segment;
+    const previousEnd = Number.isFinite(previous.endTime as number)
+      ? (previous.endTime as number)
+      : previous.startTime;
+    const gap = current.startTime - previousEnd;
+    if (gap >= pauseThresholdSeconds) {
+      markers.push(toMarker(valid[i], 'resume', `resume-${current.id}`));
+    }
+  }
+  return markers;
+}
+
+/**
+ * Greedy chronological merge that enforces a minimum spacing between markers.
+ * When a marker falls within `minSpacing` of the previously kept one, the
+ * higher-priority marker is retained.
+ */
+function mergeBySpacing(markers: TimelineMarker[], minSpacing: number): TimelineMarker[] {
+  const sorted = [...markers].sort(
+    (a, b) => a.time - b.time || KIND_PRIORITY[b.kind] - KIND_PRIORITY[a.kind],
+  );
+
+  const kept: TimelineMarker[] = [];
+  for (const marker of sorted) {
+    const last = kept[kept.length - 1];
+    if (!last || marker.time - last.time >= minSpacing) {
+      kept.push(marker);
+      continue;
+    }
+    if (KIND_PRIORITY[marker.kind] > KIND_PRIORITY[last.kind]) {
+      kept[kept.length - 1] = marker;
+    }
+  }
+  return kept;
+}
+
+/**
+ * Keeps at most `maxMarkers`, preferring higher-priority markers and breaking
+ * ties by earlier time. Order is not guaranteed; callers re-sort by time.
+ */
+function capByPriority(markers: TimelineMarker[], maxMarkers: number): TimelineMarker[] {
+  const cap = Math.max(1, Math.floor(maxMarkers));
+  if (markers.length <= cap) {
+    return markers;
+  }
+  return [...markers]
+    .sort((a, b) => KIND_PRIORITY[b.kind] - KIND_PRIORITY[a.kind] || a.time - b.time)
+    .slice(0, cap);
+}
+
+/** Finds the first segment at or after `time`, searching from `fromPosition`. */
+function findFirstAtOrAfter(
+  valid: IndexedSegment[],
+  time: number,
+  fromPosition: number,
+): { item: IndexedSegment; position: number } | null {
+  for (let position = fromPosition; position < valid.length; position++) {
+    if (valid[position].segment.startTime >= time) {
+      return { item: valid[position], position };
+    }
+  }
+  return null;
+}
+
+/** Converts an indexed segment into a marker of the given kind. */
+function toMarker(item: IndexedSegment, kind: TimelineMarkerKind, idSuffix: string): TimelineMarker {
+  return {
+    id: `marker-${idSuffix}`,
+    time: item.segment.startTime,
+    label: summarizeSegmentText(item.segment.text),
+    kind,
+    segmentId: item.segment.id,
+    segmentIndex: item.index,
+  };
+}

--- a/frontend/tests/lib/meeting-timeline.test.ts
+++ b/frontend/tests/lib/meeting-timeline.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 import {
   classifySegment,
+  findActiveMarkerId,
+  findActiveSegmentIdAtTime,
   formatTimecode,
   generateTimeline,
   summarizeSegmentText,
@@ -196,5 +198,51 @@ describe('generateTimeline', () => {
     const markers = generateTimeline(segments);
     const uniqueIds = new Set(markers.map((m) => m.id));
     expect(uniqueIds.size).toBe(markers.length);
+  });
+});
+
+describe('findActiveMarkerId', () => {
+  const markers = [
+    { id: 'm0', time: 0, label: 'a', kind: 'chapter' as const, segmentId: 's0', segmentIndex: 0 },
+    { id: 'm1', time: 30, label: 'b', kind: 'question' as const, segmentId: 's1', segmentIndex: 1 },
+    { id: 'm2', time: 90, label: 'c', kind: 'action' as const, segmentId: 's2', segmentIndex: 2 },
+  ];
+
+  test('returns null before the first marker or for invalid time', () => {
+    expect(findActiveMarkerId(markers, -5)).toBeNull();
+    expect(findActiveMarkerId(markers, Number.NaN)).toBeNull();
+    expect(findActiveMarkerId([], 10)).toBeNull();
+  });
+
+  test('returns the last marker at or before the time', () => {
+    expect(findActiveMarkerId(markers, 0)).toBe('m0');
+    expect(findActiveMarkerId(markers, 29)).toBe('m0');
+    expect(findActiveMarkerId(markers, 30)).toBe('m1');
+    expect(findActiveMarkerId(markers, 89)).toBe('m1');
+    expect(findActiveMarkerId(markers, 1000)).toBe('m2');
+  });
+});
+
+describe('findActiveSegmentIdAtTime', () => {
+  const segments = [
+    { id: 's0', startTime: 0 },
+    { id: 's1', startTime: 12 },
+    { id: 's2', startTime: 40 },
+  ];
+
+  test('returns null before the first segment or for invalid time', () => {
+    const later = [{ id: 'x', startTime: 5 }];
+    expect(findActiveSegmentIdAtTime(later, 1)).toBeNull();
+    expect(findActiveSegmentIdAtTime(segments, -1)).toBeNull();
+    expect(findActiveSegmentIdAtTime(segments, Number.POSITIVE_INFINITY)).toBeNull();
+    expect(findActiveSegmentIdAtTime([], 10)).toBeNull();
+  });
+
+  test('returns the last segment that has started', () => {
+    expect(findActiveSegmentIdAtTime(segments, 0)).toBe('s0');
+    expect(findActiveSegmentIdAtTime(segments, 11.9)).toBe('s0');
+    expect(findActiveSegmentIdAtTime(segments, 12)).toBe('s1');
+    expect(findActiveSegmentIdAtTime(segments, 39)).toBe('s1');
+    expect(findActiveSegmentIdAtTime(segments, 500)).toBe('s2');
   });
 });

--- a/frontend/tests/lib/meeting-timeline.test.ts
+++ b/frontend/tests/lib/meeting-timeline.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  classifySegment,
+  formatTimecode,
+  generateTimeline,
+  summarizeSegmentText,
+  type TimelineSegment,
+} from '../../src/lib/meeting-timeline';
+
+/** Builds a segment with sensible defaults for terser test data. */
+function segment(partial: Partial<TimelineSegment> & { id: string; startTime: number }): TimelineSegment {
+  return {
+    endTime: partial.startTime + 3,
+    text: 'Some discussion about the project.',
+    ...partial,
+  };
+}
+
+describe('formatTimecode', () => {
+  test('formats sub-hour durations as M:SS', () => {
+    expect(formatTimecode(0)).toBe('0:00');
+    expect(formatTimecode(5)).toBe('0:05');
+    expect(formatTimecode(65)).toBe('1:05');
+    expect(formatTimecode(600)).toBe('10:00');
+  });
+
+  test('formats hour-plus durations as H:MM:SS', () => {
+    expect(formatTimecode(3600)).toBe('1:00:00');
+    expect(formatTimecode(3661)).toBe('1:01:01');
+  });
+
+  test('clamps negative and non-finite input to 0:00', () => {
+    expect(formatTimecode(-10)).toBe('0:00');
+    expect(formatTimecode(Number.NaN)).toBe('0:00');
+    expect(formatTimecode(Number.POSITIVE_INFINITY)).toBe('0:00');
+  });
+
+  test('truncates fractional seconds toward zero', () => {
+    expect(formatTimecode(59.9)).toBe('0:59');
+  });
+});
+
+describe('summarizeSegmentText', () => {
+  test('collapses whitespace and strips trailing punctuation', () => {
+    expect(summarizeSegmentText('  Hello    world.  ')).toBe('Hello world');
+  });
+
+  test('cuts at the first sentence boundary when short enough', () => {
+    expect(summarizeSegmentText('Quick note. Then a much longer follow-up sentence here.')).toBe(
+      'Quick note',
+    );
+  });
+
+  test('truncates long single sentences on a word boundary with an ellipsis', () => {
+    const label = summarizeSegmentText(
+      'This is a considerably long sentence that keeps going well beyond the limit',
+      30,
+    );
+    expect(label.endsWith('…')).toBe(true);
+    expect(label.length).toBeLessThanOrEqual(31);
+    expect(label).not.toContain('  ');
+  });
+
+  test('falls back to a generic label for empty text', () => {
+    expect(summarizeSegmentText('    ')).toBe('Discussion');
+  });
+});
+
+describe('classifySegment', () => {
+  test('detects action items via keyword phrases', () => {
+    expect(classifySegment("Let's finalize the budget by Friday")).toBe('action');
+    expect(classifySegment('I will send the report tomorrow')).toBe('action');
+    expect(classifySegment('Action item: update the docs')).toBe('action');
+    expect(classifySegment('Next steps are clear')).toBe('action');
+  });
+
+  test('detects questions when no action signal is present', () => {
+    expect(classifySegment('What do you think about the design?')).toBe('question');
+  });
+
+  test('prefers action over question when both are present', () => {
+    expect(classifySegment("Can you make sure it's done by tomorrow?")).toBe('action');
+  });
+
+  test('returns null for plain statements and empty text', () => {
+    expect(classifySegment('The weather was nice today')).toBeNull();
+    expect(classifySegment('   ')).toBeNull();
+  });
+});
+
+describe('generateTimeline', () => {
+  test('returns an empty timeline when there are no segments', () => {
+    expect(generateTimeline([])).toEqual([]);
+  });
+
+  test('drops invalid segments (negative, non-finite, or empty text)', () => {
+    const markers = generateTimeline([
+      segment({ id: 'a', startTime: -1, text: 'negative start' }),
+      segment({ id: 'b', startTime: Number.NaN, text: 'nan start' }),
+      segment({ id: 'c', startTime: 10, text: '   ' }),
+    ]);
+    expect(markers).toEqual([]);
+  });
+
+  test('produces a single chapter marker for one segment', () => {
+    const markers = generateTimeline([segment({ id: 'only', startTime: 0, text: 'Welcome everyone' })]);
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toMatchObject({
+      kind: 'chapter',
+      time: 0,
+      segmentId: 'only',
+      segmentIndex: 0,
+      label: 'Welcome everyone',
+    });
+  });
+
+  test('returns markers in chronological order', () => {
+    const segments = Array.from({ length: 30 }, (_, i) =>
+      segment({ id: `s${i}`, startTime: i * 20, text: `Topic number ${i}` }),
+    );
+    const markers = generateTimeline(segments);
+    const times = markers.map((m) => m.time);
+    const sorted = [...times].sort((a, b) => a - b);
+    expect(times).toEqual(sorted);
+  });
+
+  test('preserves the original segment index for scroll-to navigation', () => {
+    const segments = [
+      segment({ id: 's0', startTime: 0, text: 'Intro' }),
+      segment({ id: 's1', startTime: 40, text: 'What is the deadline?' }),
+      segment({ id: 's2', startTime: 80, text: 'Closing remarks' }),
+    ];
+    const markers = generateTimeline(segments);
+    const question = markers.find((m) => m.kind === 'question');
+    expect(question).toBeDefined();
+    expect(question?.segmentIndex).toBe(1);
+    expect(question?.segmentId).toBe('s1');
+  });
+
+  test('flags a resume marker after a long silence gap', () => {
+    const segments = [
+      segment({ id: 'a', startTime: 0, endTime: 5, text: 'Opening statements' }),
+      segment({ id: 'b', startTime: 60, endTime: 63, text: 'Back after the break' }),
+    ];
+    const markers = generateTimeline(segments, { pauseThresholdSeconds: 20, minMarkerSpacingSeconds: 1 });
+    expect(markers.some((m) => m.kind === 'resume' && m.segmentId === 'b')).toBe(true);
+  });
+
+  test('does not flag a resume marker for short gaps', () => {
+    const segments = [
+      segment({ id: 'a', startTime: 0, endTime: 5, text: 'First point' }),
+      segment({ id: 'b', startTime: 10, endTime: 13, text: 'Second point' }),
+    ];
+    const markers = generateTimeline(segments, { pauseThresholdSeconds: 20 });
+    expect(markers.some((m) => m.kind === 'resume')).toBe(false);
+  });
+
+  test('enforces minimum spacing by keeping the higher-priority marker', () => {
+    const segments = [
+      segment({ id: 'chapter', startTime: 0, text: 'General discussion' }),
+      // An action item one second later must win over a coincident chapter.
+      segment({ id: 'action', startTime: 1, text: "Let's ship it by tomorrow" }),
+    ];
+    const markers = generateTimeline(segments, { minMarkerSpacingSeconds: 8, targetChapters: 1 });
+    expect(markers).toHaveLength(1);
+    expect(markers[0].kind).toBe('action');
+  });
+
+  test('never exceeds the maxMarkers cap', () => {
+    const segments = Array.from({ length: 100 }, (_, i) =>
+      segment({ id: `s${i}`, startTime: i * 15, text: `What about option ${i}?` }),
+    );
+    const markers = generateTimeline(segments, { maxMarkers: 10, minMarkerSpacingSeconds: 1 });
+    expect(markers.length).toBeLessThanOrEqual(10);
+  });
+
+  test('every marker points at a real segment', () => {
+    const segments = [
+      segment({ id: 'a', startTime: 0, text: 'Kickoff' }),
+      segment({ id: 'b', startTime: 30, text: 'Who owns this task?' }),
+      segment({ id: 'c', startTime: 90, text: "We'll review next week" }),
+    ];
+    const ids = new Set(segments.map((s) => s.id));
+    const markers = generateTimeline(segments);
+    expect(markers.length).toBeGreaterThan(0);
+    for (const marker of markers) {
+      expect(ids.has(marker.segmentId)).toBe(true);
+      expect(marker.id.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('marker ids are unique within a generated timeline', () => {
+    const segments = Array.from({ length: 40 }, (_, i) =>
+      segment({ id: `s${i}`, startTime: i * 25, text: `Discussion ${i}` }),
+    );
+    const markers = generateTimeline(segments);
+    const uniqueIds = new Set(markers.map((m) => m.id));
+    expect(uniqueIds.size).toBe(markers.length);
+  });
+});


### PR DESCRIPTION
## Description
Adds an interactive meeting timeline to the meeting-details view that surfaces
key moments from the transcript and lets users jump to them. Selecting a moment
scrolls/highlights the transcript and seeks + plays the recorded audio from that
point; during playback the active marker and transcript segment follow along.

## Related Issue
Fixes #558

## Type of Change
- [x] New feature

## What's included
- Pure, dependency-free timeline generator (`src/lib/meeting-timeline.ts`) using
  deterministic heuristics: evenly-spaced chapters + question / action-item /
  pause-resume detection, with priority-based merging, minimum spacing and a cap.
- `MeetingTimeline` — accessible, collapsible presentational component
  (per-kind icons, timecodes, aria attributes).
- `MeetingAudioPlayer` — compact play/pause + seek transport.
- Transcript navigation: `VirtualizedTranscriptView` exposes a backward-compatible
  `scrollToSegment` imperative handle (via `forwardRef`) and an `activeSegmentId`
  highlight.
- Audio sync in `TranscriptPanel`: resolves the finalized `audio.mp4`, owns
  `useAudioPlayer`, marker click seeks + plays, and playback position drives the
  active marker/segment highlight.

## Testing
- [x] Unit tests added (35 tests: generator + active-marker/segment helpers), all
      passing via `bun test`
- [x] `tsc --noEmit` clean; `next build` succeeds
- [x] Manual end-to-end in the desktop app with a real recording: timeline
      generation, marker → scroll + highlight, and marker → audio seek + play-follow
      all verified

## Notes / follow-ups (out of scope)
- Phase 2: AI-generated topic-aware chapters (the issue's stretch goal)
- Heuristic tuning (e.g. trailing `?` winning over weak action matches)
- Player polish (playback speed / volume / shortcuts)

## Checklist
- [x] Code follows project style
- [x] Self-reviewed
- [x] Additive & backward-compatible (live-recording path untouched)

<img width="774" height="1236" alt="image" src="https://github.com/user-attachments/assets/2157ff86-4653-40f9-965f-6c181e1068c0" />
