### PR TITLE
feat: clickable transcript timestamp references in summaries

### DIFF
--- a/frontend/src-tauri/src/summary/mod.rs
+++ b/frontend/src-tauri/src/summary/mod.rs
@@ -72,6 +72,7 @@ pub use template_commands::{
 pub use llm_client::LLMProvider;
 pub use processor::{
     chunk_text, clean_llm_markdown_output, extract_meeting_name_from_markdown,
-    generate_meeting_summary, rough_token_count,
+    extract_transcript_references, generate_meeting_summary, rough_token_count,
+    TranscriptReference,
 };
 pub use service::SummaryService;

--- a/frontend/src-tauri/src/summary/processor.rs
+++ b/frontend/src-tauri/src/summary/processor.rs
@@ -3,6 +3,7 @@ use crate::summary::templates::Template;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use reqwest::Client;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
@@ -11,6 +12,20 @@ use tracing::{error, info};
 static THINKING_TAG_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"(?s)<think(?:ing)?>.*?</think(?:ing)?>").unwrap()
 });
+
+/// Matches timestamp references like [14:32-15:18] or [2:01-3:45]
+static REFERENCE_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\[(\d{1,2}):(\d{2})-(\d{1,2}):(\d{2})\]").unwrap()
+});
+
+/// A parsed transcript reference extracted from the summary markdown.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TranscriptReference {
+    /// Start time in seconds (parsed from [MM:SS-MM:SS])
+    pub start_time: f64,
+    /// End time in seconds (parsed from [MM:SS-MM:SS])
+    pub end_time: f64,
+}
 
 const ENGLISH_BASE_SUMMARY_INSTRUCTION: &str =
     "**Write the summary/report in English regardless of transcript language; non-English prose is invalid.**";
@@ -134,15 +149,23 @@ fn translation_system_prompt(target_language: &str) -> String {
     )
 }
 
+const REFERENCE_INSTRUCTION: &str = "**TRANSCRIPT REFERENCE REQUIREMENT:**\
+\nAfter each key point, decision, action item, or important detail, include the \
+timestamp range from the transcript where this was discussed, in the format `[MM:SS-MM:SS]`.\
+Use the `[MM:SS]` prefixes shown in the transcript text.\
+\nExample: \"Decision: Migrate authentication to OAuth2. [14:32-15:18]\"\
+\nExample: \"Alice will prepare the migration plan. [27:41-28:05]\"\
+\nInclude the reference at the end of each relevant item.";
+
 fn build_chunk_summary_user_prompt(chunk: &str) -> String {
     format!(
-        "{ENGLISH_BASE_SUMMARY_INSTRUCTION}\n\nProvide a concise but comprehensive summary of the following transcript chunk. Capture all key points, decisions, action items, and mentioned individuals.\n\n<transcript_chunk>\n{chunk}\n</transcript_chunk>"
+        "{ENGLISH_BASE_SUMMARY_INSTRUCTION}\n\n{REFERENCE_INSTRUCTION}\n\nProvide a concise but comprehensive summary of the following transcript chunk. Capture all key points, decisions, action items, and mentioned individuals.\n\n<transcript_chunk>\n{chunk}\n</transcript_chunk>"
     )
 }
 
 fn build_combine_summary_user_prompt(combined_text: &str) -> String {
     format!(
-        "{ENGLISH_BASE_SUMMARY_INSTRUCTION}\n\nThe following are consecutive summaries of a meeting. Combine them into a single, coherent, and detailed narrative summary that retains all important details, organized logically.\n\n<summaries>\n{combined_text}\n</summaries>"
+        "{ENGLISH_BASE_SUMMARY_INSTRUCTION}\n\n{REFERENCE_INSTRUCTION}\n\nThe following are consecutive summaries of a meeting. Combine them into a single, coherent, and detailed narrative summary that retains all important details, organized logically. Preserve the transcript timestamp references from the individual summaries.\n\n<summaries>\n{combined_text}\n</summaries>"
     )
 }
 
@@ -161,6 +184,7 @@ fn build_final_report_system_prompt(
 5. If a section has no relevant info, write "None noted in this section."
 6. Output **only** the completed Markdown report.
 7. If unsure about something, omit it.
+8. {REFERENCE_INSTRUCTION}
 
 **SECTION-SPECIFIC INSTRUCTIONS:**
 {section_instructions}
@@ -278,6 +302,26 @@ pub fn clean_llm_markdown_output(markdown: &str) -> String {
 
     // If no fences found, return the trimmed string
     trimmed.to_string()
+}
+
+/// Extracts transcript timestamp references from markdown text.
+///
+/// Finds all `[MM:SS-MM:SS]` or `[M:SS-MM:SS]` patterns and converts
+/// them to structured `TranscriptReference` values with start/end times in seconds.
+pub fn extract_transcript_references(markdown: &str) -> Vec<TranscriptReference> {
+    let mut refs = Vec::new();
+    for cap in REFERENCE_REGEX.captures_iter(markdown) {
+        let start_m: f64 = cap[1].parse().unwrap_or(0.0);
+        let start_s: f64 = cap[2].parse().unwrap_or(0.0);
+        let end_m: f64 = cap[3].parse().unwrap_or(0.0);
+        let end_s: f64 = cap[4].parse().unwrap_or(0.0);
+        let start_time = start_m * 60.0 + start_s;
+        let end_time = end_m * 60.0 + end_s;
+        if end_time > start_time {
+            refs.push(TranscriptReference { start_time, end_time });
+        }
+    }
+    refs
 }
 
 /// Extracts meeting name from the first heading in markdown
@@ -714,6 +758,7 @@ mod tests {
         let prompt = build_chunk_summary_user_prompt("会議の内容");
 
         assert!(prompt.contains(ENGLISH_BASE_SUMMARY_INSTRUCTION));
+        assert!(prompt.contains(REFERENCE_INSTRUCTION));
         assert!(prompt.contains("<transcript_chunk>"));
     }
 
@@ -722,6 +767,7 @@ mod tests {
         let prompt = build_combine_summary_user_prompt("chunk one\n---\nchunk two");
 
         assert!(prompt.contains(ENGLISH_BASE_SUMMARY_INSTRUCTION));
+        assert!(prompt.contains(REFERENCE_INSTRUCTION));
         assert!(prompt.contains("<summaries>"));
     }
 
@@ -730,6 +776,7 @@ mod tests {
         let prompt = build_final_report_system_prompt("Fill the section", "# <Add Title here>");
 
         assert!(prompt.contains(ENGLISH_BASE_SUMMARY_INSTRUCTION));
+        assert!(prompt.contains(REFERENCE_INSTRUCTION));
         assert!(prompt.contains("SECTION-SPECIFIC INSTRUCTIONS"));
     }
 
@@ -792,6 +839,59 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    // extract_transcript_references -------------------------------------------
+
+    #[test]
+    fn extracts_single_reference() {
+        let refs = extract_transcript_references(
+            "Decision: Migrate to OAuth2. [14:32-15:18]"
+        );
+        assert_eq!(refs.len(), 1);
+        assert!((refs[0].start_time - 872.0).abs() < f64::EPSILON);
+        assert!((refs[0].end_time - 918.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn extracts_multiple_references() {
+        let refs = extract_transcript_references(
+            "First point. [01:05-02:30]\nSecond point. [27:41-28:05]"
+        );
+        assert_eq!(refs.len(), 2);
+        assert!((refs[0].start_time - 65.0).abs() < f64::EPSILON);
+        assert!((refs[1].start_time - 1661.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn no_references_returns_empty() {
+        let refs = extract_transcript_references(
+            "Just a plain summary without any timestamps."
+        );
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn malformed_brackets_are_ignored() {
+        let refs = extract_transcript_references(
+            "Some text with [not a time] or [12:345-67:890]."
+        );
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn extracts_single_digit_minutes() {
+        let refs = extract_transcript_references("[1:23-4:56]");
+        assert_eq!(refs.len(), 1);
+        assert!((refs[0].start_time - 83.0).abs() < f64::EPSILON);
+        assert!((refs[0].end_time - 296.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn ignores_zero_duration_reference() {
+        // end <= start should be skipped
+        let refs = extract_transcript_references("[05:30-05:30]");
+        assert!(refs.is_empty());
     }
 
     // resolve_cached_english matrix -------------------------------------------

--- a/frontend/src-tauri/src/summary/service.rs
+++ b/frontend/src-tauri/src/summary/service.rs
@@ -5,7 +5,8 @@ use crate::summary::llm_client::LLMProvider;
 use crate::summary::language_detection::detect_summary_language;
 use crate::summary::metadata::read_detected_summary_language_from_metadata;
 use crate::summary::processor::{
-    extract_meeting_name_from_markdown, generate_meeting_summary, language_name_from_code,
+    extract_meeting_name_from_markdown, extract_transcript_references, generate_meeting_summary,
+    language_name_from_code, TranscriptReference,
 };
 use crate::summary::templates::{self, Template};
 use crate::ollama::metadata::ModelMetadataCache;
@@ -140,8 +141,11 @@ fn build_summary_result_json(
     source: SummaryCacheSource,
     output_language: Option<&str>,
 ) -> serde_json::Value {
+    let stripped_markdown = strip_title_if_present(final_markdown);
+    let references = extract_transcript_references(&stripped_markdown);
     serde_json::json!({
-        "markdown": strip_title_if_present(final_markdown),
+        "markdown": stripped_markdown,
+        "transcript_references": references,
         ENGLISH_CACHE_FIELD: EnglishSummaryCache {
             markdown: english_markdown.to_string(),
             source,
@@ -969,6 +973,7 @@ mod tests {
             result["english_cache"]["markdown"],
             "# English Title\n## Decisions\nDone"
         );
+        assert!(result.get("transcript_references").is_some());
     }
 
     #[test]

--- a/frontend/src/app/meeting-details/page-content.tsx
+++ b/frontend/src/app/meeting-details/page-content.tsx
@@ -57,6 +57,14 @@ export default function PageContent({
   const [customPrompt, setCustomPrompt] = useState<string>('');
   const [isRecording] = useState(false);
   const [summaryResponse] = useState<SummaryResponse | null>(null);
+  const [scrollToTime, setScrollToTime] = useState<number | undefined>(undefined);
+  const [scrollToKey, setScrollToKey] = useState(0);
+
+  // Handle transcript reference click - scroll to the matching segment
+  const handleTranscriptRefClick = (startTime: number, endTime: number) => {
+    setScrollToTime(startTime);
+    setScrollToKey(k => k + 1);
+  };
 
   // Ref to store the modal open function from SummaryGeneratorButtonGroup
   const openModelSettingsRef = useRef<(() => void) | null>(null);
@@ -179,6 +187,8 @@ export default function PageContent({
           onOpenMeetingFolder={meetingOperations.handleOpenMeetingFolder}
           isRecording={isRecording}
           disableAutoScroll={true}
+          scrollToTime={scrollToTime}
+          scrollToKey={scrollToKey}
           // Pagination props for efficient loading
           usePagination={true}
           segments={segments}
@@ -226,6 +236,7 @@ export default function PageContent({
           onTemplateSelect={templates.handleTemplateSelection}
           isModelConfigLoading={false}
           onOpenModelSettings={handleRegisterModalOpen}
+          onTranscriptRefClick={handleTranscriptRefClick}
         />
       </div>
     </motion.div>

--- a/frontend/src/components/AISummary/BlockNoteSummaryView.tsx
+++ b/frontend/src/components/AISummary/BlockNoteSummaryView.tsx
@@ -26,6 +26,8 @@ interface BlockNoteSummaryViewProps {
     created_at: string;
   };
   onDirtyChange?: (isDirty: boolean) => void;
+  /** Called when a transcript reference is clicked */
+  onTranscriptRefClick?: (startTime: number, endTime: number) => void;
 }
 
 export interface BlockNoteSummaryViewRef {
@@ -73,13 +75,15 @@ export const BlockNoteSummaryView = forwardRef<BlockNoteSummaryViewRef, BlockNot
   error = null,
   onRegenerateSummary,
   meeting,
-  onDirtyChange
+  onDirtyChange,
+  onTranscriptRefClick
 }, ref) => {
   const { format, data } = detectSummaryFormat(summaryData);
   const [isDirty, setIsDirty] = useState(false);
   const [currentBlocks, setCurrentBlocks] = useState<Block[]>([]);
   const [isSaving, setIsSaving] = useState(false);
   const isContentLoaded = useRef(false);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Create BlockNote editor for markdown parsing
   const editor = useCreateBlockNote({
@@ -117,6 +121,77 @@ export const BlockNoteSummaryView = forwardRef<BlockNoteSummaryViewRef, BlockNot
       }, 100);
     }
   }, [format, data?.summary_json]);
+
+  // Make transcript references [MM:SS-MM:SS] clickable in the rendered DOM
+  useEffect(() => {
+    if ((format !== 'markdown' && format !== 'blocknote') || !containerRef.current) return;
+
+    const root = containerRef.current;
+    const TIMESTAMP_REF = /\[(\d{1,2}:\d{2})-(\d{1,2}:\d{2})\]/g;
+
+    // Find all text nodes and wrap timestamp refs in clickable elements
+    function walkTextNodes(node: Node) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const text = node.textContent || '';
+        if (!TIMESTAMP_REF.test(text)) return;
+        TIMESTAMP_REF.lastIndex = 0;
+
+        const fragment = document.createDocumentFragment();
+        let lastIndex = 0;
+        let match: RegExpExecArray | null;
+
+        while ((match = TIMESTAMP_REF.exec(text)) !== null) {
+          // Text before match
+          if (match.index > lastIndex) {
+            fragment.appendChild(document.createTextNode(text.slice(lastIndex, match.index)));
+          }
+          // Parse timestamps
+          const startM = parseInt(match[1].split(':')[0]);
+          const startS = parseInt(match[1].split(':')[1]);
+          const endM = parseInt(match[2].split(':')[0]);
+          const endS = parseInt(match[2].split(':')[1]);
+          const startTime = startM * 60 + startS;
+          const endTime = endM * 60 + endS;
+
+          const refEl = document.createElement('span');
+          refEl.textContent = match[0];
+          refEl.className = 'transcript-ref inline text-xs font-semibold text-blue-600 bg-blue-50 border border-blue-200 rounded px-1 mx-0.5 cursor-pointer select-none hover:bg-blue-100 hover:text-blue-800 transition-colors';
+          refEl.title = `Jump to transcript ${match[0]}`;
+          refEl.dataset.start = String(startTime);
+          refEl.dataset.end = String(endTime);
+          refEl.onclick = (e) => {
+            e.stopPropagation();
+            onTranscriptRefClick?.(startTime, endTime);
+          };
+          fragment.appendChild(refEl);
+
+          lastIndex = match.index + match[0].length;
+        }
+        // Remaining text after last match
+        if (lastIndex < text.length) {
+          fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
+        }
+
+        node.parentNode?.replaceChild(fragment, node);
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        // Don't go into elements that might be re-rendered by BlockNote
+        const el = node as HTMLElement;
+        if (el.classList.contains('transcript-ref')) return;
+        // Process children
+        const children = Array.from(el.childNodes);
+        for (const child of children) {
+          walkTextNodes(child);
+        }
+      }
+    }
+
+    // Wait for BlockNote to render, then walk
+    const timer = setTimeout(() => {
+      walkTextNodes(root);
+    }, 200);
+
+    return () => clearTimeout(timer);
+  }, [format, data?.markdown, data?.summary_json, onTranscriptRefClick]);
 
   const handleEditorChange = useCallback((blocks: Block[]) => {
     // Only set dirty flag if content has finished loading
@@ -237,7 +312,7 @@ export const BlockNoteSummaryView = forwardRef<BlockNoteSummaryViewRef, BlockNot
   if (format === 'blocknote') {
     console.log('🎨 Rendering BLOCKNOTE format (direct)');
     return (
-      <div className="flex flex-col w-full">
+      <div ref={containerRef} className="flex flex-col w-full">
         <div className="w-full">
           <Editor
             initialContent={data.summary_json}
@@ -256,7 +331,7 @@ export const BlockNoteSummaryView = forwardRef<BlockNoteSummaryViewRef, BlockNot
   if (format === 'markdown') {
     console.log('🎨 Rendering MARKDOWN format (parsed to BlockNote)');
     return (
-      <div className="flex flex-col w-full">
+      <div ref={containerRef} className="flex flex-col w-full">
         <div className="w-full">
           <BlockNoteView
             editor={editor}

--- a/frontend/src/components/MeetingDetails/SummaryPanel.tsx
+++ b/frontend/src/components/MeetingDetails/SummaryPanel.tsx
@@ -60,6 +60,7 @@ interface SummaryPanelProps {
   onTemplateSelect: (templateId: string, templateName: string) => void;
   isModelConfigLoading?: boolean;
   onOpenModelSettings?: (openFn: () => void) => void;
+  onTranscriptRefClick?: (startTime: number, endTime: number) => void;
 }
 
 export function SummaryPanel({
@@ -95,7 +96,8 @@ export function SummaryPanel({
   selectedTemplate,
   onTemplateSelect,
   isModelConfigLoading = false,
-  onOpenModelSettings
+  onOpenModelSettings,
+  onTranscriptRefClick,
 }: SummaryPanelProps) {
   const [summaryLang, setSummaryLang] = useState<string | null>(null);
   const [summaryLangStorage, setSummaryLangStorage] = useState<SummaryLanguageStorage>('metadata');
@@ -429,6 +431,7 @@ export function SummaryPanel({
                 title: meetingTitle,
                 created_at: meeting.created_at
               }}
+              onTranscriptRefClick={onTranscriptRefClick}
             />
           </div>
           {summaryStatus !== 'idle' && (

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -15,6 +15,10 @@ interface TranscriptPanelProps {
   isRecording: boolean;
   disableAutoScroll?: boolean;
 
+  // Scroll-to-segment support (transcript references)
+  scrollToTime?: number;
+  scrollToKey?: number;
+
   // Optional pagination props (when using virtualization)
   usePagination?: boolean;
   segments?: TranscriptSegmentData[];
@@ -38,6 +42,8 @@ export function TranscriptPanel({
   onOpenMeetingFolder,
   isRecording,
   disableAutoScroll = false,
+  scrollToTime,
+  scrollToKey,
   usePagination = false,
   segments,
   hasMore,
@@ -89,6 +95,8 @@ export function TranscriptPanel({
           enableStreaming={false}
           showConfidence={true}
           disableAutoScroll={disableAutoScroll}
+          scrollToTime={scrollToTime}
+          scrollToKey={scrollToKey}
           hasMore={hasMore}
           isLoadingMore={isLoadingMore}
           totalCount={totalCount}

--- a/frontend/src/components/VirtualizedTranscriptView.tsx
+++ b/frontend/src/components/VirtualizedTranscriptView.tsx
@@ -27,6 +27,10 @@ export interface VirtualizedTranscriptViewProps {
     showConfidence?: boolean;
     /** Completely disable auto-scroll behavior (for meeting details page) */
     disableAutoScroll?: boolean;
+    /** When set, scrolls to the segment whose timestamp contains this time (seconds) */
+    scrollToTime?: number;
+    /** Increment to trigger scrollToTime even if time value is the same */
+    scrollToKey?: number;
 
     // Pagination props (infinite scroll)
     hasMore?: boolean;
@@ -119,6 +123,8 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
     enableStreaming = false,
     showConfidence = true,
     disableAutoScroll = false,
+    scrollToTime,
+    scrollToKey,
     hasMore = false,
     isLoadingMore = false,
     totalCount = 0,
@@ -222,6 +228,33 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
 
     // Use simple rendering for small lists, virtualization for large lists
     const useVirtualization = segments.length >= VIRTUALIZATION_THRESHOLD;
+
+    // Scroll to specific segment when scrollToTime changes
+    useEffect(() => {
+        if (scrollToTime === undefined || segments.length === 0) return;
+
+        // Find the segment whose time range contains the target
+        let targetIndex = segments.findIndex(s =>
+            s.timestamp <= scrollToTime && (s.endTime ?? s.timestamp) >= scrollToTime
+        );
+        // Fallback: find nearest segment
+        if (targetIndex === -1) {
+            let best = 0;
+            let bestDist = Infinity;
+            for (let i = 0; i < segments.length; i++) {
+                const dist = Math.abs(segments[i].timestamp - scrollToTime);
+                if (dist < bestDist) { bestDist = dist; best = i; }
+            }
+            targetIndex = best;
+        }
+
+        if (useVirtualization) {
+            virtualizer.scrollToIndex(targetIndex, { align: 'center' });
+        } else {
+            const el = document.getElementById(`segment-${segments[targetIndex].id}`);
+            el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+    }, [scrollToTime, scrollToKey, segments, useVirtualization, virtualizer]);
 
     return (
         <div ref={scrollRef} className="flex flex-col h-full overflow-y-auto px-4 py-2">

--- a/frontend/src/hooks/meeting-details/useSummaryGeneration.ts
+++ b/frontend/src/hooks/meeting-details/useSummaryGeneration.ts
@@ -274,7 +274,7 @@ export function useSummaryGeneration({
           // Check if backend returned markdown format (new flow)
           if (pollingResult.data.markdown) {
             console.log('Received markdown format from backend');
-            setAiSummary({ markdown: pollingResult.data.markdown } as any);
+            setAiSummary(pollingResult.data as any);
             setSummaryStatus('completed');
 
             // Show success toast

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -79,6 +79,7 @@ export interface BlockNoteBlock {
 export interface SummaryDataResponse {
   markdown?: string;
   summary_json?: BlockNoteBlock[];
+  transcript_references?: TranscriptReference[];
   // Legacy format fields
   MeetingName?: string;
   _section_order?: string[];
@@ -98,6 +99,12 @@ export interface PaginatedTranscriptsResponse {
   transcripts: Transcript[];
   total_count: number;
   has_more: boolean;
+}
+
+// Transcript reference linking summary items to transcript segments
+export interface TranscriptReference {
+  startTime: number; // Seconds from recording start
+  endTime: number;   // Seconds from recording start
 }
 
 // Transcript segment data for virtualized display


### PR DESCRIPTION
Adds clickable `[MM:SS-MM:SS]` timestamp references in AI-generated summaries
that scroll the transcript panel to the matching segment.

### Backend
- Added `TranscriptReference` struct and `extract_transcript_references()` parser
- Injected transcript reference requirement into all LLM prompt templates
(chunk summary, combine, final report) so the model includes timestamp ranges
- Return parsed references alongside markdown in summary API response

### Frontend
- DOM walker in `BlockNoteSummaryView` makes `[MM:SS-MM:SS]` spans clickable
- `onTranscriptRefClick` propagates through `SummaryPanel` → `page-content`
- `VirtualizedTranscriptView` scrolls to the nearest segment matching the
clicked time (works with both virtualized and simple rendering)
- Added `TranscriptReference` type, `scrollToTime`/`scrollToKey` props

### Usage
Click any timestamp reference like `[14:32-15:18]` in the summary panel to
jump directly to that section of the transcript.