### PR TITLE
Fix/summary cleanup and responsive layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ experiments/
 target/
 
 frontend/src-tauri/binaries/
+.superpowers/

--- a/frontend/build-gpu.sh
+++ b/frontend/build-gpu.sh
@@ -108,7 +108,7 @@ fi
 # Note: llama-cpp-2 does NOT support coreml, only metal/cuda/vulkan
 # So for macOS Apple Silicon (which returns 'coreml' for Whisper), use 'metal' for llama-helper
 HELPER_FEATURES=""
-if [ -n "$TAURI_GPU_FEATURE" ]; then
+if [ -n "$TAURI_GPU_FEATURE" ] && [ "$TAURI_GPU_FEATURE" != "none" ]; then
     LLAMA_FEATURE="$TAURI_GPU_FEATURE"
     if [ "$LLAMA_FEATURE" = "coreml" ]; then
         LLAMA_FEATURE="metal"

--- a/frontend/build-gpu.sh
+++ b/frontend/build-gpu.sh
@@ -70,15 +70,7 @@ if [ -z "$TAURI_GPU_FEATURE" ]; then
     echo -e "${BLUE}🔍 Detecting GPU features...${NC}"
     # Run the detection script and capture output
     # We need to run it from frontend dir
-    if [ "$FRONTEND_DIR" != "." ]; then
-        cd "$FRONTEND_DIR"
-    fi
-    
     TAURI_GPU_FEATURE=$(node scripts/auto-detect-gpu.js)
-    
-    if [ "$FRONTEND_DIR" != "." ]; then
-        cd ..
-    fi
 fi
 
 if [ -n "$TAURI_GPU_FEATURE" ]; then

--- a/frontend/src-tauri/src/summary/processor.rs
+++ b/frontend/src-tauri/src/summary/processor.rs
@@ -13,7 +13,7 @@ static THINKING_TAG_REGEX: Lazy<Regex> = Lazy::new(|| {
 });
 
 static REASONING_BLOCKS_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(?s)(?im)^(?:###?\s+)?(?:\*\*|__)?(?:Thinking(?: Process)?|Self-Correction|Decision Strategy|Strict Interpretation|Wait\.\.\.|Actually checking the provided text again carefully\.\.\.?)(?:\*\*|__)?[:\-\s\n]*.*?(?P<delim>\n\s*\n|\n\s*(?:#|\*\*|__|- \*\*)|$)").unwrap()
+    Regex::new(r"(?s)(?im)^(?:###?\s+)?(?:\*\*|__)?(?:Thinking(?: Process)?|Self-Correction|Decision Strategy|Strict Interpretation|Wait\.\.\.|Actually checking the provided text again carefully\.\.\.?)(?:\*\*|__)?[:\-\s\n]*.*?(?P<delim>\n\s*(?:#+\s+|\*\*[^*]+\*\*\s*(?:\n|$)|__[^_]+__\s*(?:\n|$))|\z)").unwrap()
 });
 
 const ENGLISH_BASE_SUMMARY_INSTRUCTION: &str =
@@ -872,11 +872,6 @@ mod tests {
     #[test]
     fn test_clean_llm_markdown_output_reasoning_removal() {
         let raw_output = "\
-Thinking Process:
-1. Summarize details...
-Wait... Actually checking the provided text again carefully...
-Wait! Let me re-verify.
-
 # Meeting Title
 
 **Summary**
@@ -884,15 +879,18 @@ This is a summary.
 
 Self-Correction:
 No, let's fix that.
+We have multi-paragraph reasoning here.
+- **Bold point**: details
+- List item 2
 
 **Action Items**
 - Task 1
 ";
         let cleaned = clean_llm_markdown_output(raw_output);
         assert!(cleaned.starts_with("# Meeting Title"));
-        assert!(!cleaned.contains("Thinking Process"));
         assert!(!cleaned.contains("Self-Correction"));
-        assert!(!cleaned.contains("Actually checking"));
+        assert!(!cleaned.contains("We have multi-paragraph"));
+        assert!(!cleaned.contains("Bold point"));
         assert!(cleaned.contains("**Summary**"));
         assert!(cleaned.contains("**Action Items**"));
     }

--- a/frontend/src-tauri/src/summary/processor.rs
+++ b/frontend/src-tauri/src/summary/processor.rs
@@ -13,7 +13,7 @@ static THINKING_TAG_REGEX: Lazy<Regex> = Lazy::new(|| {
 });
 
 static REASONING_BLOCKS_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(?s)(?im)^(?:###?\s+)?(?:\*\*|__)?(?:Thinking(?: Process)?|Self-Correction|Decision Strategy|Strict Interpretation|Wait\.\.\.|Actually checking the provided text again carefully\.\.\.?)(?:\*\*|__)?[:\-\s\n]*.*?(?P<delim>\n\s*(?:#+\s+|\*\*[^*]+\*\*\s*(?:\n|$)|__[^_]+__\s*(?:\n|$))|\z)").unwrap()
+    Regex::new(r"(?s)(?im)^(?:###?\s+)?(?:\*\*|__)?(?:Thinking(?: Process)?|Self-Correction|Decision Strategy|Strict Interpretation|Wait\.\.\.|Actually checking the provided text again carefully\.\.\.?)(?:\*\*|__)?[:\-\s\n]*.*?(?P<delim>\n\s*(?:\n|#+\s+|\*\*[^*]+\*\*\s*(?:\n|$)|__[^_]+__\s*(?:\n|$))|\z)").unwrap()
 });
 
 const ENGLISH_BASE_SUMMARY_INSTRUCTION: &str =
@@ -273,11 +273,9 @@ pub fn clean_llm_markdown_output(markdown: &str) -> String {
 
     let mut trimmed = cleaned.trim().to_string();
 
-    // If there is a markdown title or sub-header, strip any preceding garbage/thinking
-    if let Some(pos) = trimmed.find("# ") {
-        trimmed = trimmed[pos..].to_string();
-    } else if let Some(pos) = trimmed.find("## ") {
-        trimmed = trimmed[pos..].to_string();
+    // Find the first markdown heading line (starts with '#') and discard any preceding noise
+    if let Some(line_idx) = trimmed.lines().position(|line| line.trim_start().starts_with('#')) {
+        trimmed = trimmed.lines().skip(line_idx).collect::<Vec<&str>>().join("\n");
     }
 
     // List of possible language identifiers for code blocks
@@ -893,5 +891,18 @@ We have multi-paragraph reasoning here.
         assert!(!cleaned.contains("Bold point"));
         assert!(cleaned.contains("**Summary**"));
         assert!(cleaned.contains("**Action Items**"));
+    }
+
+    #[test]
+    fn test_normal_content_after_thinking() {
+        let raw_output = "\
+# Title
+Summary...
+Thinking: I am thinking.
+
+Some normal content here.
+";
+        let cleaned = clean_llm_markdown_output(raw_output);
+        assert!(cleaned.contains("Some normal content here."));
     }
 }

--- a/frontend/src-tauri/src/summary/processor.rs
+++ b/frontend/src-tauri/src/summary/processor.rs
@@ -12,6 +12,10 @@ static THINKING_TAG_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"(?s)<think(?:ing)?>.*?</think(?:ing)?>").unwrap()
 });
 
+static REASONING_BLOCKS_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?s)(?im)^(?:###?\s+)?(?:\*\*|__)?(?:Thinking(?: Process)?|Self-Correction|Decision Strategy|Strict Interpretation|Wait\.\.\.|Actually checking the provided text again carefully\.\.\.?)(?:\*\*|__)?[:\-\s\n]*.*?(?P<delim>\n\s*\n|\n\s*(?:#|\*\*|__|- \*\*)|$)").unwrap()
+});
+
 const ENGLISH_BASE_SUMMARY_INSTRUCTION: &str =
     "**Write the summary/report in English regardless of transcript language; non-English prose is invalid.**";
 
@@ -262,7 +266,19 @@ pub fn clean_llm_markdown_output(markdown: &str) -> String {
     // Remove <think>...</think> or <thinking>...</thinking> blocks using cached regex
     let without_thinking = THINKING_TAG_REGEX.replace_all(markdown, "");
 
-    let trimmed = without_thinking.trim();
+    let mut cleaned = without_thinking.to_string();
+
+    // Remove block-level reasoning paragraphs
+    cleaned = REASONING_BLOCKS_REGEX.replace_all(&cleaned, "$delim").to_string();
+
+    let mut trimmed = cleaned.trim().to_string();
+
+    // If there is a markdown title or sub-header, strip any preceding garbage/thinking
+    if let Some(pos) = trimmed.find("# ") {
+        trimmed = trimmed[pos..].to_string();
+    } else if let Some(pos) = trimmed.find("## ") {
+        trimmed = trimmed[pos..].to_string();
+    }
 
     // List of possible language identifiers for code blocks
     const PREFIXES: &[&str] = &["```markdown\n", "```\n"];
@@ -276,8 +292,7 @@ pub fn clean_llm_markdown_output(markdown: &str) -> String {
         }
     }
 
-    // If no fences found, return the trimmed string
-    trimmed.to_string()
+    trimmed
 }
 
 /// Extracts meeting name from the first heading in markdown
@@ -852,5 +867,33 @@ mod tests {
     fn underscore_locale_variant_returns_none() {
         // OS locale APIs (notably macOS) may emit "en_GB" with underscore.
         assert_eq!(resolve_cached_english(Some("body"), Some("en_GB")), None);
+    }
+
+    #[test]
+    fn test_clean_llm_markdown_output_reasoning_removal() {
+        let raw_output = "\
+Thinking Process:
+1. Summarize details...
+Wait... Actually checking the provided text again carefully...
+Wait! Let me re-verify.
+
+# Meeting Title
+
+**Summary**
+This is a summary.
+
+Self-Correction:
+No, let's fix that.
+
+**Action Items**
+- Task 1
+";
+        let cleaned = clean_llm_markdown_output(raw_output);
+        assert!(cleaned.starts_with("# Meeting Title"));
+        assert!(!cleaned.contains("Thinking Process"));
+        assert!(!cleaned.contains("Self-Correction"));
+        assert!(!cleaned.contains("Actually checking"));
+        assert!(cleaned.contains("**Summary**"));
+        assert!(cleaned.contains("**Action Items**"));
     }
 }

--- a/frontend/src/app/meeting-details/page-content.tsx
+++ b/frontend/src/app/meeting-details/page-content.tsx
@@ -57,6 +57,7 @@ export default function PageContent({
   const [customPrompt, setCustomPrompt] = useState<string>('');
   const [isRecording] = useState(false);
   const [summaryResponse] = useState<SummaryResponse | null>(null);
+  const [activeTab, setActiveTab] = useState<'transcript' | 'summary'>('transcript');
 
   // Ref to store the modal open function from SummaryGeneratorButtonGroup
   const openModelSettingsRef = useRef<(() => void) | null>(null);
@@ -170,6 +171,31 @@ export default function PageContent({
       transition={{ duration: 0.3, ease: 'easeOut' }}
       className="flex flex-col h-screen bg-gray-50"
     >
+      {/* Responsive tab switcher — visible below lg when summary exists */}
+      {meetingData.aiSummary && (
+        <div className="flex lg:hidden border-b border-gray-200 bg-white sticky top-0 z-10">
+          <button
+            onClick={() => setActiveTab('transcript')}
+            className={`flex-1 py-3 text-center font-medium border-b-2 text-sm transition-colors ${
+              activeTab === 'transcript'
+                ? 'border-blue-600 text-blue-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            Transcript
+          </button>
+          <button
+            onClick={() => setActiveTab('summary')}
+            className={`flex-1 py-3 text-center font-medium border-b-2 text-sm transition-colors ${
+              activeTab === 'summary'
+                ? 'border-blue-600 text-blue-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            Summary
+          </button>
+        </div>
+      )}
       <div className="flex flex-1 overflow-hidden">
         <TranscriptPanel
           transcripts={meetingData.transcripts}
@@ -191,6 +217,7 @@ export default function PageContent({
           meetingId={meeting.id}
           meetingFolderPath={meeting.folder_path}
           onRefetchTranscripts={onRefetchTranscripts}
+          className={`${meetingData.aiSummary && activeTab !== 'transcript' ? 'hidden' : 'flex flex-1 w-full h-full'} lg:flex lg:w-1/3 lg:min-w-[320px] lg:max-w-[450px] border-r border-gray-200 bg-white flex-col relative shrink-0`}
         />
         <SummaryPanel
           meeting={meeting}
@@ -226,6 +253,7 @@ export default function PageContent({
           onTemplateSelect={templates.handleTemplateSelection}
           isModelConfigLoading={false}
           onOpenModelSettings={handleRegisterModalOpen}
+          className={`${meetingData.aiSummary && activeTab !== 'summary' ? 'hidden' : 'flex flex-1 w-full h-full'} lg:flex-1 min-w-0 flex flex-col bg-white overflow-hidden`}
         />
       </div>
     </motion.div>

--- a/frontend/src/components/MeetingDetails/SummaryPanel.tsx
+++ b/frontend/src/components/MeetingDetails/SummaryPanel.tsx
@@ -60,6 +60,7 @@ interface SummaryPanelProps {
   onTemplateSelect: (templateId: string, templateName: string) => void;
   isModelConfigLoading?: boolean;
   onOpenModelSettings?: (openFn: () => void) => void;
+  className?: string;
 }
 
 export function SummaryPanel({
@@ -95,7 +96,8 @@ export function SummaryPanel({
   selectedTemplate,
   onTemplateSelect,
   isModelConfigLoading = false,
-  onOpenModelSettings
+  onOpenModelSettings,
+  className
 }: SummaryPanelProps) {
   const [summaryLang, setSummaryLang] = useState<string | null>(null);
   const [summaryLangStorage, setSummaryLangStorage] = useState<SummaryLanguageStorage>('metadata');
@@ -253,7 +255,7 @@ export function SummaryPanel({
   );
 
   return (
-    <div className="flex-1 min-w-0 flex flex-col bg-white overflow-hidden">
+    <div className={className || "flex-1 min-w-0 flex flex-col bg-white overflow-hidden"}>
       {/* Title area */}
       <div className="p-4 border-b border-gray-200">
         {/* <EditableTitle

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -14,6 +14,7 @@ interface TranscriptPanelProps {
   onOpenMeetingFolder: () => Promise<void>;
   isRecording: boolean;
   disableAutoScroll?: boolean;
+  className?: string;
 
   // Optional pagination props (when using virtualization)
   usePagination?: boolean;
@@ -38,6 +39,7 @@ export function TranscriptPanel({
   onOpenMeetingFolder,
   isRecording,
   disableAutoScroll = false,
+  className,
   usePagination = false,
   segments,
   hasMore,
@@ -65,7 +67,7 @@ export function TranscriptPanel({
   }, [transcripts, usePagination, segments]);
 
   return (
-    <div className="hidden md:flex md:w-1/4 lg:w-1/3 min-w-0 border-r border-gray-200 bg-white flex-col relative shrink-0">
+    <div className={className || "hidden md:flex md:w-1/4 lg:w-1/3 min-w-0 border-r border-gray-200 bg-white flex-col relative shrink-0"}>
       {/* Title area */}
       <div className="p-4 border-b border-gray-200">
         <TranscriptButtonGroup


### PR DESCRIPTION
## Description
This PR resolves the GPU-only build script failure, cleans up LLM reasoning/thinking text from generated summaries without degrading H2 headings, and implements a responsive tabbed switcher on smaller screens (< `lg` breakpoint) to ensure panels remain accessible on resize.

### Changes Made:
- **Build fixes**: 
  - Handled the `none` case for `TAURI_GPU_FEATURE` in `frontend/build-gpu.sh` to prevent CPU-only builds from failing.
- **Summary Clean up**:
  - Replaced target-finding checks with line-start heading detection (`starts_with('#')`) to avoid degrading sub-headers (like `## ` becoming `# `).
  - Updated `REASONING_BLOCKS_REGEX` in the Rust backend to stop matching on double newlines (`\n\n`), preventing standard summary paragraphs that follow a thinking block from being stripped.
  - Added unit test cases covering general summary prose preservation after thinking blocks.
- **Responsive Layout**:
  - Added `className` prop to `TranscriptPanel` and `SummaryPanel` components.
  - Added an `activeTab` React state in `page-content.tsx` along with a responsive tab-switcher bar that toggles between `Transcript` and `Summary` tabs when the screen width falls below the `lg` breakpoint and a summary is active.

## Related Issue
Fixes issues with CPU-only build failures, summary reasoning cleanup, and panel resizing.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] All tests pass

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [x] Updated README if needed
