### PR TITLE
Add local Gemma 4 summary models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "meetily"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3472,9 +3472,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.146"
+version = "0.1.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b0f368c76cc0fe475e8257aeeec269e0d6569bd48b1f503efd0963fc3ee397"
+checksum = "e82ec86fd73aaa7d8f4898cc4693410c217431506ba3237ea5c856127f49d84d"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -3486,9 +3486,9 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.146"
+version = "0.1.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b291e4bc2d10c43cd8dec16d49b6104cb3cb125f596ec380a753a5db1d965dd"
+checksum = "f67dab3ed2b68e4fc4a42471eac73e128ed2ee97bd10de66ddcc609dd5d838a0"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "meetily",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "private": true,
     "main": "electron/main.js",
     "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,6 +99,7 @@
         "@tailwindcss/typography": "^0.5.15",
         "@tauri-apps/cli": "^2.1.0",
         "@tauri-apps/plugin-fs": "~2.4.0",
+        "@types/bun": "^1.3.14",
         "@types/node": "^20",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  prosemirror-model: 1.25.3
+  prosemirror-state: 1.4.3
+  prosemirror-view: 1.41.3
+  prosemirror-transform: 1.10.4
+  prosemirror-tables: 1.8.1
+
 importers:
 
   .:
@@ -186,6 +193,9 @@ importers:
       '@tauri-apps/cli':
         specifier: ^2.1.0
         version: 2.11.1
+      '@types/bun':
+        specifier: ^1.3.14
+        version: 1.3.14
       '@types/node':
         specifier: ^20
         version: 20.19.41
@@ -1820,6 +1830,9 @@ packages:
   '@tiptap/starter-kit@2.27.2':
     resolution: {integrity: sha512-bb0gJvPoDuyRUQ/iuN52j1//EtWWttw+RXAv1uJxfR0uKf8X7uAqzaOOgwjknoCIDC97+1YHwpGdnRjpDkOBxw==}
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -1981,6 +1994,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -5501,6 +5517,10 @@ snapshots:
       '@tiptap/extension-text-style': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
       '@tiptap/pm': 2.27.2
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -5659,6 +5679,10 @@ snapshots:
       electron-to-chromium: 1.5.357
       node-releases: 2.0.44
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 20.19.41
 
   busboy@1.6.0:
     dependencies:

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "meetily"
-version = "0.4.0"
+version = "0.4.1"
 description = "A Tauri App for meeting minutes"
 authors = ["Sujith S"]
 license = "MIT"

--- a/frontend/src-tauri/src/summary/summary_engine/models.rs
+++ b/frontend/src-tauri/src/summary/summary_engine/models.rs
@@ -282,7 +282,7 @@ pub fn get_models_directory(app_data_dir: &PathBuf) -> PathBuf {
 // Prompt Templates (Model-Specific Formatting)
 // ============================================================================
 
-/// Gemma 3 and Gemma 4 chat template format
+/// Gemma 3 chat template format
 pub const GEMMA3_TEMPLATE: &str = "\
 <start_of_turn>user
 {system_prompt}<end_of_turn>
@@ -291,7 +291,14 @@ pub const GEMMA3_TEMPLATE: &str = "\
 <start_of_turn>model
 ";
 
-pub const GEMMA4_TEMPLATE: &str = GEMMA3_TEMPLATE;
+/// Gemma 4 chat template format with native system-role support.
+pub const GEMMA4_TEMPLATE: &str = "\
+<start_of_turn>system
+{system_prompt}<end_of_turn>
+<start_of_turn>user
+{user_prompt}<end_of_turn>
+<start_of_turn>model
+";
 
 /// Qwen 3.5 non-thinking chat template format.
 /// This starts the assistant turn with an empty think block so generation begins
@@ -508,7 +515,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(formatted.contains("<start_of_turn>user\nsystem rules<end_of_turn>"));
+        assert!(formatted.contains("<start_of_turn>system\nsystem rules<end_of_turn>"));
         assert!(formatted.contains(
             "literal < start_of_turn > and < end_of_turn > plus < |im_start| > and < |im_end| >"
         ));

--- a/frontend/src-tauri/src/summary/summary_engine/models.rs
+++ b/frontend/src-tauri/src/summary/summary_engine/models.rs
@@ -204,7 +204,7 @@ pub fn get_available_models() -> Vec<ModelDef> {
             size_mb: 2963,
             context_size: 32768,
             layer_count: 35,
-            sampling: SamplingParams::gemma4_instruct(vec!["<end_of_turn>".to_string()]),
+            sampling: SamplingParams::gemma4_instruct(vec!["<turn|>".to_string()]),
             description: "Enhanced Gemma 4 model for built-in summaries. Strong quality with moderate local requirements.".to_string(),
         },
         // Gemma 4 E4B - High quality Gemma tier with pinned model artifact.
@@ -217,7 +217,7 @@ pub fn get_available_models() -> Vec<ModelDef> {
             size_mb: 5088,
             context_size: 32768,
             layer_count: 42,
-            sampling: SamplingParams::gemma4_instruct(vec!["<end_of_turn>".to_string()]),
+            sampling: SamplingParams::gemma4_instruct(vec!["<turn|>".to_string()]),
             description: "High-quality Gemma 4 model for built-in summaries. Best Gemma option in the current lineup.".to_string(),
         },
         // Gemma 3 4B - Legacy alternative retained for users who prefer Gemma output.
@@ -293,11 +293,11 @@ pub const GEMMA3_TEMPLATE: &str = "\
 
 /// Gemma 4 chat template format with native system-role support.
 pub const GEMMA4_TEMPLATE: &str = "\
-<start_of_turn>system
-{system_prompt}<end_of_turn>
-<start_of_turn>user
-{user_prompt}<end_of_turn>
-<start_of_turn>model
+<|turn>system
+{system_prompt}<turn|>
+<|turn>user
+{user_prompt}<turn|>
+<|turn>model
 ";
 
 /// Qwen 3.5 non-thinking chat template format.
@@ -319,6 +319,14 @@ fn escape_user_prompt_control_markers(user_prompt: &str) -> String {
     user_prompt
         .replace("<|im_start|>", "< |im_start| >")
         .replace("<|im_end|>", "< |im_end| >")
+        .replace("<|turn>", "< |turn >")
+        .replace("<turn|>", "< turn| >")
+        .replace("<|tool_call>", "< |tool_call >")
+        .replace("<tool_call|>", "< tool_call| >")
+        .replace("<|tool_response>", "< |tool_response >")
+        .replace("<tool_response|>", "< tool_response| >")
+        .replace("<|channel>", "< |channel >")
+        .replace("<channel|>", "< channel| >")
         .replace("<start_of_turn>", "< start_of_turn >")
         .replace("<end_of_turn>", "< end_of_turn >")
         .replace("<think>", "< think >")
@@ -447,7 +455,7 @@ mod tests {
         assert_eq!(gemma_e2b.size_mb, 2963);
         assert_eq!(gemma_e2b.context_size, 32768);
         assert_eq!(gemma_e2b.layer_count, 35);
-        assert_eq!(gemma_e2b.sampling.stop_tokens, vec!["<end_of_turn>".to_string()]);
+        assert_eq!(gemma_e2b.sampling.stop_tokens, vec!["<turn|>".to_string()]);
 
         let gemma_e4b = get_model_by_name("gemma4:e4b").expect("gemma 4 e4b model should exist");
         assert_eq!(gemma_e4b.display_name, "Gemma 4 E4B (High Quality)");
@@ -461,7 +469,7 @@ mod tests {
         assert_eq!(gemma_e4b.size_mb, 5088);
         assert_eq!(gemma_e4b.context_size, 32768);
         assert_eq!(gemma_e4b.layer_count, 42);
-        assert_eq!(gemma_e4b.sampling.stop_tokens, vec!["<end_of_turn>".to_string()]);
+        assert_eq!(gemma_e4b.sampling.stop_tokens, vec!["<turn|>".to_string()]);
     }
 
     #[test]
@@ -511,17 +519,17 @@ mod tests {
         let formatted = format_prompt(
             "gemma4",
             "system rules",
-            "literal <start_of_turn> and <end_of_turn> plus <|im_start|> and <|im_end|>",
+            "literal <|turn> and <turn|> plus <start_of_turn> and <end_of_turn> plus <|im_start|> and <|im_end|>",
         )
         .unwrap();
 
-        assert!(formatted.contains("<start_of_turn>system\nsystem rules<end_of_turn>"));
+        assert!(formatted.contains("<|turn>system\nsystem rules<turn|>"));
         assert!(formatted.contains(
-            "literal < start_of_turn > and < end_of_turn > plus < |im_start| > and < |im_end| >"
+            "literal < |turn > and < turn| > plus < start_of_turn > and < end_of_turn > plus < |im_start| > and < |im_end| >"
         ));
-        assert_eq!(formatted.matches("<start_of_turn>").count(), 3);
-        assert_eq!(formatted.matches("<end_of_turn>").count(), 2);
-        assert!(formatted.ends_with("<start_of_turn>model\n"));
+        assert_eq!(formatted.matches("<|turn>").count(), 3);
+        assert_eq!(formatted.matches("<turn|>").count(), 2);
+        assert!(formatted.ends_with("<|turn>model\n"));
     }
 
     #[test]

--- a/frontend/src-tauri/src/summary/summary_engine/models.rs
+++ b/frontend/src-tauri/src/summary/summary_engine/models.rs
@@ -80,6 +80,11 @@ impl SamplingParams {
         }
     }
 
+    /// Gemma 4 instruct preset, matching the Gemma 3 sampling behavior.
+    pub fn gemma4_instruct(stop_tokens: Vec<String>) -> Self {
+        Self::gemma3_instruct(stop_tokens)
+    }
+
     /// Normalize built-in presets to the subset supported by llama-helper.
     pub fn sanitize_for_llama_helper(&self) -> Self {
         let temperature = if self.temperature.is_finite() {
@@ -189,6 +194,32 @@ pub fn get_available_models() -> Vec<ModelDef> {
             sampling: SamplingParams::qwen35_summary(vec!["<|im_end|>".to_string()]),
             description: "High-quality Qwen 3.5 model for built-in summaries. Best local Qwen option in the current lineup.".to_string(),
         },
+        // Gemma 4 E2B - Enhanced Gemma tier with pinned model artifact.
+        ModelDef {
+            name: "gemma4:e2b".to_string(),
+            display_name: "Gemma 4 E2B (Enhanced)".to_string(),
+            gguf_file: "gemma-4-E2B-it-Q4_K_M.gguf".to_string(),
+            template: "gemma4".to_string(),
+            download_url: "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/90f9618340396838ee7ff5b0ba2da27da62953d3/gemma-4-E2B-it-Q4_K_M.gguf".to_string(),
+            size_mb: 2963,
+            context_size: 32768,
+            layer_count: 35,
+            sampling: SamplingParams::gemma4_instruct(vec!["<end_of_turn>".to_string()]),
+            description: "Enhanced Gemma 4 model for built-in summaries. Strong quality with moderate local requirements.".to_string(),
+        },
+        // Gemma 4 E4B - High quality Gemma tier with pinned model artifact.
+        ModelDef {
+            name: "gemma4:e4b".to_string(),
+            display_name: "Gemma 4 E4B (High Quality)".to_string(),
+            gguf_file: "gemma-4-E4B-it-Q4_K_M.gguf".to_string(),
+            template: "gemma4".to_string(),
+            download_url: "https://huggingface.co/ggml-org/gemma-4-E4B-it-GGUF/resolve/2714b5519c6c3516b1000e7c5e1eba998dfe1fe8/gemma-4-E4B-it-Q4_K_M.gguf".to_string(),
+            size_mb: 5088,
+            context_size: 32768,
+            layer_count: 42,
+            sampling: SamplingParams::gemma4_instruct(vec!["<end_of_turn>".to_string()]),
+            description: "High-quality Gemma 4 model for built-in summaries. Best Gemma option in the current lineup.".to_string(),
+        },
         // Gemma 3 4B - Legacy alternative retained for users who prefer Gemma output.
         ModelDef {
             name: "gemma3:4b".to_string(),
@@ -251,7 +282,7 @@ pub fn get_models_directory(app_data_dir: &PathBuf) -> PathBuf {
 // Prompt Templates (Model-Specific Formatting)
 // ============================================================================
 
-/// Gemma 3 chat template format
+/// Gemma 3 and Gemma 4 chat template format
 pub const GEMMA3_TEMPLATE: &str = "\
 <start_of_turn>user
 {system_prompt}<end_of_turn>
@@ -259,6 +290,8 @@ pub const GEMMA3_TEMPLATE: &str = "\
 {user_prompt}<end_of_turn>
 <start_of_turn>model
 ";
+
+pub const GEMMA4_TEMPLATE: &str = GEMMA3_TEMPLATE;
 
 /// Qwen 3.5 non-thinking chat template format.
 /// This starts the assistant turn with an empty think block so generation begins
@@ -301,6 +334,7 @@ pub fn format_prompt(
 ) -> Result<String> {
     let template = match template_name {
         "gemma3" => GEMMA3_TEMPLATE,
+        "gemma4" => GEMMA4_TEMPLATE,
         "qwen3.5_nonthinking" => QWEN35_NONTHINKING_TEMPLATE,
         _ => return Err(anyhow!("Unknown template: {}", template_name)),
     };
@@ -393,6 +427,37 @@ mod tests {
     }
 
     #[test]
+    fn gemma4_models_use_pinned_download_urls_and_verified_metadata() {
+        let gemma_e2b = get_model_by_name("gemma4:e2b").expect("gemma 4 e2b model should exist");
+        assert_eq!(gemma_e2b.display_name, "Gemma 4 E2B (Enhanced)");
+        assert_eq!(gemma_e2b.gguf_file, "gemma-4-E2B-it-Q4_K_M.gguf");
+        assert_eq!(gemma_e2b.template, "gemma4");
+        assert_eq!(
+            gemma_e2b.download_url,
+            "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/90f9618340396838ee7ff5b0ba2da27da62953d3/gemma-4-E2B-it-Q4_K_M.gguf"
+        );
+        assert!(!gemma_e2b.download_url.contains("/resolve/main/"));
+        assert_eq!(gemma_e2b.size_mb, 2963);
+        assert_eq!(gemma_e2b.context_size, 32768);
+        assert_eq!(gemma_e2b.layer_count, 35);
+        assert_eq!(gemma_e2b.sampling.stop_tokens, vec!["<end_of_turn>".to_string()]);
+
+        let gemma_e4b = get_model_by_name("gemma4:e4b").expect("gemma 4 e4b model should exist");
+        assert_eq!(gemma_e4b.display_name, "Gemma 4 E4B (High Quality)");
+        assert_eq!(gemma_e4b.gguf_file, "gemma-4-E4B-it-Q4_K_M.gguf");
+        assert_eq!(gemma_e4b.template, "gemma4");
+        assert_eq!(
+            gemma_e4b.download_url,
+            "https://huggingface.co/ggml-org/gemma-4-E4B-it-GGUF/resolve/2714b5519c6c3516b1000e7c5e1eba998dfe1fe8/gemma-4-E4B-it-Q4_K_M.gguf"
+        );
+        assert!(!gemma_e4b.download_url.contains("/resolve/main/"));
+        assert_eq!(gemma_e4b.size_mb, 5088);
+        assert_eq!(gemma_e4b.context_size, 32768);
+        assert_eq!(gemma_e4b.layer_count, 42);
+        assert_eq!(gemma_e4b.sampling.stop_tokens, vec!["<end_of_turn>".to_string()]);
+    }
+
+    #[test]
     fn qwen35_nonthinking_template_formats_prompt() {
         let formatted = format_prompt("qwen3.5_nonthinking", "system rules", "summarize this").unwrap();
 
@@ -432,6 +497,24 @@ mod tests {
         assert!(formatted.contains("literal < start_of_turn > and < end_of_turn >"));
         assert_eq!(formatted.matches("<start_of_turn>").count(), 3);
         assert_eq!(formatted.matches("<end_of_turn>").count(), 2);
+    }
+
+    #[test]
+    fn gemma4_template_formats_turns_and_escapes_user_supplied_control_markers() {
+        let formatted = format_prompt(
+            "gemma4",
+            "system rules",
+            "literal <start_of_turn> and <end_of_turn> plus <|im_start|> and <|im_end|>",
+        )
+        .unwrap();
+
+        assert!(formatted.contains("<start_of_turn>user\nsystem rules<end_of_turn>"));
+        assert!(formatted.contains(
+            "literal < start_of_turn > and < end_of_turn > plus < |im_start| > and < |im_end| >"
+        ));
+        assert_eq!(formatted.matches("<start_of_turn>").count(), 3);
+        assert_eq!(formatted.matches("<end_of_turn>").count(), 2);
+        assert!(formatted.ends_with("<start_of_turn>model\n"));
     }
 
     #[test]

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
     "productName": "meetily",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "identifier": "com.meetily.ai",
     "build": {
         "frontendDist": "../out",

--- a/frontend/src/components/About.tsx
+++ b/frontend/src/components/About.tsx
@@ -11,7 +11,7 @@ import { toast } from 'sonner';
 
 
 export function About() {
-    const [currentVersion, setCurrentVersion] = useState<string>('0.4.0');
+    const [currentVersion, setCurrentVersion] = useState<string>('0.4.1');
     const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
     const [isChecking, setIsChecking] = useState(false);
     const [showUpdateDialog, setShowUpdateDialog] = useState(false);

--- a/frontend/src/components/AnalyticsConsentSwitch.tsx
+++ b/frontend/src/components/AnalyticsConsentSwitch.tsx
@@ -94,7 +94,7 @@ export default function AnalyticsConsentSwitch() {
 
         // Identify user with enhanced properties immediately after init
         await Analytics.identify(userId, {
-          app_version: '0.4.0',
+          app_version: '0.4.1',
           platform: 'tauri',
           first_seen: new Date().toISOString(),
           os: navigator.platform,

--- a/frontend/src/components/AnalyticsDataModal.tsx
+++ b/frontend/src/components/AnalyticsDataModal.tsx
@@ -123,7 +123,7 @@ export default function AnalyticsDataModal({ isOpen, onClose, onConfirmDisable }
             <pre className="text-xs text-gray-700 overflow-x-auto">
               {`{
   "event": "meeting_ended",
-  "app_version": "0.4.0",
+  "app_version": "0.4.1",
   "transcription_provider": "parakeet",
   "transcription_model": "parakeet-tdt-0.6b-v3-int8",
   "summary_provider": "ollama",

--- a/frontend/src/components/AnalyticsProvider.tsx
+++ b/frontend/src/components/AnalyticsProvider.tsx
@@ -93,7 +93,7 @@ export default function AnalyticsProvider({ children }: AnalyticsProviderProps) 
 
       // Identify user with enhanced properties immediately after init
       await Analytics.identify(userId, {
-        app_version: '0.4.0',
+        app_version: '0.4.1',
         platform: deviceInfo.platform,
         os_version: deviceInfo.os_version,
         architecture: deviceInfo.architecture,

--- a/frontend/src/components/BuiltInModelManager.tsx
+++ b/frontend/src/components/BuiltInModelManager.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { Button } from '@/components/ui/button';
@@ -9,6 +9,10 @@ import { cn } from '@/lib/utils';
 import { Download, RefreshCw, BadgeAlert, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { formatSummaryModelSizeLabelFromMb } from '@/lib/onboarding-summary-model';
+import {
+  getFirstSelectableBuiltInModelName,
+  isSelectableBuiltInModelStatus,
+} from '@/lib/builtin-ai-models';
 
 interface ModelInfo {
   name: string;
@@ -46,6 +50,21 @@ export function BuiltInModelManager({
   const [downloadProgress, setDownloadProgress] = useState<Record<string, number>>({});
   const [downloadProgressInfo, setDownloadProgressInfo] = useState<Record<string, DownloadProgressInfo>>({});
   const [downloadingModels, setDownloadingModels] = useState<Set<string>>(new Set());
+  const selectedModelRef = useRef(selectedModel);
+  const onModelSelectRef = useRef(onModelSelect);
+
+  useEffect(() => {
+    selectedModelRef.current = selectedModel;
+  }, [selectedModel]);
+
+  useEffect(() => {
+    onModelSelectRef.current = onModelSelect;
+  }, [onModelSelect]);
+
+  const selectModel = (modelName: string) => {
+    selectedModelRef.current = modelName;
+    onModelSelectRef.current(modelName);
+  };
 
   const fetchModels = async () => {
     try {
@@ -53,11 +72,10 @@ export function BuiltInModelManager({
       const data = (await invoke('builtin_ai_list_models')) as ModelInfo[];
       setModels(data);
 
-      // Auto-select first available model if none selected
-      if (data.length > 0 && !selectedModel) {
-        const firstAvailable = data.find((m) => m.status.type === 'available');
-        if (firstAvailable) {
-          onModelSelect(firstAvailable.name);
+      if (data.length > 0 && !selectedModelRef.current) {
+        const firstSelectableModelName = getFirstSelectableBuiltInModelName(data);
+        if (firstSelectableModelName) {
+          selectModel(firstSelectableModelName);
         }
       }
     } catch (error) {
@@ -199,6 +217,8 @@ export function BuiltInModelManager({
   }, []);
 
   const downloadModel = async (modelName: string) => {
+    selectModel(modelName);
+
     try {
       // Optimistically add to downloadingModels for immediate UI feedback
       setDownloadingModels((prev) => new Set([...prev, modelName]));
@@ -295,6 +315,7 @@ export function BuiltInModelManager({
           const isNotDownloaded = model.status.type === 'not_downloaded';
           const isCorrupted = model.status.type === 'corrupted';
           const isError = model.status.type === 'error';
+          const isSelectable = isSelectableBuiltInModelStatus(model.status.type, modelIsDownloading);
 
           return (
             <div
@@ -307,11 +328,11 @@ export function BuiltInModelManager({
                 selectedModel === model.name
                   ? 'ring-2 ring-gray-800 border-gray-800'
                   : 'border-gray-200 hover:border-gray-300',
-                isAvailable && !modelIsDownloading && 'cursor-pointer'
+                isSelectable && 'cursor-pointer'
               )}
               onClick={() => {
-                if (isAvailable && !modelIsDownloading) {
-                  onModelSelect(model.name);
+                if (isSelectable) {
+                  selectModel(model.name);
                 }
               }}
             >
@@ -321,17 +342,15 @@ export function BuiltInModelManager({
                   <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
                     <span className="min-w-0 break-words text-base font-bold leading-snug text-gray-900">{model.display_name || model.name}</span>
                     {isAvailable && (
-                      <>
-                        <span className="flex shrink-0 items-center gap-1 text-xs font-medium text-green-600">
-                          <span className="h-2 w-2 rounded-full bg-green-600"></span>
-                          Ready
-                        </span>
-                        {selectedModel === model.name && (
-                          <span className="shrink-0 rounded bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
-                            Selected
-                          </span>
-                        )}
-                      </>
+                      <span className="flex shrink-0 items-center gap-1 text-xs font-medium text-green-600">
+                        <span className="h-2 w-2 rounded-full bg-green-600"></span>
+                        Ready
+                      </span>
+                    )}
+                    {selectedModel === model.name && (
+                      <span className="shrink-0 rounded bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
+                        Selected
+                      </span>
                     )}
                     {isCorrupted && (
                       <span className="flex shrink-0 items-center gap-1 rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">

--- a/frontend/src/components/ModelSettingsModal.tsx
+++ b/frontend/src/components/ModelSettingsModal.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/components/ui/command';
 import { cn, isOllamaNotInstalledError } from '@/lib/utils';
 import { toast } from 'sonner';
+import { getFirstSelectableBuiltInModelName } from '@/lib/builtin-ai-models';
 
 export interface ModelConfig {
   provider: 'ollama' | 'groq' | 'claude' | 'openai' | 'openrouter' | 'builtin-ai' | 'custom-openai';
@@ -249,10 +250,14 @@ export function ModelSettingsModal({
     !customOpenAIModel.trim()
   );
 
+  const isBuiltInModelMissing =
+    modelConfig.provider === 'builtin-ai' && !modelConfig.model;
+
   const isDoneDisabled =
     (requiresApiKey && (!apiKey || (typeof apiKey === 'string' && !apiKey.trim()))) ||
     (modelConfig.provider === 'ollama' && ollamaEndpointChanged) ||
-    isCustomOpenAIInvalid;
+    isCustomOpenAIInvalid ||
+    isBuiltInModelMissing;
 
   useEffect(() => {
     const fetchModelConfig = async () => {
@@ -510,11 +515,10 @@ export function ModelSettingsModal({
       const data = (await invoke('builtin_ai_list_models')) as any[];
       setBuiltinAiModels(data);
 
-      // Auto-select first available model if none selected
       if (data.length > 0 && !modelConfig.model) {
-        const firstAvailable = data.find((m: any) => m.status?.type === 'available');
-        if (firstAvailable) {
-          setModelConfig((prev: ModelConfig) => ({ ...prev, model: firstAvailable.name }));
+        const firstSelectableModelName = getFirstSelectableBuiltInModelName(data);
+        if (firstSelectableModelName) {
+          setModelConfig((prev: ModelConfig) => ({ ...prev, model: firstSelectableModelName }));
         }
       }
     } catch (err) {

--- a/frontend/src/components/Sidebar/index.tsx
+++ b/frontend/src/components/Sidebar/index.tsx
@@ -811,7 +811,7 @@ const Sidebar: React.FC = () => {
             </button>
             <Info isCollapsed={isCollapsed} />
             <div className="w-full flex items-center justify-center px-3 py-1 text-xs text-gray-400">
-              v0.4.0
+              v0.4.1
             </div>
           </div>
         )}

--- a/frontend/src/components/onboarding/OnboardingFlow.tsx
+++ b/frontend/src/components/onboarding/OnboardingFlow.tsx
@@ -31,10 +31,10 @@ export function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
     checkPlatform();
   }, []);
 
-  // 4-Step Onboarding Flow (System-Recommended Models):
+  // 4-Step Onboarding Flow:
   // Step 1: Welcome - Introduce Meetily features
-  // Step 2: Setup Overview - Database initialization + show recommended downloads
-  // Step 3: Download Progress - Download Parakeet + Summary Model (auto-selected based on platform/RAM)
+  // Step 2: Setup Overview - Database initialization + summary model selection
+  // Step 3: Download Progress - Download Parakeet + selected Summary Model
   // Step 4: Permissions - Request mic + system audio (macOS only)
 
   return (

--- a/frontend/src/components/onboarding/steps/SetupOverviewStep.tsx
+++ b/frontend/src/components/onboarding/steps/SetupOverviewStep.tsx
@@ -1,8 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { Info } from 'lucide-react';
+import { invoke } from '@tauri-apps/api/core';
+import { Check, Info } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { OnboardingContainer } from '../OnboardingContainer';
 import { useOnboarding } from '@/contexts/OnboardingContext';
+import { cn } from '@/lib/utils';
+import { formatSummaryModelSizeLabelFromMb } from '@/lib/onboarding-summary-model';
 import {
   Tooltip,
   TooltipContent,
@@ -10,9 +13,28 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
+interface SummaryModelOption {
+  name: string;
+  display_name: string;
+  status: {
+    type: 'not_downloaded' | 'downloading' | 'available' | 'corrupted' | 'error';
+  };
+  size_mb: number;
+  context_size: number;
+  description: string;
+}
+
 export function SetupOverviewStep() {
-  const { goNext } = useOnboarding();
+  const {
+    goNext,
+    selectedSummaryModel,
+    recommendedSummaryModel,
+    setSelectedSummaryModel,
+    setSummaryModelDownloaded,
+  } = useOnboarding();
   const [isMac, setIsMac] = useState(false);
+  const [summaryModels, setSummaryModels] = useState<SummaryModelOption[]>([]);
+  const [modelsLoading, setModelsLoading] = useState(false);
 
   useEffect(() => {
     const checkPlatform = async () => {
@@ -24,6 +46,22 @@ export function SetupOverviewStep() {
       }
     };
     checkPlatform();
+  }, []);
+
+  useEffect(() => {
+    const loadSummaryModels = async () => {
+      setModelsLoading(true);
+      try {
+        const models = await invoke<SummaryModelOption[]>('builtin_ai_list_models');
+        setSummaryModels(models);
+      } catch (error) {
+        console.error('[SetupOverviewStep] Failed to load summary models:', error);
+      } finally {
+        setModelsLoading(false);
+      }
+    };
+
+    loadSummaryModels();
   }, []);
 
   const steps = [
@@ -41,6 +79,11 @@ export function SetupOverviewStep() {
 
   const handleContinue = () => {
     goNext();
+  };
+
+  const handleSummaryModelSelect = (model: SummaryModelOption) => {
+    setSelectedSummaryModel(model.name);
+    setSummaryModelDownloaded(model.status.type === 'available');
   };
 
   return (
@@ -87,6 +130,77 @@ export function SetupOverviewStep() {
           </div>
         </div>
 
+        <div className="w-full max-w-md space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-foreground">Summary model</h3>
+            {recommendedSummaryModel && (
+              <span className="text-xs text-muted-foreground">Recommended: {recommendedSummaryModel}</span>
+            )}
+          </div>
+
+          <div className="grid gap-2">
+            {summaryModels.map((model) => {
+              const isSelected = selectedSummaryModel === model.name;
+              const isRecommended = recommendedSummaryModel === model.name;
+              const isAvailable = model.status.type === 'available';
+
+              return (
+                <button
+                  key={model.name}
+                  type="button"
+                  aria-pressed={isSelected}
+                  onClick={() => handleSummaryModelSelect(model)}
+                  className={cn(
+                    'w-full rounded-lg border bg-card p-3 text-left transition-colors',
+                    isSelected
+                      ? 'border-primary ring-2 ring-ring'
+                      : 'border-border hover:border-primary/70'
+                  )}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="break-words text-sm font-semibold text-foreground">
+                          {model.display_name || model.name}
+                        </span>
+                        {isRecommended && (
+                          <span className="rounded bg-info/15 px-2 py-0.5 text-xs font-medium text-info">
+                            Recommended
+                          </span>
+                        )}
+                      </div>
+                      {model.description && (
+                        <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                          {model.description}
+                        </p>
+                      )}
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {formatSummaryModelSizeLabelFromMb(model.size_mb)} • {model.context_size} tokens
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-2">
+                      <span
+                        className={cn(
+                          'text-xs font-medium',
+                          isAvailable ? 'text-success' : 'text-muted-foreground'
+                        )}
+                      >
+                        {isAvailable ? 'Ready' : 'Download'}
+                      </span>
+                      {isSelected && <Check className="h-4 w-4 text-primary" />}
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+
+            {modelsLoading && (
+              <div className="rounded-lg border border-border bg-card p-3 text-sm text-muted-foreground">
+                Loading summary models...
+              </div>
+            )}
+          </div>
+        </div>
 
         {/* CTA Section */}
         <div className="w-full max-w-xs space-y-4">

--- a/frontend/src/components/onboarding/steps/SetupOverviewStep.tsx
+++ b/frontend/src/components/onboarding/steps/SetupOverviewStep.tsx
@@ -24,6 +24,21 @@ interface SummaryModelOption {
   description: string;
 }
 
+function getSummaryModelStatusMeta(status: SummaryModelOption['status']) {
+  switch (status.type) {
+    case 'available':
+      return { label: 'Ready', className: 'text-success' };
+    case 'downloading':
+      return { label: 'Downloading', className: 'text-info' };
+    case 'corrupted':
+    case 'error':
+      return { label: 'Retry', className: 'text-destructive' };
+    case 'not_downloaded':
+    default:
+      return { label: 'Download', className: 'text-muted-foreground' };
+  }
+}
+
 export function SetupOverviewStep() {
   const {
     goNext,
@@ -142,7 +157,7 @@ export function SetupOverviewStep() {
             {summaryModels.map((model) => {
               const isSelected = selectedSummaryModel === model.name;
               const isRecommended = recommendedSummaryModel === model.name;
-              const isAvailable = model.status.type === 'available';
+              const statusMeta = getSummaryModelStatusMeta(model.status);
 
               return (
                 <button
@@ -182,10 +197,10 @@ export function SetupOverviewStep() {
                       <span
                         className={cn(
                           'text-xs font-medium',
-                          isAvailable ? 'text-success' : 'text-muted-foreground'
+                          statusMeta.className
                         )}
                       >
-                        {isAvailable ? 'Ready' : 'Download'}
+                        {statusMeta.label}
                       </span>
                       {isSelected && <Check className="h-4 w-4 text-primary" />}
                     </div>

--- a/frontend/src/lib/builtin-ai-models.ts
+++ b/frontend/src/lib/builtin-ai-models.ts
@@ -1,0 +1,27 @@
+export type BuiltInModelStatusType =
+  | 'not_downloaded'
+  | 'downloading'
+  | 'available'
+  | 'corrupted'
+  | 'error';
+
+export interface BuiltInModelListItem {
+  name: string;
+  status?: {
+    type?: BuiltInModelStatusType | string;
+  } | null;
+}
+
+export function isSelectableBuiltInModelStatus(
+  statusType: BuiltInModelStatusType | string | undefined,
+  isDownloading = false
+): boolean {
+  return !isDownloading && (statusType === 'available' || statusType === 'not_downloaded');
+}
+
+export function getFirstSelectableBuiltInModelName(models: BuiltInModelListItem[]): string {
+  const firstAvailable = models.find((model) => model.status?.type === 'available');
+  const firstNotDownloaded = models.find((model) => model.status?.type === 'not_downloaded');
+
+  return (firstAvailable ?? firstNotDownloaded)?.name ?? '';
+}

--- a/frontend/src/lib/onboarding-summary-model.ts
+++ b/frontend/src/lib/onboarding-summary-model.ts
@@ -14,6 +14,8 @@ const SUMMARY_MODEL_SIZES_MB: Record<string, number> = {
   'qwen3.5:4b': 2614,
   'gemma3:1b': 1019,
   'gemma3:4b': 2374,
+  'gemma4:e2b': 2963,
+  'gemma4:e4b': 5088,
 };
 
 export function resolveOnboardingSummaryModelStatus({

--- a/frontend/tests/lib/builtin-ai-models.test.mjs
+++ b/frontend/tests/lib/builtin-ai-models.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import ts from 'typescript';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const modulePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'src',
+  'lib',
+  'builtin-ai-models.ts'
+);
+const require = createRequire(import.meta.url);
+
+function loadTsModule(filePath) {
+  const source = fs.readFileSync(filePath, 'utf8');
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+    },
+  }).outputText;
+
+  const module = { exports: {} };
+  vm.runInNewContext(compiled, {
+    exports: module.exports,
+    module,
+    require,
+  });
+  return module.exports;
+}
+
+const {
+  getFirstSelectableBuiltInModelName,
+  isSelectableBuiltInModelStatus,
+} = loadTsModule(modulePath);
+
+assert.equal(isSelectableBuiltInModelStatus('available'), true);
+assert.equal(isSelectableBuiltInModelStatus('not_downloaded'), true);
+assert.equal(isSelectableBuiltInModelStatus('not_downloaded', true), false);
+assert.equal(isSelectableBuiltInModelStatus('downloading'), false);
+assert.equal(isSelectableBuiltInModelStatus('corrupted'), false);
+assert.equal(isSelectableBuiltInModelStatus('error'), false);
+
+assert.equal(
+  getFirstSelectableBuiltInModelName([
+    { name: 'gemma4:e2b', status: { type: 'not_downloaded' } },
+    { name: 'qwen3.5:2b', status: { type: 'available' } },
+  ]),
+  'qwen3.5:2b',
+  'available model should remain the default when one exists'
+);
+
+assert.equal(
+  getFirstSelectableBuiltInModelName([
+    { name: 'gemma4:e2b', status: { type: 'not_downloaded' } },
+    { name: 'gemma4:e4b', status: { type: 'not_downloaded' } },
+  ]),
+  'gemma4:e2b',
+  'not-downloaded models should still be selectable for download/save flows'
+);
+
+assert.equal(
+  getFirstSelectableBuiltInModelName([
+    { name: 'gemma4:e2b', status: { type: 'corrupted' } },
+    { name: 'gemma4:e4b', status: { type: 'error' } },
+  ]),
+  '',
+  'error states should not be auto-selected'
+);

--- a/frontend/tests/lib/onboarding-summary-model.test.mjs
+++ b/frontend/tests/lib/onboarding-summary-model.test.mjs
@@ -83,12 +83,17 @@ assert.equal(
 assert.equal(getSummaryModelSizeMb('qwen3.5:2b'), 1221);
 assert.equal(getSummaryModelSizeMb('qwen3.5:4b'), 2614);
 assert.equal(getSummaryModelSizeMb('gemma3:1b'), 1019);
+assert.equal(getSummaryModelSizeMb('gemma4:e2b'), 2963);
+assert.equal(getSummaryModelSizeMb('gemma4:e4b'), 5088);
 assert.equal(getSummaryModelSizeMb('unknown:model'), 0);
 
 assert.equal(getSummaryModelSizeLabel('qwen3.5:2b'), '~1.2 GiB');
 assert.equal(getSummaryModelSizeLabel('qwen3.5:4b'), '~2.6 GiB');
+assert.equal(getSummaryModelSizeLabel('gemma4:e2b'), '~2.9 GiB');
+assert.equal(getSummaryModelSizeLabel('gemma4:e4b'), '~5.0 GiB');
 assert.equal(getSummaryModelSizeLabel('unknown:model'), '');
 
 assert.equal(getDownloadTotalMb(0, 'qwen3.5:4b'), 2614);
+assert.equal(getDownloadTotalMb(0, 'gemma4:e2b'), 2963);
 assert.equal(getDownloadTotalMb(undefined, 'qwen3.5:2b'), 1221);
 assert.equal(getDownloadTotalMb(512, 'qwen3.5:4b'), 512);

--- a/llama-helper/Cargo.toml
+++ b/llama-helper/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-llama-cpp-2 = "=0.1.146"
+llama-cpp-2 = "=0.1.150"
 encoding_rs = "0.8"
 
 [features]

--- a/llama-helper/src/main.rs
+++ b/llama-helper/src/main.rs
@@ -13,6 +13,8 @@ use llama_cpp_2::llama_backend::LlamaBackend;
 use llama_cpp_2::llama_batch::LlamaBatch;
 use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::model::{AddBos, LlamaModel};
+use llama_cpp_2::token::{logit_bias::LlamaLogitBias, LlamaToken};
+use llama_cpp_2::token_type::LlamaTokenAttr;
 use serde::{Deserialize, Serialize};
 
 // ============================================================================
@@ -147,7 +149,7 @@ fn detect_vram_gb() -> f32 {
         }
     }
 
-    /// TODO: Vulkan VRAM detection
+    // TODO: Vulkan VRAM detection
 
     eprintln!("VRAM detection not available, using conservative estimate");
     4.0 // Conservative fallback
@@ -274,6 +276,26 @@ fn get_default_gpu_layers(model_path: &PathBuf, context_size: u32) -> u32 {
     calculate_gpu_layers(model_path, estimated_layers, vram, context_size)
 }
 
+fn parse_gpu_layers_override(raw: &str) -> Option<u32> {
+    raw.trim().parse::<u32>().ok()
+}
+
+fn get_configured_gpu_layers(model_path: &PathBuf, context_size: u32) -> u32 {
+    if let Ok(raw) = std::env::var("LLAMA_GPU_LAYERS") {
+        if let Some(layers) = parse_gpu_layers_override(&raw) {
+            eprintln!("🛠️ LLAMA_GPU_LAYERS override: {}", layers);
+            return layers;
+        }
+
+        eprintln!(
+            "⚠️ Ignoring invalid LLAMA_GPU_LAYERS value '{}', using automatic GPU layer detection",
+            raw
+        );
+    }
+
+    get_default_gpu_layers(model_path, context_size)
+}
+
 // ============================================================================
 // Model State Management
 // ============================================================================
@@ -283,6 +305,7 @@ struct ModelState {
     model: Option<LlamaModel>,
     model_path: Option<PathBuf>,
     context_size: u32,
+    suppressed_token_biases: Vec<LlamaLogitBias>,
     last_activity: Arc<AtomicU64>,
 }
 
@@ -294,6 +317,7 @@ impl ModelState {
             model: None,
             model_path: None,
             context_size: 2048,
+            suppressed_token_biases: Vec::new(),
             last_activity: Arc::new(AtomicU64::new(Self::current_timestamp())),
         })
     }
@@ -327,14 +351,27 @@ impl ModelState {
         eprintln!("📥 Loading model: {}", model_path.display());
 
         // Detect GPU layers
-        let gpu_layers = get_default_gpu_layers(&model_path, context_size);
+        let gpu_layers = get_configured_gpu_layers(&model_path, context_size);
 
         // Configure model parameters with GPU offload
-        let model_params = LlamaModelParams::default().with_n_gpu_layers(gpu_layers);
+        let mut model_params = LlamaModelParams::default().with_n_gpu_layers(gpu_layers);
+        if gpu_layers == 0 {
+            model_params = model_params
+                .with_devices(&[])
+                .context("failed to configure CPU-only llama devices")?;
+        }
         let model_params = pin!(model_params);
 
         let model = LlamaModel::load_from_file(&self.backend, model_path.clone(), &model_params)
             .with_context(|| format!("unable to load model at {:?}", model_path))?;
+
+        self.suppressed_token_biases = build_suppressed_token_biases(&model);
+        if !self.suppressed_token_biases.is_empty() {
+            eprintln!(
+                "🚫 Suppressing {} non-generative special/control tokens",
+                self.suppressed_token_biases.len()
+            );
+        }
 
         self.model = Some(model);
         self.model_path = Some(model_path);
@@ -410,41 +447,33 @@ impl ModelState {
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as u32;
-        let sampler = if sampling.temperature <= 0.0 {
-            if sampling.uses_penalties() {
-                LlamaSampler::chain_simple([
-                    LlamaSampler::penalties(
-                        sampling.penalty_last_n,
-                        sampling.repeat_penalty,
-                        sampling.frequency_penalty,
-                        sampling.presence_penalty,
-                    ),
-                    LlamaSampler::greedy(),
-                ])
-            } else {
-                LlamaSampler::chain_simple([LlamaSampler::greedy()])
-            }
-        } else if sampling.uses_penalties() {
-            LlamaSampler::chain_simple([
-                LlamaSampler::penalties(
-                    sampling.penalty_last_n,
-                    sampling.repeat_penalty,
-                    sampling.frequency_penalty,
-                    sampling.presence_penalty,
-                ),
-                LlamaSampler::top_k(sampling.top_k),
-                LlamaSampler::top_p(sampling.top_p, 1),
-                LlamaSampler::temp(sampling.temperature),
-                LlamaSampler::dist(seed),
-            ])
+        let mut sampler_chain = Vec::new();
+        if !self.suppressed_token_biases.is_empty() {
+            sampler_chain.push(LlamaSampler::logit_bias(
+                model.n_vocab(),
+                &self.suppressed_token_biases,
+            ));
+        }
+
+        if sampling.uses_penalties() {
+            sampler_chain.push(LlamaSampler::penalties(
+                sampling.penalty_last_n,
+                sampling.repeat_penalty,
+                sampling.frequency_penalty,
+                sampling.presence_penalty,
+            ));
+        }
+
+        if sampling.temperature <= 0.0 {
+            sampler_chain.push(LlamaSampler::greedy());
         } else {
-            LlamaSampler::chain_simple([
-                LlamaSampler::top_k(sampling.top_k),
-                LlamaSampler::top_p(sampling.top_p, 1),
-                LlamaSampler::temp(sampling.temperature),
-                LlamaSampler::dist(seed),
-            ])
-        };
+            sampler_chain.push(LlamaSampler::top_k(sampling.top_k));
+            sampler_chain.push(LlamaSampler::top_p(sampling.top_p, 1));
+            sampler_chain.push(LlamaSampler::temp(sampling.temperature));
+            sampler_chain.push(LlamaSampler::dist(seed));
+        }
+
+        let sampler = LlamaSampler::chain_simple(sampler_chain);
         let mut sampler = pin!(sampler);
 
         loop {
@@ -532,6 +561,23 @@ impl ModelState {
         self.update_activity();
         Ok(output)
     }
+}
+
+fn build_suppressed_token_biases(model: &LlamaModel) -> Vec<LlamaLogitBias> {
+    (0..model.n_vocab())
+        .map(LlamaToken::new)
+        .filter(|token| {
+            if model.is_eog_token(*token) {
+                return false;
+            }
+
+            let attrs = model.token_attr(*token);
+            attrs.contains(LlamaTokenAttr::Control)
+                || attrs.contains(LlamaTokenAttr::Unknown)
+                || attrs.contains(LlamaTokenAttr::Unused)
+        })
+        .map(|token| LlamaLogitBias::new(token, -1.0e9))
+        .collect()
 }
 
 // ============================================================================
@@ -746,5 +792,18 @@ mod tests {
         assert_eq!(sampling.repeat_penalty, 1.05);
         assert_eq!(sampling.penalty_last_n, 256);
         assert!(sampling.uses_penalties());
+    }
+
+    #[test]
+    fn gpu_layers_override_accepts_zero_for_cpu_only() {
+        assert_eq!(parse_gpu_layers_override("0"), Some(0));
+        assert_eq!(parse_gpu_layers_override(" 7 "), Some(7));
+    }
+
+    #[test]
+    fn gpu_layers_override_rejects_invalid_values() {
+        assert_eq!(parse_gpu_layers_override("-1"), None);
+        assert_eq!(parse_gpu_layers_override("auto"), None);
+        assert_eq!(parse_gpu_layers_override(""), None);
     }
 }


### PR DESCRIPTION
## Description
Adds local Gemma 4 summary model support on top of upstream devtest.

This PR includes:
- pinned Gemma 4 E2B/E4B GGUF model entries with stable Hugging Face download URLs and metadata
- Gemma 4 prompt formatting using the GGUF turn template
- onboarding selection for built-in summary models
- llama-helper runtime hardening for Gemma 4 special/control tokens and CPU-only override via LLAMA_GPU_LAYERS=0

## Related Issue
No linked issue.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] All tests pass

Verified locally:
- cargo test -p llama-helper
- cargo test summary::summary_engine --lib
- node tests/lib/onboarding-summary-model.test.mjs
- local Gemma 4 E2B smoke test generated a valid meeting summary

Notes:
- pnpm exec tsc --noEmit currently hits an existing devtest Bun test typing issue in tests/lib/blocknote-markdown.test.ts.
- pnpm lint invokes interactive Next ESLint setup on this base.
- pnpm exec next build could not be completed in the sandbox because Google Fonts fetch requires network access.

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)
N/A

## Additional Notes
This branch was rebuilt from upstream devtest and cherry-picked to include only Gemma 4 changes, avoiding unrelated dark-theme PR changes.