### PR TITLE
fix: resolve broken Trendshift badge link in README #574

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
         <br>
         Privacy-First AI Meeting Assistant
     </h1>
-    <a href="https://trendshift.io/repositories/21958" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21958" alt="Zackriya-Solutions%2Fmeetily | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+    <a href="https://trendshift.io/repositories/11413" target="_blank"><img src="https://trendshift.io/api/badge/repositories/11413" alt="Zackriya-Solutions%2Fmeetily | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
     <br>
     <br>
     <a href="https://github.com/Zackriya-Solutions/meeting-minutes/releases/"><img src="https://img.shields.io/badge/Pre_Release-Link-brightgreen" alt="Pre-Release"></a>


### PR DESCRIPTION
## Description
This PR fixes the issue #574 a broken hyperlink on the repository's Trendshift badge in the root `README.md` file. 

The previous Trendshift repository ID (`21958`) was pointing to a page that returned an error. It has been updated to the correct repository ID (`11413`) for `Zackriya-Solutions/meetily`. Clicking the badge or its rating stars now successfully redirects users to the correct analytics and ranking page on Trendshift.

## Changes
*   **[README.md](file:///c:/Users/Ishwari%20Jadhav/OneDrive/Desktop/github-contributions/meetily/README.md#L7)**: Updated `trendshift.io/repositories/21958` and `trendshift.io/api/badge/repositories/21958` to point to repository ID `11413`.

## Verification
*   Verified that the updated URL (`https://trendshift.io/repositories/11413`) correctly resolves to the Meetily trending insights page.
*   Verified the Markdown preview redirects correctly when clicking the badge.