### PR TITLE
fix: guard llama-helper feature flag against literal 'none' in build-gpu.sh

### DIFF
--- a/frontend/build-gpu.sh
+++ b/frontend/build-gpu.sh
@@ -108,7 +108,7 @@ fi
 # Note: llama-cpp-2 does NOT support coreml, only metal/cuda/vulkan
 # So for macOS Apple Silicon (which returns 'coreml' for Whisper), use 'metal' for llama-helper
 HELPER_FEATURES=""
-if [ -n "$TAURI_GPU_FEATURE" ]; then
+if [ -n "$TAURI_GPU_FEATURE" ] && [ "$TAURI_GPU_FEATURE" != "none" ]; then
     LLAMA_FEATURE="$TAURI_GPU_FEATURE"
     if [ "$LLAMA_FEATURE" = "coreml" ]; then
         LLAMA_FEATURE="metal"


### PR DESCRIPTION
## Description
On a CPU-only machine (no CUDA/ROCm/Vulkan SDK installed), GPU auto-detection sets `TAURI_GPU_FEATURE=none`. `frontend/build-gpu.sh`'s llama-helper feature block only guarded on the variable being non-empty, so the literal string `"none"` passed the guard and got forwarded as `cargo build --release --features none` — which fails immediately since `none` isn't a real feature on the `llama-helper` crate.

`frontend/dev-gpu.sh` already has the correct guard (`[ -n "$TAURI_GPU_FEATURE" ] && [ "$TAURI_GPU_FEATURE" != "none" ]`), as does `scripts/tauri-auto.js` (`feature && feature !== 'none'`). This PR mirrors that same guard in `build-gpu.sh` so the release build path matches the dev build path.

## Related Issue
Fixes #587

## Type of Change
- [x] Bug fix

## Testing
- [x] Manual testing performed — verified the guard logic in isolation with `TAURI_GPU_FEATURE=none` (no longer emits `--features none`) and with a real feature like `TAURI_GPU_FEATURE=cuda` (still correctly emits `--features cuda`)
- [x] `bash -n frontend/build-gpu.sh` passes

## Documentation
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Additional Notes
Single-line fix, scoped exactly as described in #587 by the reporter.