### PR TITLE
feat(diarization): add speaker diarization foundation and controls

### DIFF
--- a/docs/superpowers/plans/2026-06-26-speaker-diarization-foundation.md
+++ b/docs/superpowers/plans/2026-06-26-speaker-diarization-foundation.md
@@ -206,14 +206,14 @@ pub struct SpeakerAssignment {
 }
 
 impl SpeakerAssignment {
-    pub fn unknown(status: DiarizationStatus, method: impl Into<Option<String>>) -> Self {
+    pub fn unknown(status: DiarizationStatus, method: Option<impl Into<String>>) -> Self {
         Self {
             speaker_id: None,
             speaker_label: Some("Unknown speaker".to_string()),
             speaker_color: None,
             is_overlap: false,
             diarization_status: status,
-            diarization_method: method.into(),
+            diarization_method: method.map(Into::into),
             diarization_confidence: None,
         }
     }

--- a/docs/superpowers/plans/2026-06-26-speaker-diarization-foundation.md
+++ b/docs/superpowers/plans/2026-06-26-speaker-diarization-foundation.md
@@ -501,7 +501,7 @@ Expected after implementation: PASS when baseline build environment is fixed.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add frontend/src-tauri/src/diarization/alignment.rs
+git add frontend/src-tauri/src/diarization/alignment.rs frontend/src-tauri/src/diarization/mod.rs
 git commit -m "feat: align diarization segments to transcripts"
 ```
 

--- a/docs/superpowers/plans/2026-06-26-speaker-diarization-foundation.md
+++ b/docs/superpowers/plans/2026-06-26-speaker-diarization-foundation.md
@@ -257,10 +257,10 @@ mod tests {
 Create `frontend/src-tauri/src/diarization/mod.rs`:
 
 ```rust
-pub mod alignment;
-pub mod commands;
 pub mod types;
 ```
+
+Do not declare `alignment` or `commands` in Task 1. Those files are created by later tasks; declaring them before the files exist would introduce a non-baseline compile failure.
 
 Add this module declaration near the other module declarations in `frontend/src-tauri/src/lib.rs`:
 
@@ -382,6 +382,13 @@ cargo test -p meetily diarization::alignment::tests
 Expected before implementation: compile fails because `assign_speaker_to_transcript` is missing.
 
 - [ ] **Step 3: Implement minimal alignment**
+
+Add the alignment module declaration to `frontend/src-tauri/src/diarization/mod.rs`:
+
+```rust
+pub mod alignment;
+pub mod types;
+```
 
 Insert above the test module in `frontend/src-tauri/src/diarization/alignment.rs`:
 
@@ -723,6 +730,7 @@ git commit -m "feat: persist transcript diarization metadata"
 - Create: `frontend/src-tauri/src/database/repositories/diarization.rs`
 - Modify: `frontend/src-tauri/src/database/repositories/mod.rs` if it exists
 - Modify: `frontend/src-tauri/src/diarization/commands.rs`
+- Modify: `frontend/src-tauri/src/diarization/mod.rs`
 - Modify: `frontend/src-tauri/src/lib.rs`
 
 - [ ] **Step 1: Create repository**
@@ -866,6 +874,14 @@ pub async fn save_diarization_settings<R: Runtime>(
 
 - [ ] **Step 3: Register commands**
 
+Add the commands module declaration to `frontend/src-tauri/src/diarization/mod.rs`:
+
+```rust
+pub mod alignment;
+pub mod commands;
+pub mod types;
+```
+
 In `frontend/src-tauri/src/lib.rs`, add command registrations in the existing `tauri::generate_handler!` list:
 
 ```rust
@@ -886,7 +902,7 @@ Expected: command registration compiles when environment baseline is fixed.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add frontend/src-tauri/src/database/repositories/diarization.rs frontend/src-tauri/src/database/repositories/mod.rs frontend/src-tauri/src/diarization/commands.rs frontend/src-tauri/src/lib.rs
+git add frontend/src-tauri/src/database/repositories/diarization.rs frontend/src-tauri/src/database/repositories/mod.rs frontend/src-tauri/src/diarization/commands.rs frontend/src-tauri/src/diarization/mod.rs frontend/src-tauri/src/lib.rs
 git commit -m "feat: add diarization settings commands"
 ```
 

--- a/docs/superpowers/plans/2026-06-26-speaker-diarization-foundation.md
+++ b/docs/superpowers/plans/2026-06-26-speaker-diarization-foundation.md
@@ -683,6 +683,8 @@ Do not commit this task alone if compile is broken. Commit together with Task 4 
 
 - Modify: `frontend/src-tauri/src/database/repositories/meeting.rs`
 - Modify: `frontend/src-tauri/src/database/repositories/transcript.rs`
+- Modify: `frontend/src-tauri/src/audio/common.rs` (compile-surface update for new `TranscriptSegment` fields)
+- Modify: `frontend/src-tauri/src/audio/import.rs` (compile-surface test fixture update for new `TranscriptSegment` fields)
 
 - [ ] **Step 1: Update meeting transcript mapping**
 
@@ -751,7 +753,7 @@ Expected after mapping fixes: no diarization-related compile errors. Environment
 - [ ] **Step 4: Commit**
 
 ```bash
-git add frontend/src-tauri/migrations/20260626000100_add_diarization_foundation.sql frontend/src-tauri/src/database/models.rs frontend/src-tauri/src/api/api.rs frontend/src-tauri/src/database/repositories/meeting.rs frontend/src-tauri/src/database/repositories/transcript.rs
+git add frontend/src-tauri/migrations/20260626000100_add_diarization_foundation.sql frontend/src-tauri/src/database/models.rs frontend/src-tauri/src/api/api.rs frontend/src-tauri/src/database/repositories/meeting.rs frontend/src-tauri/src/database/repositories/transcript.rs frontend/src-tauri/src/audio/common.rs frontend/src-tauri/src/audio/import.rs
 git commit -m "feat: persist transcript diarization metadata"
 ```
 

--- a/docs/superpowers/plans/2026-06-26-speaker-diarization-foundation.md
+++ b/docs/superpowers/plans/2026-06-26-speaker-diarization-foundation.md
@@ -392,6 +392,8 @@ mod tests {
 }
 ```
 
+Also cover threshold behavior: segments below `min_overlap_ratio` are ignored, segments at the exact boundary are accepted, negative thresholds behave like `0.0`, thresholds above `1.0` behave like `1.0`, and `NaN` behaves conservatively like `1.0`.
+
 - [ ] **Step 2: Run tests to verify they fail**
 
 Run:
@@ -432,6 +434,7 @@ pub fn assign_speaker_to_transcript(
         return SpeakerAssignment::unknown(DiarizationStatus::NeedsReview, Some(method.to_string()));
     }
 
+    let min_overlap_ratio = normalize_min_overlap_ratio(min_overlap_ratio);
     let mut best_segment: Option<(&SpeakerSegment, f64)> = None;
 
     for segment in segments {
@@ -473,6 +476,14 @@ pub fn assign_speaker_to_transcript(
         diarization_status: segment.diarization_status,
         diarization_method: Some(method.to_string()),
         diarization_confidence: segment.confidence,
+    }
+}
+
+fn normalize_min_overlap_ratio(ratio: f64) -> f64 {
+    if ratio.is_nan() {
+        1.0
+    } else {
+        ratio.clamp(0.0, 1.0)
     }
 }
 ```

--- a/docs/superpowers/plans/2026-06-26-speaker-diarization-foundation.md
+++ b/docs/superpowers/plans/2026-06-26-speaker-diarization-foundation.md
@@ -15,13 +15,13 @@
 Implementation worktree:
 
 ```text
-/Users/themaddoxed/Desktop/meeting-minutes/.worktrees/speaker-diarization
+/Users/themaddoxed/Desktop/meeting-minutes/.worktrees/codex-port-v042
 ```
 
 Branch:
 
 ```text
-feature/speaker-diarization
+codex-port-v042
 ```
 
 Baseline status observed before implementation:

--- a/docs/superpowers/plans/2026-06-26-speaker-diarization-foundation.md
+++ b/docs/superpowers/plans/2026-06-26-speaker-diarization-foundation.md
@@ -1,0 +1,1701 @@
+# Speaker Diarization Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first shippable foundation for speaker diarization: persisted settings, transcript speaker metadata, deterministic interval alignment, transcript UI labels, and post-call review-ready data structures.
+
+**Architecture:** Keep transcription and recording behavior unchanged. Add a focused `diarization` Rust module for pure alignment/status logic, SQLite fields for resolved speaker labels, Tauri commands for settings/status, and frontend types/settings/rendering that can consume live or offline diarization results later. FluidAudio/Swift sidecar integration is intentionally a follow-up plan after this foundation is merged.
+
+**Tech Stack:** Tauri 2, Rust, sqlx SQLite migrations, Next.js/React, TypeScript, existing shadcn/Radix UI primitives, localStorage beta flags.
+
+---
+
+## Working directory and baseline
+
+Implementation worktree:
+
+```text
+/Users/themaddoxed/Desktop/meeting-minutes/.worktrees/speaker-diarization
+```
+
+Branch:
+
+```text
+feature/speaker-diarization
+```
+
+Baseline status observed before implementation:
+
+- `cargo test --workspace --no-run` fetches dependencies with network access, then fails before feature code because `cidre` requires full Xcode:
+
+```text
+xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
+```
+
+- Frontend baseline was not run because this clean worktree has no `frontend/node_modules` and no committed npm/pnpm/yarn lockfile. Do not run `npm install` casually because it may create a new lockfile unrelated to this feature.
+
+Before claiming full verification, either:
+
+```bash
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+```
+
+or use an environment where the Rust workspace already builds with the macOS private framework dependencies.
+
+## Scope of this first feature slice
+
+This plan implements:
+
+- speaker diarization domain types;
+- deterministic diarization interval to transcript alignment;
+- SQLite schema for resolved transcript speaker metadata and raw speaker intervals;
+- persisted diarization settings;
+- beta flag and settings UI;
+- transcript display of speaker labels, provisional/final/overlap states;
+- copy transcript with speaker labels;
+- placeholder-safe Tauri commands that allow later live/offline engines to write diarization results.
+
+This plan does not implement:
+
+- FluidAudio Swift sidecar;
+- online clustering;
+- offline VBx processing;
+- separate audio-stem recording changes;
+- pyannote enhancement.
+
+Those belong in the next plan because they touch capture, packaging, model download, sidecar lifecycle, and macOS build setup.
+
+## File structure
+
+Create:
+
+- `frontend/src-tauri/src/diarization/mod.rs` — module exports.
+- `frontend/src-tauri/src/diarization/types.rs` — serializable diarization domain types.
+- `frontend/src-tauri/src/diarization/alignment.rs` — pure interval-to-transcript alignment.
+- `frontend/src-tauri/src/diarization/commands.rs` — Tauri commands for settings/status and applying segment assignments.
+- `frontend/src-tauri/src/database/repositories/diarization.rs` — SQLite access for diarization settings, meeting status, and speaker segments.
+- `frontend/src-tauri/migrations/20260626000100_add_diarization_foundation.sql` — additive migration.
+- `frontend/src/types/diarization.ts` — frontend diarization types.
+- `frontend/src/components/settings/SettingsSection.tsx` — generic settings card primitive.
+- `frontend/src/components/settings/SettingsRow.tsx` — generic settings row primitive.
+- `frontend/src/components/settings/SettingsStatusBadge.tsx` — reusable status badge.
+- `frontend/src/components/SpeakerDiarizationSettings.tsx` — feature settings block.
+
+Modify:
+
+- `frontend/src-tauri/src/lib.rs` — register module and commands.
+- `frontend/src-tauri/src/database/repositories/mod.rs` if present; otherwise update imports at call sites.
+- `frontend/src-tauri/src/database/models.rs` — add diarization fields to `Transcript`; add setting/status structs.
+- `frontend/src-tauri/src/database/repositories/meeting.rs` — map diarization fields into API response.
+- `frontend/src-tauri/src/database/repositories/transcript.rs` — save default diarization metadata.
+- `frontend/src-tauri/src/api/api.rs` — add diarization fields to `MeetingTranscript` and `TranscriptSegment`.
+- `frontend/src-tauri/src/audio/transcription/worker.rs` — emit diarization-neutral fields only if type changes are required.
+- `frontend/src/types/index.ts` — add speaker fields to transcript types.
+- `frontend/src/services/configService.ts` — add diarization settings API wrappers.
+- `frontend/src/contexts/ConfigContext.tsx` — store diarization settings and actions.
+- `frontend/src/types/betaFeatures.ts` — add `speakerDiarization`.
+- `frontend/src/components/BetaSettings.tsx` — render the beta toggle.
+- `frontend/src/components/TranscriptSettings.tsx` — render `SpeakerDiarizationSettings` when beta flag is enabled.
+- `frontend/src/components/VirtualizedTranscriptView.tsx` — render speaker labels and badges.
+- `frontend/src/app/_components/TranscriptPanel.tsx` — pass speaker fields into virtualized segments.
+- `frontend/src/contexts/TranscriptContext.tsx` — preserve speaker fields in live updates and copy output.
+- `frontend/src/services/indexedDBService.ts` — tolerate additional diarization fields in stored transcript updates.
+
+## Task 1: Rust diarization domain types
+
+**Files:**
+
+- Create: `frontend/src-tauri/src/diarization/mod.rs`
+- Create: `frontend/src-tauri/src/diarization/types.rs`
+- Modify: `frontend/src-tauri/src/lib.rs`
+
+- [ ] **Step 1: Write the failing compile-oriented unit test**
+
+Create `frontend/src-tauri/src/diarization/types.rs` with the tests first:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diarization_status_serializes_as_snake_case() {
+        let json = serde_json::to_string(&DiarizationStatus::FallbackToLive).unwrap();
+        assert_eq!(json, "\"fallback_to_live\"");
+    }
+
+    #[test]
+    fn overlap_assignment_uses_multiple_speakers_label() {
+        let assignment = SpeakerAssignment::overlap(0.91, DiarizationStatus::Provisional, "fluid_audio_online");
+
+        assert_eq!(assignment.speaker_id, None);
+        assert_eq!(assignment.speaker_label.as_deref(), Some("Multiple speakers"));
+        assert!(assignment.is_overlap);
+        assert_eq!(assignment.diarization_status, DiarizationStatus::Provisional);
+        assert_eq!(assignment.diarization_method.as_deref(), Some("fluid_audio_online"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p meetily diarization::types::tests::diarization_status_serializes_as_snake_case
+```
+
+Expected before implementation: compile fails because `DiarizationStatus` and `SpeakerAssignment` are not defined.
+
+- [ ] **Step 3: Implement the minimal types**
+
+Replace `frontend/src-tauri/src/diarization/types.rs` with:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiarizationStatus {
+    None,
+    Provisional,
+    Final,
+    FallbackToLive,
+    Failed,
+    NeedsReview,
+}
+
+impl Default for DiarizationStatus {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SpeakerSegment {
+    pub meeting_id: String,
+    pub source: String,
+    pub start_time: f64,
+    pub end_time: f64,
+    pub speaker_id: Option<String>,
+    pub speaker_label: Option<String>,
+    pub confidence: Option<f64>,
+    pub is_overlap: bool,
+    pub diarization_status: DiarizationStatus,
+    pub diarization_method: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TranscriptWindow {
+    pub transcript_id: String,
+    pub audio_start_time: Option<f64>,
+    pub audio_end_time: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SpeakerAssignment {
+    pub speaker_id: Option<String>,
+    pub speaker_label: Option<String>,
+    pub speaker_color: Option<String>,
+    pub is_overlap: bool,
+    pub diarization_status: DiarizationStatus,
+    pub diarization_method: Option<String>,
+    pub diarization_confidence: Option<f64>,
+}
+
+impl SpeakerAssignment {
+    pub fn unknown(status: DiarizationStatus, method: impl Into<Option<String>>) -> Self {
+        Self {
+            speaker_id: None,
+            speaker_label: Some("Unknown speaker".to_string()),
+            speaker_color: None,
+            is_overlap: false,
+            diarization_status: status,
+            diarization_method: method.into(),
+            diarization_confidence: None,
+        }
+    }
+
+    pub fn overlap(confidence: f64, status: DiarizationStatus, method: impl Into<String>) -> Self {
+        Self {
+            speaker_id: None,
+            speaker_label: Some("Multiple speakers".to_string()),
+            speaker_color: Some("#f97316".to_string()),
+            is_overlap: true,
+            diarization_status: status,
+            diarization_method: Some(method.into()),
+            diarization_confidence: Some(confidence),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diarization_status_serializes_as_snake_case() {
+        let json = serde_json::to_string(&DiarizationStatus::FallbackToLive).unwrap();
+        assert_eq!(json, "\"fallback_to_live\"");
+    }
+
+    #[test]
+    fn overlap_assignment_uses_multiple_speakers_label() {
+        let assignment = SpeakerAssignment::overlap(0.91, DiarizationStatus::Provisional, "fluid_audio_online");
+
+        assert_eq!(assignment.speaker_id, None);
+        assert_eq!(assignment.speaker_label.as_deref(), Some("Multiple speakers"));
+        assert!(assignment.is_overlap);
+        assert_eq!(assignment.diarization_status, DiarizationStatus::Provisional);
+        assert_eq!(assignment.diarization_method.as_deref(), Some("fluid_audio_online"));
+    }
+}
+```
+
+Create `frontend/src-tauri/src/diarization/mod.rs`:
+
+```rust
+pub mod alignment;
+pub mod commands;
+pub mod types;
+```
+
+Add this module declaration near the other module declarations in `frontend/src-tauri/src/lib.rs`:
+
+```rust
+pub mod diarization;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p meetily diarization::types::tests::diarization_status_serializes_as_snake_case
+```
+
+Expected after implementation: PASS when the Xcode baseline blocker is resolved.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src-tauri/src/diarization frontend/src-tauri/src/lib.rs
+git commit -m "feat: add diarization domain types"
+```
+
+## Task 2: Deterministic transcript alignment
+
+**Files:**
+
+- Modify: `frontend/src-tauri/src/diarization/alignment.rs`
+- Modify: `frontend/src-tauri/src/diarization/mod.rs`
+
+- [ ] **Step 1: Write failing alignment tests**
+
+Create `frontend/src-tauri/src/diarization/alignment.rs`:
+
+```rust
+use super::types::{DiarizationStatus, SpeakerAssignment, SpeakerSegment, TranscriptWindow};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn segment(label: &str, start: f64, end: f64) -> SpeakerSegment {
+        SpeakerSegment {
+            meeting_id: "meeting-1".to_string(),
+            source: "system".to_string(),
+            start_time: start,
+            end_time: end,
+            speaker_id: Some(label.to_lowercase().replace(' ', "-")),
+            speaker_label: Some(label.to_string()),
+            confidence: Some(0.8),
+            is_overlap: false,
+            diarization_status: DiarizationStatus::Provisional,
+            diarization_method: Some("unit_test".to_string()),
+        }
+    }
+
+    #[test]
+    fn assigns_speaker_with_largest_temporal_overlap() {
+        let transcript = TranscriptWindow {
+            transcript_id: "t1".to_string(),
+            audio_start_time: Some(10.0),
+            audio_end_time: Some(16.0),
+        };
+        let segments = vec![
+            segment("Speaker 1", 10.0, 12.0),
+            segment("Speaker 2", 12.0, 16.0),
+        ];
+
+        let assignment = assign_speaker_to_transcript(&transcript, &segments, 0.1, "unit_test");
+
+        assert_eq!(assignment.speaker_label.as_deref(), Some("Speaker 2"));
+        assert_eq!(assignment.speaker_id.as_deref(), Some("speaker-2"));
+        assert!(!assignment.is_overlap);
+    }
+
+    #[test]
+    fn marks_overlap_when_matching_segment_is_overlap() {
+        let transcript = TranscriptWindow {
+            transcript_id: "t2".to_string(),
+            audio_start_time: Some(20.0),
+            audio_end_time: Some(24.0),
+        };
+        let mut overlap = segment("Speaker 1", 20.0, 24.0);
+        overlap.is_overlap = true;
+        overlap.confidence = Some(0.93);
+
+        let assignment = assign_speaker_to_transcript(&transcript, &[overlap], 0.1, "unit_test");
+
+        assert_eq!(assignment.speaker_label.as_deref(), Some("Multiple speakers"));
+        assert!(assignment.is_overlap);
+        assert_eq!(assignment.diarization_confidence, Some(0.93));
+    }
+
+    #[test]
+    fn returns_unknown_when_transcript_has_no_audio_window() {
+        let transcript = TranscriptWindow {
+            transcript_id: "t3".to_string(),
+            audio_start_time: None,
+            audio_end_time: None,
+        };
+
+        let assignment = assign_speaker_to_transcript(&transcript, &[segment("Speaker 1", 0.0, 1.0)], 0.1, "unit_test");
+
+        assert_eq!(assignment.speaker_label.as_deref(), Some("Unknown speaker"));
+        assert_eq!(assignment.diarization_status, DiarizationStatus::NeedsReview);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p meetily diarization::alignment::tests
+```
+
+Expected before implementation: compile fails because `assign_speaker_to_transcript` is missing.
+
+- [ ] **Step 3: Implement minimal alignment**
+
+Insert above the test module in `frontend/src-tauri/src/diarization/alignment.rs`:
+
+```rust
+pub fn assign_speaker_to_transcript(
+    transcript: &TranscriptWindow,
+    segments: &[SpeakerSegment],
+    min_overlap_ratio: f64,
+    method: &str,
+) -> SpeakerAssignment {
+    let Some(transcript_start) = transcript.audio_start_time else {
+        return SpeakerAssignment::unknown(DiarizationStatus::NeedsReview, Some(method.to_string()));
+    };
+    let Some(transcript_end) = transcript.audio_end_time else {
+        return SpeakerAssignment::unknown(DiarizationStatus::NeedsReview, Some(method.to_string()));
+    };
+
+    let transcript_duration = (transcript_end - transcript_start).max(0.0);
+    if transcript_duration == 0.0 {
+        return SpeakerAssignment::unknown(DiarizationStatus::NeedsReview, Some(method.to_string()));
+    }
+
+    let mut best_segment: Option<(&SpeakerSegment, f64)> = None;
+
+    for segment in segments {
+        let overlap_start = transcript_start.max(segment.start_time);
+        let overlap_end = transcript_end.min(segment.end_time);
+        let overlap = (overlap_end - overlap_start).max(0.0);
+        if overlap <= 0.0 {
+            continue;
+        }
+
+        let ratio = overlap / transcript_duration;
+        if ratio < min_overlap_ratio {
+            continue;
+        }
+
+        match best_segment {
+            Some((_, best_overlap)) if best_overlap >= overlap => {}
+            _ => best_segment = Some((segment, overlap)),
+        }
+    }
+
+    let Some((segment, _)) = best_segment else {
+        return SpeakerAssignment::unknown(DiarizationStatus::NeedsReview, Some(method.to_string()));
+    };
+
+    if segment.is_overlap {
+        return SpeakerAssignment::overlap(
+            segment.confidence.unwrap_or(0.0),
+            segment.diarization_status,
+            method.to_string(),
+        );
+    }
+
+    SpeakerAssignment {
+        speaker_id: segment.speaker_id.clone(),
+        speaker_label: segment.speaker_label.clone().or_else(|| Some("Unknown speaker".to_string())),
+        speaker_color: None,
+        is_overlap: false,
+        diarization_status: segment.diarization_status,
+        diarization_method: Some(method.to_string()),
+        diarization_confidence: segment.confidence,
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+cargo test -p meetily diarization::alignment::tests
+```
+
+Expected after implementation: PASS when baseline build environment is fixed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src-tauri/src/diarization/alignment.rs
+git commit -m "feat: align diarization segments to transcripts"
+```
+
+## Task 3: SQLite schema and Rust database models
+
+**Files:**
+
+- Create: `frontend/src-tauri/migrations/20260626000100_add_diarization_foundation.sql`
+- Modify: `frontend/src-tauri/src/database/models.rs`
+- Modify: `frontend/src-tauri/src/api/api.rs`
+
+- [ ] **Step 1: Write schema migration**
+
+Create `frontend/src-tauri/migrations/20260626000100_add_diarization_foundation.sql`:
+
+```sql
+-- Speaker diarization foundation.
+-- Existing transcripts.speaker is legacy source metadata (mic/system) and remains untouched.
+
+ALTER TABLE transcripts ADD COLUMN speaker_id TEXT;
+ALTER TABLE transcripts ADD COLUMN speaker_label TEXT;
+ALTER TABLE transcripts ADD COLUMN speaker_color TEXT;
+ALTER TABLE transcripts ADD COLUMN is_overlap INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE transcripts ADD COLUMN diarization_status TEXT NOT NULL DEFAULT 'none';
+ALTER TABLE transcripts ADD COLUMN diarization_method TEXT;
+ALTER TABLE transcripts ADD COLUMN diarization_confidence REAL;
+
+CREATE TABLE IF NOT EXISTS diarization_settings (
+    id TEXT PRIMARY KEY NOT NULL DEFAULT '1',
+    enabled INTEGER NOT NULL DEFAULT 0,
+    mode TEXT NOT NULL DEFAULT 'live_plus_post_call',
+    show_provisional_labels INTEGER NOT NULL DEFAULT 1,
+    post_call_refinement_enabled INTEGER NOT NULL DEFAULT 1,
+    overlap_handling TEXT NOT NULL DEFAULT 'multiple_speakers',
+    speaker_review_enabled INTEGER NOT NULL DEFAULT 1,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO diarization_settings (id)
+VALUES ('1')
+ON CONFLICT(id) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS meeting_diarization_status (
+    meeting_id TEXT PRIMARY KEY NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 0,
+    live_enabled INTEGER NOT NULL DEFAULT 0,
+    post_call_enabled INTEGER NOT NULL DEFAULT 0,
+    current_status TEXT NOT NULL DEFAULT 'none',
+    quality_flags TEXT,
+    processed_at DATETIME,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS speaker_segments (
+    id TEXT PRIMARY KEY NOT NULL,
+    meeting_id TEXT NOT NULL,
+    source TEXT NOT NULL,
+    start_time REAL NOT NULL,
+    end_time REAL NOT NULL,
+    speaker_id TEXT,
+    speaker_label TEXT,
+    confidence REAL,
+    is_overlap INTEGER NOT NULL DEFAULT 0,
+    diarization_status TEXT NOT NULL,
+    diarization_method TEXT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_speaker_segments_meeting_time
+ON speaker_segments(meeting_id, start_time, end_time);
+
+CREATE INDEX IF NOT EXISTS idx_transcripts_meeting_diarization
+ON transcripts(meeting_id, diarization_status);
+```
+
+- [ ] **Step 2: Update Rust models**
+
+In `frontend/src-tauri/src/database/models.rs`, add fields to `Transcript` after `duration`:
+
+```rust
+    pub speaker_id: Option<String>,
+    pub speaker_label: Option<String>,
+    pub speaker_color: Option<String>,
+    pub is_overlap: Option<i64>,
+    pub diarization_status: Option<String>,
+    pub diarization_method: Option<String>,
+    pub diarization_confidence: Option<f64>,
+```
+
+Add these structs after `TranscriptSetting`:
+
+```rust
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct DiarizationSetting {
+    pub id: String,
+    pub enabled: i64,
+    pub mode: String,
+    pub show_provisional_labels: i64,
+    pub post_call_refinement_enabled: i64,
+    pub overlap_handling: String,
+    pub speaker_review_enabled: i64,
+    pub updated_at: DateTimeUtc,
+}
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct MeetingDiarizationStatus {
+    pub meeting_id: String,
+    pub enabled: i64,
+    pub live_enabled: i64,
+    pub post_call_enabled: i64,
+    pub current_status: String,
+    pub quality_flags: Option<String>,
+    pub processed_at: Option<DateTimeUtc>,
+    pub updated_at: DateTimeUtc,
+}
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct SpeakerSegmentModel {
+    pub id: String,
+    pub meeting_id: String,
+    pub source: String,
+    pub start_time: f64,
+    pub end_time: f64,
+    pub speaker_id: Option<String>,
+    pub speaker_label: Option<String>,
+    pub confidence: Option<f64>,
+    pub is_overlap: i64,
+    pub diarization_status: String,
+    pub diarization_method: Option<String>,
+    pub created_at: DateTimeUtc,
+}
+```
+
+- [ ] **Step 3: Update API transcript DTOs**
+
+In `frontend/src-tauri/src/api/api.rs`, add to `MeetingTranscript`:
+
+```rust
+    pub speaker_id: Option<String>,
+    pub speaker_label: Option<String>,
+    pub speaker_color: Option<String>,
+    pub is_overlap: Option<bool>,
+    pub diarization_status: Option<String>,
+    pub diarization_method: Option<String>,
+    pub diarization_confidence: Option<f64>,
+```
+
+Add equivalent optional fields to `TranscriptSegment`:
+
+```rust
+    pub speaker_id: Option<String>,
+    pub speaker_label: Option<String>,
+    pub speaker_color: Option<String>,
+    pub is_overlap: Option<bool>,
+    pub diarization_status: Option<String>,
+    pub diarization_method: Option<String>,
+    pub diarization_confidence: Option<f64>,
+```
+
+- [ ] **Step 4: Run compile check**
+
+Run:
+
+```bash
+cargo check -p meetily
+```
+
+Expected before fixing mapping code: compile errors in repository mappings that construct `MeetingTranscript` or save `TranscriptSegment`.
+
+- [ ] **Step 5: Commit migration and model changes after Task 4 fixes mapping**
+
+Do not commit this task alone if compile is broken. Commit together with Task 4 after all DTO construction sites are updated.
+
+## Task 4: Repository mapping and save defaults
+
+**Files:**
+
+- Modify: `frontend/src-tauri/src/database/repositories/meeting.rs`
+- Modify: `frontend/src-tauri/src/database/repositories/transcript.rs`
+
+- [ ] **Step 1: Update meeting transcript mapping**
+
+In `frontend/src-tauri/src/database/repositories/meeting.rs`, update the `MeetingTranscript` mapping:
+
+```rust
+MeetingTranscript {
+    id: t.id,
+    text: t.transcript,
+    timestamp: t.timestamp,
+    audio_start_time: t.audio_start_time,
+    audio_end_time: t.audio_end_time,
+    duration: t.duration,
+    speaker_id: t.speaker_id,
+    speaker_label: t.speaker_label,
+    speaker_color: t.speaker_color,
+    is_overlap: t.is_overlap.map(|value| value != 0),
+    diarization_status: t.diarization_status,
+    diarization_method: t.diarization_method,
+    diarization_confidence: t.diarization_confidence,
+}
+```
+
+- [ ] **Step 2: Update transcript save insert**
+
+In `frontend/src-tauri/src/database/repositories/transcript.rs`, replace the insert query inside `save_transcript` with:
+
+```rust
+let result = sqlx::query(
+    "INSERT INTO transcripts (
+        id, meeting_id, transcript, timestamp,
+        audio_start_time, audio_end_time, duration,
+        speaker_id, speaker_label, speaker_color, is_overlap,
+        diarization_status, diarization_method, diarization_confidence
+     )
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+)
+.bind(&transcript_id)
+.bind(&meeting_id)
+.bind(&segment.text)
+.bind(&segment.timestamp)
+.bind(segment.audio_start_time)
+.bind(segment.audio_end_time)
+.bind(segment.duration)
+.bind(&segment.speaker_id)
+.bind(&segment.speaker_label)
+.bind(&segment.speaker_color)
+.bind(segment.is_overlap.unwrap_or(false) as i64)
+.bind(segment.diarization_status.as_deref().unwrap_or("none"))
+.bind(&segment.diarization_method)
+.bind(segment.diarization_confidence)
+.execute(&mut *transaction)
+.await;
+```
+
+- [ ] **Step 3: Run compile check**
+
+Run:
+
+```bash
+cargo check -p meetily
+```
+
+Expected after mapping fixes: no diarization-related compile errors. Environment may still fail on the Xcode/cidre blocker until Xcode is selected.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src-tauri/migrations/20260626000100_add_diarization_foundation.sql frontend/src-tauri/src/database/models.rs frontend/src-tauri/src/api/api.rs frontend/src-tauri/src/database/repositories/meeting.rs frontend/src-tauri/src/database/repositories/transcript.rs
+git commit -m "feat: persist transcript diarization metadata"
+```
+
+## Task 5: Diarization settings repository and commands
+
+**Files:**
+
+- Create: `frontend/src-tauri/src/database/repositories/diarization.rs`
+- Modify: `frontend/src-tauri/src/database/repositories/mod.rs` if it exists
+- Modify: `frontend/src-tauri/src/diarization/commands.rs`
+- Modify: `frontend/src-tauri/src/lib.rs`
+
+- [ ] **Step 1: Create repository**
+
+Create `frontend/src-tauri/src/database/repositories/diarization.rs`:
+
+```rust
+use crate::database::models::DiarizationSetting;
+use sqlx::SqlitePool;
+
+pub struct DiarizationRepository;
+
+impl DiarizationRepository {
+    pub async fn get_settings(pool: &SqlitePool) -> Result<DiarizationSetting, sqlx::Error> {
+        let existing = sqlx::query_as::<_, DiarizationSetting>(
+            "SELECT * FROM diarization_settings WHERE id = '1'"
+        )
+        .fetch_optional(pool)
+        .await?;
+
+        if let Some(settings) = existing {
+            return Ok(settings);
+        }
+
+        sqlx::query("INSERT INTO diarization_settings (id) VALUES ('1')")
+            .execute(pool)
+            .await?;
+
+        sqlx::query_as::<_, DiarizationSetting>(
+            "SELECT * FROM diarization_settings WHERE id = '1'"
+        )
+        .fetch_one(pool)
+        .await
+    }
+
+    pub async fn save_settings(
+        pool: &SqlitePool,
+        enabled: bool,
+        mode: &str,
+        show_provisional_labels: bool,
+        post_call_refinement_enabled: bool,
+        overlap_handling: &str,
+        speaker_review_enabled: bool,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "INSERT INTO diarization_settings (
+                id, enabled, mode, show_provisional_labels,
+                post_call_refinement_enabled, overlap_handling,
+                speaker_review_enabled, updated_at
+             )
+             VALUES ('1', ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+             ON CONFLICT(id) DO UPDATE SET
+                enabled = excluded.enabled,
+                mode = excluded.mode,
+                show_provisional_labels = excluded.show_provisional_labels,
+                post_call_refinement_enabled = excluded.post_call_refinement_enabled,
+                overlap_handling = excluded.overlap_handling,
+                speaker_review_enabled = excluded.speaker_review_enabled,
+                updated_at = CURRENT_TIMESTAMP"
+        )
+        .bind(enabled as i64)
+        .bind(mode)
+        .bind(show_provisional_labels as i64)
+        .bind(post_call_refinement_enabled as i64)
+        .bind(overlap_handling)
+        .bind(speaker_review_enabled as i64)
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
+}
+```
+
+If `frontend/src-tauri/src/database/repositories/mod.rs` exists, add:
+
+```rust
+pub mod diarization;
+```
+
+- [ ] **Step 2: Create Tauri command DTOs and commands**
+
+Create `frontend/src-tauri/src/diarization/commands.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+use tauri::{Runtime, State};
+
+use crate::{
+    database::repositories::diarization::DiarizationRepository,
+    state::AppState,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiarizationSettingsDto {
+    pub enabled: bool,
+    pub mode: String,
+    pub show_provisional_labels: bool,
+    pub post_call_refinement_enabled: bool,
+    pub overlap_handling: String,
+    pub speaker_review_enabled: bool,
+}
+
+#[tauri::command]
+pub async fn get_diarization_settings<R: Runtime>(
+    state: State<'_, AppState>,
+) -> Result<DiarizationSettingsDto, String> {
+    let settings = DiarizationRepository::get_settings(state.db_manager.pool())
+        .await
+        .map_err(|error| error.to_string())?;
+
+    Ok(DiarizationSettingsDto {
+        enabled: settings.enabled != 0,
+        mode: settings.mode,
+        show_provisional_labels: settings.show_provisional_labels != 0,
+        post_call_refinement_enabled: settings.post_call_refinement_enabled != 0,
+        overlap_handling: settings.overlap_handling,
+        speaker_review_enabled: settings.speaker_review_enabled != 0,
+    })
+}
+
+#[tauri::command]
+pub async fn save_diarization_settings<R: Runtime>(
+    state: State<'_, AppState>,
+    settings: DiarizationSettingsDto,
+) -> Result<(), String> {
+    DiarizationRepository::save_settings(
+        state.db_manager.pool(),
+        settings.enabled,
+        &settings.mode,
+        settings.show_provisional_labels,
+        settings.post_call_refinement_enabled,
+        &settings.overlap_handling,
+        settings.speaker_review_enabled,
+    )
+    .await
+    .map_err(|error| error.to_string())
+}
+```
+
+- [ ] **Step 3: Register commands**
+
+In `frontend/src-tauri/src/lib.rs`, add command registrations in the existing `tauri::generate_handler!` list:
+
+```rust
+diarization::commands::get_diarization_settings,
+diarization::commands::save_diarization_settings,
+```
+
+- [ ] **Step 4: Run compile check**
+
+Run:
+
+```bash
+cargo check -p meetily
+```
+
+Expected: command registration compiles when environment baseline is fixed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src-tauri/src/database/repositories/diarization.rs frontend/src-tauri/src/database/repositories/mod.rs frontend/src-tauri/src/diarization/commands.rs frontend/src-tauri/src/lib.rs
+git commit -m "feat: add diarization settings commands"
+```
+
+If `frontend/src-tauri/src/database/repositories/mod.rs` does not exist, omit it from `git add`.
+
+## Task 6: Frontend diarization settings state and beta flag
+
+**Files:**
+
+- Create: `frontend/src/types/diarization.ts`
+- Modify: `frontend/src/types/betaFeatures.ts`
+- Modify: `frontend/src/services/configService.ts`
+- Modify: `frontend/src/contexts/ConfigContext.tsx`
+- Modify: `frontend/src/components/BetaSettings.tsx`
+
+- [ ] **Step 1: Add frontend type file**
+
+Create `frontend/src/types/diarization.ts`:
+
+```typescript
+export type DiarizationMode = 'live_plus_post_call' | 'post_call_only' | 'off';
+export type OverlapHandling = 'multiple_speakers';
+export type DiarizationStatus =
+  | 'none'
+  | 'provisional'
+  | 'final'
+  | 'fallback_to_live'
+  | 'failed'
+  | 'needs_review';
+
+export interface DiarizationSettings {
+  enabled: boolean;
+  mode: DiarizationMode;
+  showProvisionalLabels: boolean;
+  postCallRefinementEnabled: boolean;
+  overlapHandling: OverlapHandling;
+  speakerReviewEnabled: boolean;
+}
+
+export const DEFAULT_DIARIZATION_SETTINGS: DiarizationSettings = {
+  enabled: false,
+  mode: 'live_plus_post_call',
+  showProvisionalLabels: true,
+  postCallRefinementEnabled: true,
+  overlapHandling: 'multiple_speakers',
+  speakerReviewEnabled: true,
+};
+```
+
+- [ ] **Step 2: Add beta flag**
+
+In `frontend/src/types/betaFeatures.ts`, update `BetaFeatures`:
+
+```typescript
+  speakerDiarization: boolean;
+```
+
+Update `DEFAULT_BETA_FEATURES`:
+
+```typescript
+  speakerDiarization: false,
+```
+
+Update `BETA_FEATURE_NAMES`:
+
+```typescript
+  speakerDiarization: 'Speaker Labels',
+```
+
+Update `BETA_FEATURE_DESCRIPTIONS`:
+
+```typescript
+  speakerDiarization: 'Label speakers in transcripts with live provisional labels and post-call refinement.',
+```
+
+- [ ] **Step 3: Render beta flag**
+
+In `frontend/src/components/BetaSettings.tsx`, change:
+
+```typescript
+const featureOrder: BetaFeatureKey[] = ['importAndRetranscribe'];
+```
+
+to:
+
+```typescript
+const featureOrder: BetaFeatureKey[] = ['importAndRetranscribe', 'speakerDiarization'];
+```
+
+- [ ] **Step 4: Add config service wrappers**
+
+In `frontend/src/services/configService.ts`, import:
+
+```typescript
+import { DiarizationSettings } from '@/types/diarization';
+```
+
+Add methods inside `ConfigService`:
+
+```typescript
+async getDiarizationSettings(): Promise<DiarizationSettings> {
+  return invoke<DiarizationSettings>('get_diarization_settings');
+}
+
+async saveDiarizationSettings(settings: DiarizationSettings): Promise<void> {
+  return invoke<void>('save_diarization_settings', { settings });
+}
+```
+
+- [ ] **Step 5: Add context state and actions**
+
+In `frontend/src/contexts/ConfigContext.tsx`, import:
+
+```typescript
+import { DEFAULT_DIARIZATION_SETTINGS, DiarizationSettings } from '@/types/diarization';
+```
+
+Add to `ConfigContextType`:
+
+```typescript
+  diarizationSettings: DiarizationSettings;
+  isLoadingDiarizationSettings: boolean;
+  updateDiarizationSettings: (settings: DiarizationSettings) => Promise<void>;
+```
+
+Add state in `ConfigProvider`:
+
+```typescript
+const [diarizationSettings, setDiarizationSettings] = useState<DiarizationSettings>(DEFAULT_DIARIZATION_SETTINGS);
+const [isLoadingDiarizationSettings, setIsLoadingDiarizationSettings] = useState(false);
+```
+
+Add load effect:
+
+```typescript
+useEffect(() => {
+  const loadDiarizationSettings = async () => {
+    setIsLoadingDiarizationSettings(true);
+    try {
+      const settings = await configService.getDiarizationSettings();
+      setDiarizationSettings(settings);
+    } catch (error) {
+      console.error('[ConfigContext] Failed to load diarization settings:', error);
+      setDiarizationSettings(DEFAULT_DIARIZATION_SETTINGS);
+    } finally {
+      setIsLoadingDiarizationSettings(false);
+    }
+  };
+
+  loadDiarizationSettings();
+}, []);
+```
+
+Add action:
+
+```typescript
+const updateDiarizationSettings = useCallback(async (settings: DiarizationSettings) => {
+  setDiarizationSettings(settings);
+  await configService.saveDiarizationSettings(settings);
+}, []);
+```
+
+Add these fields to the `value` object:
+
+```typescript
+diarizationSettings,
+isLoadingDiarizationSettings,
+updateDiarizationSettings,
+```
+
+- [ ] **Step 6: Run TypeScript verification**
+
+Run only after dependencies are installed intentionally:
+
+```bash
+cd frontend
+npm run build
+```
+
+Expected: TypeScript compiles after command names and context fields are consistent.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/types/diarization.ts frontend/src/types/betaFeatures.ts frontend/src/services/configService.ts frontend/src/contexts/ConfigContext.tsx frontend/src/components/BetaSettings.tsx
+git commit -m "feat: add diarization settings state"
+```
+
+## Task 7: Settings primitives and speaker diarization settings UI
+
+**Files:**
+
+- Create: `frontend/src/components/settings/SettingsSection.tsx`
+- Create: `frontend/src/components/settings/SettingsRow.tsx`
+- Create: `frontend/src/components/settings/SettingsStatusBadge.tsx`
+- Create: `frontend/src/components/SpeakerDiarizationSettings.tsx`
+- Modify: `frontend/src/components/TranscriptSettings.tsx`
+
+- [ ] **Step 1: Add generic settings primitives**
+
+Create `frontend/src/components/settings/SettingsSection.tsx`:
+
+```tsx
+import React from 'react';
+
+interface SettingsSectionProps {
+  title: string;
+  description?: string;
+  badge?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export function SettingsSection({ title, description, badge, children }: SettingsSectionProps) {
+  return (
+    <section className="bg-card text-card-foreground rounded-lg border border-border p-6 shadow-sm">
+      <div className="mb-5">
+        <div className="flex items-center gap-2">
+          <h3 className="text-lg font-semibold text-foreground">{title}</h3>
+          {badge}
+        </div>
+        {description && (
+          <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      <div className="space-y-3">{children}</div>
+    </section>
+  );
+}
+```
+
+Create `frontend/src/components/settings/SettingsRow.tsx`:
+
+```tsx
+import React from 'react';
+
+interface SettingsRowProps {
+  title: string;
+  description?: string;
+  control: React.ReactNode;
+  disabledReason?: string;
+}
+
+export function SettingsRow({ title, description, control, disabledReason }: SettingsRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-6 rounded-lg border border-border p-4">
+      <div className="min-w-0 flex-1">
+        <div className="font-medium text-foreground">{title}</div>
+        {description && (
+          <div className="mt-1 text-sm text-muted-foreground">{description}</div>
+        )}
+        {disabledReason && (
+          <div className="mt-2 text-xs text-amber-700">{disabledReason}</div>
+        )}
+      </div>
+      <div className="flex-shrink-0">{control}</div>
+    </div>
+  );
+}
+```
+
+Create `frontend/src/components/settings/SettingsStatusBadge.tsx`:
+
+```tsx
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+type SettingsStatusBadgeTone = 'beta' | 'local' | 'provisional' | 'final' | 'fallback' | 'review' | 'unavailable';
+
+const toneClassName: Record<SettingsStatusBadgeTone, string> = {
+  beta: 'bg-yellow-100 text-yellow-800',
+  local: 'bg-blue-100 text-blue-800',
+  provisional: 'bg-amber-100 text-amber-800',
+  final: 'bg-green-100 text-green-800',
+  fallback: 'bg-orange-100 text-orange-800',
+  review: 'bg-purple-100 text-purple-800',
+  unavailable: 'bg-gray-100 text-gray-700',
+};
+
+interface SettingsStatusBadgeProps {
+  tone: SettingsStatusBadgeTone;
+  children: React.ReactNode;
+}
+
+export function SettingsStatusBadge({ tone, children }: SettingsStatusBadgeProps) {
+  return (
+    <span className={cn('inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium', toneClassName[tone])}>
+      {children}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 2: Add feature settings component**
+
+Create `frontend/src/components/SpeakerDiarizationSettings.tsx`:
+
+```tsx
+'use client';
+
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { SettingsSection } from '@/components/settings/SettingsSection';
+import { SettingsRow } from '@/components/settings/SettingsRow';
+import { SettingsStatusBadge } from '@/components/settings/SettingsStatusBadge';
+import { useConfig } from '@/contexts/ConfigContext';
+import { DiarizationMode } from '@/types/diarization';
+
+export function SpeakerDiarizationSettings() {
+  const {
+    betaFeatures,
+    diarizationSettings,
+    isLoadingDiarizationSettings,
+    updateDiarizationSettings,
+  } = useConfig();
+
+  if (!betaFeatures.speakerDiarization) {
+    return null;
+  }
+
+  const update = (patch: Partial<typeof diarizationSettings>) => {
+    updateDiarizationSettings({ ...diarizationSettings, ...patch })
+      .catch(error => console.error('[SpeakerDiarizationSettings] Failed to save:', error));
+  };
+
+  const liveModeEnabled = diarizationSettings.enabled && diarizationSettings.mode === 'live_plus_post_call';
+
+  return (
+    <SettingsSection
+      title="Speaker labels"
+      description="Label who spoke in the transcript. Live labels are provisional; final labels are applied after the meeting."
+      badge={<SettingsStatusBadge tone="beta">Beta</SettingsStatusBadge>}
+    >
+      <SettingsRow
+        title="Enable speaker diarization"
+        description="Add speaker labels to transcripts without identifying people by voice."
+        control={
+          <Switch
+            checked={diarizationSettings.enabled}
+            disabled={isLoadingDiarizationSettings}
+            onCheckedChange={(enabled) => update({ enabled, mode: enabled ? diarizationSettings.mode : 'off' })}
+          />
+        }
+      />
+
+      <SettingsRow
+        title="Mode"
+        description="Recommended: show provisional labels during the call, then refine after recording stops."
+        control={
+          <Select
+            value={diarizationSettings.mode}
+            disabled={!diarizationSettings.enabled || isLoadingDiarizationSettings}
+            onValueChange={(mode) => update({ mode: mode as DiarizationMode })}
+          >
+            <SelectTrigger className="w-[260px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="live_plus_post_call">Live + post-call refinement</SelectItem>
+              <SelectItem value="post_call_only">Post-call only</SelectItem>
+              <SelectItem value="off">Off</SelectItem>
+            </SelectContent>
+          </Select>
+        }
+      />
+
+      <SettingsRow
+        title="Show provisional labels during call"
+        description="Display live Speaker 1 / Speaker 2 labels with a provisional badge."
+        disabledReason={!liveModeEnabled ? 'Available only in Live + post-call refinement mode.' : undefined}
+        control={
+          <Switch
+            checked={diarizationSettings.showProvisionalLabels}
+            disabled={!liveModeEnabled || isLoadingDiarizationSettings}
+            onCheckedChange={(showProvisionalLabels) => update({ showProvisionalLabels })}
+          />
+        }
+      />
+
+      <SettingsRow
+        title="Run post-call refinement automatically"
+        description="After the meeting, analyze the full audio and replace provisional labels when quality is good."
+        control={
+          <Switch
+            checked={diarizationSettings.postCallRefinementEnabled}
+            disabled={!diarizationSettings.enabled || diarizationSettings.mode === 'off' || isLoadingDiarizationSettings}
+            onCheckedChange={(postCallRefinementEnabled) => update({ postCallRefinementEnabled })}
+          />
+        }
+      />
+
+      <SettingsRow
+        title="Overlap handling"
+        description="Interruptions are marked as Multiple speakers."
+        control={<SettingsStatusBadge tone="local">Multiple speakers</SettingsStatusBadge>}
+      />
+
+      <SettingsRow
+        title="Speaker review"
+        description="Allow rename, merge, split, and overlap fixes after post-call processing."
+        control={
+          <Switch
+            checked={diarizationSettings.speakerReviewEnabled}
+            disabled={!diarizationSettings.enabled || isLoadingDiarizationSettings}
+            onCheckedChange={(speakerReviewEnabled) => update({ speakerReviewEnabled })}
+          />
+        }
+      />
+    </SettingsSection>
+  );
+}
+```
+
+- [ ] **Step 3: Render settings inside Transcript settings**
+
+In `frontend/src/components/TranscriptSettings.tsx`, import:
+
+```tsx
+import { SpeakerDiarizationSettings } from './SpeakerDiarizationSettings';
+```
+
+Render at the end of the outer `space-y-4 pb-6` container:
+
+```tsx
+<SpeakerDiarizationSettings />
+```
+
+- [ ] **Step 4: Run frontend verification**
+
+Run after dependencies are intentionally installed:
+
+```bash
+cd frontend
+npm run build
+```
+
+Expected: TypeScript and Next build pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/settings/SettingsSection.tsx frontend/src/components/settings/SettingsRow.tsx frontend/src/components/settings/SettingsStatusBadge.tsx frontend/src/components/SpeakerDiarizationSettings.tsx frontend/src/components/TranscriptSettings.tsx
+git commit -m "feat: add speaker diarization settings UI"
+```
+
+## Task 8: Frontend transcript speaker rendering
+
+**Files:**
+
+- Modify: `frontend/src/types/index.ts`
+- Modify: `frontend/src/app/_components/TranscriptPanel.tsx`
+- Modify: `frontend/src/components/VirtualizedTranscriptView.tsx`
+- Modify: `frontend/src/contexts/TranscriptContext.tsx`
+
+- [ ] **Step 1: Extend frontend transcript types**
+
+In `frontend/src/types/index.ts`, add to `Transcript`, `TranscriptUpdate`, and `TranscriptSegmentData`:
+
+```typescript
+speaker_id?: string | null;
+speaker_label?: string | null;
+speaker_color?: string | null;
+is_overlap?: boolean | null;
+diarization_status?: 'none' | 'provisional' | 'final' | 'fallback_to_live' | 'failed' | 'needs_review' | null;
+diarization_method?: string | null;
+diarization_confidence?: number | null;
+```
+
+- [ ] **Step 2: Preserve fields in transcript context**
+
+In `frontend/src/contexts/TranscriptContext.tsx`, when constructing `newTranscript` from `update`, add:
+
+```typescript
+speaker_id: update.speaker_id,
+speaker_label: update.speaker_label,
+speaker_color: update.speaker_color,
+is_overlap: update.is_overlap,
+diarization_status: update.diarization_status,
+diarization_method: update.diarization_method,
+diarization_confidence: update.diarization_confidence,
+```
+
+Apply this in:
+
+- main `transcriptService.onTranscriptUpdate` listener;
+- reload sync `formattedTranscripts`;
+- manual `addTranscript`.
+
+Update copy format:
+
+```typescript
+const speaker = t.is_overlap
+  ? 'Multiple speakers'
+  : (t.speaker_label || undefined);
+const speakerPrefix = speaker ? ` ${speaker}:` : '';
+return `${formatTime(t.audio_start_time)}${speakerPrefix} ${t.text}`;
+```
+
+- [ ] **Step 3: Pass fields into virtualized segments**
+
+In `frontend/src/app/_components/TranscriptPanel.tsx`, extend mapped segment:
+
+```typescript
+speaker_id: t.speaker_id,
+speaker_label: t.speaker_label,
+speaker_color: t.speaker_color,
+is_overlap: t.is_overlap,
+diarization_status: t.diarization_status,
+diarization_method: t.diarization_method,
+diarization_confidence: t.diarization_confidence,
+```
+
+- [ ] **Step 4: Render speaker label and status badges**
+
+In `frontend/src/components/VirtualizedTranscriptView.tsx`, import:
+
+```tsx
+import { DiarizationStatus } from "@/types/diarization";
+```
+
+Extend `TranscriptSegment` props:
+
+```typescript
+speakerLabel?: string | null;
+speakerColor?: string | null;
+isOverlap?: boolean | null;
+diarizationStatus?: DiarizationStatus | null;
+```
+
+Pass values from `segment` to `TranscriptSegment`.
+
+Inside `TranscriptSegment`, before transcript text, render:
+
+```tsx
+{(speakerLabel || isOverlap || diarizationStatus) && (
+  <div className="mb-1 flex items-center gap-2 text-xs">
+    <span
+      className="font-medium"
+      style={{ color: speakerColor || (isOverlap ? '#f97316' : '#475569') }}
+    >
+      {isOverlap ? 'Multiple speakers' : speakerLabel}
+    </span>
+    {diarizationStatus === 'provisional' && (
+      <span className="rounded-full bg-amber-100 px-2 py-0.5 font-medium text-amber-800">
+        Provisional
+      </span>
+    )}
+    {diarizationStatus === 'final' && (
+      <span className="rounded-full bg-green-100 px-2 py-0.5 font-medium text-green-800">
+        Final
+      </span>
+    )}
+    {diarizationStatus === 'needs_review' && (
+      <span className="rounded-full bg-purple-100 px-2 py-0.5 font-medium text-purple-800">
+        Needs review
+      </span>
+    )}
+  </div>
+)}
+```
+
+- [ ] **Step 5: Run frontend verification**
+
+Run after dependencies are intentionally installed:
+
+```bash
+cd frontend
+npm run build
+```
+
+Expected: TypeScript and Next build pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/types/index.ts frontend/src/app/_components/TranscriptPanel.tsx frontend/src/components/VirtualizedTranscriptView.tsx frontend/src/contexts/TranscriptContext.tsx
+git commit -m "feat: render speaker labels in transcripts"
+```
+
+## Task 9: Apply diarization segment assignments command
+
+**Files:**
+
+- Modify: `frontend/src-tauri/src/database/repositories/diarization.rs`
+- Modify: `frontend/src-tauri/src/diarization/commands.rs`
+
+- [ ] **Step 1: Add repository method**
+
+Append to `impl DiarizationRepository`:
+
+```rust
+pub async fn update_transcript_assignment(
+    pool: &SqlitePool,
+    transcript_id: &str,
+    assignment: &crate::diarization::types::SpeakerAssignment,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE transcripts SET
+            speaker_id = ?,
+            speaker_label = ?,
+            speaker_color = ?,
+            is_overlap = ?,
+            diarization_status = ?,
+            diarization_method = ?,
+            diarization_confidence = ?
+         WHERE id = ?"
+    )
+    .bind(&assignment.speaker_id)
+    .bind(&assignment.speaker_label)
+    .bind(&assignment.speaker_color)
+    .bind(assignment.is_overlap as i64)
+    .bind(serde_json::to_value(assignment.diarization_status).unwrap_or_else(|_| serde_json::json!("none")).as_str().unwrap_or("none"))
+    .bind(&assignment.diarization_method)
+    .bind(assignment.diarization_confidence)
+    .bind(transcript_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Add command DTO and command**
+
+Append to `frontend/src-tauri/src/diarization/commands.rs`:
+
+```rust
+use crate::diarization::alignment::assign_speaker_to_transcript;
+use crate::diarization::types::{SpeakerSegment, TranscriptWindow};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApplyDiarizationRequest {
+    pub meeting_id: String,
+    pub method: String,
+    pub segments: Vec<SpeakerSegment>,
+}
+
+#[tauri::command]
+pub async fn apply_diarization_segments<R: Runtime>(
+    state: State<'_, AppState>,
+    request: ApplyDiarizationRequest,
+) -> Result<(), String> {
+    let pool = state.db_manager.pool();
+
+    let transcripts = sqlx::query_as::<_, crate::database::models::Transcript>(
+        "SELECT * FROM transcripts WHERE meeting_id = ? ORDER BY audio_start_time ASC"
+    )
+    .bind(&request.meeting_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|error| error.to_string())?;
+
+    for transcript in transcripts {
+        let window = TranscriptWindow {
+            transcript_id: transcript.id.clone(),
+            audio_start_time: transcript.audio_start_time,
+            audio_end_time: transcript.audio_end_time,
+        };
+
+        let assignment = assign_speaker_to_transcript(
+            &window,
+            &request.segments,
+            0.1,
+            &request.method,
+        );
+
+        DiarizationRepository::update_transcript_assignment(pool, &transcript.id, &assignment)
+            .await
+            .map_err(|error| error.to_string())?;
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Register command**
+
+In `frontend/src-tauri/src/lib.rs`, add:
+
+```rust
+diarization::commands::apply_diarization_segments,
+```
+
+- [ ] **Step 4: Run targeted tests**
+
+Run:
+
+```bash
+cargo test -p meetily diarization::alignment::tests
+```
+
+Expected: alignment tests still pass.
+
+- [ ] **Step 5: Run compile check**
+
+Run:
+
+```bash
+cargo check -p meetily
+```
+
+Expected: command compiles when environment baseline is fixed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src-tauri/src/database/repositories/diarization.rs frontend/src-tauri/src/diarization/commands.rs frontend/src-tauri/src/lib.rs
+git commit -m "feat: apply diarization segments to transcripts"
+```
+
+## Task 10: Self-review and feature boundary check
+
+**Files:**
+
+- Review: all files changed in this plan.
+
+- [ ] **Step 1: Inspect changed files**
+
+Run:
+
+```bash
+git status --short
+git log --oneline --decorate -10
+```
+
+Expected: only intentional feature files changed, with commits per task.
+
+- [ ] **Step 2: Search for placeholder markers**
+
+Run:
+
+```bash
+rg -n "T[B]D|T[O]DO|FI[X]ME|P[L]ACEHOLDER|te[m]porary|ha[c]k" frontend/src-tauri/src/diarization frontend/src/components/SpeakerDiarizationSettings.tsx frontend/src/types/diarization.ts
+```
+
+Expected: no matches.
+
+- [ ] **Step 3: Run backend verification**
+
+Run when full Xcode is active:
+
+```bash
+cargo test -p meetily diarization::types::tests diarization::alignment::tests
+cargo check -p meetily
+```
+
+Expected: tests pass and crate checks.
+
+- [ ] **Step 4: Run frontend verification**
+
+Run only after frontend dependencies are intentionally installed in a controlled way:
+
+```bash
+cd frontend
+npm run build
+```
+
+Expected: build passes.
+
+- [ ] **Step 5: Document deferred work**
+
+Add a short note to the existing speaker diarization spec under rollout/follow-up if it is not already explicit:
+
+```markdown
+Follow-up implementation plans:
+
+- FluidAudio macOS sidecar and model packaging.
+- Source-aware microphone/system audio stem persistence.
+- Live provisional diarization event stream.
+- Offline post-call refinement orchestration.
+- Speaker review editor actions backed by database updates.
+```
+
+- [ ] **Step 6: Commit documentation note if changed**
+
+```bash
+git add docs/superpowers/specs/2026-06-26-speaker-diarization-design.md
+git commit -m "docs: note diarization follow-up implementation slices"
+```
+
+Skip this commit if the spec already states the follow-up boundary clearly.
+
+## Self-review checklist
+
+Spec coverage:
+
+- Local-first diarization metadata: covered by Tasks 1, 3, 4, 9.
+- No hard participant cap: preserved by segment-based data model; no max speaker count added.
+- Live labels provisional: represented in status types, settings, and UI badges.
+- Post-call final labels: represented in status types and command API; actual offline engine deferred.
+- Overlap as `Multiple speakers`: covered by Tasks 1, 2, 8.
+- Settings/design-system controls: covered by Tasks 6 and 7.
+- Dense-call manual review: data/status foundation included; full review editor deferred.
+
+Intentional gaps for next implementation plan:
+
+- FluidAudio sidecar.
+- Real online/offline diarization execution.
+- Separate audio source persistence.
+- Merge/split/rename commands and review panel.
+- Summary prompt integration with final diarization.
+
+Verification constraints:
+
+- Rust verification requires full Xcode because current macOS baseline fails in `cidre`.
+- Frontend verification requires a deliberate dependency install strategy because no lockfile is committed.

--- a/docs/superpowers/plans/2026-06-26-speaker-diarization-foundation.md
+++ b/docs/superpowers/plans/2026-06-26-speaker-diarization-foundation.md
@@ -144,7 +144,7 @@ mod tests {
 Run:
 
 ```bash
-cargo test -p meetily diarization::types::tests::diarization_status_serializes_as_snake_case
+cargo test -p meetily diarization::types::tests
 ```
 
 Expected before implementation: compile fails because `DiarizationStatus` and `SpeakerAssignment` are not defined.
@@ -251,6 +251,27 @@ mod tests {
         assert_eq!(assignment.diarization_status, DiarizationStatus::Provisional);
         assert_eq!(assignment.diarization_method.as_deref(), Some("fluid_audio_online"));
     }
+
+    #[test]
+    fn overlap_assignment_preserves_confidence() {
+        let assignment = SpeakerAssignment::overlap(0.91, DiarizationStatus::Provisional, "fluid_audio_online");
+
+        assert_eq!(assignment.diarization_confidence, Some(0.91));
+    }
+
+    #[test]
+    fn unknown_assignment_accepts_string_method() {
+        let assignment = SpeakerAssignment::unknown(DiarizationStatus::NeedsReview, Some("unit_test"));
+
+        assert_eq!(assignment.diarization_method, Some("unit_test".to_string()));
+    }
+
+    #[test]
+    fn unknown_assignment_accepts_no_method() {
+        let assignment = SpeakerAssignment::unknown(DiarizationStatus::NeedsReview, None::<String>);
+
+        assert_eq!(assignment.diarization_method, None);
+    }
 }
 ```
 
@@ -273,7 +294,7 @@ pub mod diarization;
 Run:
 
 ```bash
-cargo test -p meetily diarization::types::tests::diarization_status_serializes_as_snake_case
+cargo test -p meetily diarization::types::tests
 ```
 
 Expected after implementation: PASS when the Xcode baseline blocker is resolved.

--- a/docs/superpowers/specs/2026-06-26-speaker-diarization-design.md
+++ b/docs/superpowers/specs/2026-06-26-speaker-diarization-design.md
@@ -1,7 +1,7 @@
 # Speaker Diarization Design
 
-Date: 2026-06-26  
-Status: design draft for review  
+Date: 2026-06-26
+Status: design draft for review
 Scope: macOS Apple Silicon first, local-first speaker diarization for recorded calls
 
 ## Summary

--- a/docs/superpowers/specs/2026-06-26-speaker-diarization-design.md
+++ b/docs/superpowers/specs/2026-06-26-speaker-diarization-design.md
@@ -371,6 +371,14 @@ Rules:
 7. Add summary integration using final speaker labels.
 8. Add quality telemetry that remains local unless analytics consent explicitly allows aggregated event tracking.
 
+## Follow-up implementation plans
+
+- FluidAudio macOS sidecar and model packaging.
+- Source-aware microphone/system audio stem persistence.
+- Live provisional diarization event stream.
+- Offline post-call refinement orchestration.
+- Speaker review editor actions backed by database updates.
+
 ## Open implementation decisions
 
 - Exact minimum accumulated speech duration before surfacing a new stable speaker.

--- a/docs/superpowers/specs/2026-06-26-speaker-diarization-design.md
+++ b/docs/superpowers/specs/2026-06-26-speaker-diarization-design.md
@@ -1,0 +1,388 @@
+# Speaker Diarization Design
+
+Date: 2026-06-26  
+Status: design draft for review  
+Scope: macOS Apple Silicon first, local-first speaker diarization for recorded calls
+
+## Summary
+
+Add speaker diarization to meeting transcripts. The feature separates "who spoke when" without identifying people by real identity or storing voiceprints. Live diarization gives provisional speaker labels during the call. After the meeting, an offline diarization pass reviews the full audio and replaces provisional labels with final labels when quality is acceptable.
+
+The intended user experience is practical for dense work calls: main speakers and longer turns should be stable, interruptions should be marked honestly, and the user should be able to merge or split speakers quickly when clustering makes a mistake.
+
+## Goals
+
+- Add local speaker diarization for meeting transcripts.
+- Support automatic speaker count with no hard participant cap.
+- Treat live labels as provisional and post-call labels as authoritative.
+- Preserve the current transcription and recording behavior while adding diarization metadata.
+- Handle interruptions by marking overlap as "multiple speakers" instead of pretending to know a single speaker.
+- Keep the first implementation scoped to macOS Apple Silicon.
+- Expose feature controls through existing settings patterns and reusable design-system settings primitives.
+
+## Non-goals
+
+- Speaker identification by real name from voice.
+- Voiceprint enrollment or biometric user profiles.
+- Perfect attribution of every short backchannel, interruption, or "угу/да" in dense meetings.
+- Cloud diarization as the default path.
+- A hard maximum number of participants.
+
+## Product requirements
+
+### Speaker behavior
+
+- Local microphone audio is assigned to a stable local speaker label, displayed as "You" or the localized equivalent.
+- Remote/system audio is diarized separately from the local microphone when separate source audio is available.
+- Speaker labels use neutral names by default: `Speaker 1`, `Speaker 2`, etc.
+- Users can rename speakers after a meeting.
+- Users can merge speakers when one real person is split into multiple clusters.
+- Users can split or correct speaker assignments for obvious mistakes.
+- Short, low-confidence clusters should not immediately appear as stable speakers. The UI can hold them as "Unknown speaker" or "Short speaker" until they accumulate enough speech. This is not a speaker-count cap.
+
+### Participant count
+
+- The diarization system must not impose a user-visible maximum such as 2, 4, or 20 speakers.
+- Resource safeguards may exist for memory, runtime, and pathological audio, but they must not be described or implemented as a participant limit.
+- The system should prefer quality flags over silent truncation when a recording is too noisy or too large to diarize well.
+
+### Overlap and interruptions
+
+- Overlapping speech is represented as `multiple speakers` / `overlap`.
+- The first version should not try to assign the same transcript text to multiple speakers.
+- Overlap markings should be visible in the transcript and available to summary generation.
+
+### Live vs post-call
+
+- Live labels are provisional.
+- Post-call offline diarization is the primary source of truth.
+- If the post-call pass succeeds, it atomically replaces provisional labels.
+- If the post-call pass fails, times out, or produces poor coverage, the app keeps provisional labels and marks the meeting as `fallback_to_live`.
+- Speaker colors and numbers should remain stable across the live-to-final transition by mapping final clusters to provisional clusters through temporal overlap.
+
+## Current project context
+
+The current app already has:
+
+- A Tauri/Rust audio pipeline.
+- Local transcription providers such as Parakeet and Whisper.
+- VAD-based transcription segmentation.
+- Meeting transcript storage with timing fields.
+- Settings screens for General, Recordings, Transcription, Summary, and Beta.
+- UI primitives such as `Switch`, `Select`, `Input`, `Tabs`, and form row components.
+
+Current gaps:
+
+- Transcript records do not consistently expose speaker metadata to the frontend.
+- Recording currently centers on mixed audio. Diarization needs access to separate microphone and system audio where possible.
+- There is no diarization coordinator, speaker segment store, status model, or speaker review UI.
+- There is no settings block for enabling, configuring, or explaining speaker diarization.
+
+## Recommended approach
+
+Use a hybrid diarization pipeline:
+
+1. Live pass: lightweight online diarization on system audio for provisional labels.
+2. Post-call pass: offline diarization over the full recording for final labels.
+3. Fallback: preserve provisional labels if the offline pass is unavailable or poor.
+4. Optional later enhancement: heavier second-pass diarization for important meetings when default quality flags are poor.
+
+This gives useful live feedback without making live clustering responsible for final transcript quality.
+
+## Architecture
+
+### Audio capture and storage
+
+Keep the existing mixed audio path for recording and transcription. Add source-aware audio handling for diarization:
+
+- microphone source: saved or buffered separately;
+- system audio source: saved or buffered separately;
+- mixed audio: continues to serve current playback/transcription flows.
+
+The diarization pipeline should prefer separate stems:
+
+- local mic stem -> fixed local speaker;
+- system stem -> diarized remote speakers.
+
+If separate stems are unavailable, diarization can run on mixed audio with a visible quality warning.
+
+### Diarization engine
+
+For macOS Apple Silicon first:
+
+- Use a local Swift sidecar for FluidAudio integration.
+- Live mode uses online diarization/clustering for provisional speaker intervals.
+- Post-call mode uses offline diarization, preferably full-recording VBx-style clustering.
+- The Rust app owns orchestration, persistence, status events, and transcript alignment.
+
+The sidecar interface should exchange timestamped intervals rather than transcript text:
+
+```json
+{
+  "meeting_id": "string",
+  "source": "system",
+  "status": "provisional",
+  "segments": [
+    {
+      "start_ms": 12500,
+      "end_ms": 18100,
+      "speaker_id": "remote-1",
+      "confidence": 0.82,
+      "is_overlap": false
+    }
+  ]
+}
+```
+
+### Transcript alignment
+
+A Rust diarization coordinator aligns diarization intervals to transcript chunks using existing `audio_start_time`, `audio_end_time`, and duration fields.
+
+Rules:
+
+- Assign the speaker with the largest overlap with the transcript chunk.
+- If overlap speech is detected for the chunk, mark `is_overlap = true` and display `Multiple speakers`.
+- If no interval matches confidently, keep `speaker_id = null` and display `Unknown speaker`.
+- Preserve transcript text and timing; diarization updates metadata only.
+
+### Persistence model
+
+Add transcript-level fields:
+
+- `speaker_id`
+- `speaker_label`
+- `speaker_color`
+- `is_overlap`
+- `diarization_status`: `none | provisional | final | fallback_to_live | failed | needs_review`
+- `diarization_method`: e.g. `fluid_audio_online`, `fluid_audio_offline`, `manual`
+- `diarization_confidence`
+
+Add a meeting-level diarization status:
+
+- `enabled`
+- `live_enabled`
+- `post_call_enabled`
+- `current_status`
+- `quality_flags`
+- `processed_at`
+
+Consider a separate `speaker_segments` table for raw diarization intervals. Transcript rows should store the resolved speaker assignment for fast rendering, while raw intervals remain available for re-alignment.
+
+### Frontend transcript UI
+
+The transcript UI should show:
+
+- speaker label;
+- speaker color;
+- provisional/final state where relevant;
+- overlap badge for interruptions;
+- unknown/low-confidence label when needed.
+
+During a live meeting:
+
+- display provisional labels with a subtle `Provisional` badge;
+- avoid implying final accuracy;
+- do not require the user to fix speakers during the call.
+
+After post-call processing:
+
+- replace provisional labels with final labels;
+- show `Final labels applied` when successful;
+- show `Fallback to live labels` or `Needs review` when quality is poor.
+
+### Speaker review UI
+
+Post-call review should support:
+
+- rename speaker;
+- merge two or more speakers;
+- split selected transcript segments into a new speaker;
+- mark selected segment as multiple speakers;
+- clear speaker assignment.
+
+This is required for dense work calls. Automatic diarization will sometimes split one person across clusters or merge similar voices.
+
+## Settings and design-system controls
+
+### Placement
+
+Add the primary controls to `Settings -> Transcription`, because diarization changes transcript output. Show source-audio quality requirements inline or link to `Settings -> Recordings`.
+
+If the feature is initially beta-gated, expose a short beta toggle in `Settings -> Beta`, but keep detailed controls in `Transcription`.
+
+### User-facing settings
+
+Required settings:
+
+- `Enable speaker diarization`
+  - main switch;
+  - default off unless the feature is explicitly beta-enabled.
+- `Mode`
+  - `Live + post-call refinement` as the recommended default;
+  - `Post-call only`;
+  - `Off`.
+- `Show provisional speaker labels during call`
+  - enabled only when live mode is active.
+- `Post-call refinement`
+  - `Run automatically after meeting`;
+  - default on.
+- `Overlap handling`
+  - first version fixed to `Mark as multiple speakers`;
+  - do not expose multiple advanced options yet.
+- `Speaker review`
+  - enable merge/split/rename review tools after processing.
+- `Separate audio sources`
+  - status row or warning showing whether microphone and system audio can be saved separately.
+
+Advanced or later settings:
+
+- optional heavier second-pass enhancement for important meetings;
+- model download/status details;
+- manual re-run diarization;
+- export speaker segments.
+
+### Design-system primitives
+
+Add or standardize these settings primitives:
+
+- `SettingsSection`
+  - card wrapper with title, description, optional badge, and children.
+- `SettingsRow`
+  - label, description, right-aligned control, disabled state, disabled reason.
+- `SettingsStatusBadge`
+  - statuses: `Beta`, `Local`, `Provisional`, `Final`, `Fallback`, `Needs review`, `Unavailable`.
+- `ExpandableAdvancedSettings`
+  - collapsed by default; used for model/provider diagnostics and heavier second-pass options.
+- `ModelAvailabilityRow`
+  - model installed/downloading/unavailable states.
+
+These should be generic components, not diarization-only components.
+
+### Copy rules
+
+- Use "speaker diarization" in technical settings descriptions only when useful.
+- Prefer "speaker labels" in user-facing text.
+- Always label live output as provisional.
+- Do not promise exact attribution in dense overlapping speech.
+
+## Fallback and failure handling
+
+### Offline pass succeeds
+
+- Save final diarization intervals.
+- Map final speakers onto live speaker labels by temporal overlap.
+- Update transcript speaker fields atomically.
+- Mark meeting diarization status as `final`.
+
+### Offline pass fails
+
+- Keep live labels.
+- Mark meeting diarization status as `fallback_to_live`.
+- Show a non-blocking warning in meeting details.
+- Allow manual speaker edits.
+
+### Offline pass quality is poor
+
+Quality can be considered poor when:
+
+- too much speech is unknown;
+- too much speech is overlap;
+- speaker clusters are heavily fragmented;
+- very short clusters dominate the result;
+- source audio was mixed-only or missing.
+
+In this case:
+
+- keep final labels if they are better than live labels;
+- otherwise keep live labels;
+- mark the meeting as `needs_review`;
+- offer manual review and, later, optional enhancement.
+
+### Models unavailable
+
+- Keep diarization off.
+- Show model availability in settings.
+- Do not block transcription or recording.
+
+## Dense work call expectations
+
+This feature is sufficient for a useful beta when:
+
+- main speakers and longer turns are labeled reliably;
+- short backchannels may be unknown or overlap;
+- interruptions are marked instead of over-attributed;
+- manual merge/split fixes are fast;
+- summaries can reference speakers after final processing.
+
+It is not sufficient to claim exact speaker recognition for every utterance in crowded meetings.
+
+## Summary integration
+
+Summary generation should prefer final diarization.
+
+Rules:
+
+- If final diarization is available, include speaker labels in the transcript context passed to summaries.
+- If only provisional labels are available, either wait for post-call processing or mark speaker labels as provisional in the summary input.
+- If diarization failed, generate summaries without speaker attribution rather than using misleading labels.
+
+## Privacy
+
+- Diarization runs locally by default.
+- Do not store biometric voiceprints.
+- Do not infer real names from voices.
+- Speaker renames are user-authored meeting metadata.
+- Any optional future cloud or heavier external processing must require explicit user action.
+
+## Testing plan
+
+### Unit tests
+
+- interval-to-transcript alignment;
+- overlap detection and `Multiple speakers` assignment;
+- live-to-final speaker mapping by temporal overlap;
+- fallback status transitions;
+- settings serialization defaults.
+
+### Integration tests
+
+- diarization disabled does not alter current recording/transcription flows;
+- live provisional events render and persist;
+- offline pass replaces provisional labels atomically;
+- offline failure preserves live labels and sets fallback status;
+- mixed-only audio produces quality warning.
+
+### UI tests
+
+- settings rows render correct enabled/disabled states;
+- live transcript shows provisional badges;
+- final transcript hides provisional badges;
+- overlap segments show `Multiple speakers`;
+- speaker review supports rename and merge flows.
+
+## Rollout plan
+
+1. Add settings/data model behind a beta flag.
+2. Add source-aware audio capture and persistence without changing existing mixed recording behavior.
+3. Add diarization sidecar integration for macOS Apple Silicon.
+4. Add live provisional labels.
+5. Add post-call offline refinement and fallback.
+6. Add transcript UI and post-call speaker review.
+7. Add summary integration using final speaker labels.
+8. Add quality telemetry that remains local unless analytics consent explicitly allows aggregated event tracking.
+
+## Open implementation decisions
+
+- Exact minimum accumulated speech duration before surfacing a new stable speaker.
+- Whether raw diarization intervals belong in SQLite only or also in a sidecar JSON artifact per recording.
+- Exact UI location for speaker review: inline transcript toolbar vs separate review panel.
+- Whether optional pyannote-based enhancement is shipped in v1 or delayed until after FluidAudio beta validation.
+
+## Success criteria
+
+- No visible hard participant cap.
+- Provisional labels appear during live calls when enabled.
+- Final labels replace provisional labels after post-call processing.
+- Overlaps are visible as `Multiple speakers`.
+- Manual merge/split/rename can correct common dense-call diarization mistakes.
+- Disabling diarization leaves existing recording and transcription behavior unchanged.

--- a/frontend/design/speaker-diarization-settings.pen
+++ b/frontend/design/speaker-diarization-settings.pen
@@ -1,0 +1,465 @@
+{
+  "version": "2.11",
+  "name": "Speaker Diarization Settings",
+  "context": "Pencil-level UI plan for speaker diarization settings, live transcript states, and post-call speaker review. Created 2026-06-26.",
+  "children": [
+    {
+      "id": "speaker_diarization_settings_transcription",
+      "type": "frame",
+      "name": "01 Settings - Transcription - Speaker Labels",
+      "context": "Primary settings placement. Controls should be built from reusable settings primitives: SettingsSection, SettingsRow, SettingsStatusBadge, ExpandableAdvancedSettings, ModelAvailabilityRow.",
+      "x": 0,
+      "y": 0,
+      "width": 1440,
+      "height": 1024,
+      "fill": {
+        "type": "solid",
+        "color": "#0f172a"
+      },
+      "children": [
+        {
+          "id": "settings_header",
+          "type": "text",
+          "text": "Settings / Transcription",
+          "x": 96,
+          "y": 72,
+          "width": 520,
+          "height": 40,
+          "style": {
+            "fontSize": 28,
+            "fontWeight": 700,
+            "color": "#f8fafc"
+          }
+        },
+        {
+          "id": "speaker_section_card",
+          "type": "rect",
+          "x": 96,
+          "y": 152,
+          "width": 880,
+          "height": 620,
+          "radius": 16,
+          "fill": {
+            "type": "solid",
+            "color": "#111827"
+          },
+          "stroke": {
+            "color": "#334155",
+            "width": 1
+          }
+        },
+        {
+          "id": "speaker_section_title",
+          "type": "text",
+          "text": "Speaker labels",
+          "x": 128,
+          "y": 184,
+          "width": 320,
+          "height": 32,
+          "style": {
+            "fontSize": 22,
+            "fontWeight": 700,
+            "color": "#f8fafc"
+          }
+        },
+        {
+          "id": "speaker_section_badge",
+          "type": "badge",
+          "text": "Beta",
+          "x": 312,
+          "y": 184,
+          "width": 64,
+          "height": 28,
+          "fill": {
+            "type": "solid",
+            "color": "#1d4ed8"
+          },
+          "style": {
+            "fontSize": 13,
+            "fontWeight": 600,
+            "color": "#dbeafe"
+          }
+        },
+        {
+          "id": "speaker_section_description",
+          "type": "text",
+          "text": "Label who spoke in the transcript. Live labels are provisional; final labels are applied after the meeting.",
+          "x": 128,
+          "y": 224,
+          "width": 760,
+          "height": 44,
+          "style": {
+            "fontSize": 15,
+            "color": "#94a3b8"
+          }
+        },
+        {
+          "id": "row_enable",
+          "type": "settings-row",
+          "title": "Enable speaker diarization",
+          "description": "Add speaker labels to transcripts without identifying people by voice.",
+          "control": "switch:on",
+          "x": 128,
+          "y": 296,
+          "width": 816,
+          "height": 76
+        },
+        {
+          "id": "row_mode",
+          "type": "settings-row",
+          "title": "Mode",
+          "description": "Recommended: show provisional labels during the call, then refine after recording stops.",
+          "control": "select:Live + post-call refinement",
+          "x": 128,
+          "y": 388,
+          "width": 816,
+          "height": 88
+        },
+        {
+          "id": "row_provisional",
+          "type": "settings-row",
+          "title": "Show provisional labels during call",
+          "description": "Display live Speaker 1 / Speaker 2 labels with a provisional badge.",
+          "control": "switch:on",
+          "x": 128,
+          "y": 492,
+          "width": 816,
+          "height": 76
+        },
+        {
+          "id": "row_post_call",
+          "type": "settings-row",
+          "title": "Run post-call refinement automatically",
+          "description": "After the meeting, analyze the full audio and replace provisional labels when quality is good.",
+          "control": "switch:on",
+          "x": 128,
+          "y": 584,
+          "width": 816,
+          "height": 88
+        },
+        {
+          "id": "row_overlap",
+          "type": "settings-row",
+          "title": "Overlap handling",
+          "description": "Interruptions are marked as Multiple speakers.",
+          "control": "locked-value:Multiple speakers",
+          "x": 128,
+          "y": 688,
+          "width": 816,
+          "height": 64
+        },
+        {
+          "id": "source_quality_card",
+          "type": "rect",
+          "x": 1008,
+          "y": 152,
+          "width": 336,
+          "height": 316,
+          "radius": 16,
+          "fill": {
+            "type": "solid",
+            "color": "#082f49"
+          },
+          "stroke": {
+            "color": "#0369a1",
+            "width": 1
+          }
+        },
+        {
+          "id": "source_quality_title",
+          "type": "text",
+          "text": "Audio source quality",
+          "x": 1032,
+          "y": 184,
+          "width": 260,
+          "height": 28,
+          "style": {
+            "fontSize": 18,
+            "fontWeight": 700,
+            "color": "#e0f2fe"
+          }
+        },
+        {
+          "id": "source_quality_body",
+          "type": "text",
+          "text": "Best results require separate microphone and system audio. If only mixed audio is available, show a warning and keep diarization optional.",
+          "x": 1032,
+          "y": 228,
+          "width": 280,
+          "height": 112,
+          "style": {
+            "fontSize": 14,
+            "color": "#bae6fd"
+          }
+        },
+        {
+          "id": "model_status",
+          "type": "model-availability-row",
+          "text": "Diarization model: Installed / Local",
+          "x": 1032,
+          "y": 368,
+          "width": 280,
+          "height": 48,
+          "status": "local"
+        }
+      ]
+    },
+    {
+      "id": "speaker_diarization_live_transcript",
+      "type": "frame",
+      "name": "02 Live Transcript - Provisional Labels",
+      "context": "Live state. Speaker labels are useful but explicitly provisional. Overlap is marked as Multiple speakers.",
+      "x": 1520,
+      "y": 0,
+      "width": 1440,
+      "height": 1024,
+      "fill": {
+        "type": "solid",
+        "color": "#f8fafc"
+      },
+      "children": [
+        {
+          "id": "live_title",
+          "type": "text",
+          "text": "Live transcript",
+          "x": 96,
+          "y": 72,
+          "width": 360,
+          "height": 40,
+          "style": {
+            "fontSize": 28,
+            "fontWeight": 700,
+            "color": "#0f172a"
+          }
+        },
+        {
+          "id": "live_status_badge",
+          "type": "badge",
+          "text": "Speaker labels provisional",
+          "x": 396,
+          "y": 78,
+          "width": 220,
+          "height": 28,
+          "fill": {
+            "type": "solid",
+            "color": "#fef3c7"
+          },
+          "style": {
+            "fontSize": 13,
+            "fontWeight": 600,
+            "color": "#92400e"
+          }
+        },
+        {
+          "id": "transcript_panel",
+          "type": "rect",
+          "x": 96,
+          "y": 152,
+          "width": 912,
+          "height": 680,
+          "radius": 16,
+          "fill": {
+            "type": "solid",
+            "color": "#ffffff"
+          },
+          "stroke": {
+            "color": "#e2e8f0",
+            "width": 1
+          }
+        },
+        {
+          "id": "line_you",
+          "type": "transcript-line",
+          "speaker": "You",
+          "speakerColor": "#2563eb",
+          "timestamp": "00:12",
+          "text": "Let's walk through the action items first.",
+          "x": 128,
+          "y": 192,
+          "width": 820,
+          "height": 72
+        },
+        {
+          "id": "line_speaker_1",
+          "type": "transcript-line",
+          "speaker": "Speaker 1",
+          "speakerColor": "#16a34a",
+          "timestamp": "00:20",
+          "badge": "Provisional",
+          "text": "I can take the analytics follow-up.",
+          "x": 128,
+          "y": 288,
+          "width": 820,
+          "height": 72
+        },
+        {
+          "id": "line_overlap",
+          "type": "transcript-line",
+          "speaker": "Multiple speakers",
+          "speakerColor": "#f97316",
+          "timestamp": "00:25",
+          "badge": "Overlap",
+          "text": "— yeah, one second — / — can I add something?",
+          "x": 128,
+          "y": 384,
+          "width": 820,
+          "height": 88
+        },
+        {
+          "id": "line_unknown",
+          "type": "transcript-line",
+          "speaker": "Unknown speaker",
+          "speakerColor": "#64748b",
+          "timestamp": "00:34",
+          "badge": "Low confidence",
+          "text": "Short backchannels should not create permanent new speakers.",
+          "x": 128,
+          "y": 496,
+          "width": 820,
+          "height": 88
+        },
+        {
+          "id": "live_side_note",
+          "type": "callout",
+          "title": "Live rule",
+          "text": "Do not feed provisional speaker labels into final summary as if they were authoritative. Prefer post-call final labels.",
+          "x": 1040,
+          "y": 152,
+          "width": 304,
+          "height": 188,
+          "tone": "warning"
+        }
+      ]
+    },
+    {
+      "id": "speaker_diarization_post_call_review",
+      "type": "frame",
+      "name": "03 Meeting Details - Post-call Speaker Review",
+      "context": "Post-call state. Offline labels replace live labels when successful. Review tools handle dense-call mistakes such as split speakers and overlap.",
+      "x": 3040,
+      "y": 0,
+      "width": 1440,
+      "height": 1024,
+      "fill": {
+        "type": "solid",
+        "color": "#f8fafc"
+      },
+      "children": [
+        {
+          "id": "review_title",
+          "type": "text",
+          "text": "Meeting transcript",
+          "x": 96,
+          "y": 72,
+          "width": 420,
+          "height": 40,
+          "style": {
+            "fontSize": 28,
+            "fontWeight": 700,
+            "color": "#0f172a"
+          }
+        },
+        {
+          "id": "final_status_badge",
+          "type": "badge",
+          "text": "Final speaker labels applied",
+          "x": 420,
+          "y": 78,
+          "width": 224,
+          "height": 28,
+          "fill": {
+            "type": "solid",
+            "color": "#dcfce7"
+          },
+          "style": {
+            "fontSize": 13,
+            "fontWeight": 600,
+            "color": "#166534"
+          }
+        },
+        {
+          "id": "review_toolbar",
+          "type": "toolbar",
+          "x": 96,
+          "y": 144,
+          "width": 912,
+          "height": 64,
+          "actions": [
+            "Rename speaker",
+            "Merge speakers",
+            "Split selection",
+            "Mark overlap",
+            "Re-run diarization"
+          ]
+        },
+        {
+          "id": "speaker_list_card",
+          "type": "rect",
+          "x": 1040,
+          "y": 144,
+          "width": 304,
+          "height": 420,
+          "radius": 16,
+          "fill": {
+            "type": "solid",
+            "color": "#ffffff"
+          },
+          "stroke": {
+            "color": "#e2e8f0",
+            "width": 1
+          }
+        },
+        {
+          "id": "speaker_list",
+          "type": "speaker-list",
+          "x": 1064,
+          "y": 176,
+          "width": 256,
+          "height": 328,
+          "speakers": [
+            {
+              "label": "You",
+              "color": "#2563eb",
+              "duration": "18m"
+            },
+            {
+              "label": "Speaker 1",
+              "color": "#16a34a",
+              "duration": "24m"
+            },
+            {
+              "label": "Speaker 2",
+              "color": "#9333ea",
+              "duration": "11m"
+            },
+            {
+              "label": "Unknown / short",
+              "color": "#64748b",
+              "duration": "1m"
+            }
+          ]
+        },
+        {
+          "id": "quality_flags",
+          "type": "callout",
+          "title": "Quality flags",
+          "text": "Show Needs review when clusters are fragmented, too much speech is unknown, or only mixed audio was available.",
+          "x": 1040,
+          "y": 596,
+          "width": 304,
+          "height": 160,
+          "tone": "info"
+        },
+        {
+          "id": "review_notes",
+          "type": "annotation",
+          "text": "Dense-call acceptance: main speakers stable, overlaps honest, manual corrections fast. Do not promise exact attribution for every short interruption.",
+          "x": 96,
+          "y": 864,
+          "width": 900,
+          "height": 72
+        }
+      ]
+    }
+  ]
+}

--- a/frontend/src-tauri/migrations/20260626000100_add_diarization_foundation.sql
+++ b/frontend/src-tauri/migrations/20260626000100_add_diarization_foundation.sql
@@ -1,0 +1,59 @@
+-- Speaker diarization foundation.
+-- Existing transcripts.speaker is legacy source metadata (mic/system) and remains untouched.
+
+ALTER TABLE transcripts ADD COLUMN speaker_id TEXT;
+ALTER TABLE transcripts ADD COLUMN speaker_label TEXT;
+ALTER TABLE transcripts ADD COLUMN speaker_color TEXT;
+ALTER TABLE transcripts ADD COLUMN is_overlap INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE transcripts ADD COLUMN diarization_status TEXT NOT NULL DEFAULT 'none';
+ALTER TABLE transcripts ADD COLUMN diarization_method TEXT;
+ALTER TABLE transcripts ADD COLUMN diarization_confidence REAL;
+
+CREATE TABLE IF NOT EXISTS diarization_settings (
+    id TEXT PRIMARY KEY NOT NULL DEFAULT '1',
+    enabled INTEGER NOT NULL DEFAULT 0,
+    mode TEXT NOT NULL DEFAULT 'live_plus_post_call',
+    show_provisional_labels INTEGER NOT NULL DEFAULT 1,
+    post_call_refinement_enabled INTEGER NOT NULL DEFAULT 1,
+    overlap_handling TEXT NOT NULL DEFAULT 'multiple_speakers',
+    speaker_review_enabled INTEGER NOT NULL DEFAULT 1,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO diarization_settings (id)
+VALUES ('1')
+ON CONFLICT(id) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS meeting_diarization_status (
+    meeting_id TEXT PRIMARY KEY NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 0,
+    live_enabled INTEGER NOT NULL DEFAULT 0,
+    post_call_enabled INTEGER NOT NULL DEFAULT 0,
+    current_status TEXT NOT NULL DEFAULT 'none',
+    quality_flags TEXT,
+    processed_at DATETIME,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS speaker_segments (
+    id TEXT PRIMARY KEY NOT NULL,
+    meeting_id TEXT NOT NULL,
+    source TEXT NOT NULL,
+    start_time REAL NOT NULL,
+    end_time REAL NOT NULL,
+    speaker_id TEXT,
+    speaker_label TEXT,
+    confidence REAL,
+    is_overlap INTEGER NOT NULL DEFAULT 0,
+    diarization_status TEXT NOT NULL,
+    diarization_method TEXT,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_speaker_segments_meeting_time
+ON speaker_segments(meeting_id, start_time, end_time);
+
+CREATE INDEX IF NOT EXISTS idx_transcripts_meeting_diarization
+ON transcripts(meeting_id, diarization_status);

--- a/frontend/src-tauri/src/api/api.rs
+++ b/frontend/src-tauri/src/api/api.rs
@@ -137,6 +137,13 @@ pub struct MeetingTranscript {
     pub audio_end_time: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<f64>,
+    pub speaker_id: Option<String>,
+    pub speaker_label: Option<String>,
+    pub speaker_color: Option<String>,
+    pub is_overlap: Option<bool>,
+    pub diarization_status: Option<String>,
+    pub diarization_method: Option<String>,
+    pub diarization_confidence: Option<f64>,
 }
 
 /// Meeting metadata without transcripts (for pagination)
@@ -188,6 +195,13 @@ pub struct TranscriptSegment {
     pub audio_end_time: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<f64>,
+    pub speaker_id: Option<String>,
+    pub speaker_label: Option<String>,
+    pub speaker_color: Option<String>,
+    pub is_overlap: Option<bool>,
+    pub diarization_status: Option<String>,
+    pub diarization_method: Option<String>,
+    pub diarization_confidence: Option<f64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -815,7 +829,10 @@ pub async fn api_get_meeting_metadata<R: Runtime>(
     meeting_id: String,
     state: tauri::State<'_, AppState>,
 ) -> Result<MeetingMetadata, String> {
-    log_info!("api_get_meeting_metadata called for meeting_id: {}", meeting_id);
+    log_info!(
+        "api_get_meeting_metadata called for meeting_id: {}",
+        meeting_id
+    );
 
     let pool = state.db_manager.pool();
 
@@ -859,7 +876,9 @@ pub async fn api_get_meeting_transcripts<R: Runtime>(
 
     let pool = state.db_manager.pool();
 
-    match MeetingsRepository::get_meeting_transcripts_paginated(pool, &meeting_id, limit, offset).await {
+    match MeetingsRepository::get_meeting_transcripts_paginated(pool, &meeting_id, limit, offset)
+        .await
+    {
         Ok((transcripts, total_count)) => {
             log_info!(
                 "Successfully retrieved {} transcripts for meeting {} (total: {})",
@@ -878,6 +897,13 @@ pub async fn api_get_meeting_transcripts<R: Runtime>(
                     audio_start_time: t.audio_start_time,
                     audio_end_time: t.audio_end_time,
                     duration: t.duration,
+                    speaker_id: t.speaker_id,
+                    speaker_label: t.speaker_label,
+                    speaker_color: t.speaker_color,
+                    is_overlap: t.is_overlap.map(|value| value != 0),
+                    diarization_status: t.diarization_status,
+                    diarization_method: t.diarization_method,
+                    diarization_confidence: t.diarization_confidence,
                 })
                 .collect::<Vec<_>>();
 
@@ -890,7 +916,11 @@ pub async fn api_get_meeting_transcripts<R: Runtime>(
             })
         }
         Err(e) => {
-            log_error!("Error retrieving transcripts for meeting {}: {}", meeting_id, e);
+            log_error!(
+                "Error retrieving transcripts for meeting {}: {}",
+                meeting_id,
+                e
+            );
             Err(format!("Failed to retrieve transcripts: {}", e))
         }
     }
@@ -958,7 +988,10 @@ pub async fn api_save_transcript<R: Runtime>(
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| {
             log_error!("Failed to parse transcript segments: {}", e);
-            format!("Invalid transcript data format: {}. Please check the data structure.", e)
+            format!(
+                "Invalid transcript data format: {}. Please check the data structure.",
+                e
+            )
         })?;
 
     // Log parsed segments count and first segment details
@@ -1228,7 +1261,10 @@ pub async fn api_save_custom_openai_config<R: Runtime>(
 
     match SettingsRepository::save_custom_openai_config(pool, &config).await {
         Ok(()) => {
-            log_info!("✅ Successfully saved custom OpenAI config for endpoint: {}", config.endpoint);
+            log_info!(
+                "✅ Successfully saved custom OpenAI config for endpoint: {}",
+                config.endpoint
+            );
             Ok(serde_json::json!({
                 "status": "success",
                 "message": "Custom OpenAI configuration saved successfully"
@@ -1254,8 +1290,11 @@ pub async fn api_get_custom_openai_config<R: Runtime>(
     match SettingsRepository::get_custom_openai_config(pool).await {
         Ok(config) => {
             if let Some(ref c) = config {
-                log_info!("✅ Found custom OpenAI config: endpoint='{}', model='{}'",
-                    c.endpoint, c.model);
+                log_info!(
+                    "✅ Found custom OpenAI config: endpoint='{}', model='{}'",
+                    c.endpoint,
+                    c.model
+                );
             } else {
                 log_info!("No custom OpenAI config found");
             }
@@ -1338,7 +1377,7 @@ pub async fn api_test_custom_openai_connection<R: Runtime>(
                                             .get("message")
                                             .and_then(|m| {
                                                 m.get("content")
-                                                .or_else(|| m.get("reasoning_content"))
+                                                    .or_else(|| m.get("reasoning_content"))
                                             })
                                             .is_some();
 
@@ -1356,17 +1395,33 @@ pub async fn api_test_custom_openai_connection<R: Runtime>(
                         }
 
                         // Response was 200 but doesn't match OpenAI format
-                        log_warn!("⚠️ Endpoint returned 200 but response doesn't match OpenAI format: {}", response_text);
+                        log_warn!(
+                            "⚠️ Endpoint returned 200 but response doesn't match OpenAI format: {}",
+                            response_text
+                        );
                         Err("Endpoint is reachable but doesn't appear to be OpenAI-compatible. Response is missing 'choices' array or 'message.content' / 'message.reasoning_content' field.".to_string())
                     }
                     Err(e) => {
-                        log_warn!("⚠️ Endpoint returned 200 but response is not valid JSON: {}", e);
-                        Err(format!("Endpoint is reachable but returned invalid JSON: {}. Response: {}", e, response_text))
+                        log_warn!(
+                            "⚠️ Endpoint returned 200 but response is not valid JSON: {}",
+                            e
+                        );
+                        Err(format!(
+                            "Endpoint is reachable but returned invalid JSON: {}. Response: {}",
+                            e, response_text
+                        ))
                     }
                 }
             } else {
-                log_warn!("⚠️ Custom OpenAI connection test failed with status {}: {}", status, response_text);
-                Err(format!("Connection failed with status {}: {}", status, response_text))
+                log_warn!(
+                    "⚠️ Custom OpenAI connection test failed with status {}: {}",
+                    status,
+                    response_text
+                );
+                Err(format!(
+                    "Connection failed with status {}: {}",
+                    status, response_text
+                ))
             }
         }
         Err(e) => {

--- a/frontend/src-tauri/src/audio/common.rs
+++ b/frontend/src-tauri/src/audio/common.rs
@@ -48,7 +48,9 @@ pub(crate) async fn unload_engine_after_batch(use_parakeet: bool) {
 
 /// Create transcript segments from transcription results.
 /// Each tuple is (text, start_ms, end_ms) from VAD timestamps.
-pub(crate) fn create_transcript_segments(transcripts: &[(String, f64, f64)]) -> Vec<TranscriptSegment> {
+pub(crate) fn create_transcript_segments(
+    transcripts: &[(String, f64, f64)],
+) -> Vec<TranscriptSegment> {
     transcripts
         .iter()
         .map(|(text, start_ms, end_ms)| {
@@ -63,6 +65,13 @@ pub(crate) fn create_transcript_segments(transcripts: &[(String, f64, f64)]) -> 
                 audio_start_time: Some(start_seconds),
                 audio_end_time: Some(end_seconds),
                 duration: Some(duration),
+                speaker_id: None,
+                speaker_label: None,
+                speaker_color: None,
+                is_overlap: Some(false),
+                diarization_status: Some("none".to_string()),
+                diarization_method: None,
+                diarization_confidence: None,
             }
         })
         .collect()
@@ -126,8 +135,8 @@ pub(crate) fn split_segment_at_silence(
         return vec![segment.clone()];
     }
 
-    let ms_per_sample = (segment.end_timestamp_ms - segment.start_timestamp_ms)
-        / segment.samples.len() as f64;
+    let ms_per_sample =
+        (segment.end_timestamp_ms - segment.start_timestamp_ms) / segment.samples.len() as f64;
     let mut result = Vec::new();
     let mut pos = 0usize;
 

--- a/frontend/src-tauri/src/audio/device_detection.rs
+++ b/frontend/src-tauri/src/audio/device_detection.rs
@@ -483,7 +483,11 @@ mod tests {
             3840,
             48000,
         );
-        assert_eq!(timeout, Duration::from_millis(160));
+        assert!(
+            timeout.abs_diff(Duration::from_millis(160)) <= Duration::from_micros(10),
+            "expected timeout close to 160ms, got {:?}",
+            timeout
+        );
     }
 
     #[test]

--- a/frontend/src-tauri/src/audio/devices/fallback.rs
+++ b/frontend/src-tauri/src/audio/devices/fallback.rs
@@ -51,7 +51,7 @@ use crate::audio::device_detection::InputDeviceKind;
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,ignore
 /// // When AirPods are default mic, built-in speaker is default output:
 /// let (mic, system) = get_safe_recording_devices_macos()?;
 ///

--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -1181,6 +1181,13 @@ mod tests {
                 audio_start_time: Some(0.0),
                 audio_end_time: Some(1.5),
                 duration: Some(1.5),
+                speaker_id: None,
+                speaker_label: None,
+                speaker_color: None,
+                is_overlap: Some(false),
+                diarization_status: Some("none".to_string()),
+                diarization_method: None,
+                diarization_confidence: None,
             },
             TranscriptSegment {
                 id: "t-2".to_string(),
@@ -1189,6 +1196,13 @@ mod tests {
                 audio_start_time: Some(2.0),
                 audio_end_time: Some(3.5),
                 duration: Some(1.5),
+                speaker_id: None,
+                speaker_label: None,
+                speaker_color: None,
+                is_overlap: Some(false),
+                diarization_status: Some("none".to_string()),
+                diarization_method: None,
+                diarization_confidence: None,
             },
         ];
 

--- a/frontend/src-tauri/src/database/models.rs
+++ b/frontend/src-tauri/src/database/models.rs
@@ -35,6 +35,13 @@ pub struct Transcript {
     pub audio_start_time: Option<f64>,
     pub audio_end_time: Option<f64>,
     pub duration: Option<f64>,
+    pub speaker_id: Option<String>,
+    pub speaker_label: Option<String>,
+    pub speaker_color: Option<String>,
+    pub is_overlap: Option<i64>,
+    pub diarization_status: Option<String>,
+    pub diarization_method: Option<String>,
+    pub diarization_confidence: Option<f64>,
 }
 
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
@@ -49,7 +56,7 @@ pub struct SummaryProcess {
     pub end_time: Option<chrono::DateTime<chrono::Utc>>,
     pub chunk_count: i64,
     pub processing_time: f64,
-    pub metadata: Option<String>, // JSON
+    pub metadata: Option<String>,      // JSON
     pub result_backup: Option<String>, // Backup of result before regeneration
     pub result_backup_timestamp: Option<chrono::DateTime<chrono::Utc>>, // When backup was created
 }
@@ -101,9 +108,9 @@ pub struct Setting {
 impl Setting {
     /// Parse the custom OpenAI config from JSON string
     pub fn get_custom_openai_config(&self) -> Option<crate::summary::CustomOpenAIConfig> {
-        self.custom_openai_config.as_ref().and_then(|json| {
-            serde_json::from_str(json).ok()
-        })
+        self.custom_openai_config
+            .as_ref()
+            .and_then(|json| serde_json::from_str(json).ok())
     }
 }
 
@@ -127,4 +134,44 @@ pub struct TranscriptSetting {
     #[sqlx(rename = "openaiApiKey")]
     #[serde(rename = "openaiApiKey")]
     pub openai_api_key: Option<String>,
+}
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct DiarizationSetting {
+    pub id: String,
+    pub enabled: i64,
+    pub mode: String,
+    pub show_provisional_labels: i64,
+    pub post_call_refinement_enabled: i64,
+    pub overlap_handling: String,
+    pub speaker_review_enabled: i64,
+    pub updated_at: DateTimeUtc,
+}
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct MeetingDiarizationStatus {
+    pub meeting_id: String,
+    pub enabled: i64,
+    pub live_enabled: i64,
+    pub post_call_enabled: i64,
+    pub current_status: String,
+    pub quality_flags: Option<String>,
+    pub processed_at: Option<DateTimeUtc>,
+    pub updated_at: DateTimeUtc,
+}
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct SpeakerSegmentModel {
+    pub id: String,
+    pub meeting_id: String,
+    pub source: String,
+    pub start_time: f64,
+    pub end_time: f64,
+    pub speaker_id: Option<String>,
+    pub speaker_label: Option<String>,
+    pub confidence: Option<f64>,
+    pub is_overlap: i64,
+    pub diarization_status: String,
+    pub diarization_method: Option<String>,
+    pub created_at: DateTimeUtc,
 }

--- a/frontend/src-tauri/src/database/repositories/diarization.rs
+++ b/frontend/src-tauri/src/database/repositories/diarization.rs
@@ -1,7 +1,17 @@
 use crate::database::models::DiarizationSetting;
+use serde::Serialize;
 use sqlx::{Sqlite, SqlitePool};
 
 pub struct DiarizationRepository;
+
+#[derive(Debug, Clone, sqlx::FromRow, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MeetingSpeaker {
+    pub speaker_id: String,
+    pub speaker_label: String,
+    pub speaker_color: Option<String>,
+    pub segment_count: i64,
+}
 
 impl DiarizationRepository {
     pub async fn get_settings(pool: &SqlitePool) -> Result<DiarizationSetting, sqlx::Error> {
@@ -96,6 +106,72 @@ impl DiarizationRepository {
 
         Ok(())
     }
+
+    pub async fn get_meeting_speakers(
+        pool: &SqlitePool,
+        meeting_id: &str,
+    ) -> Result<Vec<MeetingSpeaker>, sqlx::Error> {
+        sqlx::query_as::<_, MeetingSpeaker>(
+            "SELECT
+                speaker_id AS speaker_id,
+                COALESCE(NULLIF(TRIM(MAX(speaker_label)), ''), speaker_id) AS speaker_label,
+                MAX(speaker_color) AS speaker_color,
+                COUNT(*) AS segment_count
+             FROM transcripts
+             WHERE meeting_id = ?
+                AND speaker_id IS NOT NULL
+                AND TRIM(speaker_id) <> ''
+             GROUP BY speaker_id
+             ORDER BY MIN(COALESCE(audio_start_time, 0)), speaker_id",
+        )
+        .bind(meeting_id)
+        .fetch_all(pool)
+        .await
+    }
+
+    pub async fn rename_speaker(
+        pool: &SqlitePool,
+        meeting_id: &str,
+        speaker_id: &str,
+        speaker_label: &str,
+    ) -> Result<u64, sqlx::Error> {
+        let mut transaction = pool.begin().await?;
+
+        let transcript_result = sqlx::query(
+            "UPDATE transcripts
+             SET speaker_label = ?
+             WHERE meeting_id = ? AND speaker_id = ?",
+        )
+        .bind(speaker_label)
+        .bind(meeting_id)
+        .bind(speaker_id)
+        .execute(&mut *transaction)
+        .await?;
+
+        let segment_result = sqlx::query(
+            "UPDATE speaker_segments
+             SET speaker_label = ?
+             WHERE meeting_id = ? AND speaker_id = ?",
+        )
+        .bind(speaker_label)
+        .bind(meeting_id)
+        .bind(speaker_id)
+        .execute(&mut *transaction)
+        .await?;
+
+        sqlx::query(
+            "UPDATE meeting_diarization_status
+             SET updated_at = CURRENT_TIMESTAMP
+             WHERE meeting_id = ?",
+        )
+        .bind(meeting_id)
+        .execute(&mut *transaction)
+        .await?;
+
+        transaction.commit().await?;
+
+        Ok(transcript_result.rows_affected() + segment_result.rows_affected())
+    }
 }
 
 pub(crate) fn diarization_status_to_database_value(
@@ -140,6 +216,146 @@ mod tests {
             .execute(&pool)
             .await
             .expect("transcript row should be inserted");
+
+        pool
+    }
+
+    async fn speaker_test_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("test pool should connect");
+
+        sqlx::query(
+            "CREATE TABLE transcripts (
+                id TEXT PRIMARY KEY,
+                meeting_id TEXT NOT NULL,
+                speaker_id TEXT,
+                speaker_label TEXT,
+                speaker_color TEXT,
+                audio_start_time REAL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("transcripts table should be created");
+
+        sqlx::query(
+            "CREATE TABLE speaker_segments (
+                id TEXT PRIMARY KEY,
+                meeting_id TEXT NOT NULL,
+                source TEXT NOT NULL,
+                start_time REAL NOT NULL,
+                end_time REAL NOT NULL,
+                speaker_id TEXT,
+                speaker_label TEXT,
+                confidence REAL,
+                is_overlap INTEGER NOT NULL DEFAULT 0,
+                diarization_status TEXT NOT NULL,
+                diarization_method TEXT,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("speaker_segments table should be created");
+
+        sqlx::query(
+            "CREATE TABLE meeting_diarization_status (
+                meeting_id TEXT PRIMARY KEY NOT NULL,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("meeting_diarization_status table should be created");
+
+        sqlx::query(
+            "INSERT INTO meeting_diarization_status (meeting_id) VALUES ('meeting-1')",
+        )
+        .execute(&pool)
+        .await
+        .expect("meeting diarization status should be inserted");
+
+        for (id, meeting_id, speaker_id, speaker_label, speaker_color, audio_start_time) in [
+            (
+                "t-1",
+                "meeting-1",
+                Some("speaker-1"),
+                Some("Speaker 1"),
+                Some("#2563eb"),
+                0.0,
+            ),
+            (
+                "t-2",
+                "meeting-1",
+                Some("speaker-1"),
+                Some("Speaker 1"),
+                Some("#2563eb"),
+                1.0,
+            ),
+            (
+                "t-3",
+                "meeting-1",
+                Some("speaker-2"),
+                Some("Speaker 2"),
+                Some("#16a34a"),
+                2.0,
+            ),
+            (
+                "t-4",
+                "meeting-2",
+                Some("speaker-1"),
+                Some("Other meeting speaker"),
+                Some("#dc2626"),
+                3.0,
+            ),
+            ("t-5", "meeting-1", None, None, None, 4.0),
+        ] {
+            sqlx::query(
+                "INSERT INTO transcripts (
+                    id, meeting_id, speaker_id, speaker_label, speaker_color, audio_start_time
+                 )
+                 VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            .bind(id)
+            .bind(meeting_id)
+            .bind(speaker_id)
+            .bind(speaker_label)
+            .bind(speaker_color)
+            .bind(audio_start_time)
+            .execute(&pool)
+            .await
+            .expect("transcript row should be inserted");
+        }
+
+        for (id, meeting_id, speaker_id, speaker_label) in [
+            ("s-1", "meeting-1", Some("speaker-1"), Some("Speaker 1")),
+            ("s-2", "meeting-1", Some("speaker-1"), Some("Speaker 1")),
+            ("s-3", "meeting-1", Some("speaker-2"), Some("Speaker 2")),
+            (
+                "s-4",
+                "meeting-2",
+                Some("speaker-1"),
+                Some("Other meeting speaker"),
+            ),
+        ] {
+            sqlx::query(
+                "INSERT INTO speaker_segments (
+                    id, meeting_id, source, start_time, end_time,
+                    speaker_id, speaker_label, diarization_status
+                 )
+                 VALUES (?, ?, 'unit_test', 0, 1, ?, ?, 'final')",
+            )
+            .bind(id)
+            .bind(meeting_id)
+            .bind(speaker_id)
+            .bind(speaker_label)
+            .execute(&pool)
+            .await
+            .expect("speaker segment row should be inserted");
+        }
 
         pool
     }
@@ -191,5 +407,67 @@ mod tests {
         assert_eq!(row.4, "final");
         assert_eq!(row.5.as_deref(), Some("pyannote-rs"));
         assert_eq!(row.6, Some(0.82));
+    }
+
+    #[tokio::test]
+    async fn get_meeting_speakers_returns_distinct_speakers_for_full_meeting() {
+        let pool = speaker_test_pool().await;
+
+        let speakers = DiarizationRepository::get_meeting_speakers(&pool, "meeting-1")
+            .await
+            .expect("speakers should be loaded");
+
+        assert_eq!(speakers.len(), 2);
+        assert_eq!(speakers[0].speaker_id, "speaker-1");
+        assert_eq!(speakers[0].speaker_label, "Speaker 1");
+        assert_eq!(speakers[0].speaker_color.as_deref(), Some("#2563eb"));
+        assert_eq!(speakers[0].segment_count, 2);
+        assert_eq!(speakers[1].speaker_id, "speaker-2");
+        assert_eq!(speakers[1].speaker_label, "Speaker 2");
+        assert_eq!(speakers[1].segment_count, 1);
+    }
+
+    #[tokio::test]
+    async fn rename_speaker_updates_transcripts_and_segments_for_one_meeting() {
+        let pool = speaker_test_pool().await;
+
+        let updated_count =
+            DiarizationRepository::rename_speaker(&pool, "meeting-1", "speaker-1", "Alice")
+                .await
+                .expect("speaker should be renamed");
+
+        assert_eq!(updated_count, 4);
+
+        let meeting_one_labels: Vec<String> = sqlx::query_scalar(
+            "SELECT speaker_label FROM transcripts
+             WHERE meeting_id = 'meeting-1' AND speaker_id = 'speaker-1'
+             ORDER BY id",
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("meeting one transcript labels should be fetched");
+
+        assert_eq!(meeting_one_labels, vec!["Alice", "Alice"]);
+
+        let meeting_two_label: String = sqlx::query_scalar(
+            "SELECT speaker_label FROM transcripts
+             WHERE meeting_id = 'meeting-2' AND speaker_id = 'speaker-1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("meeting two transcript label should be fetched");
+
+        assert_eq!(meeting_two_label, "Other meeting speaker");
+
+        let segment_labels: Vec<String> = sqlx::query_scalar(
+            "SELECT speaker_label FROM speaker_segments
+             WHERE meeting_id = 'meeting-1' AND speaker_id = 'speaker-1'
+             ORDER BY id",
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("speaker segment labels should be fetched");
+
+        assert_eq!(segment_labels, vec!["Alice", "Alice"]);
     }
 }

--- a/frontend/src-tauri/src/database/repositories/diarization.rs
+++ b/frontend/src-tauri/src/database/repositories/diarization.rs
@@ -1,0 +1,63 @@
+use crate::database::models::DiarizationSetting;
+use sqlx::SqlitePool;
+
+pub struct DiarizationRepository;
+
+impl DiarizationRepository {
+    pub async fn get_settings(pool: &SqlitePool) -> Result<DiarizationSetting, sqlx::Error> {
+        let existing = sqlx::query_as::<_, DiarizationSetting>(
+            "SELECT * FROM diarization_settings WHERE id = '1'",
+        )
+        .fetch_optional(pool)
+        .await?;
+
+        if let Some(settings) = existing {
+            return Ok(settings);
+        }
+
+        sqlx::query("INSERT INTO diarization_settings (id) VALUES ('1')")
+            .execute(pool)
+            .await?;
+
+        sqlx::query_as::<_, DiarizationSetting>("SELECT * FROM diarization_settings WHERE id = '1'")
+            .fetch_one(pool)
+            .await
+    }
+
+    pub async fn save_settings(
+        pool: &SqlitePool,
+        enabled: bool,
+        mode: &str,
+        show_provisional_labels: bool,
+        post_call_refinement_enabled: bool,
+        overlap_handling: &str,
+        speaker_review_enabled: bool,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "INSERT INTO diarization_settings (
+                id, enabled, mode, show_provisional_labels,
+                post_call_refinement_enabled, overlap_handling,
+                speaker_review_enabled, updated_at
+             )
+             VALUES ('1', ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+             ON CONFLICT(id) DO UPDATE SET
+                enabled = excluded.enabled,
+                mode = excluded.mode,
+                show_provisional_labels = excluded.show_provisional_labels,
+                post_call_refinement_enabled = excluded.post_call_refinement_enabled,
+                overlap_handling = excluded.overlap_handling,
+                speaker_review_enabled = excluded.speaker_review_enabled,
+                updated_at = CURRENT_TIMESTAMP",
+        )
+        .bind(enabled as i64)
+        .bind(mode)
+        .bind(show_provisional_labels as i64)
+        .bind(post_call_refinement_enabled as i64)
+        .bind(overlap_handling)
+        .bind(speaker_review_enabled as i64)
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
+}

--- a/frontend/src-tauri/src/database/repositories/diarization.rs
+++ b/frontend/src-tauri/src/database/repositories/diarization.rs
@@ -1,5 +1,5 @@
 use crate::database::models::DiarizationSetting;
-use sqlx::SqlitePool;
+use sqlx::{Sqlite, SqlitePool};
 
 pub struct DiarizationRepository;
 
@@ -61,11 +61,14 @@ impl DiarizationRepository {
         Ok(())
     }
 
-    pub async fn update_transcript_assignment(
-        pool: &SqlitePool,
+    pub async fn update_transcript_assignment<'e, E>(
+        executor: E,
         transcript_id: &str,
         assignment: &crate::diarization::types::SpeakerAssignment,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<(), sqlx::Error>
+    where
+        E: sqlx::Executor<'e, Database = Sqlite>,
+    {
         let diarization_status =
             diarization_status_to_database_value(assignment.diarization_status);
 
@@ -88,14 +91,14 @@ impl DiarizationRepository {
         .bind(&assignment.diarization_method)
         .bind(assignment.diarization_confidence)
         .bind(transcript_id)
-        .execute(pool)
+        .execute(executor)
         .await?;
 
         Ok(())
     }
 }
 
-fn diarization_status_to_database_value(
+pub(crate) fn diarization_status_to_database_value(
     status: crate::diarization::types::DiarizationStatus,
 ) -> String {
     serde_json::to_value(status)

--- a/frontend/src-tauri/src/database/repositories/diarization.rs
+++ b/frontend/src-tauri/src/database/repositories/diarization.rs
@@ -60,4 +60,133 @@ impl DiarizationRepository {
 
         Ok(())
     }
+
+    pub async fn update_transcript_assignment(
+        pool: &SqlitePool,
+        transcript_id: &str,
+        assignment: &crate::diarization::types::SpeakerAssignment,
+    ) -> Result<(), sqlx::Error> {
+        let diarization_status =
+            diarization_status_to_database_value(assignment.diarization_status);
+
+        sqlx::query(
+            "UPDATE transcripts SET
+                speaker_id = ?,
+                speaker_label = ?,
+                speaker_color = ?,
+                is_overlap = ?,
+                diarization_status = ?,
+                diarization_method = ?,
+                diarization_confidence = ?
+             WHERE id = ?",
+        )
+        .bind(&assignment.speaker_id)
+        .bind(&assignment.speaker_label)
+        .bind(&assignment.speaker_color)
+        .bind(assignment.is_overlap as i64)
+        .bind(diarization_status)
+        .bind(&assignment.diarization_method)
+        .bind(assignment.diarization_confidence)
+        .bind(transcript_id)
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
+}
+
+fn diarization_status_to_database_value(
+    status: crate::diarization::types::DiarizationStatus,
+) -> String {
+    serde_json::to_value(status)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_owned))
+        .unwrap_or_else(|| "none".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diarization::types::{DiarizationStatus, SpeakerAssignment};
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn transcript_test_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("test pool should connect");
+
+        sqlx::query(
+            "CREATE TABLE transcripts (
+                id TEXT PRIMARY KEY,
+                speaker_id TEXT,
+                speaker_label TEXT,
+                speaker_color TEXT,
+                is_overlap INTEGER NOT NULL DEFAULT 0,
+                diarization_status TEXT NOT NULL DEFAULT 'none',
+                diarization_method TEXT,
+                diarization_confidence REAL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("transcripts table should be created");
+
+        sqlx::query("INSERT INTO transcripts (id) VALUES ('transcript-1')")
+            .execute(&pool)
+            .await
+            .expect("transcript row should be inserted");
+
+        pool
+    }
+
+    #[tokio::test]
+    async fn update_transcript_assignment_persists_assignment_fields() {
+        let pool = transcript_test_pool().await;
+        let assignment = SpeakerAssignment {
+            speaker_id: Some("speaker-1".to_string()),
+            speaker_label: Some("Speaker 1".to_string()),
+            speaker_color: Some("#2563eb".to_string()),
+            is_overlap: true,
+            diarization_status: DiarizationStatus::Final,
+            diarization_method: Some("pyannote-rs".to_string()),
+            diarization_confidence: Some(0.82),
+        };
+
+        DiarizationRepository::update_transcript_assignment(&pool, "transcript-1", &assignment)
+            .await
+            .expect("assignment should be persisted");
+
+        let row: (
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            i64,
+            String,
+            Option<String>,
+            Option<f64>,
+        ) = sqlx::query_as(
+            "SELECT
+                speaker_id,
+                speaker_label,
+                speaker_color,
+                is_overlap,
+                diarization_status,
+                diarization_method,
+                diarization_confidence
+             FROM transcripts WHERE id = 'transcript-1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("updated transcript row should be fetched");
+
+        assert_eq!(row.0.as_deref(), Some("speaker-1"));
+        assert_eq!(row.1.as_deref(), Some("Speaker 1"));
+        assert_eq!(row.2.as_deref(), Some("#2563eb"));
+        assert_eq!(row.3, 1);
+        assert_eq!(row.4, "final");
+        assert_eq!(row.5.as_deref(), Some("pyannote-rs"));
+        assert_eq!(row.6, Some(0.82));
+    }
 }

--- a/frontend/src-tauri/src/database/repositories/meeting.rs
+++ b/frontend/src-tauri/src/database/repositories/meeting.rs
@@ -61,11 +61,12 @@ impl MeetingsRepository {
         let mut transaction = conn.begin().await?;
 
         // Get meeting details
-        let meeting: Option<MeetingModel> =
-            sqlx::query_as("SELECT id, title, created_at, updated_at, folder_path FROM meetings WHERE id = ?")
-                .bind(meeting_id)
-                .fetch_optional(&mut *transaction)
-                .await?;
+        let meeting: Option<MeetingModel> = sqlx::query_as(
+            "SELECT id, title, created_at, updated_at, folder_path FROM meetings WHERE id = ?",
+        )
+        .bind(meeting_id)
+        .fetch_optional(&mut *transaction)
+        .await?;
 
         if meeting.is_none() {
             transaction.rollback().await?;
@@ -92,6 +93,13 @@ impl MeetingsRepository {
                     audio_start_time: t.audio_start_time,
                     audio_end_time: t.audio_end_time,
                     duration: t.duration,
+                    speaker_id: t.speaker_id,
+                    speaker_label: t.speaker_label,
+                    speaker_color: t.speaker_color,
+                    is_overlap: t.is_overlap.map(|value| value != 0),
+                    diarization_status: t.diarization_status,
+                    diarization_method: t.diarization_method,
+                    diarization_confidence: t.diarization_confidence,
                 })
                 .collect::<Vec<_>>();
 
@@ -119,11 +127,12 @@ impl MeetingsRepository {
             ));
         }
 
-        let meeting: Option<MeetingModel> =
-            sqlx::query_as("SELECT id, title, created_at, updated_at, folder_path FROM meetings WHERE id = ?")
-                .bind(meeting_id)
-                .fetch_optional(pool)
-                .await?;
+        let meeting: Option<MeetingModel> = sqlx::query_as(
+            "SELECT id, title, created_at, updated_at, folder_path FROM meetings WHERE id = ?",
+        )
+        .bind(meeting_id)
+        .fetch_optional(pool)
+        .await?;
 
         Ok(meeting)
     }
@@ -142,19 +151,17 @@ impl MeetingsRepository {
         }
 
         // Get total count of transcripts for this meeting
-        let total: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM transcripts WHERE meeting_id = ?"
-        )
-        .bind(meeting_id)
-        .fetch_one(pool)
-        .await?;
+        let total: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM transcripts WHERE meeting_id = ?")
+            .bind(meeting_id)
+            .fetch_one(pool)
+            .await?;
 
         // Get paginated transcripts ordered by audio_start_time
         let transcripts = sqlx::query_as::<_, Transcript>(
             "SELECT * FROM transcripts
              WHERE meeting_id = ?
              ORDER BY audio_start_time ASC
-             LIMIT ? OFFSET ?"
+             LIMIT ? OFFSET ?",
         )
         .bind(meeting_id)
         .bind(limit)

--- a/frontend/src-tauri/src/database/repositories/mod.rs
+++ b/frontend/src-tauri/src/database/repositories/mod.rs
@@ -1,3 +1,4 @@
+pub mod diarization;
 pub mod meeting;
 pub mod setting;
 pub mod summary;

--- a/frontend/src-tauri/src/database/repositories/transcript.rs
+++ b/frontend/src-tauri/src/database/repositories/transcript.rs
@@ -47,8 +47,13 @@ impl TranscriptsRepository {
         for segment in transcripts {
             let transcript_id = format!("transcript-{}", Uuid::new_v4());
             let result = sqlx::query(
-                "INSERT INTO transcripts (id, meeting_id, transcript, timestamp, audio_start_time, audio_end_time, duration)
-                 VALUES (?, ?, ?, ?, ?, ?, ?)"
+                "INSERT INTO transcripts (
+                    id, meeting_id, transcript, timestamp,
+                    audio_start_time, audio_end_time, duration,
+                    speaker_id, speaker_label, speaker_color, is_overlap,
+                    diarization_status, diarization_method, diarization_confidence
+                 )
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(&transcript_id)
             .bind(&meeting_id)
@@ -57,6 +62,13 @@ impl TranscriptsRepository {
             .bind(segment.audio_start_time)
             .bind(segment.audio_end_time)
             .bind(segment.duration)
+            .bind(&segment.speaker_id)
+            .bind(&segment.speaker_label)
+            .bind(&segment.speaker_color)
+            .bind(segment.is_overlap.unwrap_or(false) as i64)
+            .bind(segment.diarization_status.as_deref().unwrap_or("none"))
+            .bind(&segment.diarization_method)
+            .bind(segment.diarization_confidence)
             .execute(&mut *transaction)
             .await;
 

--- a/frontend/src-tauri/src/diarization/alignment.rs
+++ b/frontend/src-tauri/src/diarization/alignment.rs
@@ -27,6 +27,7 @@ pub fn assign_speaker_to_transcript(
         );
     }
 
+    let min_overlap_ratio = normalize_min_overlap_ratio(min_overlap_ratio);
     let mut best_segment: Option<(&SpeakerSegment, f64)> = None;
 
     for segment in segments {
@@ -74,6 +75,14 @@ pub fn assign_speaker_to_transcript(
         diarization_status: segment.diarization_status,
         diarization_method: Some(method.to_string()),
         diarization_confidence: segment.confidence,
+    }
+}
+
+fn normalize_min_overlap_ratio(ratio: f64) -> f64 {
+    if ratio.is_nan() {
+        1.0
+    } else {
+        ratio.clamp(0.0, 1.0)
     }
 }
 
@@ -148,6 +157,107 @@ mod tests {
             &transcript,
             &[segment("Speaker 1", 0.0, 1.0)],
             0.1,
+            "unit_test",
+        );
+
+        assert_eq!(assignment.speaker_label.as_deref(), Some("Unknown speaker"));
+        assert_eq!(
+            assignment.diarization_status,
+            DiarizationStatus::NeedsReview
+        );
+    }
+
+    #[test]
+    fn ignores_segment_below_min_overlap_ratio() {
+        let transcript = TranscriptWindow {
+            transcript_id: "t4".to_string(),
+            audio_start_time: Some(10.0),
+            audio_end_time: Some(20.0),
+        };
+
+        let assignment = assign_speaker_to_transcript(
+            &transcript,
+            &[segment("Speaker 1", 10.0, 12.0)],
+            0.5,
+            "unit_test",
+        );
+
+        assert_eq!(assignment.speaker_label.as_deref(), Some("Unknown speaker"));
+        assert_eq!(
+            assignment.diarization_status,
+            DiarizationStatus::NeedsReview
+        );
+    }
+
+    #[test]
+    fn accepts_segment_at_min_overlap_ratio_boundary() {
+        let transcript = TranscriptWindow {
+            transcript_id: "t5".to_string(),
+            audio_start_time: Some(10.0),
+            audio_end_time: Some(20.0),
+        };
+
+        let assignment = assign_speaker_to_transcript(
+            &transcript,
+            &[segment("Speaker 1", 10.0, 15.0)],
+            0.5,
+            "unit_test",
+        );
+
+        assert_eq!(assignment.speaker_label.as_deref(), Some("Speaker 1"));
+        assert_eq!(assignment.speaker_id.as_deref(), Some("speaker-1"));
+    }
+
+    #[test]
+    fn negative_min_overlap_ratio_behaves_like_zero() {
+        let transcript = TranscriptWindow {
+            transcript_id: "t6".to_string(),
+            audio_start_time: Some(10.0),
+            audio_end_time: Some(20.0),
+        };
+
+        let assignment = assign_speaker_to_transcript(
+            &transcript,
+            &[segment("Speaker 1", 10.0, 11.0)],
+            -0.5,
+            "unit_test",
+        );
+
+        assert_eq!(assignment.speaker_label.as_deref(), Some("Speaker 1"));
+        assert_eq!(assignment.speaker_id.as_deref(), Some("speaker-1"));
+    }
+
+    #[test]
+    fn min_overlap_ratio_above_one_behaves_like_one() {
+        let transcript = TranscriptWindow {
+            transcript_id: "t7".to_string(),
+            audio_start_time: Some(10.0),
+            audio_end_time: Some(20.0),
+        };
+
+        let assignment = assign_speaker_to_transcript(
+            &transcript,
+            &[segment("Speaker 1", 10.0, 20.0)],
+            1.5,
+            "unit_test",
+        );
+
+        assert_eq!(assignment.speaker_label.as_deref(), Some("Speaker 1"));
+        assert_eq!(assignment.speaker_id.as_deref(), Some("speaker-1"));
+    }
+
+    #[test]
+    fn nan_min_overlap_ratio_behaves_like_one() {
+        let transcript = TranscriptWindow {
+            transcript_id: "t8".to_string(),
+            audio_start_time: Some(10.0),
+            audio_end_time: Some(20.0),
+        };
+
+        let assignment = assign_speaker_to_transcript(
+            &transcript,
+            &[segment("Speaker 1", 10.0, 15.0)],
+            f64::NAN,
             "unit_test",
         );
 

--- a/frontend/src-tauri/src/diarization/alignment.rs
+++ b/frontend/src-tauri/src/diarization/alignment.rs
@@ -28,7 +28,8 @@ pub fn assign_speaker_to_transcript(
     }
 
     let min_overlap_ratio = normalize_min_overlap_ratio(min_overlap_ratio);
-    let mut best_segment: Option<(&SpeakerSegment, f64)> = None;
+    let mut best_overlap_segment: Option<(&SpeakerSegment, f64)> = None;
+    let mut best_speaker_segment: Option<(&SpeakerSegment, f64)> = None;
 
     for segment in segments {
         let overlap_start = transcript_start.max(segment.start_time);
@@ -43,26 +44,33 @@ pub fn assign_speaker_to_transcript(
             continue;
         }
 
-        match best_segment {
-            Some((_, best_overlap)) if best_overlap >= overlap => {}
-            _ => best_segment = Some((segment, overlap)),
+        if segment.is_overlap {
+            match best_overlap_segment {
+                Some((_, best_overlap)) if best_overlap >= overlap => {}
+                _ => best_overlap_segment = Some((segment, overlap)),
+            }
+        } else {
+            match best_speaker_segment {
+                Some((_, best_overlap)) if best_overlap >= overlap => {}
+                _ => best_speaker_segment = Some((segment, overlap)),
+            }
         }
     }
 
-    let Some((segment, _)) = best_segment else {
-        return SpeakerAssignment::unknown(
-            DiarizationStatus::NeedsReview,
-            Some(method.to_string()),
-        );
-    };
-
-    if segment.is_overlap {
+    if let Some((segment, _)) = best_overlap_segment {
         return SpeakerAssignment::overlap(
             segment.confidence.unwrap_or(0.0),
             segment.diarization_status,
             method.to_string(),
         );
     }
+
+    let Some((segment, _)) = best_speaker_segment else {
+        return SpeakerAssignment::unknown(
+            DiarizationStatus::NeedsReview,
+            Some(method.to_string()),
+        );
+    };
 
     SpeakerAssignment {
         speaker_id: segment.speaker_id.clone(),
@@ -143,6 +151,29 @@ mod tests {
         );
         assert!(assignment.is_overlap);
         assert_eq!(assignment.diarization_confidence, Some(0.93));
+    }
+
+    #[test]
+    fn marks_overlap_even_when_shorter_than_primary_speaker_segment() {
+        let transcript = TranscriptWindow {
+            transcript_id: "t2-overlap-precedence".to_string(),
+            audio_start_time: Some(10.0),
+            audio_end_time: Some(20.0),
+        };
+        let primary = segment("Speaker 1", 10.0, 20.0);
+        let mut interruption = segment("Speaker 2", 14.0, 15.0);
+        interruption.is_overlap = true;
+        interruption.confidence = Some(0.77);
+
+        let assignment =
+            assign_speaker_to_transcript(&transcript, &[primary, interruption], 0.1, "unit_test");
+
+        assert_eq!(
+            assignment.speaker_label.as_deref(),
+            Some("Multiple speakers")
+        );
+        assert!(assignment.is_overlap);
+        assert_eq!(assignment.diarization_confidence, Some(0.77));
     }
 
     #[test]

--- a/frontend/src-tauri/src/diarization/alignment.rs
+++ b/frontend/src-tauri/src/diarization/alignment.rs
@@ -1,0 +1,160 @@
+use super::types::{DiarizationStatus, SpeakerAssignment, SpeakerSegment, TranscriptWindow};
+
+pub fn assign_speaker_to_transcript(
+    transcript: &TranscriptWindow,
+    segments: &[SpeakerSegment],
+    min_overlap_ratio: f64,
+    method: &str,
+) -> SpeakerAssignment {
+    let Some(transcript_start) = transcript.audio_start_time else {
+        return SpeakerAssignment::unknown(
+            DiarizationStatus::NeedsReview,
+            Some(method.to_string()),
+        );
+    };
+    let Some(transcript_end) = transcript.audio_end_time else {
+        return SpeakerAssignment::unknown(
+            DiarizationStatus::NeedsReview,
+            Some(method.to_string()),
+        );
+    };
+
+    let transcript_duration = (transcript_end - transcript_start).max(0.0);
+    if transcript_duration == 0.0 {
+        return SpeakerAssignment::unknown(
+            DiarizationStatus::NeedsReview,
+            Some(method.to_string()),
+        );
+    }
+
+    let mut best_segment: Option<(&SpeakerSegment, f64)> = None;
+
+    for segment in segments {
+        let overlap_start = transcript_start.max(segment.start_time);
+        let overlap_end = transcript_end.min(segment.end_time);
+        let overlap = (overlap_end - overlap_start).max(0.0);
+        if overlap <= 0.0 {
+            continue;
+        }
+
+        let ratio = overlap / transcript_duration;
+        if ratio < min_overlap_ratio {
+            continue;
+        }
+
+        match best_segment {
+            Some((_, best_overlap)) if best_overlap >= overlap => {}
+            _ => best_segment = Some((segment, overlap)),
+        }
+    }
+
+    let Some((segment, _)) = best_segment else {
+        return SpeakerAssignment::unknown(
+            DiarizationStatus::NeedsReview,
+            Some(method.to_string()),
+        );
+    };
+
+    if segment.is_overlap {
+        return SpeakerAssignment::overlap(
+            segment.confidence.unwrap_or(0.0),
+            segment.diarization_status,
+            method.to_string(),
+        );
+    }
+
+    SpeakerAssignment {
+        speaker_id: segment.speaker_id.clone(),
+        speaker_label: segment
+            .speaker_label
+            .clone()
+            .or_else(|| Some("Unknown speaker".to_string())),
+        speaker_color: None,
+        is_overlap: false,
+        diarization_status: segment.diarization_status,
+        diarization_method: Some(method.to_string()),
+        diarization_confidence: segment.confidence,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn segment(label: &str, start: f64, end: f64) -> SpeakerSegment {
+        SpeakerSegment {
+            meeting_id: "meeting-1".to_string(),
+            source: "system".to_string(),
+            start_time: start,
+            end_time: end,
+            speaker_id: Some(label.to_lowercase().replace(' ', "-")),
+            speaker_label: Some(label.to_string()),
+            confidence: Some(0.8),
+            is_overlap: false,
+            diarization_status: DiarizationStatus::Provisional,
+            diarization_method: Some("unit_test".to_string()),
+        }
+    }
+
+    #[test]
+    fn assigns_speaker_with_largest_temporal_overlap() {
+        let transcript = TranscriptWindow {
+            transcript_id: "t1".to_string(),
+            audio_start_time: Some(10.0),
+            audio_end_time: Some(16.0),
+        };
+        let segments = vec![
+            segment("Speaker 1", 10.0, 12.0),
+            segment("Speaker 2", 12.0, 16.0),
+        ];
+
+        let assignment = assign_speaker_to_transcript(&transcript, &segments, 0.1, "unit_test");
+
+        assert_eq!(assignment.speaker_label.as_deref(), Some("Speaker 2"));
+        assert_eq!(assignment.speaker_id.as_deref(), Some("speaker-2"));
+        assert!(!assignment.is_overlap);
+    }
+
+    #[test]
+    fn marks_overlap_when_matching_segment_is_overlap() {
+        let transcript = TranscriptWindow {
+            transcript_id: "t2".to_string(),
+            audio_start_time: Some(20.0),
+            audio_end_time: Some(24.0),
+        };
+        let mut overlap = segment("Speaker 1", 20.0, 24.0);
+        overlap.is_overlap = true;
+        overlap.confidence = Some(0.93);
+
+        let assignment = assign_speaker_to_transcript(&transcript, &[overlap], 0.1, "unit_test");
+
+        assert_eq!(
+            assignment.speaker_label.as_deref(),
+            Some("Multiple speakers")
+        );
+        assert!(assignment.is_overlap);
+        assert_eq!(assignment.diarization_confidence, Some(0.93));
+    }
+
+    #[test]
+    fn returns_unknown_when_transcript_has_no_audio_window() {
+        let transcript = TranscriptWindow {
+            transcript_id: "t3".to_string(),
+            audio_start_time: None,
+            audio_end_time: None,
+        };
+
+        let assignment = assign_speaker_to_transcript(
+            &transcript,
+            &[segment("Speaker 1", 0.0, 1.0)],
+            0.1,
+            "unit_test",
+        );
+
+        assert_eq!(assignment.speaker_label.as_deref(), Some("Unknown speaker"));
+        assert_eq!(
+            assignment.diarization_status,
+            DiarizationStatus::NeedsReview
+        );
+    }
+}

--- a/frontend/src-tauri/src/diarization/commands.rs
+++ b/frontend/src-tauri/src/diarization/commands.rs
@@ -2,10 +2,13 @@ use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::{
-    database::{models::Transcript, repositories::diarization::DiarizationRepository},
+    database::{
+        models::Transcript,
+        repositories::diarization::{diarization_status_to_database_value, DiarizationRepository},
+    },
     diarization::{
         alignment::assign_speaker_to_transcript,
-        types::{SpeakerSegment, TranscriptWindow},
+        types::{DiarizationStatus, SpeakerSegment, TranscriptWindow},
     },
     state::AppState,
 };
@@ -78,11 +81,20 @@ pub async fn apply_diarization_segments(
     } = request;
     let segments = segments_for_meeting(segments, &meeting_id);
 
+    let mut transaction = pool.begin().await.map_err(|error| error.to_string())?;
+
+    replace_speaker_segments(&mut transaction, &meeting_id, &method, &segments)
+        .await
+        .map_err(|error| error.to_string())?;
+    upsert_meeting_diarization_status(&mut transaction, &meeting_id, &method, &segments)
+        .await
+        .map_err(|error| error.to_string())?;
+
     let transcripts = sqlx::query_as::<_, Transcript>(
         "SELECT * FROM transcripts WHERE meeting_id = ? ORDER BY audio_start_time ASC",
     )
     .bind(&meeting_id)
-    .fetch_all(pool)
+    .fetch_all(&mut *transaction)
     .await
     .map_err(|error| error.to_string())?;
 
@@ -95,10 +107,19 @@ pub async fn apply_diarization_segments(
 
         let assignment = assign_speaker_to_transcript(&window, &segments, 0.1, &method);
 
-        DiarizationRepository::update_transcript_assignment(pool, &transcript.id, &assignment)
-            .await
-            .map_err(|error| error.to_string())?;
+        DiarizationRepository::update_transcript_assignment(
+            &mut *transaction,
+            &transcript.id,
+            &assignment,
+        )
+        .await
+        .map_err(|error| error.to_string())?;
     }
+
+    transaction
+        .commit()
+        .await
+        .map_err(|error| error.to_string())?;
 
     Ok(())
 }
@@ -110,10 +131,134 @@ fn segments_for_meeting(segments: Vec<SpeakerSegment>, meeting_id: &str) -> Vec<
         .collect()
 }
 
+async fn replace_speaker_segments(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    meeting_id: &str,
+    method: &str,
+    segments: &[SpeakerSegment],
+) -> Result<(), sqlx::Error> {
+    sqlx::query("DELETE FROM speaker_segments WHERE meeting_id = ?")
+        .bind(meeting_id)
+        .execute(&mut **transaction)
+        .await?;
+
+    for (index, segment) in segments.iter().enumerate() {
+        let segment_id = format!("{meeting_id}:{method}:{index}");
+        let segment_status = diarization_status_to_database_value(segment.diarization_status);
+        let segment_method = segment.diarization_method.as_deref().unwrap_or(method);
+
+        sqlx::query(
+            "INSERT INTO speaker_segments (
+                id, meeting_id, source, start_time, end_time,
+                speaker_id, speaker_label, confidence, is_overlap,
+                diarization_status, diarization_method
+             )
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(segment_id)
+        .bind(meeting_id)
+        .bind(&segment.source)
+        .bind(segment.start_time)
+        .bind(segment.end_time)
+        .bind(&segment.speaker_id)
+        .bind(&segment.speaker_label)
+        .bind(segment.confidence)
+        .bind(segment.is_overlap as i64)
+        .bind(segment_status)
+        .bind(segment_method)
+        .execute(&mut **transaction)
+        .await?;
+    }
+
+    Ok(())
+}
+
+async fn upsert_meeting_diarization_status(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    meeting_id: &str,
+    method: &str,
+    segments: &[SpeakerSegment],
+) -> Result<(), sqlx::Error> {
+    let current_status = meeting_status_from_segments(segments);
+    let method = method.to_ascii_lowercase();
+    let live_enabled = current_status == "provisional"
+        || current_status == "fallback_to_live"
+        || method.contains("live")
+        || method.contains("online");
+    let post_call_enabled =
+        current_status == "final" || method.contains("post") || method.contains("offline");
+
+    sqlx::query(
+        "INSERT INTO meeting_diarization_status (
+            meeting_id, enabled, live_enabled, post_call_enabled,
+            current_status, quality_flags, processed_at, updated_at
+         )
+         VALUES (?, 1, ?, ?, ?, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+         ON CONFLICT(meeting_id) DO UPDATE SET
+            enabled = 1,
+            live_enabled = excluded.live_enabled,
+            post_call_enabled = excluded.post_call_enabled,
+            current_status = excluded.current_status,
+            quality_flags = NULL,
+            processed_at = CURRENT_TIMESTAMP,
+            updated_at = CURRENT_TIMESTAMP",
+    )
+    .bind(meeting_id)
+    .bind(live_enabled as i64)
+    .bind(post_call_enabled as i64)
+    .bind(current_status)
+    .execute(&mut **transaction)
+    .await?;
+
+    Ok(())
+}
+
+fn meeting_status_from_segments(segments: &[SpeakerSegment]) -> &'static str {
+    if segments.is_empty() {
+        return "needs_review";
+    }
+
+    if segments
+        .iter()
+        .any(|segment| segment.diarization_status == DiarizationStatus::Failed)
+    {
+        return "failed";
+    }
+
+    if segments
+        .iter()
+        .any(|segment| segment.diarization_status == DiarizationStatus::NeedsReview)
+    {
+        return "needs_review";
+    }
+
+    if segments
+        .iter()
+        .any(|segment| segment.diarization_status == DiarizationStatus::FallbackToLive)
+    {
+        return "fallback_to_live";
+    }
+
+    if segments
+        .iter()
+        .any(|segment| segment.diarization_status == DiarizationStatus::Provisional)
+    {
+        return "provisional";
+    }
+
+    if segments
+        .iter()
+        .all(|segment| segment.diarization_status == DiarizationStatus::Final)
+    {
+        return "final";
+    }
+
+    "none"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::diarization::types::DiarizationStatus;
 
     fn segment(meeting_id: &str, speaker_label: &str) -> SpeakerSegment {
         SpeakerSegment {
@@ -143,5 +288,23 @@ mod tests {
         assert_eq!(segments.len(), 1);
         assert_eq!(segments[0].meeting_id, "meeting-1");
         assert_eq!(segments[0].speaker_label.as_deref(), Some("Speaker 1"));
+    }
+
+    #[test]
+    fn meeting_status_from_segments_returns_needs_review_for_empty_segments() {
+        assert_eq!(meeting_status_from_segments(&[]), "needs_review");
+    }
+
+    #[test]
+    fn meeting_status_from_segments_prefers_failed_over_final_segments() {
+        let mut failed = segment("meeting-1", "Speaker 1");
+        failed.diarization_status = DiarizationStatus::Failed;
+        let mut final_segment = segment("meeting-1", "Speaker 2");
+        final_segment.diarization_status = DiarizationStatus::Final;
+
+        assert_eq!(
+            meeting_status_from_segments(&[final_segment, failed]),
+            "failed"
+        );
     }
 }

--- a/frontend/src-tauri/src/diarization/commands.rs
+++ b/frontend/src-tauri/src/diarization/commands.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::{database::repositories::diarization::DiarizationRepository, state::AppState};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiarizationSettingsDto {
+    pub enabled: bool,
+    pub mode: String,
+    pub show_provisional_labels: bool,
+    pub post_call_refinement_enabled: bool,
+    pub overlap_handling: String,
+    pub speaker_review_enabled: bool,
+}
+
+#[tauri::command]
+pub async fn get_diarization_settings(
+    state: State<'_, AppState>,
+) -> Result<DiarizationSettingsDto, String> {
+    let settings = DiarizationRepository::get_settings(state.db_manager.pool())
+        .await
+        .map_err(|error| error.to_string())?;
+
+    Ok(DiarizationSettingsDto {
+        enabled: settings.enabled != 0,
+        mode: settings.mode,
+        show_provisional_labels: settings.show_provisional_labels != 0,
+        post_call_refinement_enabled: settings.post_call_refinement_enabled != 0,
+        overlap_handling: settings.overlap_handling,
+        speaker_review_enabled: settings.speaker_review_enabled != 0,
+    })
+}
+
+#[tauri::command]
+pub async fn save_diarization_settings(
+    state: State<'_, AppState>,
+    settings: DiarizationSettingsDto,
+) -> Result<(), String> {
+    DiarizationRepository::save_settings(
+        state.db_manager.pool(),
+        settings.enabled,
+        &settings.mode,
+        settings.show_provisional_labels,
+        settings.post_call_refinement_enabled,
+        &settings.overlap_handling,
+        settings.speaker_review_enabled,
+    )
+    .await
+    .map_err(|error| error.to_string())
+}

--- a/frontend/src-tauri/src/diarization/commands.rs
+++ b/frontend/src-tauri/src/diarization/commands.rs
@@ -1,7 +1,14 @@
 use serde::{Deserialize, Serialize};
 use tauri::State;
 
-use crate::{database::repositories::diarization::DiarizationRepository, state::AppState};
+use crate::{
+    database::{models::Transcript, repositories::diarization::DiarizationRepository},
+    diarization::{
+        alignment::assign_speaker_to_transcript,
+        types::{SpeakerSegment, TranscriptWindow},
+    },
+    state::AppState,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -48,4 +55,93 @@ pub async fn save_diarization_settings(
     )
     .await
     .map_err(|error| error.to_string())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApplyDiarizationRequest {
+    pub meeting_id: String,
+    pub method: String,
+    pub segments: Vec<SpeakerSegment>,
+}
+
+#[tauri::command]
+pub async fn apply_diarization_segments(
+    state: State<'_, AppState>,
+    request: ApplyDiarizationRequest,
+) -> Result<(), String> {
+    let pool = state.db_manager.pool();
+    let ApplyDiarizationRequest {
+        meeting_id,
+        method,
+        segments,
+    } = request;
+    let segments = segments_for_meeting(segments, &meeting_id);
+
+    let transcripts = sqlx::query_as::<_, Transcript>(
+        "SELECT * FROM transcripts WHERE meeting_id = ? ORDER BY audio_start_time ASC",
+    )
+    .bind(&meeting_id)
+    .fetch_all(pool)
+    .await
+    .map_err(|error| error.to_string())?;
+
+    for transcript in transcripts {
+        let window = TranscriptWindow {
+            transcript_id: transcript.id.clone(),
+            audio_start_time: transcript.audio_start_time,
+            audio_end_time: transcript.audio_end_time,
+        };
+
+        let assignment = assign_speaker_to_transcript(&window, &segments, 0.1, &method);
+
+        DiarizationRepository::update_transcript_assignment(pool, &transcript.id, &assignment)
+            .await
+            .map_err(|error| error.to_string())?;
+    }
+
+    Ok(())
+}
+
+fn segments_for_meeting(segments: Vec<SpeakerSegment>, meeting_id: &str) -> Vec<SpeakerSegment> {
+    segments
+        .into_iter()
+        .filter(|segment| segment.meeting_id.as_str() == meeting_id)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diarization::types::DiarizationStatus;
+
+    fn segment(meeting_id: &str, speaker_label: &str) -> SpeakerSegment {
+        SpeakerSegment {
+            meeting_id: meeting_id.to_string(),
+            source: "unit_test".to_string(),
+            start_time: 0.0,
+            end_time: 1.0,
+            speaker_id: Some(speaker_label.to_lowercase().replace(' ', "-")),
+            speaker_label: Some(speaker_label.to_string()),
+            confidence: Some(0.8),
+            is_overlap: false,
+            diarization_status: DiarizationStatus::Provisional,
+            diarization_method: Some("unit_test".to_string()),
+        }
+    }
+
+    #[test]
+    fn segments_for_meeting_excludes_segments_from_other_meetings() {
+        let segments = segments_for_meeting(
+            vec![
+                segment("meeting-1", "Speaker 1"),
+                segment("meeting-2", "Speaker 2"),
+            ],
+            "meeting-1",
+        );
+
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].meeting_id, "meeting-1");
+        assert_eq!(segments[0].speaker_label.as_deref(), Some("Speaker 1"));
+    }
 }

--- a/frontend/src-tauri/src/diarization/commands.rs
+++ b/frontend/src-tauri/src/diarization/commands.rs
@@ -4,7 +4,9 @@ use tauri::State;
 use crate::{
     database::{
         models::Transcript,
-        repositories::diarization::{diarization_status_to_database_value, DiarizationRepository},
+        repositories::diarization::{
+            diarization_status_to_database_value, DiarizationRepository, MeetingSpeaker,
+        },
     },
     diarization::{
         alignment::assign_speaker_to_transcript,
@@ -58,6 +60,64 @@ pub async fn save_diarization_settings(
     )
     .await
     .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn get_meeting_speakers(
+    state: State<'_, AppState>,
+    meeting_id: String,
+) -> Result<Vec<MeetingSpeaker>, String> {
+    if meeting_id.trim().is_empty() {
+        return Err("Meeting id cannot be empty".to_string());
+    }
+
+    DiarizationRepository::get_meeting_speakers(state.db_manager.pool(), &meeting_id)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RenameSpeakerRequest {
+    pub meeting_id: String,
+    pub speaker_id: String,
+    pub label: String,
+}
+
+#[tauri::command]
+pub async fn rename_speaker(
+    state: State<'_, AppState>,
+    request: RenameSpeakerRequest,
+) -> Result<(), String> {
+    let RenameSpeakerRequest {
+        meeting_id,
+        speaker_id,
+        label,
+    } = request;
+    let label = normalize_speaker_label(&label)?;
+
+    if meeting_id.trim().is_empty() {
+        return Err("Meeting id cannot be empty".to_string());
+    }
+
+    if speaker_id.trim().is_empty() {
+        return Err("Speaker id cannot be empty".to_string());
+    }
+
+    let updated_count = DiarizationRepository::rename_speaker(
+        state.db_manager.pool(),
+        &meeting_id,
+        &speaker_id,
+        &label,
+    )
+    .await
+    .map_err(|error| error.to_string())?;
+
+    if updated_count == 0 {
+        return Err("Speaker not found for meeting".to_string());
+    }
+
+    Ok(())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -256,6 +316,16 @@ fn meeting_status_from_segments(segments: &[SpeakerSegment]) -> &'static str {
     "none"
 }
 
+fn normalize_speaker_label(label: &str) -> Result<String, String> {
+    let label = label.trim();
+
+    if label.is_empty() {
+        return Err("Speaker label cannot be empty".to_string());
+    }
+
+    Ok(label.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -305,6 +375,22 @@ mod tests {
         assert_eq!(
             meeting_status_from_segments(&[final_segment, failed]),
             "failed"
+        );
+    }
+
+    #[test]
+    fn normalize_speaker_label_trims_non_empty_label() {
+        assert_eq!(
+            normalize_speaker_label("  Alice Johnson  ").expect("label should be valid"),
+            "Alice Johnson"
+        );
+    }
+
+    #[test]
+    fn normalize_speaker_label_rejects_blank_label() {
+        assert_eq!(
+            normalize_speaker_label(" \n\t ").expect_err("blank label should be rejected"),
+            "Speaker label cannot be empty"
         );
     }
 }

--- a/frontend/src-tauri/src/diarization/mod.rs
+++ b/frontend/src-tauri/src/diarization/mod.rs
@@ -1,0 +1,1 @@
+pub mod types;

--- a/frontend/src-tauri/src/diarization/mod.rs
+++ b/frontend/src-tauri/src/diarization/mod.rs
@@ -1,2 +1,3 @@
 pub mod alignment;
+pub mod commands;
 pub mod types;

--- a/frontend/src-tauri/src/diarization/mod.rs
+++ b/frontend/src-tauri/src/diarization/mod.rs
@@ -1,1 +1,2 @@
+pub mod alignment;
 pub mod types;

--- a/frontend/src-tauri/src/diarization/types.rs
+++ b/frontend/src-tauri/src/diarization/types.rs
@@ -1,0 +1,108 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiarizationStatus {
+    None,
+    Provisional,
+    Final,
+    FallbackToLive,
+    Failed,
+    NeedsReview,
+}
+
+impl Default for DiarizationStatus {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SpeakerSegment {
+    pub meeting_id: String,
+    pub source: String,
+    pub start_time: f64,
+    pub end_time: f64,
+    pub speaker_id: Option<String>,
+    pub speaker_label: Option<String>,
+    pub confidence: Option<f64>,
+    pub is_overlap: bool,
+    pub diarization_status: DiarizationStatus,
+    pub diarization_method: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TranscriptWindow {
+    pub transcript_id: String,
+    pub audio_start_time: Option<f64>,
+    pub audio_end_time: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SpeakerAssignment {
+    pub speaker_id: Option<String>,
+    pub speaker_label: Option<String>,
+    pub speaker_color: Option<String>,
+    pub is_overlap: bool,
+    pub diarization_status: DiarizationStatus,
+    pub diarization_method: Option<String>,
+    pub diarization_confidence: Option<f64>,
+}
+
+impl SpeakerAssignment {
+    pub fn unknown(status: DiarizationStatus, method: impl Into<Option<String>>) -> Self {
+        Self {
+            speaker_id: None,
+            speaker_label: Some("Unknown speaker".to_string()),
+            speaker_color: None,
+            is_overlap: false,
+            diarization_status: status,
+            diarization_method: method.into(),
+            diarization_confidence: None,
+        }
+    }
+
+    pub fn overlap(confidence: f64, status: DiarizationStatus, method: impl Into<String>) -> Self {
+        Self {
+            speaker_id: None,
+            speaker_label: Some("Multiple speakers".to_string()),
+            speaker_color: Some("#f97316".to_string()),
+            is_overlap: true,
+            diarization_status: status,
+            diarization_method: Some(method.into()),
+            diarization_confidence: Some(confidence),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diarization_status_serializes_as_snake_case() {
+        let json = serde_json::to_string(&DiarizationStatus::FallbackToLive).unwrap();
+        assert_eq!(json, "\"fallback_to_live\"");
+    }
+
+    #[test]
+    fn overlap_assignment_uses_multiple_speakers_label() {
+        let assignment =
+            SpeakerAssignment::overlap(0.91, DiarizationStatus::Provisional, "fluid_audio_online");
+
+        assert_eq!(assignment.speaker_id, None);
+        assert_eq!(
+            assignment.speaker_label.as_deref(),
+            Some("Multiple speakers")
+        );
+        assert!(assignment.is_overlap);
+        assert_eq!(
+            assignment.diarization_status,
+            DiarizationStatus::Provisional
+        );
+        assert_eq!(
+            assignment.diarization_method.as_deref(),
+            Some("fluid_audio_online")
+        );
+    }
+}

--- a/frontend/src-tauri/src/diarization/types.rs
+++ b/frontend/src-tauri/src/diarization/types.rs
@@ -50,14 +50,14 @@ pub struct SpeakerAssignment {
 }
 
 impl SpeakerAssignment {
-    pub fn unknown(status: DiarizationStatus, method: impl Into<Option<String>>) -> Self {
+    pub fn unknown(status: DiarizationStatus, method: Option<impl Into<String>>) -> Self {
         Self {
             speaker_id: None,
             speaker_label: Some("Unknown speaker".to_string()),
             speaker_color: None,
             is_overlap: false,
             diarization_status: status,
-            diarization_method: method.into(),
+            diarization_method: method.map(Into::into),
             diarization_confidence: None,
         }
     }
@@ -104,5 +104,28 @@ mod tests {
             assignment.diarization_method.as_deref(),
             Some("fluid_audio_online")
         );
+    }
+
+    #[test]
+    fn overlap_assignment_preserves_confidence() {
+        let assignment =
+            SpeakerAssignment::overlap(0.91, DiarizationStatus::Provisional, "fluid_audio_online");
+
+        assert_eq!(assignment.diarization_confidence, Some(0.91));
+    }
+
+    #[test]
+    fn unknown_assignment_accepts_string_method() {
+        let assignment =
+            SpeakerAssignment::unknown(DiarizationStatus::NeedsReview, Some("unit_test"));
+
+        assert_eq!(assignment.diarization_method, Some("unit_test".to_string()));
+    }
+
+    #[test]
+    fn unknown_assignment_accepts_no_method() {
+        let assignment = SpeakerAssignment::unknown(DiarizationStatus::NeedsReview, None::<String>);
+
+        assert_eq!(assignment.diarization_method, None);
     }
 }

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -644,6 +644,9 @@ pub fn run() {
             api::api_get_transcript_config,
             api::api_save_transcript_config,
             api::api_get_transcript_api_key,
+            // Diarization settings commands
+            diarization::commands::get_diarization_settings,
+            diarization::commands::save_diarization_settings,
             api::api_delete_meeting,
             api::api_get_meeting,
             api::api_get_meeting_metadata,

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -647,6 +647,8 @@ pub fn run() {
             // Diarization settings commands
             diarization::commands::get_diarization_settings,
             diarization::commands::save_diarization_settings,
+            diarization::commands::get_meeting_speakers,
+            diarization::commands::rename_speaker,
             diarization::commands::apply_diarization_segments,
             api::api_delete_meeting,
             api::api_get_meeting,

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -647,6 +647,7 @@ pub fn run() {
             // Diarization settings commands
             diarization::commands::get_diarization_settings,
             diarization::commands::save_diarization_settings,
+            diarization::commands::apply_diarization_segments,
             api::api_delete_meeting,
             api::api_get_meeting,
             api::api_get_meeting_metadata,

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub mod audio;
 pub mod config;
 pub mod console_utils;
 pub mod database;
+pub mod diarization;
 pub mod notifications;
 pub mod ollama;
 pub mod onboarding;

--- a/frontend/src/app/_components/TranscriptPanel.tsx
+++ b/frontend/src/app/_components/TranscriptPanel.tsx
@@ -45,6 +45,13 @@ export function TranscriptPanel({
       endTime: t.audio_end_time,
       text: t.text,
       confidence: t.confidence,
+      speaker_id: t.speaker_id,
+      speaker_label: t.speaker_label,
+      speaker_color: t.speaker_color,
+      is_overlap: t.is_overlap,
+      diarization_status: t.diarization_status,
+      diarization_method: t.diarization_method,
+      diarization_confidence: t.diarization_confidence,
     })),
     [transcripts]
   );

--- a/frontend/src/components/BetaSettings.tsx
+++ b/frontend/src/components/BetaSettings.tsx
@@ -13,7 +13,7 @@ export function BetaSettings() {
   const { betaFeatures, toggleBetaFeature } = useConfig();
 
   // Define feature order for display (allows custom ordering)
-  const featureOrder: BetaFeatureKey[] = ['importAndRetranscribe'];
+  const featureOrder: BetaFeatureKey[] = ['importAndRetranscribe', 'speakerDiarization'];
 
   return (
     <div className="space-y-6">

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { Transcript, TranscriptSegmentData } from '@/types';
-import { TranscriptView } from '@/components/TranscriptView';
+import { MeetingSpeaker, Transcript, TranscriptSegmentData } from '@/types';
 import { VirtualizedTranscriptView } from '@/components/VirtualizedTranscriptView';
 import { TranscriptButtonGroup } from './TranscriptButtonGroup';
-import { useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { invoke } from '@tauri-apps/api/core';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
 
 interface TranscriptPanelProps {
   transcripts: Transcript[];
@@ -71,6 +74,105 @@ export function TranscriptPanel({
     }));
   }, [transcripts, usePagination, segments]);
 
+  const [speakers, setSpeakers] = useState<MeetingSpeaker[]>([]);
+  const [isLoadingSpeakers, setIsLoadingSpeakers] = useState(false);
+  const [editingSpeakerId, setEditingSpeakerId] = useState<string | null>(null);
+  const [draftSpeakerLabel, setDraftSpeakerLabel] = useState('');
+  const [savingSpeakerId, setSavingSpeakerId] = useState<string | null>(null);
+
+  const speakerSourceCount = usePagination
+    ? totalCount ?? convertedSegments.length
+    : transcripts.length;
+
+  const loadSpeakers = useCallback(async () => {
+    if (!meetingId || speakerSourceCount === 0) {
+      setSpeakers([]);
+      return;
+    }
+
+    setIsLoadingSpeakers(true);
+    try {
+      const loadedSpeakers = await invoke<MeetingSpeaker[]>('get_meeting_speakers', { meetingId });
+      setSpeakers(loadedSpeakers);
+    } catch (error) {
+      console.error('Failed to load meeting speakers:', error);
+      toast.error('Failed to load speakers');
+    } finally {
+      setIsLoadingSpeakers(false);
+    }
+  }, [meetingId, speakerSourceCount]);
+
+  useEffect(() => {
+    if (isRecording) {
+      setSpeakers([]);
+      setEditingSpeakerId(null);
+      return;
+    }
+
+    void loadSpeakers();
+  }, [isRecording, loadSpeakers]);
+
+  const startEditingSpeaker = useCallback((speaker: MeetingSpeaker) => {
+    setEditingSpeakerId(speaker.speakerId);
+    setDraftSpeakerLabel(speaker.speakerLabel);
+  }, []);
+
+  const cancelEditingSpeaker = useCallback(() => {
+    setEditingSpeakerId(null);
+    setDraftSpeakerLabel('');
+  }, []);
+
+  const saveSpeakerLabel = useCallback(async (speaker: MeetingSpeaker) => {
+    if (!meetingId) {
+      return;
+    }
+
+    const label = draftSpeakerLabel.trim();
+    if (!label) {
+      toast.error('Speaker name cannot be empty');
+      return;
+    }
+
+    if (label === speaker.speakerLabel) {
+      cancelEditingSpeaker();
+      return;
+    }
+
+    setSavingSpeakerId(speaker.speakerId);
+    try {
+      await invoke('rename_speaker', {
+        request: {
+          meetingId,
+          speakerId: speaker.speakerId,
+          label,
+        },
+      });
+
+      setSpeakers(previousSpeakers =>
+        previousSpeakers.map(previousSpeaker =>
+          previousSpeaker.speakerId === speaker.speakerId
+            ? { ...previousSpeaker, speakerLabel: label }
+            : previousSpeaker
+        )
+      );
+      cancelEditingSpeaker();
+
+      if (onRefetchTranscripts) {
+        await onRefetchTranscripts();
+      }
+      await loadSpeakers();
+
+      toast.success('Speaker renamed');
+    } catch (error) {
+      console.error('Failed to rename speaker:', error);
+      toast.error('Failed to rename speaker', {
+        description: String(error),
+      });
+    } finally {
+      setSavingSpeakerId(null);
+    }
+  }, [cancelEditingSpeaker, draftSpeakerLabel, loadSpeakers, meetingId, onRefetchTranscripts]);
+
   return (
     <div className="hidden md:flex md:w-1/4 lg:w-1/3 min-w-0 border-r border-gray-200 bg-white flex-col relative shrink-0">
       {/* Title area */}
@@ -84,6 +186,101 @@ export function TranscriptPanel({
           onRefetchTranscripts={onRefetchTranscripts}
         />
       </div>
+
+      {!isRecording && meetingId && (speakers.length > 0 || isLoadingSpeakers) && (
+        <div className="px-4 py-3 border-b border-border space-y-3">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Speakers{speakers.length > 0 ? ` (${speakers.length})` : ''}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Names are applied to transcript labels and copied text.
+              </p>
+            </div>
+            {isLoadingSpeakers && (
+              <span className="text-xs text-muted-foreground">Loading…</span>
+            )}
+          </div>
+
+          <div className="max-h-56 space-y-2 overflow-y-auto pr-1">
+            {speakers.map((speaker) => {
+              const isEditing = editingSpeakerId === speaker.speakerId;
+              const isSaving = savingSpeakerId === speaker.speakerId;
+              const transcriptSegmentLabel =
+                speaker.segmentCount === 1 ? 'transcript segment' : 'transcript segments';
+
+              return (
+                <div
+                  key={speaker.speakerId}
+                  className="rounded-md border border-border bg-background/60 px-3 py-2"
+                >
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="h-2.5 w-2.5 rounded-full border border-border shrink-0"
+                      style={{ backgroundColor: speaker.speakerColor || '#94a3b8' }}
+                    />
+
+                    {isEditing ? (
+                      <>
+                        <Input
+                          aria-label="Speaker name"
+                          className="h-8 min-w-0 flex-1"
+                          value={draftSpeakerLabel}
+                          disabled={isSaving}
+                          onChange={(event) => setDraftSpeakerLabel(event.target.value)}
+                          onKeyDown={(event) => {
+                            if (event.key === 'Enter') {
+                              void saveSpeakerLabel(speaker);
+                            }
+                            if (event.key === 'Escape') {
+                              cancelEditingSpeaker();
+                            }
+                          }}
+                        />
+                        <Button
+                          size="sm"
+                          onClick={() => void saveSpeakerLabel(speaker)}
+                          disabled={isSaving}
+                        >
+                          Save
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={cancelEditingSpeaker}
+                          disabled={isSaving}
+                        >
+                          Cancel
+                        </Button>
+                      </>
+                    ) : (
+                      <>
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm font-medium text-foreground">
+                            {speaker.speakerLabel}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {speaker.segmentCount} {transcriptSegmentLabel}
+                          </p>
+                        </div>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => startEditingSpeaker(speaker)}
+                          disabled={savingSpeakerId !== null}
+                        >
+                          Rename
+                        </Button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       {/* Transcript content - use virtualized view for better performance */}
       <div className="flex-1 overflow-hidden pb-4">

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -61,6 +61,13 @@ export function TranscriptPanel({
       endTime: t.audio_end_time,
       text: t.text,
       confidence: t.confidence,
+      speaker_id: t.speaker_id,
+      speaker_label: t.speaker_label,
+      speaker_color: t.speaker_color,
+      is_overlap: t.is_overlap,
+      diarization_status: t.diarization_status,
+      diarization_method: t.diarization_method,
+      diarization_confidence: t.diarization_confidence,
     }));
   }, [transcripts, usePagination, segments]);
 

--- a/frontend/src/components/SpeakerDiarizationSettings.tsx
+++ b/frontend/src/components/SpeakerDiarizationSettings.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { SettingsSection } from '@/components/settings/SettingsSection';
+import { SettingsRow } from '@/components/settings/SettingsRow';
+import { SettingsStatusBadge } from '@/components/settings/SettingsStatusBadge';
+import { useConfig } from '@/contexts/ConfigContext';
+import type { DiarizationMode } from '@/types/diarization';
+
+export function SpeakerDiarizationSettings() {
+  const {
+    betaFeatures,
+    diarizationSettings,
+    isLoadingDiarizationSettings,
+    updateDiarizationSettings,
+  } = useConfig();
+
+  if (!betaFeatures.speakerDiarization) {
+    return null;
+  }
+
+  const update = (patch: Partial<typeof diarizationSettings>) => {
+    updateDiarizationSettings({ ...diarizationSettings, ...patch })
+      .catch(error => console.error('[SpeakerDiarizationSettings] Failed to save:', error));
+  };
+
+  const liveModeEnabled = diarizationSettings.enabled && diarizationSettings.mode === 'live_plus_post_call';
+
+  return (
+    <SettingsSection
+      title="Speaker labels"
+      description="Label who spoke in the transcript. Live labels are provisional; final labels are applied after the meeting."
+      badge={<SettingsStatusBadge tone="beta">Beta</SettingsStatusBadge>}
+    >
+      <SettingsRow
+        title="Enable speaker diarization"
+        description="Add speaker labels to transcripts without identifying people by voice."
+        control={
+          <Switch
+            checked={diarizationSettings.enabled}
+            disabled={isLoadingDiarizationSettings}
+            onCheckedChange={(enabled) => update({ enabled, mode: enabled ? diarizationSettings.mode : 'off' })}
+          />
+        }
+      />
+
+      <SettingsRow
+        title="Mode"
+        description="Recommended: show provisional labels during the call, then refine after recording stops."
+        control={
+          <Select
+            value={diarizationSettings.mode}
+            disabled={!diarizationSettings.enabled || isLoadingDiarizationSettings}
+            onValueChange={(mode) => update({ mode: mode as DiarizationMode })}
+          >
+            <SelectTrigger className="w-[260px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="live_plus_post_call">Live + post-call refinement</SelectItem>
+              <SelectItem value="post_call_only">Post-call only</SelectItem>
+              <SelectItem value="off">Off</SelectItem>
+            </SelectContent>
+          </Select>
+        }
+      />
+
+      <SettingsRow
+        title="Show provisional labels during call"
+        description="Display live Speaker 1 / Speaker 2 labels with a provisional badge."
+        disabledReason={!liveModeEnabled ? 'Available only in Live + post-call refinement mode.' : undefined}
+        control={
+          <Switch
+            checked={diarizationSettings.showProvisionalLabels}
+            disabled={!liveModeEnabled || isLoadingDiarizationSettings}
+            onCheckedChange={(showProvisionalLabels) => update({ showProvisionalLabels })}
+          />
+        }
+      />
+
+      <SettingsRow
+        title="Run post-call refinement automatically"
+        description="After the meeting, analyze the full audio and replace provisional labels when quality is good."
+        control={
+          <Switch
+            checked={diarizationSettings.postCallRefinementEnabled}
+            disabled={!diarizationSettings.enabled || diarizationSettings.mode === 'off' || isLoadingDiarizationSettings}
+            onCheckedChange={(postCallRefinementEnabled) => update({ postCallRefinementEnabled })}
+          />
+        }
+      />
+
+      <SettingsRow
+        title="Overlap handling"
+        description="Interruptions are marked as Multiple speakers."
+        control={<SettingsStatusBadge tone="local">Multiple speakers</SettingsStatusBadge>}
+      />
+
+      <SettingsRow
+        title="Speaker review"
+        description="Allow rename, merge, split, and overlap fixes after post-call processing."
+        control={
+          <Switch
+            checked={diarizationSettings.speakerReviewEnabled}
+            disabled={!diarizationSettings.enabled || isLoadingDiarizationSettings}
+            onCheckedChange={(speakerReviewEnabled) => update({ speakerReviewEnabled })}
+          />
+        }
+      />
+    </SettingsSection>
+  );
+}

--- a/frontend/src/components/SpeakerDiarizationSettings.tsx
+++ b/frontend/src/components/SpeakerDiarizationSettings.tsx
@@ -31,6 +31,27 @@ export function SpeakerDiarizationSettings() {
       .catch(error => console.error('[SpeakerDiarizationSettings] Failed to save:', error));
   };
 
+  const handleEnabledChange = (enabled: boolean) => {
+    if (!enabled) {
+      update({ enabled: false, mode: 'off' });
+      return;
+    }
+
+    update({
+      enabled: true,
+      mode: diarizationSettings.mode === 'off' ? 'live_plus_post_call' : diarizationSettings.mode,
+    });
+  };
+
+  const handleModeChange = (mode: DiarizationMode) => {
+    if (mode === 'off') {
+      update({ mode: 'off', enabled: false });
+      return;
+    }
+
+    update({ mode, enabled: true });
+  };
+
   const liveModeEnabled = diarizationSettings.enabled && diarizationSettings.mode === 'live_plus_post_call';
 
   return (
@@ -46,7 +67,7 @@ export function SpeakerDiarizationSettings() {
           <Switch
             checked={diarizationSettings.enabled}
             disabled={isLoadingDiarizationSettings}
-            onCheckedChange={(enabled) => update({ enabled, mode: enabled ? diarizationSettings.mode : 'off' })}
+            onCheckedChange={handleEnabledChange}
           />
         }
       />
@@ -58,7 +79,7 @@ export function SpeakerDiarizationSettings() {
           <Select
             value={diarizationSettings.mode}
             disabled={!diarizationSettings.enabled || isLoadingDiarizationSettings}
-            onValueChange={(mode) => update({ mode: mode as DiarizationMode })}
+            onValueChange={(mode) => handleModeChange(mode as DiarizationMode)}
           >
             <SelectTrigger className="w-[260px]">
               <SelectValue />

--- a/frontend/src/components/TranscriptSettings.tsx
+++ b/frontend/src/components/TranscriptSettings.tsx
@@ -7,6 +7,7 @@ import { Label } from './ui/label';
 import { Eye, EyeOff, Lock, Unlock } from 'lucide-react';
 import { ModelManager } from './WhisperModelManager';
 import { ParakeetModelManager } from './ParakeetModelManager';
+import { SpeakerDiarizationSettings } from './SpeakerDiarizationSettings';
 
 
 export interface TranscriptModelProps {
@@ -219,12 +220,13 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                             </div>
                         </div>
                     )}
+
+                    <SpeakerDiarizationSettings />
                 </div>
             </div>
         </div >
     )
 }
-
 
 
 

--- a/frontend/src/components/VirtualizedTranscriptView.tsx
+++ b/frontend/src/components/VirtualizedTranscriptView.tsx
@@ -64,6 +64,16 @@ function cleanStopWords(text: string): string {
     return cleanedText.replace(/\s+/g, ' ').trim();
 }
 
+type VisibleDiarizationStatus = Exclude<DiarizationStatus, 'none'>;
+
+const DIARIZATION_STATUS_BADGES: Record<VisibleDiarizationStatus, { label: string; toneClassName: string }> = {
+    provisional: { label: 'Provisional', toneClassName: 'bg-amber-100 text-amber-800' },
+    final: { label: 'Final', toneClassName: 'bg-green-100 text-green-800' },
+    needs_review: { label: 'Needs review', toneClassName: 'bg-purple-100 text-purple-800' },
+    fallback_to_live: { label: 'Live fallback', toneClassName: 'bg-orange-100 text-orange-800' },
+    failed: { label: 'Failed', toneClassName: 'bg-destructive/15 text-destructive' },
+};
+
 // Memoized transcript segment component
 const TranscriptSegment = memo(function TranscriptSegment({
     id,
@@ -89,6 +99,11 @@ const TranscriptSegment = memo(function TranscriptSegment({
     showConfidence: boolean;
 }) {
     const displayText = cleanStopWords(text) || (text.trim() === '' ? '[Silence]' : text);
+    const visibleSpeakerLabel = isOverlap ? 'Multiple speakers' : speakerLabel?.trim();
+    const statusBadge =
+        diarizationStatus && diarizationStatus !== 'none'
+            ? DIARIZATION_STATUS_BADGES[diarizationStatus]
+            : null;
 
     return (
         <div id={`segment-${id}`} className="mb-3">
@@ -106,27 +121,19 @@ const TranscriptSegment = memo(function TranscriptSegment({
                     </TooltipContent>
                 </Tooltip>
                 <div className="flex-1">
-                    {(speakerLabel || isOverlap || diarizationStatus) && (
+                    {(visibleSpeakerLabel || statusBadge) && (
                         <div className="mb-1 flex items-center gap-2 text-xs">
-                            <span
-                                className="font-medium"
-                                style={{ color: speakerColor || (isOverlap ? '#f97316' : '#475569') }}
-                            >
-                                {isOverlap ? 'Multiple speakers' : speakerLabel}
-                            </span>
-                            {diarizationStatus === 'provisional' && (
-                                <span className="rounded-full bg-amber-100 px-2 py-0.5 font-medium text-amber-800">
-                                    Provisional
+                            {visibleSpeakerLabel && (
+                                <span
+                                    className="font-medium"
+                                    style={{ color: speakerColor || (isOverlap ? '#f97316' : undefined) }}
+                                >
+                                    {visibleSpeakerLabel}
                                 </span>
                             )}
-                            {diarizationStatus === 'final' && (
-                                <span className="rounded-full bg-green-100 px-2 py-0.5 font-medium text-green-800">
-                                    Final
-                                </span>
-                            )}
-                            {diarizationStatus === 'needs_review' && (
-                                <span className="rounded-full bg-purple-100 px-2 py-0.5 font-medium text-purple-800">
-                                    Needs review
+                            {statusBadge && (
+                                <span className={`rounded-full px-2 py-0.5 font-medium ${statusBadge.toneClassName}`}>
+                                    {statusBadge.label}
                                 </span>
                             )}
                         </div>

--- a/frontend/src/components/VirtualizedTranscriptView.tsx
+++ b/frontend/src/components/VirtualizedTranscriptView.tsx
@@ -9,6 +9,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { RecordingStatusBar } from "./RecordingStatusBar";
 import { motion, AnimatePresence } from "framer-motion";
 import { TranscriptSegmentData } from "@/types";
+import type { DiarizationStatus } from "@/types/diarization";
 
 export interface VirtualizedTranscriptViewProps {
     /** Transcript segments to display */
@@ -69,6 +70,10 @@ const TranscriptSegment = memo(function TranscriptSegment({
     timestamp,
     text,
     confidence,
+    speakerLabel,
+    speakerColor,
+    isOverlap,
+    diarizationStatus,
     isStreaming,
     showConfidence,
 }: {
@@ -76,6 +81,10 @@ const TranscriptSegment = memo(function TranscriptSegment({
     timestamp: number;
     text: string;
     confidence?: number;
+    speakerLabel?: string | null;
+    speakerColor?: string | null;
+    isOverlap?: boolean | null;
+    diarizationStatus?: DiarizationStatus | null;
     isStreaming: boolean;
     showConfidence: boolean;
 }) {
@@ -97,6 +106,31 @@ const TranscriptSegment = memo(function TranscriptSegment({
                     </TooltipContent>
                 </Tooltip>
                 <div className="flex-1">
+                    {(speakerLabel || isOverlap || diarizationStatus) && (
+                        <div className="mb-1 flex items-center gap-2 text-xs">
+                            <span
+                                className="font-medium"
+                                style={{ color: speakerColor || (isOverlap ? '#f97316' : '#475569') }}
+                            >
+                                {isOverlap ? 'Multiple speakers' : speakerLabel}
+                            </span>
+                            {diarizationStatus === 'provisional' && (
+                                <span className="rounded-full bg-amber-100 px-2 py-0.5 font-medium text-amber-800">
+                                    Provisional
+                                </span>
+                            )}
+                            {diarizationStatus === 'final' && (
+                                <span className="rounded-full bg-green-100 px-2 py-0.5 font-medium text-green-800">
+                                    Final
+                                </span>
+                            )}
+                            {diarizationStatus === 'needs_review' && (
+                                <span className="rounded-full bg-purple-100 px-2 py-0.5 font-medium text-purple-800">
+                                    Needs review
+                                </span>
+                            )}
+                        </div>
+                    )}
                     {isStreaming ? (
                         <div className="bg-gray-100 border border-gray-200 rounded-lg px-3 py-2">
                             <p className="text-base text-gray-800 leading-relaxed">{displayText}</p>
@@ -294,6 +328,10 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                                         timestamp={segment.timestamp}
                                         text={getDisplayText(segment)}
                                         confidence={segment.confidence}
+                                        speakerLabel={segment.speaker_label}
+                                        speakerColor={segment.speaker_color}
+                                        isOverlap={segment.is_overlap}
+                                        diarizationStatus={segment.diarization_status}
                                         isStreaming={isStreaming}
                                         showConfidence={showConfidence}
                                     />
@@ -350,6 +388,10 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                                         timestamp={segment.timestamp}
                                         text={getDisplayText(segment)}
                                         confidence={segment.confidence}
+                                        speakerLabel={segment.speaker_label}
+                                        speakerColor={segment.speaker_color}
+                                        isOverlap={segment.is_overlap}
+                                        diarizationStatus={segment.diarization_status}
                                         isStreaming={isStreaming}
                                         showConfidence={showConfidence}
                                     />

--- a/frontend/src/components/settings/SettingsRow.tsx
+++ b/frontend/src/components/settings/SettingsRow.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface SettingsRowProps {
+  title: string;
+  description?: string;
+  control: React.ReactNode;
+  disabledReason?: string;
+}
+
+export function SettingsRow({ title, description, control, disabledReason }: SettingsRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-6 rounded-lg border border-border p-4">
+      <div className="min-w-0 flex-1">
+        <div className="font-medium text-foreground">{title}</div>
+        {description && (
+          <div className="mt-1 text-sm text-muted-foreground">{description}</div>
+        )}
+        {disabledReason && (
+          <div className="mt-2 text-xs text-amber-700">{disabledReason}</div>
+        )}
+      </div>
+      <div className="flex-shrink-0">{control}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/SettingsSection.tsx
+++ b/frontend/src/components/settings/SettingsSection.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface SettingsSectionProps {
+  title: string;
+  description?: string;
+  badge?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export function SettingsSection({ title, description, badge, children }: SettingsSectionProps) {
+  return (
+    <section className="bg-card text-card-foreground rounded-lg border border-border p-6 shadow-sm">
+      <div className="mb-5">
+        <div className="flex items-center gap-2">
+          <h3 className="text-lg font-semibold text-foreground">{title}</h3>
+          {badge}
+        </div>
+        {description && (
+          <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      <div className="space-y-3">{children}</div>
+    </section>
+  );
+}

--- a/frontend/src/components/settings/SettingsStatusBadge.tsx
+++ b/frontend/src/components/settings/SettingsStatusBadge.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+type SettingsStatusBadgeTone = 'beta' | 'local' | 'provisional' | 'final' | 'fallback' | 'review' | 'unavailable';
+
+const toneClassName: Record<SettingsStatusBadgeTone, string> = {
+  beta: 'bg-yellow-100 text-yellow-800',
+  local: 'bg-blue-100 text-blue-800',
+  provisional: 'bg-amber-100 text-amber-800',
+  final: 'bg-green-100 text-green-800',
+  fallback: 'bg-orange-100 text-orange-800',
+  review: 'bg-purple-100 text-purple-800',
+  unavailable: 'bg-gray-100 text-gray-700',
+};
+
+interface SettingsStatusBadgeProps {
+  tone: SettingsStatusBadgeTone;
+  children: React.ReactNode;
+}
+
+export function SettingsStatusBadge({ tone, children }: SettingsStatusBadgeProps) {
+  return (
+    <span className={cn('inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium', toneClassName[tone])}>
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/components/settings/SettingsStatusBadge.tsx
+++ b/frontend/src/components/settings/SettingsStatusBadge.tsx
@@ -10,7 +10,7 @@ const toneClassName: Record<SettingsStatusBadgeTone, string> = {
   final: 'bg-green-100 text-green-800',
   fallback: 'bg-orange-100 text-orange-800',
   review: 'bg-purple-100 text-purple-800',
-  unavailable: 'bg-gray-100 text-gray-700',
+  unavailable: 'bg-muted text-muted-foreground',
 };
 
 interface SettingsStatusBadgeProps {

--- a/frontend/src/contexts/ConfigContext.tsx
+++ b/frontend/src/contexts/ConfigContext.tsx
@@ -7,6 +7,7 @@ import { configService, ModelConfig } from '@/services/configService';
 import { invoke } from '@tauri-apps/api/core';
 import Analytics from '@/lib/analytics';
 import { BetaFeatures, BetaFeatureKey, loadBetaFeatures, saveBetaFeatures } from '@/types/betaFeatures';
+import { DEFAULT_DIARIZATION_SETTINGS, type DiarizationSettings } from '@/types/diarization';
 
 export interface OllamaModel {
   name: string;
@@ -66,6 +67,11 @@ interface ConfigContextType {
   // Beta features
   betaFeatures: BetaFeatures;
   toggleBetaFeature: (featureKey: BetaFeatureKey, enabled: boolean) => void;
+
+  // Speaker diarization settings
+  diarizationSettings: DiarizationSettings;
+  isLoadingDiarizationSettings: boolean;
+  updateDiarizationSettings: (settings: DiarizationSettings) => Promise<void>;
 
   // Ollama models
   models: OllamaModel[];
@@ -167,6 +173,10 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
   const [betaFeatures, setBetaFeatures] = useState<BetaFeatures>(() => {
     return loadBetaFeatures();
   });
+
+  // Speaker diarization settings state
+  const [diarizationSettings, setDiarizationSettings] = useState<DiarizationSettings>(DEFAULT_DIARIZATION_SETTINGS);
+  const [isLoadingDiarizationSettings, setIsLoadingDiarizationSettings] = useState(false);
 
   // Preference settings state (lazy loaded)
   const [notificationSettings, setNotificationSettings] = useState<NotificationSettings | null>(null);
@@ -361,6 +371,24 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     loadDevicePreferences();
   }, []);
 
+  // Load speaker diarization settings on mount
+  useEffect(() => {
+    const loadDiarizationSettings = async () => {
+      setIsLoadingDiarizationSettings(true);
+      try {
+        const settings = await configService.getDiarizationSettings();
+        setDiarizationSettings(settings);
+      } catch (error) {
+        console.error('[ConfigContext] Failed to load diarization settings:', error);
+        setDiarizationSettings(DEFAULT_DIARIZATION_SETTINGS);
+      } finally {
+        setIsLoadingDiarizationSettings(false);
+      }
+    };
+
+    loadDiarizationSettings();
+  }, []);
+
   // Calculate model options based on available models
   const modelOptions: Record<ModelConfig['provider'], string[]> = {
     ollama: models.map(model => model.name),
@@ -403,6 +431,11 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
 
       return updated;
     });
+  }, []);
+
+  const updateDiarizationSettings = useCallback(async (settings: DiarizationSettings) => {
+    setDiarizationSettings(settings);
+    await configService.saveDiarizationSettings(settings);
   }, []);
 
   // Update individual provider API key
@@ -499,6 +532,9 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     toggleConfidenceIndicator,
     betaFeatures,
     toggleBetaFeature,
+    diarizationSettings,
+    isLoadingDiarizationSettings,
+    updateDiarizationSettings,
     models,
     modelOptions,
     error,
@@ -521,6 +557,9 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     toggleConfidenceIndicator,
     betaFeatures,
     toggleBetaFeature,
+    diarizationSettings,
+    isLoadingDiarizationSettings,
+    updateDiarizationSettings,
     models,
     modelOptions,
     error,

--- a/frontend/src/contexts/TranscriptContext.tsx
+++ b/frontend/src/contexts/TranscriptContext.tsx
@@ -315,6 +315,13 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
             audio_start_time: update.audio_start_time,
             audio_end_time: update.audio_end_time,
             duration: update.duration,
+            speaker_id: update.speaker_id,
+            speaker_label: update.speaker_label,
+            speaker_color: update.speaker_color,
+            is_overlap: update.is_overlap,
+            diarization_status: update.diarization_status,
+            diarization_method: update.diarization_method,
+            diarization_confidence: update.diarization_confidence,
           };
 
           // Add to buffer
@@ -383,6 +390,13 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
             audio_start_time: segment.audio_start_time,
             audio_end_time: segment.audio_end_time,
             duration: segment.duration,
+            speaker_id: segment.speaker_id,
+            speaker_label: segment.speaker_label,
+            speaker_color: segment.speaker_color,
+            is_overlap: segment.is_overlap,
+            diarization_status: segment.diarization_status,
+            diarization_method: segment.diarization_method,
+            diarization_confidence: segment.diarization_confidence,
           }));
 
           setTranscripts(formattedTranscripts);
@@ -424,6 +438,13 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
       audio_start_time: update.audio_start_time,
       audio_end_time: update.audio_end_time,
       duration: update.duration,
+      speaker_id: update.speaker_id,
+      speaker_label: update.speaker_label,
+      speaker_color: update.speaker_color,
+      is_overlap: update.is_overlap,
+      diarization_status: update.diarization_status,
+      diarization_method: update.diarization_method,
+      diarization_confidence: update.diarization_confidence,
     };
 
     setTranscripts(prev => {
@@ -465,7 +486,13 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
     };
 
     const fullTranscript = transcripts
-      .map(t => `${formatTime(t.audio_start_time)} ${t.text}`)
+      .map(t => {
+        const speaker = t.is_overlap
+          ? 'Multiple speakers'
+          : (t.speaker_label || undefined);
+        const speakerPrefix = speaker ? ` ${speaker}:` : '';
+        return `${formatTime(t.audio_start_time)}${speakerPrefix} ${t.text}`;
+      })
       .join('\n');
     navigator.clipboard.writeText(fullTranscript);
 

--- a/frontend/src/hooks/meeting-details/useCopyOperations.ts
+++ b/frontend/src/hooks/meeting-details/useCopyOperations.ts
@@ -85,8 +85,17 @@ export function useCopyOperations({
 
     const header = `# Transcript of the Meeting: ${meeting.id} - ${meetingTitle ?? meeting.title}\n\n`;
     const date = `## Date: ${new Date(meeting.created_at).toLocaleDateString()}\n\n`;
+    const formatSpeakerPrefix = (transcript: Transcript): string => {
+      if (transcript.is_overlap) {
+        return 'Multiple speakers: ';
+      }
+
+      const speakerLabel = transcript.speaker_label?.trim();
+      return speakerLabel ? `${speakerLabel}: ` : '';
+    };
+
     const fullTranscript = allTranscripts
-      .map(t => `${formatTime(t.audio_start_time, t.timestamp)} ${t.text}  `)
+      .map(t => `${formatTime(t.audio_start_time, t.timestamp)} ${formatSpeakerPrefix(t)}${t.text}  `)
       .join('\n');
 
     await navigator.clipboard.writeText(header + date + fullTranscript);

--- a/frontend/src/hooks/usePaginatedTranscripts.ts
+++ b/frontend/src/hooks/usePaginatedTranscripts.ts
@@ -37,6 +37,13 @@ function convertTranscriptsToSegments(transcripts: Transcript[]): TranscriptSegm
         endTime: t.audio_end_time,
         text: t.text,
         confidence: t.confidence,
+        speaker_id: t.speaker_id,
+        speaker_label: t.speaker_label,
+        speaker_color: t.speaker_color,
+        is_overlap: t.is_overlap,
+        diarization_status: t.diarization_status,
+        diarization_method: t.diarization_method,
+        diarization_confidence: t.diarization_confidence,
     }));
 }
 

--- a/frontend/src/services/configService.ts
+++ b/frontend/src/services/configService.ts
@@ -7,6 +7,7 @@
 
 import { invoke } from '@tauri-apps/api/core';
 import { TranscriptModelProps } from '@/components/TranscriptSettings';
+import type { DiarizationSettings } from '@/types/diarization';
 
 export interface ModelConfig {
   provider: 'ollama' | 'groq' | 'claude' | 'openrouter' | 'openai' | 'builtin-ai' | 'custom-openai';
@@ -68,6 +69,22 @@ export class ConfigService {
    */
   async getRecordingPreferences(): Promise<RecordingPreferences> {
     return invoke<RecordingPreferences>('get_recording_preferences');
+  }
+
+  /**
+   * Get saved diarization settings
+   * @returns Promise with diarization settings
+   */
+  async getDiarizationSettings(): Promise<DiarizationSettings> {
+    return invoke<DiarizationSettings>('get_diarization_settings');
+  }
+
+  /**
+   * Save diarization settings
+   * @param settings - DiarizationSettings to save
+   */
+  async saveDiarizationSettings(settings: DiarizationSettings): Promise<void> {
+    return invoke<void>('save_diarization_settings', { settings });
   }
 
   /**

--- a/frontend/src/types/betaFeatures.ts
+++ b/frontend/src/types/betaFeatures.ts
@@ -22,10 +22,17 @@ export interface BetaFeatures {
    * @since v0.3.0
    */
   importAndRetranscribe: boolean;
+
+  /**
+   * Label speakers in transcripts with live provisional labels and post-call refinement
+   * @since v0.4.2
+   */
+  speakerDiarization: boolean;
 }
 
 export const DEFAULT_BETA_FEATURES: BetaFeatures = {
   importAndRetranscribe: true, // Default: enabled
+  speakerDiarization: false,
 };
 
 
@@ -34,6 +41,7 @@ export const DEFAULT_BETA_FEATURES: BetaFeatures = {
  */
 export const BETA_FEATURE_NAMES: Record<keyof BetaFeatures, string> = {
   importAndRetranscribe: 'Import Audio & Retranscribe',
+  speakerDiarization: 'Speaker Labels',
 };
 
 /**
@@ -41,6 +49,7 @@ export const BETA_FEATURE_NAMES: Record<keyof BetaFeatures, string> = {
  */
 export const BETA_FEATURE_DESCRIPTIONS: Record<keyof BetaFeatures, string> = {
   importAndRetranscribe: 'Import audio files to transcribe or retranscribe existing meetings with different language settings.',
+  speakerDiarization: 'Label speakers in transcripts with live provisional labels and post-call refinement.',
 };
 
 /**

--- a/frontend/src/types/diarization.ts
+++ b/frontend/src/types/diarization.ts
@@ -1,0 +1,27 @@
+export type DiarizationMode = 'live_plus_post_call' | 'post_call_only' | 'off';
+export type OverlapHandling = 'multiple_speakers';
+export type DiarizationStatus =
+  | 'none'
+  | 'provisional'
+  | 'final'
+  | 'fallback_to_live'
+  | 'failed'
+  | 'needs_review';
+
+export interface DiarizationSettings {
+  enabled: boolean;
+  mode: DiarizationMode;
+  showProvisionalLabels: boolean;
+  postCallRefinementEnabled: boolean;
+  overlapHandling: OverlapHandling;
+  speakerReviewEnabled: boolean;
+}
+
+export const DEFAULT_DIARIZATION_SETTINGS: DiarizationSettings = {
+  enabled: false,
+  mode: 'live_plus_post_call',
+  showProvisionalLabels: true,
+  postCallRefinementEnabled: true,
+  overlapHandling: 'multiple_speakers',
+  speakerReviewEnabled: true,
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -16,6 +16,13 @@ export interface Transcript {
   audio_start_time?: number; // Seconds from recording start (e.g., 125.3)
   audio_end_time?: number;   // Seconds from recording start (e.g., 128.6)
   duration?: number;          // Segment duration in seconds (e.g., 3.3)
+  speaker_id?: string | null;
+  speaker_label?: string | null;
+  speaker_color?: string | null;
+  is_overlap?: boolean | null;
+  diarization_status?: 'none' | 'provisional' | 'final' | 'fallback_to_live' | 'failed' | 'needs_review' | null;
+  diarization_method?: string | null;
+  diarization_confidence?: number | null;
 }
 
 export interface TranscriptUpdate {
@@ -30,6 +37,13 @@ export interface TranscriptUpdate {
   audio_start_time: number; // Seconds from recording start
   audio_end_time: number;   // Seconds from recording start
   duration: number;          // Segment duration in seconds
+  speaker_id?: string | null;
+  speaker_label?: string | null;
+  speaker_color?: string | null;
+  is_overlap?: boolean | null;
+  diarization_status?: 'none' | 'provisional' | 'final' | 'fallback_to_live' | 'failed' | 'needs_review' | null;
+  diarization_method?: string | null;
+  diarization_confidence?: number | null;
 }
 
 export interface Block {
@@ -107,4 +121,11 @@ export interface TranscriptSegmentData {
   endTime?: number; // audio_end_time in seconds
   text: string;
   confidence?: number;
+  speaker_id?: string | null;
+  speaker_label?: string | null;
+  speaker_color?: string | null;
+  is_overlap?: boolean | null;
+  diarization_status?: 'none' | 'provisional' | 'final' | 'fallback_to_live' | 'failed' | 'needs_review' | null;
+  diarization_method?: string | null;
+  diarization_confidence?: number | null;
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -129,3 +129,10 @@ export interface TranscriptSegmentData {
   diarization_method?: string | null;
   diarization_confidence?: number | null;
 }
+
+export interface MeetingSpeaker {
+  speakerId: string;
+  speakerLabel: string;
+  speakerColor?: string | null;
+  segmentCount: number;
+}


### PR DESCRIPTION
## Description
Adds the speaker diarization foundation and speaker-management workflow for meeting transcripts:

- Adds diarization domain types, database persistence, transcript assignment, overlap handling, and meeting-level status metadata.
- Adds Tauri commands and frontend state for diarization settings.
- Renders speaker labels and diarization status in meeting transcripts.
- Adds a full-meeting speaker list with inline rename, validation, and persistence to both transcript and speaker-segment rows.
- Adds the diarization design/specification and Pencil settings artifact.
- Stabilizes two pre-existing Rust verification gates: floating-point duration tolerance and a non-compiling documentation example.

### Review scope cleanup

The branch was rebuilt directly from the current `devtest` head after review. Dark-theme and Gemma 4 commits/files are no longer part of this PR.

## Related Issue
Not linked — follow-up implementation for the 0.42 speaker diarization branch.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] All tests pass

Validation run locally after rebuilding the branch:

- `git diff --check upstream/devtest...HEAD`
- `pnpm run build`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer cargo check -p meetily`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer cargo test -p meetily`
  - Unit tests: 210 passed, 3 ignored
  - Doc tests: 1 passed, 1 ignored

## Documentation
- [x] Documentation updated
- [ ] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is based directly on current `devtest`
- [x] No merge conflicts
- [x] Unrelated theme and Gemma changes removed

## Screenshots (if applicable)
Not captured in this session.

## Additional Notes
The PR now contains 24 commits across 36 files, reduced from the previous stacked diff of 38 commits across 156 files.
