### PR TITLE
feat(transcription): add Mandarin Parakeet CTC CoreML model

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+LIBONNXRUNTIME_NO_PKG_CONFIG = { value = "1", force = true }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,6 +1101,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreml-native"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322ddf1574fe27fb381f4c259f6e87fbb8e5ca7eba4e7dad0aa128274b95cb9f"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-core-ml",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "cpal"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3621,6 +3633,7 @@ dependencies = [
  "cidre",
  "clap 4.6.1",
  "core-graphics 0.23.2",
+ "coreml-native",
  "cpal",
  "criterion",
  "crossbeam",
@@ -4131,6 +4144,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-ml"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201b055e6acfa0f9f15568255d3f03ce2b54bc86d1814442dc69138e36813e18"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-image-io",
+ "objc2-metal",
+]
+
+[[package]]
 name = "objc2-core-text"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4140,6 +4169,19 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -4171,6 +4213,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-image-io"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4179,6 +4232,17 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ MIT License - Feel free to use this project for your own purposes.
 - We borrowed some code from [transcribe-rs](https://crates.io/crates/transcribe-rs).
 - Thanks to **NVIDIA** for developing the **Parakeet** model.
 - Thanks to [istupakov](https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx) for providing the **ONNX conversion** of the Parakeet model.
+- See [Third-Party Model Notices](THIRD_PARTY_MODELS.md) for downloadable model sources and license terms.
 
 ## Star History
 

--- a/THIRD_PARTY_MODELS.md
+++ b/THIRD_PARTY_MODELS.md
@@ -1,0 +1,15 @@
+# Third-Party Model Notices
+
+Meetily does not bundle the following model weights. They are downloaded separately at the user's request.
+
+## Parakeet CTC 0.6B zh-CN CoreML
+
+- CoreML conversion: [FluidInference/parakeet-ctc-0.6b-zh-cn-coreml](https://huggingface.co/FluidInference/parakeet-ctc-0.6b-zh-cn-coreml)
+- Pinned revision: `ad0da3a453ce93ae53263f9a757ad365ce90bd58`
+- Original model: [NVIDIA Parakeet CTC 0.6B zh-CN](https://build.nvidia.com/nvidia/parakeet-ctc-0_6b-zh-cn/modelcard)
+- Conversion repository license label: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
+- Original model terms: [NVIDIA Community Model License](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-community-models-license/)
+
+The conversion repository labels its artifacts as CC BY 4.0, while NVIDIA's official model card states that the original model is governed by the NVIDIA Community Model License. Distributors should review both sets of terms before enabling this download in a production release.
+
+Attribution: Parakeet was developed by NVIDIA. The CoreML conversion and validation were provided by Fluid Inference.

--- a/frontend/src-tauri/.cargo/config.toml
+++ b/frontend/src-tauri/.cargo/config.toml
@@ -11,3 +11,4 @@ rustflags = [
 [env]
 MACOSX_DEPLOYMENT_TARGET = { value = "14.2", force = true }
 CMAKE_OSX_DEPLOYMENT_TARGET = "14.2"
+LIBONNXRUNTIME_NO_PKG_CONFIG = { value = "1", force = true }

--- a/frontend/src-tauri/.cargo/config.toml
+++ b/frontend/src-tauri/.cargo/config.toml
@@ -11,4 +11,3 @@ rustflags = [
 [env]
 MACOSX_DEPLOYMENT_TARGET = { value = "14.2", force = true }
 CMAKE_OSX_DEPLOYMENT_TARGET = "14.2"
-LIBONNXRUNTIME_NO_PKG_CONFIG = { value = "1", force = true }

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -162,6 +162,7 @@ tauri-plugin-single-instance = "=2.3.7"
 # macOS-specific dependencies with Metal GPU acceleration
 [target.'cfg(target_os = "macos")'.dependencies]
 tauri = { version = "2.6.2", features = ["protocol-asset", "macos-private-api", "tray-icon"] }
+coreml-native = "=0.2.0"
 once_cell = "1.17.1"
 objc = "0.2.7"
 tauri-plugin-log = { version = "2.6.0", features = ["colored"] }

--- a/frontend/src-tauri/build.rs
+++ b/frontend/src-tauri/build.rs
@@ -9,6 +9,7 @@ fn main() {
     {
         println!("cargo:rustc-link-lib=framework=AVFoundation");
         println!("cargo:rustc-link-lib=framework=Cocoa");
+        println!("cargo:rustc-link-lib=framework=CoreML");
         println!("cargo:rustc-link-lib=framework=Foundation");
 
         // Let the enhanced_macos crate handle its own Swift compilation

--- a/frontend/src-tauri/src/audio/common.rs
+++ b/frontend/src-tauri/src/audio/common.rs
@@ -104,9 +104,9 @@ pub(crate) fn write_transcripts_json(folder: &Path, segments: &[TranscriptSegmen
 
 /// Split a long speech segment at the lowest-energy (silence) point near the target size.
 ///
-/// Scans for 100ms windows with minimal RMS energy within +/-3 seconds of each target
-/// split point. If no clear silence is found, falls back to a 1-second overlap split
-/// to avoid cutting words at boundaries.
+/// Scans for 100ms windows with minimal RMS energy in the three seconds before each
+/// target split point. Every returned segment is bounded by `max_samples`; if no clear
+/// silence is found, the segment is cut at the target.
 pub(crate) fn split_segment_at_silence(
     segment: &crate::audio::vad::SpeechSegment,
     max_samples: usize,
@@ -114,12 +114,10 @@ pub(crate) fn split_segment_at_silence(
     const SAMPLE_RATE: usize = 16000;
     // 100ms window for energy measurement (1600 samples at 16kHz)
     const ENERGY_WINDOW: usize = SAMPLE_RATE / 10;
-    // Search +/-3 seconds around the target split point
+    // Search up to 3 seconds before the target split point.
     const SEARCH_RADIUS: usize = SAMPLE_RATE * 3;
     // RMS threshold below which we consider a window "silent"
     const SILENCE_RMS_THRESHOLD: f32 = 0.02;
-    // Overlap to use when no silence boundary is found (1 second)
-    const FALLBACK_OVERLAP: usize = SAMPLE_RATE;
 
     let total = segment.samples.len();
     if total <= max_samples {
@@ -150,9 +148,9 @@ pub(crate) fn split_segment_at_silence(
         // Target split point
         let target = pos + max_samples;
 
-        // Search window: [target - SEARCH_RADIUS, target + SEARCH_RADIUS]
+        // Search only before the target so `max_samples` remains a hard upper bound.
         let search_start = target.saturating_sub(SEARCH_RADIUS).max(pos + SAMPLE_RATE);
-        let search_end = (target + SEARCH_RADIUS).min(total.saturating_sub(ENERGY_WINDOW));
+        let search_end = target.min(total.saturating_sub(ENERGY_WINDOW));
 
         // Find the lowest-energy 100ms window in the search range
         let mut best_split = target.min(total); // fallback: exact target
@@ -180,16 +178,15 @@ pub(crate) fn split_segment_at_silence(
             );
         } else {
             debug!(
-                "No silence found near target (best RMS={:.4}), splitting with overlap at sample {}",
-                best_rms, split_at
+                "No silence found before target (best RMS={:.4}), splitting at sample {}",
+                best_rms, target
             );
         }
 
-        // Determine the actual end of this chunk (with overlap if no silence)
-        let chunk_end = if best_rms > SILENCE_RMS_THRESHOLD {
-            (split_at + FALLBACK_OVERLAP).min(total)
+        let chunk_end = if best_rms <= SILENCE_RMS_THRESHOLD {
+            split_at.min(target)
         } else {
-            split_at
+            target
         };
 
         let chunk_samples = segment.samples[pos..chunk_end].to_vec();
@@ -203,8 +200,6 @@ pub(crate) fn split_segment_at_silence(
             confidence: segment.confidence,
         });
 
-        // Advance position to where the current chunk actually ends
-        // to avoid transcribing the overlap region twice
         pos = chunk_end;
     }
 

--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -522,18 +522,21 @@ async fn run_import<R: Runtime>(
     // Split very long segments at silence boundaries for better transcription quality.
     // Hard cuts at arbitrary sample positions lose words at boundaries. Instead, scan
     // for the lowest-energy window near the target split point and cut there.
-    const MAX_SEGMENT_SAMPLES: usize = 25 * 16000; // 25 seconds at 16kHz
+    let max_segment_samples = match parakeet_engine.as_ref() {
+        Some(engine) => engine.max_segment_samples().await,
+        None => 25 * 16_000,
+    };
 
     let mut processable_segments: Vec<crate::audio::vad::SpeechSegment> = Vec::new();
     for segment in &speech_segments {
-        if segment.samples.len() > MAX_SEGMENT_SAMPLES {
+        if segment.samples.len() > max_segment_samples {
             debug!(
                 "Splitting large segment ({:.0}ms, {} samples) at silence boundaries",
                 segment.end_timestamp_ms - segment.start_timestamp_ms,
                 segment.samples.len()
             );
 
-            let sub_segments = split_segment_at_silence(segment, MAX_SEGMENT_SAMPLES);
+            let sub_segments = split_segment_at_silence(segment, max_segment_samples);
             debug!("Split into {} sub-segments", sub_segments.len());
             processable_segments.extend(sub_segments);
         } else {
@@ -1153,8 +1156,8 @@ mod tests {
     }
 
     #[test]
-    fn test_split_segment_at_silence_no_silence_uses_overlap() {
-        // Continuous speech (constant energy) — should still split with overlap
+    fn test_split_segment_at_silence_never_exceeds_maximum() {
+        // Continuous speech has no silence boundary, so it is cut at the hard limit.
         let segment = crate::audio::vad::SpeechSegment {
             samples: vec![0.5f32; 60 * 16000], // 60 seconds of "speech"
             start_timestamp_ms: 0.0,
@@ -1165,9 +1168,11 @@ mod tests {
         let result = split_segment_at_silence(&segment, 25 * 16000);
         assert!(result.len() >= 2);
 
-        // Total samples should exceed input due to overlap
+        assert!(result
+            .iter()
+            .all(|segment| segment.samples.len() <= 25 * 16000));
         let total_samples: usize = result.iter().map(|s| s.samples.len()).sum();
-        assert!(total_samples >= 60 * 16000, "Overlap should not lose samples");
+        assert_eq!(total_samples, 60 * 16000, "Splitting should not lose samples");
     }
 
     #[test]

--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -11,7 +11,7 @@ use rubato::{Resampler, SincFixedIn, SincInterpolationParameters, SincInterpolat
 use super::devices::AudioDevice;
 use super::recording_state::{AudioChunk, AudioError, RecordingState, DeviceType};
 use super::audio_processing::{audio_to_mono, LoudnessNormalizer, NoiseSuppressionProcessor, HighPassFilter};
-use super::vad::{ContinuousVadProcessor};
+use super::vad::{ContinuousVadProcessor, MIN_TRANSCRIPTION_SEGMENT_SAMPLES};
 
 /// Ring buffer for synchronized audio mixing
 /// Accumulates samples from mic and system streams until we have aligned windows
@@ -701,7 +701,7 @@ impl AudioPipeline {
         receiver: mpsc::UnboundedReceiver<AudioChunk>,
         transcription_sender: mpsc::UnboundedSender<AudioChunk>,
         state: Arc<RecordingState>,
-        target_chunk_duration_ms: u32,
+        max_live_segment_duration_ms: Option<u32>,
         sample_rate: u32,
         mic_device_name: String,
         mic_device_kind: super::device_detection::InputDeviceKind,
@@ -726,9 +726,19 @@ impl AudioPipeline {
 
         let redemption_time = if cfg!(target_os = "macos") { 400 } else { 400 };
 
-        let vad_processor = match ContinuousVadProcessor::new(sample_rate, redemption_time) {
+        let vad_processor = match ContinuousVadProcessor::new_with_max_segment_duration(
+            sample_rate,
+            redemption_time,
+            max_live_segment_duration_ms,
+        ) {
             Ok(processor) => {
-                info!("VAD-driven pipeline: VAD segments will be sent directly to Whisper (no time-based accumulation)");
+                match max_live_segment_duration_ms {
+                    Some(duration_ms) => info!(
+                        "VAD-driven pipeline: natural speech boundaries with a {}ms live transcription limit",
+                        duration_ms
+                    ),
+                    None => info!("VAD-driven pipeline: using natural speech boundaries"),
+                }
                 processor
             }
             Err(e) => {
@@ -740,9 +750,6 @@ impl AudioPipeline {
         // Initialize professional audio mixing components
         let ring_buffer = AudioMixerRingBuffer::new(sample_rate);
         let mixer = ProfessionalAudioMixer::new(sample_rate);
-
-        // Note: target_chunk_duration_ms is ignored - VAD controls segmentation now
-        let _ = target_chunk_duration_ms;
 
         Self {
             receiver,
@@ -837,7 +844,7 @@ impl AudioPipeline {
                                     for segment in speech_segments {
                                         let duration_ms = segment.end_timestamp_ms - segment.start_timestamp_ms;
 
-                                        if segment.samples.len() >= 800 {  // Minimum 50ms at 16kHz - matches Parakeet capability
+                                        if segment.samples.len() >= MIN_TRANSCRIPTION_SEGMENT_SAMPLES {
                                             info!("📤 Sending VAD segment: {:.1}ms, {} samples",
                                                   duration_ms, segment.samples.len());
 
@@ -855,8 +862,8 @@ impl AudioPipeline {
                                                 self.chunk_id_counter += 1;
                                             }
                                         } else {
-                                            debug!("⏭️ Dropping short VAD segment: {:.1}ms ({} samples < 800)",
-                                                   duration_ms, segment.samples.len());
+                                            debug!("⏭️ Dropping short VAD segment: {:.1}ms ({} samples < {})",
+                                                   duration_ms, segment.samples.len(), MIN_TRANSCRIPTION_SEGMENT_SAMPLES);
                                         }
                                     }
                                 }
@@ -906,8 +913,8 @@ impl AudioPipeline {
                 for segment in final_segments {
                     let duration_ms = segment.end_timestamp_ms - segment.start_timestamp_ms;
 
-                    // Send segments >= 50ms (800 samples at 16kHz) - matches main pipeline filter
-                    if segment.samples.len() >= 800 {
+                    // Keep this aligned with the live checkpoint's reserved tail.
+                    if segment.samples.len() >= MIN_TRANSCRIPTION_SEGMENT_SAMPLES {
                         info!("📤 Sending final VAD segment to Whisper: {:.1}ms duration, {} samples",
                               duration_ms, segment.samples.len());
 
@@ -925,8 +932,8 @@ impl AudioPipeline {
                             self.chunk_id_counter += 1;
                         }
                     } else {
-                        info!("⏭️ Skipping short final segment: {:.1}ms ({} samples < 800)",
-                              duration_ms, segment.samples.len());
+                        info!("⏭️ Skipping short final segment: {:.1}ms ({} samples < {})",
+                              duration_ms, segment.samples.len(), MIN_TRANSCRIPTION_SEGMENT_SAMPLES);
                     }
                 }
             }
@@ -959,7 +966,7 @@ impl AudioPipelineManager {
         &mut self,
         state: Arc<RecordingState>,
         transcription_sender: mpsc::UnboundedSender<AudioChunk>,
-        target_chunk_duration_ms: u32,
+        max_live_segment_duration_ms: Option<u32>,
         sample_rate: u32,
         recording_sender: Option<mpsc::UnboundedSender<AudioChunk>>,
         mic_device_name: String,
@@ -983,7 +990,7 @@ impl AudioPipelineManager {
             audio_receiver,
             transcription_sender,
             state.clone(),
-            target_chunk_duration_ms,
+            max_live_segment_duration_ms,
             sample_rate,
             mic_device_name,
             mic_device_kind,

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -91,19 +91,23 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
 
     // Validate that transcription models are available before starting recording
     info!("🔍 Validating transcription model availability before starting recording...");
-    if let Err(validation_error) = transcription::validate_transcription_model_ready(&app).await {
-        error!("Model validation failed: {}", validation_error);
+    let max_live_segment_duration_ms =
+        match transcription::validate_transcription_model_ready(&app).await {
+            Ok(duration) => duration,
+            Err(validation_error) => {
+                error!("Model validation failed: {}", validation_error);
 
-        // Emit error event for frontend - actionable: false to show toast instead of modal
-        // (download progress is already shown in top-right toast)
-        let _ = app.emit("transcription-error", serde_json::json!({
-            "error": validation_error,
-            "userMessage": "Recording cannot start: Transcription model is still downloading. Please wait for the download to complete.",
-            "actionable": false
-        }));
+                // Emit error event for frontend - actionable: false to show toast instead of modal
+                // (download progress is already shown in top-right toast)
+                let _ = app.emit("transcription-error", serde_json::json!({
+                    "error": validation_error,
+                    "userMessage": "Recording cannot start: Transcription model is still downloading. Please wait for the download to complete.",
+                    "actionable": false
+                }));
 
-        return Err(validation_error);
-    }
+                return Err(validation_error);
+            }
+        };
     info!("✅ Transcription model validation passed");
 
     // Async-first approach - no more blocking operations!
@@ -234,7 +238,12 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
 
     // Start recording with resolved devices (replaces start_recording_with_defaults_and_auto_save call)
     let transcription_receiver = manager
-        .start_recording(microphone_device, system_device, auto_save)
+        .start_recording(
+            microphone_device,
+            system_device,
+            auto_save,
+            max_live_segment_duration_ms,
+        )
         .await
         .map_err(|e| format!("Failed to start recording: {}", e))?;
 
@@ -337,19 +346,23 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
 
     // Validate that transcription models are available before starting recording
     info!("🔍 Validating transcription model availability before starting recording...");
-    if let Err(validation_error) = transcription::validate_transcription_model_ready(&app).await {
-        error!("Model validation failed: {}", validation_error);
+    let max_live_segment_duration_ms =
+        match transcription::validate_transcription_model_ready(&app).await {
+            Ok(duration) => duration,
+            Err(validation_error) => {
+                error!("Model validation failed: {}", validation_error);
 
-        // Emit error event for frontend - actionable: false to show toast instead of modal
-        // (download progress is already shown in top-right toast)
-        let _ = app.emit("transcription-error", serde_json::json!({
-            "error": validation_error,
-            "userMessage": "Recording cannot start: Transcription model is still downloading. Please wait for the download to complete.",
-            "actionable": false
-        }));
+                // Emit error event for frontend - actionable: false to show toast instead of modal
+                // (download progress is already shown in top-right toast)
+                let _ = app.emit("transcription-error", serde_json::json!({
+                    "error": validation_error,
+                    "userMessage": "Recording cannot start: Transcription model is still downloading. Please wait for the download to complete.",
+                    "actionable": false
+                }));
 
-        return Err(validation_error);
-    }
+                return Err(validation_error);
+            }
+        };
     info!("✅ Transcription model validation passed");
 
     // Parse devices
@@ -405,7 +418,12 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
 
     // Start recording with specified devices and auto_save setting
     let transcription_receiver = manager
-        .start_recording(mic_device, system_device, auto_save)
+        .start_recording(
+            mic_device,
+            system_device,
+            auto_save,
+            max_live_segment_duration_ms,
+        )
         .await
         .map_err(|e| format!("Failed to start recording: {}", e))?;
 

--- a/frontend/src-tauri/src/audio/recording_manager.rs
+++ b/frontend/src-tauri/src/audio/recording_manager.rs
@@ -65,6 +65,7 @@ impl RecordingManager {
         microphone_device: Option<Arc<AudioDevice>>,
         system_device: Option<Arc<AudioDevice>>,
         auto_save: bool,
+        max_live_segment_duration_ms: Option<u32>,
     ) -> Result<mpsc::UnboundedReceiver<AudioChunk>> {
         info!("Starting recording manager (auto_save: {})", auto_save);
 
@@ -109,7 +110,7 @@ impl RecordingManager {
         self.pipeline_manager.start(
             self.state.clone(),
             transcription_sender,
-            0, // Ignored - using dynamic sizing internally
+            max_live_segment_duration_ms,
             48000, // 48kHz sample rate
             Some(recording_sender), // CRITICAL: Pass recording sender to receive pre-mixed audio
             mic_name,
@@ -167,7 +168,11 @@ impl RecordingManager {
     ///
     /// User still hears audio via Bluetooth (playback), but recording captures
     /// via stable wired path for best quality.
-    pub async fn start_recording_with_defaults_and_auto_save(&mut self, auto_save: bool) -> Result<mpsc::UnboundedReceiver<AudioChunk>> {
+    pub async fn start_recording_with_defaults_and_auto_save(
+        &mut self,
+        auto_save: bool,
+        max_live_segment_duration_ms: Option<u32>,
+    ) -> Result<mpsc::UnboundedReceiver<AudioChunk>> {
         #[cfg(target_os = "macos")]
         {
             info!("🎙️ [macOS] Starting recording with smart device selection (Bluetooth override enabled)");
@@ -186,7 +191,12 @@ impl RecordingManager {
             }
 
             // Start recording with selected devices and auto_save setting
-            self.start_recording(microphone_device, system_device, auto_save).await
+            self.start_recording(
+                microphone_device,
+                system_device,
+                auto_save,
+                max_live_segment_duration_ms,
+            ).await
         }
 
         #[cfg(not(target_os = "macos"))]
@@ -221,7 +231,12 @@ impl RecordingManager {
                 return Err(anyhow::anyhow!("No microphone device available"));
             }
 
-            self.start_recording(microphone_device, system_device, auto_save).await
+            self.start_recording(
+                microphone_device,
+                system_device,
+                auto_save,
+                max_live_segment_duration_ms,
+            ).await
         }
     }
 

--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -313,18 +313,21 @@ async fn run_retranscription<R: Runtime>(
     // Split very long segments at silence boundaries for better transcription quality.
     // Hard cuts at arbitrary sample positions lose words at boundaries. Instead, scan
     // for the lowest-energy window near the target split point and cut there.
-    const MAX_SEGMENT_SAMPLES: usize = 25 * 16000; // 25 seconds at 16kHz
+    let max_segment_samples = match parakeet_engine.as_ref() {
+        Some(engine) => engine.max_segment_samples().await,
+        None => 25 * 16_000,
+    };
 
     let mut processable_segments: Vec<crate::audio::vad::SpeechSegment> = Vec::new();
     for segment in &speech_segments {
-        if segment.samples.len() > MAX_SEGMENT_SAMPLES {
+        if segment.samples.len() > max_segment_samples {
             debug!(
                 "Splitting large segment ({:.0}ms, {} samples) at silence boundaries",
                 segment.end_timestamp_ms - segment.start_timestamp_ms,
                 segment.samples.len()
             );
 
-            let sub_segments = split_segment_at_silence(segment, MAX_SEGMENT_SAMPLES);
+            let sub_segments = split_segment_at_silence(segment, max_segment_samples);
             debug!("Split into {} sub-segments", sub_segments.len());
             processable_segments.extend(sub_segments);
         } else {

--- a/frontend/src-tauri/src/audio/transcription/engine.rs
+++ b/frontend/src-tauri/src/audio/transcription/engine.rs
@@ -7,6 +7,14 @@ use log::{info, warn};
 use std::sync::Arc;
 use tauri::{AppHandle, Manager, Runtime};
 
+const COREML_CTC_LIVE_SEGMENT_DURATION_MS: u32 = 5_000;
+
+fn max_live_segment_duration_ms(provider: &str, model: &str) -> Option<u32> {
+    (provider == "parakeet"
+        && model == crate::parakeet_engine::ctc::PARAKEET_CTC_ZH_CN_MODEL)
+        .then_some(COREML_CTC_LIVE_SEGMENT_DURATION_MS)
+}
+
 // ============================================================================
 // TRANSCRIPTION ENGINE ENUM
 // ============================================================================
@@ -51,8 +59,11 @@ impl TranscriptionEngine {
 // MODEL VALIDATION AND INITIALIZATION
 // ============================================================================
 
-/// Validate that transcription models (Whisper or Parakeet) are ready before starting recording
-pub async fn validate_transcription_model_ready<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+/// Validate that transcription models (Whisper or Parakeet) are ready before starting recording.
+/// Returns the maximum live segment duration for models that require bounded-latency chunks.
+pub async fn validate_transcription_model_ready<R: Runtime>(
+    app: &AppHandle<R>,
+) -> Result<Option<u32>, String> {
     // Check transcript configuration to determine which engine to validate
     let config = match crate::api::api::api_get_transcript_config(
         app.clone(),
@@ -103,7 +114,7 @@ pub async fn validate_transcription_model_ready<R: Runtime>(app: &AppHandle<R>) 
             match crate::whisper_engine::commands::whisper_validate_model_ready_with_config(app).await {
                 Ok(model_name) => {
                     info!("✅ Whisper model validation successful: {} is ready", model_name);
-                    Ok(())
+                    Ok(None)
                 }
                 Err(e) => {
                     warn!("❌ Whisper model validation failed: {}", e);
@@ -127,7 +138,7 @@ pub async fn validate_transcription_model_ready<R: Runtime>(app: &AppHandle<R>) 
             match crate::parakeet_engine::commands::parakeet_validate_model_ready_with_config(app).await {
                 Ok(model_name) => {
                     info!("✅ Parakeet model validation successful: {} is ready", model_name);
-                    Ok(())
+                    Ok(max_live_segment_duration_ms("parakeet", &model_name))
                 }
                 Err(e) => {
                     warn!("❌ Parakeet model validation failed: {}", e);
@@ -142,6 +153,33 @@ pub async fn validate_transcription_model_ready<R: Runtime>(app: &AppHandle<R>) 
                 other
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::max_live_segment_duration_ms;
+
+    #[test]
+    fn live_segmentation_is_limited_to_coreml_ctc() {
+        assert_eq!(
+            max_live_segment_duration_ms(
+                "parakeet",
+                crate::parakeet_engine::ctc::PARAKEET_CTC_ZH_CN_MODEL,
+            ),
+            Some(5_000),
+        );
+        assert_eq!(
+            max_live_segment_duration_ms("parakeet", "parakeet-tdt-0.6b-v3-int8"),
+            None,
+        );
+        assert_eq!(
+            max_live_segment_duration_ms(
+                "localWhisper",
+                crate::parakeet_engine::ctc::PARAKEET_CTC_ZH_CN_MODEL,
+            ),
+            None,
+        );
     }
 }
 

--- a/frontend/src-tauri/src/audio/transcription/engine.rs
+++ b/frontend/src-tauri/src/audio/transcription/engine.rs
@@ -201,8 +201,15 @@ pub async fn get_or_init_transcription_engine<R: Runtime>(
                     if engine.is_model_loaded().await {
                         let model_name = engine.get_current_model().await
                             .unwrap_or_else(|| "unknown".to_string());
-                        info!("✅ Parakeet model '{}' already loaded", model_name);
-                        Ok(TranscriptionEngine::Parakeet(engine))
+                        if model_name != config.model {
+                            Err(format!(
+                                "Loaded Parakeet model '{}' does not match configured model '{}'",
+                                model_name, config.model
+                            ))
+                        } else {
+                            info!("✅ Parakeet model '{}' already loaded", model_name);
+                            Ok(TranscriptionEngine::Parakeet(engine))
+                        }
                     } else {
                         Err("Parakeet engine initialized but no model loaded. This should not happen after validation.".to_string())
                     }

--- a/frontend/src-tauri/src/audio/vad.rs
+++ b/frontend/src-tauri/src/audio/vad.rs
@@ -4,6 +4,9 @@ use log::{debug, info, warn};
 use std::collections::VecDeque;
 use std::time::Duration;
 
+const VAD_SAMPLE_RATE: usize = 16_000;
+pub(crate) const MIN_TRANSCRIPTION_SEGMENT_SAMPLES: usize = 800;
+
 /// Represents a complete speech segment detected by VAD
 #[derive(Debug, Clone)]
 pub struct SpeechSegment {
@@ -20,22 +23,31 @@ pub struct ContinuousVadProcessor {
     sample_rate: u32,
     buffer: Vec<f32>,
     speech_segments: VecDeque<SpeechSegment>,
-    current_speech: Vec<f32>,
     in_speech: bool,
     processed_samples: usize,
-    speech_start_sample: usize,
+    speech_start_timestamp_ms: Option<f64>,
+    emitted_speech_samples: usize,
+    max_live_segment_samples: Option<usize>,
     // State tracking for smart logging
     last_logged_state: bool,
 }
 
 impl ContinuousVadProcessor {
     pub fn new(input_sample_rate: u32, redemption_time_ms: u32) -> Result<Self> {
+        Self::new_with_max_segment_duration(input_sample_rate, redemption_time_ms, None)
+    }
+
+    pub fn new_with_max_segment_duration(
+        input_sample_rate: u32,
+        redemption_time_ms: u32,
+        max_live_segment_duration_ms: Option<u32>,
+    ) -> Result<Self> {
         // Silero VAD MUST use 16kHz - this is hardcoded requirement
-        const VAD_SAMPLE_RATE: u32 = 16000;
+        const VAD_SAMPLE_RATE_HZ: u32 = VAD_SAMPLE_RATE as u32;
 
         // Use STRICT settings to prevent silence from reaching Whisper
         let mut config = VadConfig::default();
-        config.sample_rate = VAD_SAMPLE_RATE as usize;
+        config.sample_rate = VAD_SAMPLE_RATE;
 
         // CONTINUOUS SPEECH FIX: Tuned for capturing complete 5+ second utterances
         // Previous: 0.55/0.40 with 400ms redemption was fragmenting speech into 40ms segments
@@ -62,10 +74,13 @@ impl ContinuousVadProcessor {
             .map_err(|e| anyhow!("Failed to create VAD session: {:?}", e))?;
 
         // VAD uses 30ms chunks at 16kHz (480 samples)
-        let vad_chunk_size = (VAD_SAMPLE_RATE as f32 * 0.03) as usize; // 480 samples
+        let vad_chunk_size = (VAD_SAMPLE_RATE_HZ as f32 * 0.03) as usize; // 480 samples
+        let max_live_segment_samples = max_live_segment_duration_ms.map(|duration_ms| {
+            ((duration_ms as usize * VAD_SAMPLE_RATE) / 1000).max(vad_chunk_size)
+        });
 
-        info!("VAD processor created: input={}Hz, vad={}Hz, chunk_size={} samples",
-              input_sample_rate, VAD_SAMPLE_RATE, vad_chunk_size);
+        info!("VAD processor created: input={}Hz, vad={}Hz, chunk_size={} samples, live_segment_limit={:?}ms",
+              input_sample_rate, VAD_SAMPLE_RATE_HZ, vad_chunk_size, max_live_segment_duration_ms);
 
         Ok(Self {
             session,
@@ -73,10 +88,11 @@ impl ContinuousVadProcessor {
             sample_rate: input_sample_rate, // Store input rate for resampling ratio in resample_to_16k()
             buffer: Vec::with_capacity(vad_chunk_size * 2),
             speech_segments: VecDeque::new(),
-            current_speech: Vec::new(),
             in_speech: false,
             processed_samples: 0,
-            speech_start_sample: 0,
+            speech_start_timestamp_ms: None,
+            emitted_speech_samples: 0,
+            max_live_segment_samples,
             // Initialize state tracking
             last_logged_state: false,
         })
@@ -161,8 +177,9 @@ impl ContinuousVadProcessor {
 
     /// Flush any remaining audio and return final speech segments
     pub fn flush(&mut self) -> Result<Vec<SpeechSegment>> {
-        debug!("VAD flush: in_speech={}, current_speech_len={}, buffer_len={}, speech_segments_queued={}",
-              self.in_speech, self.current_speech.len(), self.buffer.len(), self.speech_segments.len());
+        debug!("VAD flush: in_speech={}, current_speech_len={}, emitted_speech_len={}, buffer_len={}, speech_segments_queued={}",
+              self.in_speech, self.session.current_speech_samples(), self.emitted_speech_samples,
+              self.buffer.len(), self.speech_segments.len());
 
         let mut completed_segments = Vec::new();
 
@@ -181,24 +198,25 @@ impl ContinuousVadProcessor {
         }
 
         // Force end any ongoing speech
-        if self.in_speech && !self.current_speech.is_empty() {
-            // processed_samples and speech_start_sample always count 16kHz samples (post-resampling)
-            let start_ms = (self.speech_start_sample as f64 / 16000.0) * 1000.0;
-            let end_ms = (self.processed_samples as f64 / 16000.0) * 1000.0;
+        if self.in_speech {
+            let current_speech = self.session.get_current_speech();
+            if let Some(segment) = remaining_speech_segment(
+                current_speech,
+                self.speech_start_timestamp_ms.unwrap_or_else(|| {
+                    samples_to_ms(self.processed_samples.saturating_sub(current_speech.len()))
+                }),
+                self.emitted_speech_samples,
+                0.8,
+            ) {
+                debug!("VAD flush: Force-ending speech - start={}ms, end={}ms, duration={}ms, samples={}",
+                      segment.start_timestamp_ms, segment.end_timestamp_ms,
+                      segment.end_timestamp_ms - segment.start_timestamp_ms, segment.samples.len());
+                self.speech_segments.push_back(segment);
+            }
 
-            debug!("VAD flush: Force-ending speech - start={}ms, end={}ms, duration={}ms, samples={}",
-                  start_ms, end_ms, end_ms - start_ms, self.current_speech.len());
-
-            let segment = SpeechSegment {
-                samples: self.current_speech.clone(),
-                start_timestamp_ms: start_ms,
-                end_timestamp_ms: end_ms,
-                confidence: 0.8, // Estimated confidence for forced end
-            };
-
-            self.speech_segments.push_back(segment);
-            self.current_speech.clear();
             self.in_speech = false;
+            self.speech_start_timestamp_ms = None;
+            self.emitted_speech_samples = 0;
         }
 
         // Extract all remaining segments
@@ -211,7 +229,7 @@ impl ContinuousVadProcessor {
 
     fn process_chunk(&mut self, chunk: &[f32]) -> Result<()> {
         // Track accumulated speech buffer size to detect memory issues
-        let current_speech_size = self.current_speech.len();
+        let current_speech_size = self.session.current_speech_samples();
         if current_speech_size > 1_000_000 {
             // More than ~62 seconds of accumulated speech at 16kHz
             warn!("VAD: Accumulated speech buffer is large: {} samples ({:.1}s) - possible memory issue",
@@ -236,9 +254,8 @@ impl ContinuousVadProcessor {
                         self.last_logged_state = true;
                     }
                     self.in_speech = true;
-                    // Use 16000 (VAD processing rate) since processed_samples counts 16kHz samples
-                    self.speech_start_sample = self.processed_samples + (timestamp_ms * 16000 / 1000);
-                    self.current_speech.clear();
+                    self.speech_start_timestamp_ms = Some(timestamp_ms as f64);
+                    self.emitted_speech_samples = 0;
                 }
                 VadTransition::SpeechEnd { start_timestamp_ms, end_timestamp_ms, samples } => {
                     // Only log if we were previously in speech state
@@ -248,40 +265,106 @@ impl ContinuousVadProcessor {
                     }
                     self.in_speech = false;
 
-                    // Use samples from VAD transition if available, otherwise use accumulated samples
+                    // Use samples from VAD transition if available, otherwise use the session cache.
                     let speech_samples = if !samples.is_empty() {
                         samples
                     } else {
-                        self.current_speech.clone()
+                        self.session.get_current_speech().to_vec()
                     };
 
-                    if !speech_samples.is_empty() {
-                        let segment = SpeechSegment {
-                            samples: speech_samples,
-                            start_timestamp_ms: start_timestamp_ms as f64,
-                            end_timestamp_ms: end_timestamp_ms as f64,
-                            confidence: 0.9, // VAD confidence
-                        };
-
+                    if let Some(segment) = remaining_speech_segment(
+                        &speech_samples,
+                        start_timestamp_ms as f64,
+                        self.emitted_speech_samples,
+                        0.9,
+                    ) {
                         info!("VAD: Completed speech segment: {:.1}ms duration, {} samples",
-                              end_timestamp_ms - start_timestamp_ms, segment.samples.len());
+                              segment.end_timestamp_ms - segment.start_timestamp_ms, segment.samples.len());
 
                         self.speech_segments.push_back(segment);
                     }
 
-                    self.current_speech.clear();
+                    self.speech_start_timestamp_ms = None;
+                    self.emitted_speech_samples = 0;
                 }
             }
         }
 
-        // Accumulate speech if we're currently in a speech state
+        // Natural SpeechEnd remains the preferred boundary. For uninterrupted speech,
+        // emit fixed-size checkpoints so live captions do not wait until recording stops.
         if self.in_speech {
-            self.current_speech.extend_from_slice(chunk);
+            let current_speech = self.session.get_current_speech();
+            let live_segments = collect_live_segments(
+                current_speech,
+                self.speech_start_timestamp_ms.unwrap_or(0.0),
+                &mut self.emitted_speech_samples,
+                self.max_live_segment_samples,
+            );
+            for segment in live_segments {
+                info!("VAD: Live speech checkpoint: {:.1}ms duration, {} samples",
+                      segment.end_timestamp_ms - segment.start_timestamp_ms, segment.samples.len());
+                self.speech_segments.push_back(segment);
+            }
         }
 
         self.processed_samples += chunk.len();
         Ok(())
     }
+}
+
+fn samples_to_ms(samples: usize) -> f64 {
+    samples as f64 * 1000.0 / VAD_SAMPLE_RATE as f64
+}
+
+fn collect_live_segments(
+    current_speech: &[f32],
+    speech_start_timestamp_ms: f64,
+    emitted_speech_samples: &mut usize,
+    max_live_segment_samples: Option<usize>,
+) -> Vec<SpeechSegment> {
+    let Some(max_segment_samples) = max_live_segment_samples else {
+        return Vec::new();
+    };
+    if *emitted_speech_samples > current_speech.len() {
+        warn!("VAD live cursor exceeded current speech buffer: {} > {}",
+              *emitted_speech_samples, current_speech.len());
+        *emitted_speech_samples = current_speech.len();
+    }
+
+    let mut segments = Vec::new();
+    let checkpoint_threshold =
+        max_segment_samples.saturating_add(MIN_TRANSCRIPTION_SEGMENT_SAMPLES);
+    while current_speech.len().saturating_sub(*emitted_speech_samples) >= checkpoint_threshold {
+        let start = *emitted_speech_samples;
+        let end = start + max_segment_samples;
+        segments.push(SpeechSegment {
+            samples: current_speech[start..end].to_vec(),
+            start_timestamp_ms: speech_start_timestamp_ms + samples_to_ms(start),
+            end_timestamp_ms: speech_start_timestamp_ms + samples_to_ms(end),
+            confidence: 0.8,
+        });
+        *emitted_speech_samples = end;
+    }
+    segments
+}
+
+fn remaining_speech_segment(
+    speech_samples: &[f32],
+    speech_start_timestamp_ms: f64,
+    emitted_speech_samples: usize,
+    confidence: f32,
+) -> Option<SpeechSegment> {
+    let start = emitted_speech_samples.min(speech_samples.len());
+    if start == speech_samples.len() {
+        return None;
+    }
+
+    Some(SpeechSegment {
+        samples: speech_samples[start..].to_vec(),
+        start_timestamp_ms: speech_start_timestamp_ms + samples_to_ms(start),
+        end_timestamp_ms: speech_start_timestamp_ms + samples_to_ms(speech_samples.len()),
+        confidence,
+    })
 }
 
 /// Legacy function for backward compatibility - now uses the optimized approach
@@ -447,6 +530,175 @@ mod tests {
     }
 
     #[test]
+    fn test_live_segments_are_emitted_once_with_remaining_tail() {
+        let five_seconds = 5 * VAD_SAMPLE_RATE;
+        let mut speech: Vec<f32> = (0..five_seconds * 2 + VAD_SAMPLE_RATE / 2)
+            .map(|index| index as f32)
+            .collect();
+        let mut emitted = 0;
+
+        let segments = collect_live_segments(&speech, 1_250.0, &mut emitted, Some(five_seconds));
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].samples.len(), five_seconds);
+        assert_eq!(segments[0].start_timestamp_ms, 1_250.0);
+        assert_eq!(segments[0].end_timestamp_ms, 6_250.0);
+        assert_eq!(segments[1].start_timestamp_ms, 6_250.0);
+        assert_eq!(segments[1].end_timestamp_ms, 11_250.0);
+        assert_eq!(emitted, five_seconds * 2);
+
+        assert!(collect_live_segments(&speech, 1_250.0, &mut emitted, Some(five_seconds)).is_empty());
+
+        let tail = remaining_speech_segment(&speech, 1_250.0, emitted, 0.9)
+            .expect("expected the final half-second tail");
+        assert_eq!(tail.samples.len(), VAD_SAMPLE_RATE / 2);
+        assert_eq!(tail.start_timestamp_ms, 11_250.0);
+        assert_eq!(tail.end_timestamp_ms, 11_750.0);
+
+        let reconstructed: Vec<f32> = segments
+            .iter()
+            .flat_map(|segment| segment.samples.iter().copied())
+            .chain(tail.samples.iter().copied())
+            .collect();
+        assert_eq!(reconstructed, speech);
+
+        speech.extend((speech.len()..speech.len() + five_seconds).map(|index| index as f32));
+        let next = collect_live_segments(&speech, 1_250.0, &mut emitted, Some(five_seconds));
+        assert_eq!(next.len(), 1);
+        assert_eq!(next[0].start_timestamp_ms, 11_250.0);
+        assert_eq!(next[0].end_timestamp_ms, 16_250.0);
+    }
+
+    #[test]
+    fn test_live_checkpoint_always_preserves_a_transcribable_tail() {
+        let max_segment_samples = 5 * VAD_SAMPLE_RATE;
+        let cases = [
+            (max_segment_samples + MIN_TRANSCRIPTION_SEGMENT_SAMPLES - 1, 0),
+            (max_segment_samples + MIN_TRANSCRIPTION_SEGMENT_SAMPLES, 1),
+            (2 * max_segment_samples + MIN_TRANSCRIPTION_SEGMENT_SAMPLES, 2),
+        ];
+
+        for (sample_count, expected_live_segments) in cases {
+            let speech: Vec<f32> = (0..sample_count).map(|index| index as f32).collect();
+            let mut emitted = 0;
+            let live_segments = collect_live_segments(
+                &speech,
+                500.0,
+                &mut emitted,
+                Some(max_segment_samples),
+            );
+            let tail = remaining_speech_segment(&speech, 500.0, emitted, 0.9)
+                .expect("expected a reserved final tail");
+
+            assert_eq!(live_segments.len(), expected_live_segments);
+            assert!(live_segments
+                .iter()
+                .all(|segment| segment.samples.len() == max_segment_samples));
+            assert!(tail.samples.len() >= MIN_TRANSCRIPTION_SEGMENT_SAMPLES);
+
+            let reconstructed: Vec<f32> = live_segments
+                .iter()
+                .flat_map(|segment| segment.samples.iter().copied())
+                .chain(tail.samples.iter().copied())
+                .collect();
+            assert_eq!(reconstructed, speech);
+        }
+    }
+
+    #[test]
+    fn test_live_vad_emits_before_flush_for_continuous_speech() {
+        let audio = generate_test_audio_with_speech(4.0, VAD_SAMPLE_RATE as u32);
+        let mut processor = ContinuousVadProcessor::new_with_max_segment_duration(
+            VAD_SAMPLE_RATE as u32,
+            400,
+            Some(1_000),
+        )
+        .expect("failed to create live VAD processor");
+
+        let mut live_segments = Vec::new();
+        let mut processed_samples = 0;
+        for chunk in audio.chunks(processor.chunk_size) {
+            let segments = processor
+                .process_audio(chunk)
+                .expect("continuous speech processing failed");
+            processed_samples += chunk.len();
+            live_segments.extend(segments);
+            if !live_segments.is_empty() && processor.in_speech {
+                break;
+            }
+        }
+        assert!(
+            !live_segments.is_empty(),
+            "expected live segments before flush, found {}",
+            live_segments.len()
+        );
+        assert!(live_segments.iter().all(|segment| {
+            segment.samples.len() <= VAD_SAMPLE_RATE
+                && segment.end_timestamp_ms > segment.start_timestamp_ms
+        }));
+
+        let expected_speech = processor.session.get_current_speech().to_vec();
+        let final_segments = processor.flush().expect("first flush failed");
+        assert!(!final_segments.is_empty(), "expected a reserved final tail");
+        assert!(final_segments
+            .iter()
+            .all(|segment| segment.samples.len() >= MIN_TRANSCRIPTION_SEGMENT_SAMPLES));
+        for flush_index in 2..=4 {
+            assert!(
+                processor.flush().unwrap_or_else(|_| panic!("flush {flush_index} failed")).is_empty(),
+                "repeated flush must not emit duplicate audio"
+            );
+        }
+
+        let all_segments: Vec<&SpeechSegment> = live_segments
+            .iter()
+            .chain(final_segments.iter())
+            .collect();
+        assert!(all_segments.windows(2).all(|pair| {
+            (pair[0].end_timestamp_ms - pair[1].start_timestamp_ms).abs() < f64::EPSILON
+        }));
+
+        let total_samples: usize = all_segments
+            .iter()
+            .map(|segment| segment.samples.len())
+            .sum();
+        assert!(total_samples <= processed_samples);
+        let reconstructed: Vec<f32> = all_segments
+            .iter()
+            .flat_map(|segment| segment.samples.iter().copied())
+            .collect();
+        assert_eq!(reconstructed, expected_speech);
+    }
+
+    #[test]
+    fn test_live_vad_natural_speech_end_keeps_contiguous_audio() {
+        let audio = generate_test_audio_with_speech(7.0, VAD_SAMPLE_RATE as u32);
+        let mut processor = ContinuousVadProcessor::new_with_max_segment_duration(
+            VAD_SAMPLE_RATE as u32,
+            400,
+            Some(1_000),
+        )
+        .expect("failed to create live VAD processor");
+
+        let segments = processor
+            .process_audio(&audio)
+            .expect("speech ending processing failed");
+        let expected_speech = processor.session.get_current_speech().to_vec();
+        assert!(segments.len() >= 2, "expected checkpoints and a natural tail");
+        assert!(segments.windows(2).all(|pair| {
+            (pair[0].end_timestamp_ms - pair[1].start_timestamp_ms).abs() < f64::EPSILON
+        }));
+        assert!(segments
+            .last()
+            .is_some_and(|segment| segment.samples.len() >= MIN_TRANSCRIPTION_SEGMENT_SAMPLES));
+        let reconstructed: Vec<f32> = segments
+            .iter()
+            .flat_map(|segment| segment.samples.iter().copied())
+            .collect();
+        assert_eq!(reconstructed, expected_speech);
+        assert!(processor.flush().expect("flush after SpeechEnd failed").is_empty());
+    }
+
+    #[test]
     fn test_vad_chunked_vs_single_processing() {
         // Generate 60 seconds of audio with speech patterns at 16kHz
         let audio = generate_test_audio_with_speech(60.0, 16000);
@@ -592,4 +844,3 @@ mod tests {
         }
     }
 }
-

--- a/frontend/src-tauri/src/parakeet_engine/commands.rs
+++ b/frontend/src-tauri/src/parakeet_engine/commands.rs
@@ -236,15 +236,7 @@ pub async fn parakeet_validate_model_ready_with_config<R: tauri::Runtime>(
     };
 
     if let Some(engine) = engine {
-        // Check if a model is currently loaded
-        if engine.is_model_loaded().await {
-            if let Some(current_model) = engine.get_current_model().await {
-                log::info!("Parakeet model already loaded: {}", current_model);
-                return Ok(current_model);
-            }
-        }
-
-        // No model loaded - try to load user's configured model from transcript config
+        // Resolve the configured model before deciding whether an existing model can be reused.
         let model_to_load = match crate::api::api::api_get_transcript_config(
             app.clone(),
             app.state(),
@@ -282,6 +274,33 @@ pub async fn parakeet_validate_model_ready_with_config<R: tauri::Runtime>(
             }
         };
 
+        if let Some(current_model) = engine.get_current_model().await {
+            match model_to_load.as_ref() {
+                Some(configured_model) if configured_model == &current_model => {
+                    log::info!(
+                        "Configured Parakeet model already loaded: {}",
+                        current_model
+                    );
+                    return Ok(current_model);
+                }
+                Some(configured_model) => {
+                    log::info!(
+                        "Reloading Parakeet model: configured={}, loaded={}",
+                        configured_model,
+                        current_model
+                    );
+                    engine.unload_model().await;
+                }
+                None => {
+                    log::info!(
+                        "No model configured; reusing loaded Parakeet model: {}",
+                        current_model
+                    );
+                    return Ok(current_model);
+                }
+            }
+        }
+
         // Check available models
         let models = engine
             .discover_models()
@@ -307,18 +326,10 @@ pub async fn parakeet_validate_model_ready_with_config<R: tauri::Runtime>(
                 log::info!("Loading user's configured Parakeet model: {}", configured_model);
                 configured_model
             } else {
-                log::warn!(
-                    "Configured Parakeet model '{}' not found, falling back to first available int8 model",
+                return Err(format!(
+                    "Configured Parakeet model '{}' is not downloaded. Download it from Transcript Settings before recording.",
                     configured_model
-                );
-                // Prefer int8 quantization for best speed/quality tradeoff
-                available_models
-                    .iter()
-                    .find(|m| m.quantization == crate::parakeet_engine::QuantizationType::Int8)
-                    .or_else(|| available_models.first())
-                    .unwrap()
-                    .name
-                    .clone()
+                ));
             }
         } else {
             // No configured model, prefer int8 for best speed/quality balance
@@ -445,6 +456,19 @@ pub async fn parakeet_download_model<R: Runtime>(
                 Ok(())
             }
             Err(e) => {
+                // Reset transient state for every failure path so the normal Download
+                // button can retry without requiring the separate retry command.
+                {
+                    let mut active = engine.active_downloads.write().await;
+                    active.remove(&model_name);
+                }
+                {
+                    let mut models = engine.available_models.write().await;
+                    if let Some(model) = models.get_mut(&model_name) {
+                        model.status = ModelStatus::Missing;
+                    }
+                }
+
                 // Emit error event
                 if let Err(emit_e) = app_handle.emit(
                     "parakeet-model-download-error",

--- a/frontend/src-tauri/src/parakeet_engine/coreml_ctc.rs
+++ b/frontend/src-tauri/src/parakeet_engine/coreml_ctc.rs
@@ -1,0 +1,309 @@
+use super::ctc::{
+    decode_ctc_logits, join_chunk_text, PARAKEET_CTC_ZH_CN_BLANK_ID, PARAKEET_CTC_ZH_CN_MAX_SAMPLES,
+};
+use super::model::TimestampedResult;
+use coreml_native::{BorrowedTensor, ComputeUnits, Model};
+use std::fs;
+use std::path::Path;
+use std::sync::mpsc::{self, Receiver, SyncSender};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+const PREPROCESSOR_DIR: &str = "Preprocessor.mlmodelc";
+const ENCODER_DIR: &str = "Encoder-v2-int8.mlmodelc";
+const DECODER_DIR: &str = "Decoder.mlmodelc";
+const VOCAB_FILE: &str = "vocab.json";
+
+#[derive(thiserror::Error, Debug)]
+pub enum CoreMlCtcError {
+    #[error("CoreML model initialization failed: {0}")]
+    Initialization(String),
+    #[error("CoreML inference failed: {0}")]
+    Inference(String),
+    #[error("CoreML worker is not available")]
+    WorkerUnavailable,
+}
+
+enum WorkerRequest {
+    Transcribe {
+        samples: Vec<f32>,
+        response: mpsc::Sender<Result<TimestampedResult, String>>,
+    },
+    Shutdown,
+}
+
+pub struct CoreMlCtcModel {
+    request_sender: SyncSender<WorkerRequest>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl CoreMlCtcModel {
+    pub fn new(model_dir: &Path) -> Result<Self, CoreMlCtcError> {
+        let (request_sender, request_receiver) = mpsc::sync_channel(1);
+        let (ready_sender, ready_receiver) = mpsc::sync_channel(1);
+        let model_dir = model_dir.to_path_buf();
+
+        let worker = thread::Builder::new()
+            .name("parakeet-coreml-ctc".to_string())
+            .spawn(move || {
+                let pipeline = CoreMlCtcPipeline::load(&model_dir);
+                let ready = pipeline.as_ref().map(|_| ()).map_err(ToString::to_string);
+                let _ = ready_sender.send(ready);
+
+                let Ok(mut pipeline) = pipeline else {
+                    return;
+                };
+                pipeline.run(request_receiver);
+            })
+            .map_err(|error| CoreMlCtcError::Initialization(error.to_string()))?;
+
+        match ready_receiver.recv_timeout(Duration::from_secs(120)) {
+            Ok(Ok(())) => Ok(Self {
+                request_sender,
+                worker: Some(worker),
+            }),
+            Ok(Err(error)) => {
+                let _ = worker.join();
+                Err(CoreMlCtcError::Initialization(error))
+            }
+            Err(error) => {
+                let _ = request_sender.try_send(WorkerRequest::Shutdown);
+                let _ = worker.join();
+                Err(CoreMlCtcError::Initialization(format!(
+                    "Timed out while loading CoreML model: {error}"
+                )))
+            }
+        }
+    }
+
+    pub fn transcribe_samples(
+        &self,
+        samples: Vec<f32>,
+    ) -> Result<TimestampedResult, CoreMlCtcError> {
+        if samples.is_empty() {
+            return Err(CoreMlCtcError::Inference(
+                "Audio contains no samples".to_string(),
+            ));
+        }
+        if samples.iter().all(|sample| sample.abs() < 1.0e-6) {
+            return Ok(TimestampedResult {
+                text: String::new(),
+                timestamps: Vec::new(),
+                tokens: Vec::new(),
+            });
+        }
+
+        let mut texts = Vec::new();
+        let mut timestamps = Vec::new();
+        let mut tokens = Vec::new();
+
+        for (chunk_index, chunk) in samples.chunks(PARAKEET_CTC_ZH_CN_MAX_SAMPLES).enumerate() {
+            let mut result = self.transcribe_chunk(chunk.to_vec())?;
+            let timestamp_offset =
+                chunk_index as f32 * PARAKEET_CTC_ZH_CN_MAX_SAMPLES as f32 / 16_000.0;
+            timestamps.extend(
+                result
+                    .timestamps
+                    .drain(..)
+                    .map(|value| value + timestamp_offset),
+            );
+            tokens.append(&mut result.tokens);
+            if !result.text.is_empty() {
+                texts.push(result.text);
+            }
+        }
+
+        Ok(TimestampedResult {
+            text: join_chunk_text(&texts),
+            timestamps,
+            tokens,
+        })
+    }
+
+    fn transcribe_chunk(&self, samples: Vec<f32>) -> Result<TimestampedResult, CoreMlCtcError> {
+        let (response_sender, response_receiver) = mpsc::channel();
+        self.request_sender
+            .send(WorkerRequest::Transcribe {
+                samples,
+                response: response_sender,
+            })
+            .map_err(|_| CoreMlCtcError::WorkerUnavailable)?;
+
+        response_receiver
+            .recv()
+            .map_err(|_| CoreMlCtcError::WorkerUnavailable)?
+            .map_err(CoreMlCtcError::Inference)
+    }
+}
+
+impl Drop for CoreMlCtcModel {
+    fn drop(&mut self) {
+        let _ = self.request_sender.try_send(WorkerRequest::Shutdown);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+struct CoreMlCtcPipeline {
+    preprocessor: Model,
+    encoder: Model,
+    decoder: Model,
+    vocab: Vec<String>,
+}
+
+impl CoreMlCtcPipeline {
+    fn load(model_dir: &Path) -> Result<Self, CoreMlCtcError> {
+        let preprocessor = Model::load(model_dir.join(PREPROCESSOR_DIR), ComputeUnits::All)
+            .map_err(|error| CoreMlCtcError::Initialization(error.to_string()))?;
+        let encoder = Model::load(model_dir.join(ENCODER_DIR), ComputeUnits::All)
+            .map_err(|error| CoreMlCtcError::Initialization(error.to_string()))?;
+        let decoder = Model::load(model_dir.join(DECODER_DIR), ComputeUnits::All)
+            .map_err(|error| CoreMlCtcError::Initialization(error.to_string()))?;
+
+        let vocab = fs::read_to_string(model_dir.join(VOCAB_FILE))
+            .map_err(|error| CoreMlCtcError::Initialization(error.to_string()))
+            .and_then(|content| {
+                serde_json::from_str::<Vec<String>>(&content)
+                    .map_err(|error| CoreMlCtcError::Initialization(error.to_string()))
+            })?;
+        if vocab.len() != PARAKEET_CTC_ZH_CN_BLANK_ID {
+            return Err(CoreMlCtcError::Initialization(format!(
+                "Expected {} vocabulary tokens, found {}",
+                PARAKEET_CTC_ZH_CN_BLANK_ID,
+                vocab.len()
+            )));
+        }
+
+        Ok(Self {
+            preprocessor,
+            encoder,
+            decoder,
+            vocab,
+        })
+    }
+
+    fn run(&mut self, receiver: Receiver<WorkerRequest>) {
+        while let Ok(request) = receiver.recv() {
+            match request {
+                WorkerRequest::Transcribe { samples, response } => {
+                    let result = self
+                        .transcribe_chunk(&samples)
+                        .map_err(|error| error.to_string());
+                    let _ = response.send(result);
+                }
+                WorkerRequest::Shutdown => break,
+            }
+        }
+    }
+
+    fn transcribe_chunk(&self, samples: &[f32]) -> Result<TimestampedResult, CoreMlCtcError> {
+        if samples.len() > PARAKEET_CTC_ZH_CN_MAX_SAMPLES {
+            return Err(CoreMlCtcError::Inference(format!(
+                "CoreML CTC input exceeds {} samples",
+                PARAKEET_CTC_ZH_CN_MAX_SAMPLES
+            )));
+        }
+
+        let mut padded_audio = vec![0.0_f32; PARAKEET_CTC_ZH_CN_MAX_SAMPLES];
+        padded_audio[..samples.len()].copy_from_slice(samples);
+
+        let audio_length = [samples.len() as i32];
+        let audio = BorrowedTensor::from_f32(&padded_audio, &[1, PARAKEET_CTC_ZH_CN_MAX_SAMPLES])
+            .map_err(|error| CoreMlCtcError::Inference(error.to_string()))?;
+        let audio_length = BorrowedTensor::from_i32(&audio_length, &[1])
+            .map_err(|error| CoreMlCtcError::Inference(error.to_string()))?;
+
+        let preprocessor_outputs = self
+            .preprocessor
+            .predict(&[("audio_signal", &audio), ("audio_length", &audio_length)])
+            .map_err(|error| CoreMlCtcError::Inference(error.to_string()))?;
+        let (mel, mel_shape) = preprocessor_outputs
+            .get_f32("mel")
+            .map_err(|error| CoreMlCtcError::Inference(error.to_string()))?;
+        let (mel_length, mel_length_shape) = preprocessor_outputs
+            .get_i32("mel_length")
+            .map_err(|error| CoreMlCtcError::Inference(error.to_string()))?;
+        let mel_tensor = BorrowedTensor::from_f32(&mel, &mel_shape)
+            .map_err(|error| CoreMlCtcError::Inference(error.to_string()))?;
+        let mel_length_tensor = BorrowedTensor::from_i32(&mel_length, &mel_length_shape)
+            .map_err(|error| CoreMlCtcError::Inference(error.to_string()))?;
+
+        let encoder_outputs = self
+            .encoder
+            .predict(&[
+                ("audio_signal", &mel_tensor),
+                ("length", &mel_length_tensor),
+            ])
+            .map_err(|error| CoreMlCtcError::Inference(error.to_string()))?;
+        let (encoded_length, _) = encoder_outputs
+            .get_i32("encoded_length")
+            .map_err(|error| CoreMlCtcError::Inference(error.to_string()))?;
+        let encoded_length = encoded_length
+            .first()
+            .copied()
+            .ok_or_else(|| CoreMlCtcError::Inference("Missing encoded_length value".to_string()))?;
+        let (encoder_output, encoder_output_shape) = encoder_outputs
+            .get_f32("encoder_output")
+            .map_err(|error| CoreMlCtcError::Inference(error.to_string()))?;
+        let encoder_output_tensor =
+            BorrowedTensor::from_f32(&encoder_output, &encoder_output_shape)
+                .map_err(|error| CoreMlCtcError::Inference(error.to_string()))?;
+
+        let decoder_outputs = self
+            .decoder
+            .predict(&[("encoder_output", &encoder_output_tensor)])
+            .map_err(|error| CoreMlCtcError::Inference(error.to_string()))?;
+        let (logits, shape) = decoder_outputs
+            .get_f32("ctc_logits")
+            .map_err(|error| CoreMlCtcError::Inference(error.to_string()))?;
+        if shape.len() != 3 || shape[0] != 1 {
+            return Err(CoreMlCtcError::Inference(format!(
+                "Unexpected CTC logits shape: {shape:?}"
+            )));
+        }
+
+        decode_ctc_logits(
+            &logits,
+            shape[1],
+            shape[2],
+            encoded_length.max(0) as usize,
+            &self.vocab,
+            PARAKEET_CTC_ZH_CN_BLANK_ID,
+        )
+        .map_err(CoreMlCtcError::Inference)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "requires the separately downloaded CoreML model"]
+    fn full_pipeline_smoke_test() {
+        let model_dir = std::env::var("PARAKEET_CTC_COREML_MODEL_DIR")
+            .expect("PARAKEET_CTC_COREML_MODEL_DIR must point to the downloaded model");
+        let samples = match std::env::var("PARAKEET_CTC_AUDIO_F32LE") {
+            Ok(path) => fs::read(path)
+                .expect("failed to read test audio")
+                .chunks_exact(4)
+                .map(|bytes| f32::from_le_bytes(bytes.try_into().unwrap()))
+                .collect(),
+            Err(_) => vec![0.0; 16_000],
+        };
+
+        let model =
+            CoreMlCtcModel::new(Path::new(&model_dir)).expect("failed to load CoreML model");
+        let result = model
+            .transcribe_samples(samples)
+            .expect("CoreML pipeline inference failed");
+
+        if std::env::var_os("PARAKEET_CTC_AUDIO_F32LE").is_some() {
+            assert!(
+                !result.text.trim().is_empty(),
+                "test audio produced no text"
+            );
+        }
+    }
+}

--- a/frontend/src-tauri/src/parakeet_engine/ctc.rs
+++ b/frontend/src-tauri/src/parakeet_engine/ctc.rs
@@ -1,0 +1,159 @@
+use super::model::TimestampedResult;
+
+pub const PARAKEET_CTC_ZH_CN_MODEL: &str = "parakeet-ctc-0.6b-zh-cn-int8";
+pub const PARAKEET_CTC_ZH_CN_MAX_SAMPLES: usize = 15 * 16_000;
+pub const PARAKEET_CTC_ZH_CN_BLANK_ID: usize = 7_000;
+const CTC_FRAME_SECONDS: f32 = 0.08;
+
+pub fn decode_ctc_logits(
+    logits: &[f32],
+    time_steps: usize,
+    vocab_size_with_blank: usize,
+    valid_time_steps: usize,
+    vocab: &[String],
+    blank_id: usize,
+) -> Result<TimestampedResult, String> {
+    if vocab_size_with_blank == 0 || logits.len() != time_steps * vocab_size_with_blank {
+        return Err(format!(
+            "Invalid CTC logits shape: {} values for {}x{}",
+            logits.len(),
+            time_steps,
+            vocab_size_with_blank
+        ));
+    }
+    if blank_id >= vocab_size_with_blank {
+        return Err(format!("Invalid CTC blank token id: {}", blank_id));
+    }
+
+    let mut previous = None;
+    let mut token_ids = Vec::new();
+    let mut timestamps = Vec::new();
+
+    for (time_index, frame) in logits
+        .chunks_exact(vocab_size_with_blank)
+        .take(valid_time_steps.min(time_steps))
+        .enumerate()
+    {
+        let token_id = frame
+            .iter()
+            .enumerate()
+            .max_by(|(_, left), (_, right)| {
+                left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .map(|(index, _)| index)
+            .unwrap_or(blank_id);
+
+        if token_id != blank_id && previous != Some(token_id) {
+            token_ids.push(token_id);
+            timestamps.push(time_index as f32 * CTC_FRAME_SECONDS);
+        }
+        previous = Some(token_id);
+    }
+
+    let tokens: Vec<String> = token_ids
+        .into_iter()
+        .filter_map(|token_id| vocab.get(token_id).cloned())
+        .collect();
+    let text = normalize_ctc_text(&tokens.join("").replace('\u{2581}', " "));
+
+    Ok(TimestampedResult {
+        text,
+        timestamps,
+        tokens,
+    })
+}
+
+pub fn join_chunk_text(parts: &[String]) -> String {
+    normalize_ctc_text(&parts.join(" "))
+}
+
+fn normalize_ctc_text(text: &str) -> String {
+    let compact = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let chars: Vec<char> = compact.chars().collect();
+    let mut result = String::with_capacity(compact.len());
+
+    for (index, character) in chars.iter().copied().enumerate() {
+        if character == ' ' {
+            let previous = result.chars().next_back();
+            let next = chars.get(index + 1).copied();
+            let between_cjk = previous.is_some_and(is_cjk) && next.is_some_and(is_cjk);
+            let after_punctuation = previous.is_some_and(is_cjk_punctuation);
+            let before_punctuation = next.is_some_and(is_cjk_punctuation);
+            if between_cjk || after_punctuation || before_punctuation {
+                continue;
+            }
+        }
+        result.push(character);
+    }
+
+    result.trim().to_string()
+}
+
+fn is_cjk(character: char) -> bool {
+    matches!(
+        character as u32,
+        0x3400..=0x4DBF
+            | 0x4E00..=0x9FFF
+            | 0xF900..=0xFAFF
+            | 0x20000..=0x2FA1F
+    )
+}
+
+fn is_cjk_punctuation(character: char) -> bool {
+    matches!(
+        character,
+        '\u{3002}' | '\u{FF0C}' | '\u{FF1F}' | '\u{FF01}' | '\u{FF1A}' | '\u{FF1B}'
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ctc_decode_collapses_repeats_but_preserves_tokens_separated_by_blank() {
+        let vocab = vec![
+            "\u{2581}\u{4F60}".to_string(),
+            "\u{2581}\u{597D}".to_string(),
+        ];
+        let logits = vec![
+            5.0, 0.0, 0.0, // token 0
+            5.0, 0.0, 0.0, // repeated token 0
+            0.0, 0.0, 5.0, // blank
+            5.0, 0.0, 0.0, // token 0 again
+            0.0, 5.0, 0.0, // token 1
+        ];
+
+        let result = decode_ctc_logits(&logits, 5, 3, 5, &vocab, 2).unwrap();
+
+        assert_eq!(result.text, "\u{4F60}\u{4F60}\u{597D}");
+        assert_eq!(result.tokens.len(), 3);
+        assert_eq!(result.timestamps, vec![0.0, 0.24, 0.32]);
+    }
+
+    #[test]
+    fn ctc_decode_ignores_padded_time_steps() {
+        let vocab = vec!["a".to_string()];
+        let logits = vec![1.0, 0.0, 0.0, 1.0];
+
+        let result = decode_ctc_logits(&logits, 2, 2, 1, &vocab, 1).unwrap();
+
+        assert_eq!(result.text, "a");
+    }
+
+    #[test]
+    fn text_normalization_keeps_english_spaces_and_removes_chinese_token_spaces() {
+        assert_eq!(
+            normalize_ctc_text("\u{4F60} \u{597D} OpenAI \u{6A21} \u{578B} \u{3002}"),
+            "\u{4F60}\u{597D} OpenAI \u{6A21}\u{578B}\u{3002}"
+        );
+    }
+
+    #[test]
+    fn chunk_join_removes_spaces_around_chinese_punctuation() {
+        assert_eq!(
+            join_chunk_text(&["\u{4F60}\u{597D}\u{3002}".into(), "\u{4E16}\u{754C}".into()]),
+            "\u{4F60}\u{597D}\u{3002}\u{4E16}\u{754C}"
+        );
+    }
+}

--- a/frontend/src-tauri/src/parakeet_engine/loaded_model.rs
+++ b/frontend/src-tauri/src/parakeet_engine/loaded_model.rs
@@ -1,0 +1,42 @@
+use super::model::{ParakeetError, ParakeetModel, TimestampedResult};
+use std::path::Path;
+
+pub enum LoadedParakeetModel {
+    Tdt(ParakeetModel),
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    CoreMlCtc(super::coreml_ctc::CoreMlCtcModel),
+}
+
+impl LoadedParakeetModel {
+    pub fn load_tdt(model_dir: &Path, quantized: bool) -> Result<Self, ParakeetError> {
+        ParakeetModel::new(model_dir, quantized).map(Self::Tdt)
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    pub fn load_coreml_ctc(model_dir: &Path) -> Result<Self, ParakeetError> {
+        super::coreml_ctc::CoreMlCtcModel::new(model_dir)
+            .map(Self::CoreMlCtc)
+            .map_err(|error| ParakeetError::Other(error.to_string()))
+    }
+
+    pub fn transcribe_samples(
+        &mut self,
+        samples: Vec<f32>,
+    ) -> Result<TimestampedResult, ParakeetError> {
+        match self {
+            Self::Tdt(model) => model.transcribe_samples(samples),
+            #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+            Self::CoreMlCtc(model) => model
+                .transcribe_samples(samples)
+                .map_err(|error| ParakeetError::Other(error.to_string())),
+        }
+    }
+
+    pub fn max_segment_samples(&self) -> usize {
+        match self {
+            Self::Tdt(_) => 25 * 16_000,
+            #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+            Self::CoreMlCtc(_) => super::ctc::PARAKEET_CTC_ZH_CN_MAX_SAMPLES,
+        }
+    }
+}

--- a/frontend/src-tauri/src/parakeet_engine/mod.rs
+++ b/frontend/src-tauri/src/parakeet_engine/mod.rs
@@ -20,6 +20,10 @@
 pub mod parakeet_engine;
 pub mod model;
 pub mod commands;
+pub mod ctc;
+mod loaded_model;
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+mod coreml_ctc;
 
 pub use parakeet_engine::{ParakeetEngine, ParakeetEngineError, QuantizationType, ModelInfo, ModelStatus, DownloadProgress};
 pub use model::{ParakeetModel, ParakeetError, TimestampedResult};

--- a/frontend/src-tauri/src/parakeet_engine/model.rs
+++ b/frontend/src-tauri/src/parakeet_engine/model.rs
@@ -41,6 +41,8 @@ pub enum ParakeetError {
     OutputNotFound(String),
     #[error("Failed to get tensor shape for input: {0}")]
     TensorShape(String),
+    #[error("{0}")]
+    Other(String),
 }
 
 pub struct ParakeetModel {

--- a/frontend/src-tauri/src/parakeet_engine/parakeet_engine.rs
+++ b/frontend/src-tauri/src/parakeet_engine/parakeet_engine.rs
@@ -1,4 +1,5 @@
-use crate::parakeet_engine::model::ParakeetModel;
+use crate::parakeet_engine::ctc::PARAKEET_CTC_ZH_CN_MODEL;
+use crate::parakeet_engine::loaded_model::LoadedParakeetModel;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -10,11 +11,63 @@ use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 use tokio::time::timeout;
 
+const COREML_CTC_BASE_URL: &str = "https://huggingface.co/FluidInference/parakeet-ctc-0.6b-zh-cn-coreml/resolve/ad0da3a453ce93ae53263f9a757ad365ce90bd58";
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn coreml_ctc_is_supported() -> bool {
+    static SUPPORTED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *SUPPORTED.get_or_init(|| {
+        std::process::Command::new("/usr/bin/sw_vers")
+            .arg("-productVersion")
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .and_then(|output| String::from_utf8(output.stdout).ok())
+            .and_then(|version| version.trim().split('.').next()?.parse::<u32>().ok())
+            .is_some_and(|major| major >= 14)
+    })
+}
+
+fn coreml_ctc_file_sizes() -> Vec<(&'static str, u64)> {
+    vec![
+        ("Preprocessor.mlmodelc/analytics/coremldata.bin", 243),
+        ("Preprocessor.mlmodelc/coremldata.bin", 502),
+        ("Preprocessor.mlmodelc/metadata.json", 2_827),
+        ("Preprocessor.mlmodelc/model.mil", 27_134),
+        ("Preprocessor.mlmodelc/weights/weight.bin", 807_968),
+        ("Encoder-v2-int8.mlmodelc/analytics/coremldata.bin", 243),
+        ("Encoder-v2-int8.mlmodelc/coremldata.bin", 513),
+        ("Encoder-v2-int8.mlmodelc/metadata.json", 2_943),
+        ("Encoder-v2-int8.mlmodelc/model.mil", 1_098_426),
+        ("Encoder-v2-int8.mlmodelc/weights/weight.bin", 593_429_888),
+        ("Decoder.mlmodelc/analytics/coremldata.bin", 243),
+        ("Decoder.mlmodelc/coremldata.bin", 471),
+        ("Decoder.mlmodelc/metadata.json", 1_850),
+        ("Decoder.mlmodelc/model.mil", 3_610),
+        ("Decoder.mlmodelc/weights/weight.bin", 14_352_242),
+        ("vocab.json", 67_395),
+        ("pipeline_metadata.json", 2_170),
+    ]
+}
+
+fn coreml_ctc_required_files() -> Vec<&'static str> {
+    coreml_ctc_file_sizes()
+        .into_iter()
+        .map(|(filename, _)| filename)
+        .collect()
+}
+
 /// Quantization type for Parakeet models
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum QuantizationType {
     FP32,   // Full precision
     Int8,   // 8-bit integer quantization (faster)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ModelArchitecture {
+    Tdt,
+    Ctc,
 }
 
 impl Default for QuantizationType {
@@ -75,6 +128,7 @@ pub struct ModelInfo {
     pub path: PathBuf,
     pub size_mb: u32,
     pub quantization: QuantizationType,
+    pub architecture: ModelArchitecture,
     pub speed: String,     // Performance description
     pub status: ModelStatus,
     pub description: String,
@@ -113,7 +167,7 @@ impl From<std::io::Error> for ParakeetEngineError {
 
 pub struct ParakeetEngine {
     models_dir: PathBuf,
-    current_model: Arc<RwLock<Option<ParakeetModel>>>,
+    current_model: Arc<RwLock<Option<LoadedParakeetModel>>>,
     current_model_name: Arc<RwLock<Option<String>>>,
     pub(crate) available_models: Arc<RwLock<HashMap<String, ModelInfo>>>,
     cancel_download_flag: Arc<RwLock<Option<String>>>, // Model name being cancelled
@@ -171,15 +225,26 @@ impl ParakeetEngine {
         // Parakeet model configurations
         // Model name format: parakeet-tdt-0.6b-v{version}-{quantization}
         // Sizes match actual download sizes (encoder + decoder + preprocessor + vocab)
-        let model_configs = [
-            ("parakeet-tdt-0.6b-v3-int8", 670, QuantizationType::Int8, "Ultra Fast (v3)", "Real time on M4 Max, latest version with int8 quantization"),
-            ("parakeet-tdt-0.6b-v2-int8", 661, QuantizationType::Int8, "Fast (v2)", "Previous version with int8 quantization, good balance of speed and accuracy"),
+        let mut model_configs = vec![
+            ("parakeet-tdt-0.6b-v3-int8", 670, QuantizationType::Int8, ModelArchitecture::Tdt, "Ultra Fast (v3)", "Real time on M4 Max, latest version with int8 quantization"),
+            ("parakeet-tdt-0.6b-v2-int8", 661, QuantizationType::Int8, ModelArchitecture::Tdt, "Fast (v2)", "Previous version with int8 quantization, good balance of speed and accuracy"),
         ];
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        if coreml_ctc_is_supported() {
+            model_configs.push((
+                PARAKEET_CTC_ZH_CN_MODEL,
+                582,
+                QuantizationType::Int8,
+                ModelArchitecture::Ctc,
+                "Apple Neural Engine",
+                "Mandarin Chinese, English, and code-switching via CoreML",
+            ));
+        }
 
         // Get active downloads to override status
         let active_downloads = self.active_downloads.read().await;
 
-        for (name, size_mb, quantization, speed, description) in model_configs {
+        for (name, size_mb, quantization, architecture, speed, description) in model_configs {
             let model_path = models_dir.join(name);
 
             // Check if model is currently downloading
@@ -190,19 +255,23 @@ impl ParakeetEngine {
                 ModelStatus::Downloading { progress: 0 }
             } else if model_path.exists() {
                 // Check for required ONNX files
-                let required_files = match quantization {
-                    QuantizationType::Int8 => vec![
-                        "encoder-model.int8.onnx",
-                        "decoder_joint-model.int8.onnx",
-                        "nemo128.onnx",
-                        "vocab.txt",
-                    ],
-                    QuantizationType::FP32 => vec![
-                        "encoder-model.onnx",
-                        "decoder_joint-model.onnx",
-                        "nemo128.onnx",
-                        "vocab.txt",
-                    ],
+                let required_files = if architecture == ModelArchitecture::Ctc {
+                    coreml_ctc_required_files()
+                } else {
+                    match quantization {
+                        QuantizationType::Int8 => vec![
+                            "encoder-model.int8.onnx",
+                            "decoder_joint-model.int8.onnx",
+                            "nemo128.onnx",
+                            "vocab.txt",
+                        ],
+                        QuantizationType::FP32 => vec![
+                            "encoder-model.onnx",
+                            "decoder_joint-model.onnx",
+                            "nemo128.onnx",
+                            "vocab.txt",
+                        ],
+                    }
                 };
 
                 let all_files_exist = required_files.iter().all(|file| {
@@ -211,7 +280,7 @@ impl ParakeetEngine {
 
                 if all_files_exist {
                     // Validate model by checking file sizes
-                    match self.validate_model_directory(&model_path).await {
+                    match self.validate_model_directory(name, &model_path).await {
                         Ok(_) => ModelStatus::Available,
                         Err(_) => {
                             log::warn!("Model directory {} appears corrupted", name);
@@ -240,6 +309,7 @@ impl ParakeetEngine {
                 path: model_path,
                 size_mb: size_mb as u32,
                 quantization: quantization.clone(),
+                architecture,
                 speed: speed.to_string(),
                 status,
                 description: description.to_string(),
@@ -259,7 +329,25 @@ impl ParakeetEngine {
     }
 
     /// Validate model directory by checking if all required files exist AND have valid sizes
-    async fn validate_model_directory(&self, model_dir: &PathBuf) -> Result<()> {
+    async fn validate_model_directory(&self, model_name: &str, model_dir: &PathBuf) -> Result<()> {
+        if model_name == PARAKEET_CTC_ZH_CN_MODEL {
+            for (filename, expected_size) in coreml_ctc_file_sizes() {
+                let file_path = model_dir.join(filename);
+                let actual_size = std::fs::metadata(&file_path)
+                    .map_err(|error| anyhow!("{} not found or unreadable: {}", filename, error))?
+                    .len();
+                if actual_size != expected_size {
+                    return Err(anyhow!(
+                        "{} has {} bytes; expected {}",
+                        filename,
+                        actual_size,
+                        expected_size
+                    ));
+                }
+            }
+            return Ok(());
+        }
+
         // Check if vocab.txt exists and is readable
         let vocab_path = model_dir.join("vocab.txt");
         if !vocab_path.exists() {
@@ -327,13 +415,38 @@ impl ParakeetEngine {
 
     /// Clean incomplete model directory before download
     /// Removes all files if directory exists but model is not Available
-    async fn clean_incomplete_model_directory(&self, model_dir: &PathBuf) -> Result<()> {
+    async fn clean_incomplete_model_directory(
+        &self,
+        model_name: &str,
+        model_dir: &PathBuf,
+    ) -> Result<()> {
         if !model_dir.exists() {
             return Ok(()); // Nothing to clean
         }
 
+        // Preserve partial files for the revision-pinned CoreML model so the large
+        // encoder can resume with HTTP Range requests. Only oversized files cannot
+        // be valid prefixes and need to be restarted.
+        if model_name == PARAKEET_CTC_ZH_CN_MODEL {
+            for (filename, expected_size) in coreml_ctc_file_sizes() {
+                let file_path = model_dir.join(filename);
+                if let Ok(metadata) = fs::metadata(&file_path).await {
+                    if metadata.len() > expected_size {
+                        fs::remove_file(&file_path).await.map_err(|error| {
+                            anyhow!(
+                                "Failed to remove invalid partial file {}: {}",
+                                filename,
+                                error
+                            )
+                        })?;
+                    }
+                }
+            }
+            return Ok(());
+        }
+
         // Validate the directory
-        match self.validate_model_directory(model_dir).await {
+        match self.validate_model_directory(model_name, model_dir).await {
             Ok(_) => {
                 log::info!("Model directory is valid, no cleanup needed");
                 return Ok(());
@@ -374,15 +487,19 @@ impl ParakeetEngine {
 
     /// Load a Parakeet model
     pub async fn load_model(&self, model_name: &str) -> Result<()> {
-        let models = self.available_models.read().await;
-        let model_info = models
-            .get(model_name)
-            .ok_or_else(|| anyhow!("Model {} not found", model_name))?;
+        let model_info = {
+            let models = self.available_models.read().await;
+            models
+                .get(model_name)
+                .cloned()
+                .ok_or_else(|| anyhow!("Model {} not found", model_name))?
+        };
 
         match model_info.status {
             ModelStatus::Available => {
                 // Check if this model is already loaded
-                if let Some(current_model) = self.current_model_name.read().await.as_ref() {
+                let current_model = self.current_model_name.read().await.clone();
+                if let Some(current_model) = current_model {
                     if current_model == model_name {
                         log::info!("Parakeet model {} is already loaded, skipping reload", model_name);
                         return Ok(());
@@ -397,8 +514,23 @@ impl ParakeetEngine {
 
                 // Load model based on quantization type
                 let quantized = model_info.quantization == QuantizationType::Int8;
-                let model = ParakeetModel::new(&model_info.path, quantized)
-                    .map_err(|e| anyhow!("Failed to load Parakeet model {}: {}", model_name, e))?;
+                let model = match model_info.architecture {
+                    ModelArchitecture::Tdt => LoadedParakeetModel::load_tdt(&model_info.path, quantized),
+                    ModelArchitecture::Ctc => {
+                        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+                        {
+                            LoadedParakeetModel::load_coreml_ctc(&model_info.path)
+                        }
+                        #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+                        {
+                            Err(crate::parakeet_engine::model::ParakeetError::Other(
+                                "Parakeet CTC zh-CN currently requires Apple Silicon and macOS 14 or newer"
+                                    .to_string(),
+                            ))
+                        }
+                    }
+                }
+                .map_err(|e| anyhow!("Failed to load Parakeet model {}: {}", model_name, e))?;
 
                 // Update current model and model name
                 *self.current_model.write().await = Some(model);
@@ -448,6 +580,15 @@ impl ParakeetEngine {
     /// Check if a model is loaded
     pub async fn is_model_loaded(&self) -> bool {
         self.current_model.read().await.is_some()
+    }
+
+    pub async fn max_segment_samples(&self) -> usize {
+        self.current_model
+            .read()
+            .await
+            .as_ref()
+            .map(LoadedParakeetModel::max_segment_samples)
+            .unwrap_or(25 * 16_000)
     }
 
     /// Transcribe audio samples using the loaded Parakeet model
@@ -590,8 +731,10 @@ impl ParakeetEngine {
             }
         }
 
-        // HuggingFace base URL for Parakeet models (version-specific)
-        let base_url = if model_name.contains("-v2-") {
+        // Model artifacts are pinned to immutable revisions where available.
+        let base_url = if model_name == PARAKEET_CTC_ZH_CN_MODEL {
+            COREML_CTC_BASE_URL
+        } else if model_name.contains("-v2-") {
             "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v2-onnx/resolve/main"
         } else {
             // Default to v3 for v3 models
@@ -599,19 +742,23 @@ impl ParakeetEngine {
         };
 
         // Determine which files to download based on quantization
-        let files_to_download = match model_info.quantization {
-            QuantizationType::Int8 => vec![
-                "encoder-model.int8.onnx",
-                "decoder_joint-model.int8.onnx",
-                "nemo128.onnx",
-                "vocab.txt",
-            ],
-            QuantizationType::FP32 => vec![
-                "encoder-model.onnx",
-                "decoder_joint-model.onnx",
-                "nemo128.onnx",
-                "vocab.txt",
-            ],
+        let files_to_download = if model_name == PARAKEET_CTC_ZH_CN_MODEL {
+            coreml_ctc_required_files()
+        } else {
+            match model_info.quantization {
+                QuantizationType::Int8 => vec![
+                    "encoder-model.int8.onnx",
+                    "decoder_joint-model.int8.onnx",
+                    "nemo128.onnx",
+                    "vocab.txt",
+                ],
+                QuantizationType::FP32 => vec![
+                    "encoder-model.onnx",
+                    "decoder_joint-model.onnx",
+                    "nemo128.onnx",
+                    "vocab.txt",
+                ],
+            }
         };
 
         // Create model directory
@@ -627,7 +774,10 @@ impl ParakeetEngine {
 
         // Clean up incomplete downloads before starting
         log::info!("Checking for incomplete model files to clean up...");
-        if let Err(e) = self.clean_incomplete_model_directory(model_dir).await {
+        if let Err(e) = self
+            .clean_incomplete_model_directory(model_name, model_dir)
+            .await
+        {
             log::warn!("Failed to clean incomplete model directory: {}", e);
             // Continue anyway - we'll handle errors during download
         }
@@ -645,34 +795,33 @@ impl ParakeetEngine {
 
         // Calculate total download size for weighted progress
         // Note: These are approximate sizes based on HuggingFace repo inspection
-        let file_sizes: std::collections::HashMap<&str, u64> = match model_info.quantization {
-            QuantizationType::Int8 => {
-                if model_name.contains("-v2-") {
-                    // V2 model sizes
-                    [
-                        ("encoder-model.int8.onnx", 652_000_000u64),       // 652 MB
-                        ("decoder_joint-model.int8.onnx", 9_000_000u64),   // 9 MB
-                        ("nemo128.onnx", 140_000u64),                      // 140 KB
-                        ("vocab.txt", 9_380u64),                           // 9.38 KB
-                    ].iter().cloned().collect()
-                } else {
-                    // V3 model sizes (default)
-                    [
-                        ("encoder-model.int8.onnx", 652_000_000u64),       // 652 MB
-                        ("decoder_joint-model.int8.onnx", 18_200_000u64),  // 18.2 MB
-                        ("nemo128.onnx", 140_000u64),                      // 140 KB
-                        ("vocab.txt", 93_900u64),                          // 93.9 KB
-                    ].iter().cloned().collect()
+        let file_sizes: std::collections::HashMap<&str, u64> = if model_name == PARAKEET_CTC_ZH_CN_MODEL {
+            coreml_ctc_file_sizes().into_iter().collect()
+        } else {
+            match model_info.quantization {
+                QuantizationType::Int8 => {
+                    if model_name.contains("-v2-") {
+                        [
+                            ("encoder-model.int8.onnx", 652_000_000u64),
+                            ("decoder_joint-model.int8.onnx", 9_000_000u64),
+                            ("nemo128.onnx", 140_000u64),
+                            ("vocab.txt", 9_380u64),
+                        ].iter().cloned().collect()
+                    } else {
+                        [
+                            ("encoder-model.int8.onnx", 652_000_000u64),
+                            ("decoder_joint-model.int8.onnx", 18_200_000u64),
+                            ("nemo128.onnx", 140_000u64),
+                            ("vocab.txt", 93_900u64),
+                        ].iter().cloned().collect()
+                    }
                 }
-            }
-            QuantizationType::FP32 => {
-                // FP32 model sizes (encoder has .onnx + .onnx.data)
-                [
-                    ("encoder-model.onnx", 41_800_000u64 + 2_440_000_000u64), // 41.8 MB + 2.44 GB
-                    ("decoder_joint-model.onnx", 72_500_000u64),               // 72.5 MB
-                    ("nemo128.onnx", 140_000u64),                              // 140 KB
-                    ("vocab.txt", 93_900u64),                                  // 93.9 KB
-                ].iter().cloned().collect()
+                QuantizationType::FP32 => [
+                    ("encoder-model.onnx", 41_800_000u64 + 2_440_000_000u64),
+                    ("decoder_joint-model.onnx", 72_500_000u64),
+                    ("nemo128.onnx", 140_000u64),
+                    ("vocab.txt", 93_900u64),
+                ].iter().cloned().collect(),
             }
         };
 
@@ -725,9 +874,14 @@ impl ParakeetEngine {
 
             let expected_size = file_sizes.get(*filename).copied().unwrap_or(0);
 
-            // Skip if file is already complete (with 1% tolerance for size variations)
-            let size_tolerance = (expected_size as f64 * 0.99) as u64;
-            if existing_size >= size_tolerance && expected_size > 0 {
+            // CoreML bundles use exact, revision-pinned file sizes. Legacy mirrors
+            // retain their historical tolerance because they are not revision-pinned.
+            let complete_size = if model_name == PARAKEET_CTC_ZH_CN_MODEL {
+                expected_size
+            } else {
+                (expected_size as f64 * 0.99) as u64
+            };
+            if existing_size >= complete_size && expected_size > 0 {
                 log::info!(
                     "Skipping complete file: {} ({:.2} MB, expected: {:.2} MB)",
                     filename,
@@ -738,6 +892,12 @@ impl ParakeetEngine {
             }
 
             log::info!("Downloading file {}/{}: {} (resuming from {} bytes)", index + 1, total_files, filename, existing_size);
+
+            if let Some(parent) = file_path.parent() {
+                fs::create_dir_all(parent)
+                    .await
+                    .map_err(|e| anyhow!("Failed to create directory for {}: {}", filename, e))?;
+            }
 
             // Build request with optional Range header for resume
             let mut request = client.get(&file_url);
@@ -767,8 +927,12 @@ impl ParakeetEngine {
                 // 416: Range not satisfiable - file complete or invalid range
                 log::warn!("Server returned 416 Range Not Satisfiable for {}", filename);
 
-                let size_tolerance = (expected_size as f64 * 0.99) as u64;
-                if existing_size >= size_tolerance && expected_size > 0 {
+                let complete_size = if model_name == PARAKEET_CTC_ZH_CN_MODEL {
+                    expected_size
+                } else {
+                    (expected_size as f64 * 0.99) as u64
+                };
+                if existing_size >= complete_size && expected_size > 0 {
                     // File is complete - skip it
                     log::info!("File {} complete ({} bytes). Skipping.", filename, existing_size);
                     continue;
@@ -778,7 +942,6 @@ impl ParakeetEngine {
                         "File {} incomplete ({}/{} bytes). Deleting and retrying.",
                         filename, existing_size, expected_size
                     );
-
                     if let Err(e) = fs::remove_file(&file_path).await {
                         let mut active = self.active_downloads.write().await;
                         active.remove(model_name);
@@ -1006,6 +1169,18 @@ impl ParakeetEngine {
                 file_downloaded as f64 / 1_048_576.0,
                 (total_downloaded as f64 / total_size_bytes as f64) * 100.0
             );
+        }
+
+        if let Err(error) = self.validate_model_directory(model_name, model_dir).await {
+            let mut active = self.active_downloads.write().await;
+            active.remove(model_name);
+            drop(active);
+
+            let mut models = self.available_models.write().await;
+            if let Some(model) = models.get_mut(model_name) {
+                model.status = ModelStatus::Missing;
+            }
+            return Err(anyhow!("Downloaded model validation failed: {}", error));
         }
 
         // Report 100% progress with final speed

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -104,7 +104,8 @@
         "macOS": {
             "entitlements": "entitlements.plist",
             "signingIdentity": "-",
-            "hardenedRuntime": true
+            "hardenedRuntime": true,
+            "minimumSystemVersion": "14.2"
         },
         "windows": {
             "signCommand": "powershell -ExecutionPolicy Bypass -File scripts/sign-windows.ps1 -FilePath %1"

--- a/frontend/src/app/_components/SettingsModal.tsx
+++ b/frontend/src/app/_components/SettingsModal.tsx
@@ -227,6 +227,7 @@ export function SettingsModals({
             onLanguageChange={setSelectedLanguage}
             disabled={isRecording}
             provider={transcriptModelConfig.provider}
+            model={transcriptModelConfig.model}
           />
 
           <div className="mt-6 flex justify-end">

--- a/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
+++ b/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
@@ -37,6 +37,7 @@ import { useRouter } from 'next/navigation';
 import { useSidebar } from '../Sidebar/SidebarProvider';
 import { LANGUAGES } from '@/constants/languages';
 import { useTranscriptionModels, ModelOption } from '@/hooks/useTranscriptionModels';
+import { getTranscriptionLanguageCapability } from '@/lib/parakeet';
 
 
 interface ImportAudioDialogProps {
@@ -170,12 +171,16 @@ export function ImportAudioDialog({
     return availableModels.find((m) => m.provider === provider && m.name === name);
   }, [selectedModelKey, availableModels]);
   const isParakeetModel = selectedModel?.provider === 'parakeet';
+  const languageCapability = useMemo(
+    () => getTranscriptionLanguageCapability(selectedModel?.provider, selectedModel?.name),
+    [selectedModel?.provider, selectedModel?.name]
+  );
 
   useEffect(() => {
-    if (isParakeetModel && selectedLang !== 'auto') {
+    if (!languageCapability.allowsLanguageSelection && selectedLang !== 'auto') {
       setSelectedLang('auto');
     }
-  }, [isParakeetModel, selectedLang]);
+  }, [languageCapability.allowsLanguageSelection, selectedLang]);
 
   const handleSelectFile = async () => {
     const info = await selectFile();
@@ -343,7 +348,7 @@ export function ImportAudioDialog({
                   {showAdvanced && (
                     <div className="p-3 pt-0 space-y-4 border-t">
                       {/* Language selector */}
-                      {!isParakeetModel ? (
+                      {languageCapability.allowsLanguageSelection ? (
                         <div className="space-y-2">
                           <div className="flex items-center gap-2">
                             <Globe className="h-4 w-4 text-muted-foreground" />
@@ -369,7 +374,7 @@ export function ImportAudioDialog({
                             <span className="text-sm font-medium">Language</span>
                           </div>
                           <p className="text-xs text-muted-foreground">
-                            Language selection isn't supported for Parakeet. It always uses automatic detection.
+                            {languageCapability.description}
                           </p>
                         </div>
                       )}

--- a/frontend/src/components/LanguageSelection.tsx
+++ b/frontend/src/components/LanguageSelection.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { Globe } from 'lucide-react';
+import { Globe, Info } from 'lucide-react';
 import Analytics from '@/lib/analytics';
 import { toast } from 'sonner';
 import { useConfig } from '@/contexts/ConfigContext';
+import { getTranscriptionLanguageCapability } from '@/lib/parakeet';
 
 export interface Language {
   code: string;
@@ -119,22 +120,26 @@ interface LanguageSelectionProps {
   onLanguageChange: (language: string) => void;
   disabled?: boolean;
   provider?: 'localWhisper' | 'parakeet' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
+  model?: string;
 }
 
 export function LanguageSelection({
   selectedLanguage,
   onLanguageChange,
   disabled = false,
-  provider = 'localWhisper'
+  provider = 'localWhisper',
+  model
 }: LanguageSelectionProps) {
   const [saving, setSaving] = useState(false);
   const { setSelectedLanguage } = useConfig();
 
-  // Parakeet only supports auto-detection (doesn't support manual language selection)
-  const isParakeet = provider === 'parakeet';
-  const availableLanguages = isParakeet
-    ? LANGUAGES.filter(lang => lang.code === 'auto' || lang.code === 'auto-translate')
+  const languageCapability = getTranscriptionLanguageCapability(provider, model);
+  const availableLanguages = !languageCapability.allowsLanguageSelection
+    ? [{ code: 'auto', name: languageCapability.displayName }]
     : LANGUAGES;
+  const effectiveLanguage = languageCapability.allowsLanguageSelection
+    ? selectedLanguage
+    : 'auto';
 
   const handleLanguageChange = async (languageCode: string) => {
     setSaving(true);
@@ -170,8 +175,11 @@ export function LanguageSelection({
 
   // Find the selected language name for display
   const selectedLanguageName = LANGUAGES.find(
-    lang => lang.code === selectedLanguage
+    lang => lang.code === effectiveLanguage
   )?.name || 'Auto Detect (Original Language)';
+  const displayedLanguageName = languageCapability.allowsLanguageSelection
+    ? selectedLanguageName
+    : languageCapability.displayName;
 
   return (
     <div className="space-y-4">
@@ -184,9 +192,9 @@ export function LanguageSelection({
 
       <div className="space-y-2">
         <select
-          value={selectedLanguage}
+          value={effectiveLanguage}
           onChange={(e) => handleLanguageChange(e.target.value)}
-          disabled={disabled || saving}
+          disabled={disabled || saving || !languageCapability.allowsLanguageSelection}
           className="w-full px-3 py-2 text-sm bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-50 disabled:text-gray-500"
         >
           {availableLanguages.map((language) => (
@@ -197,32 +205,34 @@ export function LanguageSelection({
           ))}
         </select>
 
-        {/* Parakeet language limitation warning */}
-        {isParakeet && (
+        {!languageCapability.allowsLanguageSelection && (
           <div className="p-2 bg-amber-50 border border-amber-200 rounded text-amber-800">
-            <p className="font-medium">ℹ️ Parakeet Language Support</p>
-            <p className="mt-1 text-xs">Parakeet currently only supports automatic language detection. Manual language selection is not available. Use Whisper if you need to specify a particular language.</p>
+            <p className="font-medium flex items-center gap-1.5">
+              <Info className="h-3.5 w-3.5" />
+              Parakeet language support
+            </p>
+            <p className="mt-1 text-xs">{languageCapability.description}</p>
           </div>
         )}
 
         {/* Info text */}
         <div className="text-xs space-y-2 pt-2">
           <p className="text-gray-600">
-            <strong>Current:</strong> {selectedLanguageName}
+            <strong>Current:</strong> {displayedLanguageName}
           </p>
-          {selectedLanguage === 'auto' && (
+          {languageCapability.allowsLanguageSelection && selectedLanguage === 'auto' && (
             <div className="p-2 bg-yellow-50 border border-yellow-200 rounded text-yellow-800">
               <p className="font-medium">⚠️ Auto Detect may produce incorrect results</p>
               <p className="mt-1">For best accuracy, select your specific language (e.g., English, Spanish, etc.)</p>
             </div>
           )}
-          {selectedLanguage === 'auto-translate' && (
+          {languageCapability.allowsLanguageSelection && selectedLanguage === 'auto-translate' && (
             <div className="p-2 bg-blue-50 border border-blue-200 rounded text-blue-800">
               <p className="font-medium">🌐 Translation Mode Active</p>
               <p className="mt-1">All audio will be automatically translated to English. Best for multilingual meetings where you need English output.</p>
             </div>
           )}
-          {selectedLanguage !== 'auto' && selectedLanguage !== 'auto-translate' && (
+          {languageCapability.allowsLanguageSelection && selectedLanguage !== 'auto' && selectedLanguage !== 'auto-translate' && (
             <p className="text-gray-600">
               Transcription will be optimized for <strong>{selectedLanguageName}</strong>
             </p>

--- a/frontend/src/components/MeetingDetails/RetranscribeDialog.tsx
+++ b/frontend/src/components/MeetingDetails/RetranscribeDialog.tsx
@@ -23,6 +23,7 @@ import { useConfig } from '@/contexts/ConfigContext';
 import { LANGUAGES } from '@/constants/languages';
 import { useTranscriptionModels, ModelOption } from '@/hooks/useTranscriptionModels';
 import Analytics from '@/lib/analytics';
+import { getTranscriptionLanguageCapability } from '@/lib/parakeet';
 
 interface RetranscribeDialogProps {
   open: boolean;
@@ -93,12 +94,19 @@ export function RetranscribeDialog({
     return availableModels.find(m => m.provider === provider && m.name === name);
   }, [selectedModelKey, availableModels]);
   const isParakeetModel = selectedModelDetails?.provider === 'parakeet';
+  const languageCapability = useMemo(
+    () => getTranscriptionLanguageCapability(
+      selectedModelDetails?.provider,
+      selectedModelDetails?.name
+    ),
+    [selectedModelDetails?.provider, selectedModelDetails?.name]
+  );
 
   useEffect(() => {
-    if (isParakeetModel && selectedLang !== 'auto') {
+    if (!languageCapability.allowsLanguageSelection && selectedLang !== 'auto') {
       setSelectedLang('auto');
     }
-  }, [isParakeetModel, selectedLang]);
+  }, [languageCapability.allowsLanguageSelection, selectedLang]);
 
   // Reset state only when dialog transitions from closed to open
   // This prevents re-initialization when config changes while dialog is already open
@@ -209,7 +217,9 @@ export function RetranscribeDialog({
     try {
       const languageToSend = isParakeetModel ? null : selectedLang === 'auto' ? null : selectedLang;
       await Analytics.track('enhance_transcript_started', {
-        language: isParakeetModel ? 'auto' : (selectedLang === 'auto' ? 'auto' : selectedLang),
+        language: isParakeetModel
+          ? languageCapability.analyticsLanguage
+          : (selectedLang === 'auto' ? 'auto' : selectedLang),
         model_provider: selectedModelDetails?.provider || '',
         model_name: selectedModelDetails?.name || ''
       });
@@ -301,7 +311,7 @@ export function RetranscribeDialog({
 
         <div className="space-y-4 py-4">
           {!isProcessing && !error && (
-            !isParakeetModel ? (
+            languageCapability.allowsLanguageSelection ? (
               <div className="space-y-3">
                 <div className="flex items-center gap-2">
                   <Globe className="h-4 w-4 text-muted-foreground" />
@@ -330,7 +340,7 @@ export function RetranscribeDialog({
                   <span className="text-sm font-medium">Language</span>
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  Language selection isn't supported for Parakeet. It always uses automatic detection.
+                  {languageCapability.description}
                 </p>
               </div>
             )

--- a/frontend/src/components/ParakeetModelManager.tsx
+++ b/frontend/src/components/ParakeetModelManager.tsx
@@ -9,6 +9,7 @@ import {
   ParakeetAPI,
   getModelDisplayInfo,
   getModelDisplayName,
+  getModelDownloadProgress,
   formatFileSize
 } from '../lib/parakeet';
 
@@ -100,7 +101,7 @@ export function ParakeetModelManager({
             setModels(prevModels =>
               prevModels.map(model =>
                 model.name === modelName
-                  ? { ...model, status: { Downloading: progress } as ModelStatus }
+                  ? { ...model, status: { Downloading: { progress } } as ModelStatus }
                   : model
               )
             );
@@ -255,7 +256,7 @@ export function ParakeetModelManager({
       setModels(prevModels =>
         prevModels.map(model =>
           model.name === modelName
-            ? { ...model, status: { Downloading: 0 } as ModelStatus }
+            ? { ...model, status: { Downloading: { progress: 0 } } as ModelStatus }
             : model
         )
       );
@@ -444,10 +445,7 @@ function ModelCard({
   const isMissing = model.status === 'Missing';
   const isError = typeof model.status === 'object' && 'Error' in model.status;
   const isCorrupted = typeof model.status === 'object' && 'Corrupted' in model.status;
-  const downloadProgress =
-    typeof model.status === 'object' && 'Downloading' in model.status
-      ? model.status.Downloading
-      : null;
+  const downloadProgress = getModelDownloadProgress(model.status);
 
   return (
     <motion.div

--- a/frontend/src/components/shared/DownloadProgressToast.tsx
+++ b/frontend/src/components/shared/DownloadProgressToast.tsx
@@ -5,6 +5,10 @@ import { listen } from '@tauri-apps/api/event';
 import { toast } from 'sonner';
 import { X, Download, Check, Loader2, ArrowBigDownDash } from 'lucide-react';
 import { getDownloadTotalMb } from '@/lib/onboarding-summary-model';
+import {
+  getModelDisplayName,
+  getParakeetModelSizeMb,
+} from '@/lib/parakeet';
 
 interface DownloadProgress {
   modelName: string;
@@ -230,13 +234,14 @@ export function useDownloadProgressToast() {
       status?: string;
     }>('parakeet-model-download-progress', (event) => {
       const { modelName, progress, downloaded_mb, total_mb, speed_mbps, status } = event.payload;
+      const configuredSizeMb = getParakeetModelSizeMb(modelName);
 
       const downloadData: DownloadProgress = {
         modelName,
-        displayName: 'Transcription Model (Parakeet)',
+        displayName: `Parakeet: ${getModelDisplayName(modelName)}`,
         progress,
         downloadedMb: downloaded_mb ?? 0,
-        totalMb: total_mb ?? 670,
+        totalMb: total_mb ?? configuredSizeMb,
         speedMbps: speed_mbps ?? 0,
         status: status === 'cancelled'
           ? 'cancelled'
@@ -258,12 +263,13 @@ export function useDownloadProgressToast() {
       'parakeet-model-download-complete',
       (event) => {
         const { modelName } = event.payload;
+        const totalMb = getParakeetModelSizeMb(modelName);
         const downloadData: DownloadProgress = {
           modelName,
-          displayName: 'Transcription Model (Parakeet)',
+          displayName: `Parakeet: ${getModelDisplayName(modelName)}`,
           progress: 100,
-          downloadedMb: 670,
-          totalMb: 670,
+          downloadedMb: totalMb,
+          totalMb,
           speedMbps: 0,
           status: 'completed',
         };
@@ -277,12 +283,13 @@ export function useDownloadProgressToast() {
       'parakeet-model-download-error',
       (event) => {
         const { modelName, error } = event.payload;
+        const totalMb = getParakeetModelSizeMb(modelName);
         const downloadData: DownloadProgress = {
           modelName,
-          displayName: 'Transcription Model (Parakeet)',
+          displayName: `Parakeet: ${getModelDisplayName(modelName)}`,
           progress: 0,
           downloadedMb: 0,
-          totalMb: 670,
+          totalMb,
           speedMbps: 0,
           status: 'error',
           error: categorizeError(error),

--- a/frontend/src/hooks/useRecordingStart.ts
+++ b/frontend/src/hooks/useRecordingStart.ts
@@ -8,6 +8,7 @@ import { recordingService } from '@/services/recordingService';
 import Analytics from '@/lib/analytics';
 import { showRecordingNotification } from '@/lib/recordingNotification';
 import { toast } from 'sonner';
+import { ParakeetModelInfo } from '@/lib/parakeet';
 
 interface UseRecordingStartReturn {
   handleRecordingStart: () => Promise<void>;
@@ -34,7 +35,7 @@ export function useRecordingStart(
 
   const { clearTranscripts, setMeetingTitle } = useTranscripts();
   const { setIsMeetingActive } = useSidebar();
-  const { selectedDevices } = useConfig();
+  const { selectedDevices, transcriptModelConfig } = useConfig();
   const { setStatus } = useRecordingState();
 
   // Generate meeting title with timestamp
@@ -51,33 +52,37 @@ export function useRecordingStart(
 
   // Check if Parakeet transcription model is ready
   const checkParakeetReady = useCallback(async (): Promise<boolean> => {
+    if (transcriptModelConfig.provider !== 'parakeet') return true;
+
     try {
       await invoke('parakeet_init');
-      const hasModels = await invoke<boolean>('parakeet_has_available_models');
-      return hasModels;
+      const models = await invoke<ParakeetModelInfo[]>('parakeet_get_available_models');
+      return models.some(
+        model => model.name === transcriptModelConfig.model && model.status === 'Available'
+      );
     } catch (error) {
       console.error('Failed to check Parakeet status:', error);
       return false;
     }
-  }, []);
+  }, [transcriptModelConfig.provider, transcriptModelConfig.model]);
 
-  // Check if any model is currently downloading
+  // Check whether the selected Parakeet model is currently downloading.
   const checkIfModelDownloading = useCallback(async (): Promise<boolean> => {
+    if (transcriptModelConfig.provider !== 'parakeet') return false;
+
     try {
-      const models = await invoke<any[]>('parakeet_get_available_models');
+      const models = await invoke<ParakeetModelInfo[]>('parakeet_get_available_models');
       const isDownloading = models.some(m =>
-        m.status && (
-          typeof m.status === 'object'
-            ? 'Downloading' in m.status
-            : m.status === 'Downloading'
-        )
+        m.name === transcriptModelConfig.model &&
+        typeof m.status === 'object' &&
+        'Downloading' in m.status
       );
       return isDownloading;
     } catch (error) {
       console.error('Failed to check model download status:', error);
       return false; // Default to not downloading (will show error + modal)
     }
-  }, []);
+  }, [transcriptModelConfig.provider, transcriptModelConfig.model]);
 
   // Handle manual recording start (from button click)
   const handleRecordingStart = useCallback(async () => {

--- a/frontend/src/hooks/useTranscriptionModels.ts
+++ b/frontend/src/hooks/useTranscriptionModels.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { getModelDisplayName } from '@/lib/parakeet';
 
 export interface RawModelInfo {
   name: string;
@@ -69,7 +70,7 @@ export function useTranscriptionModels(transcriptModelConfig: TranscriptModelCon
         .map((m) => ({
           provider: 'parakeet' as const,
           name: m.name,
-          displayName: `⚡ Parakeet: ${m.name}`,
+          displayName: `⚡ Parakeet: ${getModelDisplayName(m.name)}`,
           size_mb: m.size_mb,
         }));
       allModels.push(...availableParakeet);

--- a/frontend/src/lib/parakeet.ts
+++ b/frontend/src/lib/parakeet.ts
@@ -8,6 +8,7 @@ export interface ParakeetModelInfo {
   status: ModelStatus;
   description?: string;
   quantization: QuantizationType;
+  architecture?: 'Tdt' | 'Ctc';
 }
 
 export type QuantizationType = 'FP32' | 'Int8';
@@ -17,7 +18,7 @@ export type ProcessingSpeed = 'Slow' | 'Medium' | 'Fast' | 'Very Fast' | 'Ultra 
 export type ModelStatus =
   | 'Available'
   | 'Missing'
-  | { Downloading: number }
+  | { Downloading: number | { progress: number } }
   | { Error: string }
   | { Corrupted: { file_size: number; expected_min_size: number } };
 
@@ -35,6 +36,15 @@ export interface ModelDisplayInfo {
   tagline: string;
   recommended?: boolean;
   tier: 'fastest' | 'balanced' | 'precise';
+}
+
+export const PARAKEET_CTC_ZH_CN_MODEL = 'parakeet-ctc-0.6b-zh-cn-int8';
+
+export interface TranscriptionLanguageCapability {
+  allowsLanguageSelection: boolean;
+  displayName: string;
+  description: string;
+  analyticsLanguage: string;
 }
 
 export const MODEL_DISPLAY_CONFIG: Record<string, ModelDisplayInfo> = {
@@ -56,6 +66,12 @@ export const MODEL_DISPLAY_CONFIG: Record<string, ModelDisplayInfo> = {
     icon: '🎯',
     tagline: '20x real-time • Higher accuracy',
     tier: 'precise'
+  },
+  [PARAKEET_CTC_ZH_CN_MODEL]: {
+    friendlyName: 'Mandarin CoreML',
+    icon: '中',
+    tagline: 'Experimental • Mandarin + English • Apple Silicon',
+    tier: 'balanced'
   }
 };
 
@@ -83,6 +99,13 @@ export const PARAKEET_MODEL_CONFIGS: Record<string, Partial<ParakeetModelInfo>> 
     accuracy: 'High',
     speed: 'Fast',
     quantization: 'FP32'
+  },
+  [PARAKEET_CTC_ZH_CN_MODEL]: {
+    description: 'CoreML model for Mandarin, English, and mixed Chinese-English speech',
+    size_mb: 582,
+    accuracy: 'High',
+    speed: 'Ultra Fast',
+    quantization: 'Int8'
   }
 };
 
@@ -105,6 +128,47 @@ export function getModelDisplayName(modelName: string): string {
 // Get model display info (icon, tagline, etc.)
 export function getModelDisplayInfo(modelName: string): ModelDisplayInfo | null {
   return MODEL_DISPLAY_CONFIG[modelName] || null;
+}
+
+export function getModelDownloadProgress(status: ModelStatus): number | null {
+  if (typeof status !== 'object' || !('Downloading' in status)) return null;
+  return typeof status.Downloading === 'number'
+    ? status.Downloading
+    : status.Downloading.progress;
+}
+
+export function getParakeetModelSizeMb(modelName: string): number {
+  return PARAKEET_MODEL_CONFIGS[modelName]?.size_mb ?? 0;
+}
+
+export function getTranscriptionLanguageCapability(
+  provider?: string,
+  modelName?: string
+): TranscriptionLanguageCapability {
+  if (provider !== 'parakeet') {
+    return {
+      allowsLanguageSelection: true,
+      displayName: '',
+      description: '',
+      analyticsLanguage: 'selected',
+    };
+  }
+
+  if (modelName === PARAKEET_CTC_ZH_CN_MODEL) {
+    return {
+      allowsLanguageSelection: false,
+      displayName: 'Mandarin Chinese + English',
+      description: 'Supports Mandarin Chinese, English, and mixed Chinese-English speech. Translation is not available.',
+      analyticsLanguage: 'zh-en',
+    };
+  }
+
+  return {
+    allowsLanguageSelection: false,
+    displayName: 'English',
+    description: 'This Parakeet model transcribes English. Language selection and translation are not available.',
+    analyticsLanguage: 'en',
+  };
 }
 
 export function getStatusColor(status: ModelStatus): string {

--- a/frontend/tests/lib/parakeet.test.mjs
+++ b/frontend/tests/lib/parakeet.test.mjs
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import {
+  PARAKEET_CTC_ZH_CN_MODEL,
+  getModelDisplayName,
+  getModelDownloadProgress,
+  getParakeetModelSizeMb,
+  getTranscriptionLanguageCapability,
+} from '../../src/lib/parakeet';
+
+describe('Parakeet model metadata', () => {
+  test('reads the Rust Downloading struct variant', () => {
+    expect(getModelDownloadProgress({ Downloading: { progress: 42 } })).toBe(42);
+    expect(getModelDownloadProgress('Available')).toBeNull();
+  });
+
+  test('describes the Mandarin CoreML model', () => {
+    expect(getModelDisplayName(PARAKEET_CTC_ZH_CN_MODEL)).toBe('Mandarin CoreML');
+    expect(getParakeetModelSizeMb(PARAKEET_CTC_ZH_CN_MODEL)).toBe(582);
+
+    const capability = getTranscriptionLanguageCapability(
+      'parakeet',
+      PARAKEET_CTC_ZH_CN_MODEL
+    );
+    expect(capability.allowsLanguageSelection).toBe(false);
+    expect(capability.displayName).toBe('Mandarin Chinese + English');
+    expect(capability.analyticsLanguage).toBe('zh-en');
+    expect(capability.description).toContain('Mandarin Chinese');
+    expect(capability.description).toContain('Translation is not available');
+  });
+
+  test('keeps English TDT and selectable-language providers distinct', () => {
+    expect(
+      getTranscriptionLanguageCapability('parakeet', 'parakeet-tdt-0.6b-v3-int8')
+        .analyticsLanguage
+    ).toBe('en');
+    expect(getTranscriptionLanguageCapability('localWhisper', 'large-v3'))
+      .toMatchObject({ allowsLanguageSelection: true });
+  });
+});


### PR DESCRIPTION
## Description
Adds the Mandarin Chinese Parakeet CTC 0.6B model as a downloadable CoreML transcription option on macOS Apple Silicon.

The implementation keeps the existing English Parakeet TDT path intact while introducing a dedicated CTC decoder, model-specific metadata and language capability UI, import/retranscription support, and bounded live VAD checkpoints so captions are emitted during continuous speech rather than only when recording stops.

The branch also makes macOS bundles portable by using the static ONNX Runtime setup at the workspace level and avoiding Homebrew-specific runtime library paths. Model artifacts are downloaded only after user action and are pinned/documented in `THIRD_PARTY_MODELS.md`.

## Related Issue
Fixes #644

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] All tests pass

Validated on macOS Apple Silicon:

- `bun test` (11 passed)
- `bun run build`
- `cargo check`
- Full Tauri release build with `--bundles app`
- Mandarin live transcription, including captions emitted before recording stops

The macOS application bundle was produced and ad-hoc signed successfully. Notarization was skipped because Apple signing credentials are not available in the local environment.

## Documentation
- [x] Documentation updated
- [ ] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [x] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)
No screenshot attached. The model appears in the existing Parakeet model manager as `Mandarin CoreML` with its language capability and download state.

## Additional Notes
The CoreML model is macOS Apple Silicon only. Its weights are not bundled with Meetily and are downloaded from the pinned FluidInference revision when the user requests them.
