### PR TITLE
fix(summary): preserve transcript coverage across chunks

### DIFF
--- a/frontend/src-tauri/src/summary/processor.rs
+++ b/frontend/src-tauri/src/summary/processor.rs
@@ -214,11 +214,10 @@ pub fn chunk_text(text: &str, chunk_size_tokens: usize, overlap_tokens: usize) -
 
     let mut chunks = Vec::new();
     let mut start_char = 0;
-    // Step is the size of the non-overlapping part of the window
-    let step = chunk_size_chars.saturating_sub(overlap_chars).max(1);
 
     while start_char < total_chars {
         let end_char = (start_char + chunk_size_chars).min(total_chars);
+        let mut emitted_end_char = end_char;
 
         // Convert character indices to byte indices for string slicing
         let start_byte: usize = chars[..start_char].iter().map(|c| c.len_utf8()).sum();
@@ -227,24 +226,30 @@ pub fn chunk_text(text: &str, chunk_size_tokens: usize, overlap_tokens: usize) -
         // Try to break at sentence or word boundary for cleaner chunks
         if end_char < total_chars {
             let slice = &text[start_byte..end_byte];
-            // Look for sentence boundary (period followed by space)
-            if let Some(last_period) = slice.rfind(". ") {
-                end_byte = start_byte + last_period + 2;
-            } else if let Some(last_space) = slice.rfind(' ') {
-                // Fall back to word boundary (space)
-                end_byte = start_byte + last_space + 1;
+            let sentence_boundary = slice.rfind(". ").map(|index| index + 2);
+            let word_boundary = slice.rfind(' ').map(|index| index + 1);
+            let boundary = sentence_boundary
+                .filter(|end| slice[..*end].chars().count() > overlap_chars)
+                .or_else(|| {
+                    word_boundary.filter(|end| slice[..*end].chars().count() > overlap_chars)
+                });
+
+            if let Some(boundary) = boundary {
+                end_byte = start_byte + boundary;
+                emitted_end_char = start_char + slice[..boundary].chars().count();
             }
         }
 
         // Extract chunk
         chunks.push(text[start_byte..end_byte].to_string());
 
-        if end_char >= total_chars {
+        if emitted_end_char >= total_chars {
             break;
         }
 
-        // Move to next chunk with overlap (in character units)
-        start_char += step;
+        start_char = emitted_end_char
+            .saturating_sub(overlap_chars)
+            .max(start_char + 1);
     }
 
     info!("Created {} chunks from text", chunks.len());
@@ -708,6 +713,29 @@ async fn normalize_markdown_to_english(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn chunk_text_preserves_content_after_early_sentence_boundary() {
+        let marker = "LOST_MARKER";
+        let text = format!("Intro. {marker} trailing content ensures chunking");
+
+        let chunks = chunk_text(&text, 10, 1);
+
+        assert!(
+            chunks.iter().any(|chunk| chunk.contains(marker)),
+            "marker was omitted from all chunks: {chunks:?}"
+        );
+    }
+
+    #[test]
+    fn chunk_text_keeps_unicode_boundaries() {
+        assert_eq!(chunk_text("é ab", 1, 0), vec!["é ", "ab"]);
+    }
+
+    #[test]
+    fn chunk_text_progresses_when_overlap_matches_window() {
+        assert_eq!(chunk_text("abcd", 1, 1), vec!["abc", "bcd"]);
+    }
 
     #[test]
     fn chunk_summary_prompt_forces_english_base_output() {


### PR DESCRIPTION
## Description

Keep long local-summary chunks contiguous when sentence or word boundaries shorten a window. The next chunk now starts from the boundary that was actually emitted, preserving the configured overlap instead of skipping the gap up to the original fixed-size cursor.

Boundaries that cannot leave forward progress after overlap fall back to the next usable word boundary or the full window. Focused regressions cover the original omission, Unicode text, and overlap equal to the chunk window.

## Related Issue

Fixes #602

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x] Added focused Rust unit tests for coverage, Unicode boundaries, and progress
- [x] Extracted `chunk_text` from the changed source and ran its three regressions with `rustc --test`: 3 passed
- [x] Ran existing frontend library tests with `bun test tests/lib`: 8 passed
- [x] Ran `git diff --check`

## Documentation

- [x] No documentation needed

## Checklist

- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Branch is up to date with `devtest`
- [x] No merge conflicts

## Additional Notes

The hierarchical summary path uses this chunker for long Ollama and BuiltInAI transcripts. Cloud-provider and short-transcript single-pass behavior is unchanged.
