### PR TITLE
fix(recording): respect selected transcription provider

### DIFF
--- a/frontend/src/hooks/useRecordingStart.ts
+++ b/frontend/src/hooks/useRecordingStart.ts
@@ -7,11 +7,20 @@ import { useRecordingState, RecordingStatus } from '@/contexts/RecordingStateCon
 import { recordingService } from '@/services/recordingService';
 import Analytics from '@/lib/analytics';
 import { showRecordingNotification } from '@/lib/recordingNotification';
+import {
+  getProviderCommands,
+  hasDownloadingModel,
+  type ModelWithStatus,
+} from '@/lib/transcription-model-readiness';
 import { toast } from 'sonner';
 
 interface UseRecordingStartReturn {
   handleRecordingStart: () => Promise<void>;
   isAutoStarting: boolean;
+}
+
+interface TranscriptConfig {
+  provider?: string;
 }
 
 /**
@@ -49,44 +58,61 @@ export function useRecordingStart(
     return `Meeting ${day}_${month}_${year}_${hours}_${minutes}_${seconds}`;
   }, []);
 
-  // Check if Parakeet transcription model is ready
-  const checkParakeetReady = useCallback(async (): Promise<boolean> => {
+  const getTranscriptionProvider = useCallback(async (): Promise<string> => {
     try {
-      await invoke('parakeet_init');
-      const hasModels = await invoke<boolean>('parakeet_has_available_models');
-      return hasModels;
+      const config = await invoke<TranscriptConfig | null>('api_get_transcript_config');
+      return config?.provider || 'parakeet';
     } catch (error) {
-      console.error('Failed to check Parakeet status:', error);
-      return false;
+      console.error('Failed to load transcription provider:', error);
+      return 'parakeet';
     }
   }, []);
 
-  // Check if any model is currently downloading
+  // Check the selected local transcription provider, not a hardcoded engine.
+  const checkTranscriptionModelReady = useCallback(async (): Promise<boolean> => {
+    try {
+      const provider = await getTranscriptionProvider();
+      const commands = getProviderCommands(provider);
+
+      if (commands) {
+        await invoke(commands.initialize);
+        return await invoke<boolean>(commands.hasAvailableModels);
+      }
+
+      console.error(`Unsupported transcription provider: ${provider}`);
+      return false;
+    } catch (error) {
+      console.error('Failed to check transcription model status:', error);
+      return false;
+    }
+  }, [getTranscriptionProvider]);
+
+  // Check download status for the selected local transcription provider.
   const checkIfModelDownloading = useCallback(async (): Promise<boolean> => {
     try {
-      const models = await invoke<any[]>('parakeet_get_available_models');
-      const isDownloading = models.some(m =>
-        m.status && (
-          typeof m.status === 'object'
-            ? 'Downloading' in m.status
-            : m.status === 'Downloading'
-        )
-      );
-      return isDownloading;
+      const provider = await getTranscriptionProvider();
+      const commands = getProviderCommands(provider);
+      if (!commands) return false;
+
+      const models = await invoke<ModelWithStatus[]>(commands.getAvailableModels);
+      return hasDownloadingModel(models);
     } catch (error) {
       console.error('Failed to check model download status:', error);
       return false; // Default to not downloading (will show error + modal)
     }
-  }, []);
+  }, [getTranscriptionProvider]);
+
+  // The Rust recording command validates the same provider again before capture.
+  const checkModelReady = checkTranscriptionModelReady;
 
   // Handle manual recording start (from button click)
   const handleRecordingStart = useCallback(async () => {
     try {
-      console.log('handleRecordingStart called - checking Parakeet model status');
+      console.log('handleRecordingStart called - checking selected transcription model status');
 
-      // Check if Parakeet transcription model is ready before starting
-      const parakeetReady = await checkParakeetReady();
-      if (!parakeetReady) {
+      // Check the selected transcription model before starting.
+      const modelReady = await checkModelReady();
+      if (!modelReady) {
         const isDownloading = await checkIfModelDownloading();
         if (isDownloading) {
           toast.info('Model download in progress', {
@@ -106,7 +132,7 @@ export function useRecordingStart(
         return;
       }
 
-      console.log('Parakeet ready - setting up meeting title and state');
+      console.log('Selected transcription model ready - setting up meeting title and state');
 
       const randomTitle = generateMeetingTitle();
       setMeetingTitle(randomTitle);
@@ -141,7 +167,7 @@ export function useRecordingStart(
       // Re-throw so RecordingControls can handle device-specific errors
       throw error;
     }
-  }, [generateMeetingTitle, setMeetingTitle, setIsRecording, clearTranscripts, setIsMeetingActive, checkParakeetReady, checkIfModelDownloading, selectedDevices, showModal, setStatus]);
+  }, [generateMeetingTitle, setMeetingTitle, setIsRecording, clearTranscripts, setIsMeetingActive, checkModelReady, checkIfModelDownloading, selectedDevices, showModal, setStatus]);
 
   // Check for autoStartRecording flag and start recording automatically
   useEffect(() => {
@@ -153,9 +179,9 @@ export function useRecordingStart(
           setIsAutoStarting(true);
           sessionStorage.removeItem('autoStartRecording'); // Clear the flag
 
-          // Check if Parakeet transcription model is ready before starting
-          const parakeetReady = await checkParakeetReady();
-          if (!parakeetReady) {
+          // Check the selected transcription model before starting.
+          const modelReady = await checkModelReady();
+          if (!modelReady) {
             const isDownloading = await checkIfModelDownloading();
             if (isDownloading) {
               toast.info('Model download in progress', {
@@ -224,7 +250,7 @@ export function useRecordingStart(
     setIsRecording,
     clearTranscripts,
     setIsMeetingActive,
-    checkParakeetReady,
+    checkModelReady,
     checkIfModelDownloading,
     showModal,
     setStatus,
@@ -238,12 +264,12 @@ export function useRecordingStart(
         return;
       }
 
-      console.log('Direct start from sidebar - checking Parakeet model status');
+      console.log('Direct start from sidebar - checking selected transcription model status');
       setIsAutoStarting(true);
 
-      // Check if Parakeet transcription model is ready before starting
-      const parakeetReady = await checkParakeetReady();
-      if (!parakeetReady) {
+      // Check the selected transcription model before starting.
+      const modelReady = await checkModelReady();
+      if (!modelReady) {
         const isDownloading = await checkIfModelDownloading();
         if (isDownloading) {
           toast.info('Model download in progress', {
@@ -313,7 +339,7 @@ export function useRecordingStart(
     setIsRecording,
     clearTranscripts,
     setIsMeetingActive,
-    checkParakeetReady,
+    checkModelReady,
     checkIfModelDownloading,
     showModal,
     setStatus,

--- a/frontend/src/lib/transcription-model-readiness.ts
+++ b/frontend/src/lib/transcription-model-readiness.ts
@@ -1,0 +1,33 @@
+export interface ModelWithStatus {
+  status?: unknown;
+}
+
+interface ProviderCommands {
+  initialize: string;
+  hasAvailableModels: string;
+  getAvailableModels: string;
+}
+
+const PROVIDER_COMMANDS: Record<string, ProviderCommands> = {
+  localWhisper: {
+    initialize: 'whisper_init',
+    hasAvailableModels: 'whisper_has_available_models',
+    getAvailableModels: 'whisper_get_available_models',
+  },
+  parakeet: {
+    initialize: 'parakeet_init',
+    hasAvailableModels: 'parakeet_has_available_models',
+    getAvailableModels: 'parakeet_get_available_models',
+  },
+};
+
+export function getProviderCommands(provider: string): ProviderCommands | null {
+  return PROVIDER_COMMANDS[provider] ?? null;
+}
+
+export function hasDownloadingModel(models: ModelWithStatus[]): boolean {
+  return models.some(({ status }) => (
+    status === 'Downloading'
+    || (status !== null && typeof status === 'object' && 'Downloading' in status)
+  ));
+}

--- a/frontend/tests/lib/transcription-model-readiness.test.ts
+++ b/frontend/tests/lib/transcription-model-readiness.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  getProviderCommands,
+  hasDownloadingModel,
+} from '../../src/lib/transcription-model-readiness';
+
+describe('transcription model readiness', () => {
+  test('uses Whisper commands when Whisper is the configured provider', () => {
+    expect(getProviderCommands('localWhisper')).toEqual({
+      initialize: 'whisper_init',
+      hasAvailableModels: 'whisper_has_available_models',
+      getAvailableModels: 'whisper_get_available_models',
+    });
+  });
+
+  test('uses Parakeet commands when Parakeet is the configured provider', () => {
+    expect(getProviderCommands('parakeet')).toEqual({
+      initialize: 'parakeet_init',
+      hasAvailableModels: 'parakeet_has_available_models',
+      getAvailableModels: 'parakeet_get_available_models',
+    });
+  });
+
+  test('does not silently treat an unsupported provider as Parakeet', () => {
+    expect(getProviderCommands('deepgram')).toBeNull();
+  });
+
+  test('recognizes only active downloads', () => {
+    expect(hasDownloadingModel([{ status: 'Available' }])).toBeFalse();
+    expect(hasDownloadingModel([{ status: 'Downloading' }])).toBeTrue();
+    expect(hasDownloadingModel([{ status: { Downloading: 42 } }])).toBeTrue();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #637 by making the recording preflight use the configured local transcription provider instead of always checking Parakeet.

- `localWhisper` now initializes and checks Whisper models.
- `parakeet` retains its existing Parakeet checks.
- Download-in-progress detection uses the matching provider's model list.
- Unsupported providers fail explicitly rather than silently falling back to Parakeet.

## Root cause

All three recording entry points in `useRecordingStart` called only `parakeet_init` and `parakeet_has_available_models`. A user with a downloaded Whisper model but no Parakeet bundle was blocked before the Rust recording command could validate the selected Whisper configuration.

## Validation

- `bun test frontend/tests/lib/transcription-model-readiness.test.ts` — 4 passed
- `corepack pnpm build` in `frontend/` — production build completed successfully
- `git diff --check`