### PR TITLE
feat(transcription): attribute transcripts to audio sources

### DIFF
--- a/frontend/src-tauri/src/api/api.rs
+++ b/frontend/src-tauri/src/api/api.rs
@@ -137,6 +137,8 @@ pub struct MeetingTranscript {
     pub audio_end_time: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }
 
 /// Meeting metadata without transcripts (for pagination)
@@ -188,6 +190,8 @@ pub struct TranscriptSegment {
     pub audio_end_time: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -878,6 +882,7 @@ pub async fn api_get_meeting_transcripts<R: Runtime>(
                     audio_start_time: t.audio_start_time,
                     audio_end_time: t.audio_end_time,
                     duration: t.duration,
+                    source: t.speaker,
                 })
                 .collect::<Vec<_>>();
 

--- a/frontend/src-tauri/src/audio/common.rs
+++ b/frontend/src-tauri/src/audio/common.rs
@@ -63,6 +63,7 @@ pub(crate) fn create_transcript_segments(transcripts: &[(String, f64, f64)]) -> 
                 audio_start_time: Some(start_seconds),
                 audio_end_time: Some(end_seconds),
                 duration: Some(duration),
+                source: None,
             }
         })
         .collect()

--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -1181,6 +1181,7 @@ mod tests {
                 audio_start_time: Some(0.0),
                 audio_end_time: Some(1.5),
                 duration: Some(1.5),
+                source: None,
             },
             TranscriptSegment {
                 id: "t-2".to_string(),
@@ -1189,6 +1190,7 @@ mod tests {
                 audio_start_time: Some(2.0),
                 audio_end_time: Some(3.5),
                 duration: Some(1.5),
+                source: None,
             },
         ];
 

--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -13,6 +13,8 @@ use super::recording_state::{AudioChunk, AudioError, RecordingState, DeviceType}
 use super::audio_processing::{audio_to_mono, LoudnessNormalizer, NoiseSuppressionProcessor, HighPassFilter};
 use super::vad::{ContinuousVadProcessor};
 
+const MIN_TRANSCRIPTION_SEGMENT_SAMPLES: usize = 800;
+
 /// Ring buffer for synchronized audio mixing
 /// Accumulates samples from mic and system streams until we have aligned windows
 struct AudioMixerRingBuffer {
@@ -681,7 +683,10 @@ pub struct AudioPipeline {
     receiver: mpsc::UnboundedReceiver<AudioChunk>,
     transcription_sender: mpsc::UnboundedSender<AudioChunk>,
     state: Arc<RecordingState>,
-    vad_processor: ContinuousVadProcessor,
+    microphone_vad_processor: ContinuousVadProcessor,
+    system_vad_processor: ContinuousVadProcessor,
+    microphone_time_offset: Option<f64>,
+    system_time_offset: Option<f64>,
     sample_rate: u32,
     chunk_id_counter: u64,
     // Performance optimization: reduce logging frequency
@@ -726,16 +731,13 @@ impl AudioPipeline {
 
         let redemption_time = if cfg!(target_os = "macos") { 400 } else { 400 };
 
-        let vad_processor = match ContinuousVadProcessor::new(sample_rate, redemption_time) {
-            Ok(processor) => {
-                info!("VAD-driven pipeline: VAD segments will be sent directly to Whisper (no time-based accumulation)");
-                processor
-            }
-            Err(e) => {
-                error!("Failed to create VAD processor: {}", e);
-                panic!("VAD processor creation failed: {}", e);
-            }
+        let create_vad_processor = || {
+            ContinuousVadProcessor::new(sample_rate, redemption_time)
+            .unwrap_or_else(|error| panic!("VAD processor creation failed: {error}"))
         };
+        let microphone_vad_processor = create_vad_processor();
+        let system_vad_processor = create_vad_processor();
+        info!("Source-separated VAD pipeline: using natural speech boundaries");
 
         // Initialize professional audio mixing components
         let ring_buffer = AudioMixerRingBuffer::new(sample_rate);
@@ -748,7 +750,10 @@ impl AudioPipeline {
             receiver,
             transcription_sender,
             state,
-            vad_processor,
+            microphone_vad_processor,
+            system_vad_processor,
+            microphone_time_offset: None,
+            system_time_offset: None,
             sample_rate,
             chunk_id_counter: 0,
             // Performance optimization: reduce logging frequency
@@ -814,12 +819,15 @@ impl AudioPipeline {
                         self.last_summary_time = std::time::Instant::now();
                     }
 
-                    // STEP 1: Add raw audio to ring buffer for mixing
+                    // STEP 1: Run VAD independently so transcription retains audio provenance.
+                    self.process_source_audio(&chunk.device_type, chunk.timestamp, &chunk.data);
+
+                    // STEP 2: Add raw audio to ring buffer for mixed recording.
                     // Microphone audio is already normalized at capture level (AudioCapture)
                     // System audio remains raw
                     self.ring_buffer.add_samples(chunk.device_type.clone(), chunk.data);
 
-                    // STEP 2: Mix audio in fixed windows when both streams have sufficient data
+                    // STEP 3: Mix audio in fixed windows when either stream has sufficient data.
                     while self.ring_buffer.can_mix() {
                         if let Some((mic_window, sys_window)) = self.ring_buffer.extract_window() {
                             // Simple mixing without aggressive ducking
@@ -831,41 +839,7 @@ impl AudioPipeline {
                             // Previous 2x gain was causing excessive limiting/distortion
                             let mixed_with_gain = mixed_clean;
 
-                            // STEP 3: Send mixed audio for transcription (VAD + Whisper)
-                            match self.vad_processor.process_audio(&mixed_with_gain) {
-                                Ok(speech_segments) => {
-                                    for segment in speech_segments {
-                                        let duration_ms = segment.end_timestamp_ms - segment.start_timestamp_ms;
-
-                                        if segment.samples.len() >= 800 {  // Minimum 50ms at 16kHz - matches Parakeet capability
-                                            info!("📤 Sending VAD segment: {:.1}ms, {} samples",
-                                                  duration_ms, segment.samples.len());
-
-                                            let transcription_chunk = AudioChunk {
-                                                data: segment.samples,
-                                                sample_rate: 16000,
-                                                timestamp: segment.start_timestamp_ms / 1000.0,
-                                                chunk_id: self.chunk_id_counter,
-                                                device_type: DeviceType::Microphone,  // Mixed audio
-                                            };
-
-                                            if let Err(e) = self.transcription_sender.send(transcription_chunk) {
-                                                warn!("Failed to send VAD segment: {}", e);
-                                            } else {
-                                                self.chunk_id_counter += 1;
-                                            }
-                                        } else {
-                                            debug!("⏭️ Dropping short VAD segment: {:.1}ms ({} samples < 800)",
-                                                   duration_ms, segment.samples.len());
-                                        }
-                                    }
-                                }
-                                Err(e) => {
-                                    warn!("⚠️ VAD error: {}", e);
-                                }
-                            }
-
-                            // STEP 4: Send mixed audio for recording (WAV file)
+                            // STEP 4: Send mixed audio for recording (WAV file).
                             if let Some(ref sender) = self.recording_sender_for_mixed {
                                 let recording_chunk = AudioChunk {
                                     data: mixed_with_gain.clone(),
@@ -897,42 +871,82 @@ impl AudioPipeline {
         Ok(())
     }
 
+    fn process_source_audio(
+        &mut self,
+        device_type: &DeviceType,
+        timestamp: f64,
+        samples: &[f32],
+    ) {
+        let (speech_segments, time_offset) = match device_type {
+            DeviceType::Microphone => (
+                self.microphone_vad_processor.process_audio(samples),
+                *self.microphone_time_offset.get_or_insert(timestamp),
+            ),
+            DeviceType::System => (
+                self.system_vad_processor.process_audio(samples),
+                *self.system_time_offset.get_or_insert(timestamp),
+            ),
+        };
+        match speech_segments {
+            Ok(speech_segments) => {
+                self.send_speech_segments(speech_segments, *device_type, time_offset)
+            }
+            Err(error) => warn!("VAD error for {:?}: {}", device_type, error),
+        }
+    }
+
+    fn send_speech_segments(
+        &mut self,
+        speech_segments: Vec<super::vad::SpeechSegment>,
+        device_type: DeviceType,
+        time_offset: f64,
+    ) {
+        for segment in speech_segments {
+            let duration_ms = segment.end_timestamp_ms - segment.start_timestamp_ms;
+            if segment.samples.len() < MIN_TRANSCRIPTION_SEGMENT_SAMPLES {
+                debug!(
+                    "Dropping short {:?} VAD segment: {:.1}ms ({} samples < {})",
+                    device_type,
+                    duration_ms,
+                    segment.samples.len(),
+                    MIN_TRANSCRIPTION_SEGMENT_SAMPLES
+                );
+                continue;
+            }
+
+            let transcription_chunk = AudioChunk {
+                data: segment.samples,
+                sample_rate: 16_000,
+                timestamp: time_offset + segment.start_timestamp_ms / 1000.0,
+                chunk_id: self.chunk_id_counter,
+                device_type,
+            };
+            if let Err(error) = self.transcription_sender.send(transcription_chunk) {
+                warn!("Failed to send {:?} VAD segment: {}", device_type, error);
+            } else {
+                self.chunk_id_counter += 1;
+            }
+        }
+    }
+
     fn flush_remaining_audio(&mut self) -> Result<()> {
         info!("Flushing remaining audio from pipeline (processed {} chunks)", self.processed_chunks);
 
-        // Flush any remaining audio from VAD processor and send segments to transcription
-        match self.vad_processor.flush() {
-            Ok(final_segments) => {
-                for segment in final_segments {
-                    let duration_ms = segment.end_timestamp_ms - segment.start_timestamp_ms;
-
-                    // Send segments >= 50ms (800 samples at 16kHz) - matches main pipeline filter
-                    if segment.samples.len() >= 800 {
-                        info!("📤 Sending final VAD segment to Whisper: {:.1}ms duration, {} samples",
-                              duration_ms, segment.samples.len());
-
-                        let transcription_chunk = AudioChunk {
-                            data: segment.samples,
-                            sample_rate: 16000,
-                            timestamp: segment.start_timestamp_ms / 1000.0,
-                            chunk_id: self.chunk_id_counter,
-                            device_type: DeviceType::Microphone,
-                        };
-
-                        if let Err(e) = self.transcription_sender.send(transcription_chunk) {
-                            warn!("Failed to send final VAD segment: {}", e);
-                        } else {
-                            self.chunk_id_counter += 1;
-                        }
-                    } else {
-                        info!("⏭️ Skipping short final segment: {:.1}ms ({} samples < 800)",
-                              duration_ms, segment.samples.len());
-                    }
-                }
-            }
-            Err(e) => {
-                warn!("Failed to flush VAD processor: {}", e);
-            }
+        match self.microphone_vad_processor.flush() {
+            Ok(segments) => self.send_speech_segments(
+                segments,
+                DeviceType::Microphone,
+                self.microphone_time_offset.unwrap_or(0.0),
+            ),
+            Err(error) => warn!("Failed to flush microphone VAD processor: {}", error),
+        }
+        match self.system_vad_processor.flush() {
+            Ok(segments) => self.send_speech_segments(
+                segments,
+                DeviceType::System,
+                self.system_time_offset.unwrap_or(0.0),
+            ),
+            Err(error) => warn!("Failed to flush system VAD processor: {}", error),
         }
 
         Ok(())

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -275,6 +275,7 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
                     display_time: update.timestamp.clone(), // Use wall-clock timestamp for display
                     confidence: update.confidence,
                     sequence_id: update.sequence_id,
+                    source: Some(update.source),
                 };
 
                 // Save to recording manager
@@ -446,6 +447,7 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
                     display_time: update.timestamp.clone(), // Use wall-clock timestamp for display
                     confidence: update.confidence,
                     sequence_id: update.sequence_id,
+                    source: Some(update.source),
                 };
 
                 // Save to recording manager

--- a/frontend/src-tauri/src/audio/recording_saver.rs
+++ b/frontend/src-tauri/src/audio/recording_saver.rs
@@ -8,6 +8,7 @@ use serde::{Serialize, Deserialize};
 use std::path::PathBuf;
 
 use super::recording_state::AudioChunk;
+use super::recording_state::TranscriptSource;
 use super::audio_processing::create_meeting_folder;
 use super::incremental_saver::IncrementalAudioSaver;
 
@@ -22,6 +23,8 @@ pub struct TranscriptSegment {
     pub display_time: String,   // Formatted time for display like "[02:15]"
     pub confidence: f32,
     pub sequence_id: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<TranscriptSource>,
 }
 
 /// Meeting metadata structure
@@ -129,6 +132,7 @@ impl RecordingSaver {
             display_time: "[00:00]".to_string(),
             confidence: 1.0,
             sequence_id: 0,
+            source: None,
         };
         self.add_transcript_segment(segment);
     }
@@ -481,5 +485,43 @@ impl RecordingSaver {
 impl Default for RecordingSaver {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transcript_source_is_backward_compatible_in_recording_json() {
+        let legacy = r#"{
+            "id":"seg_1",
+            "text":"legacy",
+            "audio_start_time":0.0,
+            "audio_end_time":1.0,
+            "duration":1.0,
+            "display_time":"[00:00]",
+            "confidence":0.9,
+            "sequence_id":1
+        }"#;
+        let segment: TranscriptSegment = serde_json::from_str(legacy).unwrap();
+        assert_eq!(segment.source, None);
+        assert!(serde_json::to_value(segment).unwrap().get("source").is_none());
+
+        let sourced = TranscriptSegment {
+            id: "seg_2".to_string(),
+            text: "system".to_string(),
+            audio_start_time: 1.0,
+            audio_end_time: 2.0,
+            duration: 1.0,
+            display_time: "[00:01]".to_string(),
+            confidence: 0.9,
+            sequence_id: 2,
+            source: Some(TranscriptSource::SystemAudio),
+        };
+        assert_eq!(
+            serde_json::to_value(sourced).unwrap()["source"],
+            "system"
+        );
     }
 }

--- a/frontend/src-tauri/src/audio/recording_state.rs
+++ b/frontend/src-tauri/src/audio/recording_state.rs
@@ -3,15 +3,33 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::sync::mpsc;
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 
 use super::devices::AudioDevice;
 use super::buffer_pool::AudioBufferPool;
 
 /// Device type for audio chunks
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeviceType {
     Microphone,
     System,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TranscriptSource {
+    #[serde(rename = "mic")]
+    Microphone,
+    #[serde(rename = "system")]
+    SystemAudio,
+}
+
+impl From<DeviceType> for TranscriptSource {
+    fn from(device_type: DeviceType) -> Self {
+        match device_type {
+            DeviceType::Microphone => Self::Microphone,
+            DeviceType::System => Self::SystemAudio,
+        }
+    }
 }
 
 /// Audio chunk with metadata for processing

--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -4,9 +4,11 @@
 
 use super::engine::TranscriptionEngine;
 use super::provider::TranscriptionError;
+use crate::audio::recording_state::TranscriptSource;
 use crate::audio::AudioChunk;
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Runtime};
@@ -27,7 +29,7 @@ pub fn reset_speech_detected_flag() {
 pub struct TranscriptUpdate {
     pub text: String,
     pub timestamp: String, // Wall-clock time for reference (e.g., "14:30:05")
-    pub source: String,
+    pub source: TranscriptSource,
     pub sequence_id: u64,
     pub chunk_start_time: f64, // Legacy field, kept for compatibility
     pub is_partial: bool,
@@ -36,6 +38,109 @@ pub struct TranscriptUpdate {
     pub audio_start_time: f64, // Seconds from recording start (e.g., 125.3)
     pub audio_end_time: f64,   // Seconds from recording start (e.g., 128.6)
     pub duration: f64,          // Segment duration in seconds (e.g., 3.3)
+}
+
+#[derive(Debug, Clone)]
+struct RecentTranscript {
+    text: String,
+    source: TranscriptSource,
+    sequence_id: u64,
+    start_time: f64,
+    end_time: f64,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum DeduplicationDecision {
+    EmitNew,
+    ReplaceMicrophone(u64),
+    SuppressMicrophone,
+}
+
+fn deduplication_decision(
+    recent: &VecDeque<RecentTranscript>,
+    text: &str,
+    source: TranscriptSource,
+    start_time: f64,
+    end_time: f64,
+) -> DeduplicationDecision {
+    let duplicate = recent.iter().rev().find(|candidate| {
+        candidate.source != source
+            && transcript_windows_overlap(
+                candidate.start_time,
+                candidate.end_time,
+                start_time,
+                end_time,
+            )
+            && normalized_text_similarity(&candidate.text, text) >= 0.82
+    });
+
+    match (source, duplicate) {
+        (TranscriptSource::Microphone, Some(candidate))
+            if candidate.source == TranscriptSource::SystemAudio =>
+        {
+            DeduplicationDecision::SuppressMicrophone
+        }
+        (TranscriptSource::SystemAudio, Some(candidate))
+            if candidate.source == TranscriptSource::Microphone =>
+        {
+            DeduplicationDecision::ReplaceMicrophone(candidate.sequence_id)
+        }
+        _ => DeduplicationDecision::EmitNew,
+    }
+}
+
+fn transcript_windows_overlap(
+    first_start: f64,
+    first_end: f64,
+    second_start: f64,
+    second_end: f64,
+) -> bool {
+    let overlap = first_end.min(second_end) - first_start.max(second_start);
+    let shortest_duration = (first_end - first_start)
+        .min(second_end - second_start)
+        .max(0.001);
+    overlap > 0.0 && overlap / shortest_duration >= 0.35
+}
+
+fn normalized_text_similarity(left: &str, right: &str) -> f64 {
+    let left = normalize_transcript(left);
+    let right = normalize_transcript(right);
+    if left.is_empty() || right.is_empty() {
+        return 0.0;
+    }
+
+    let left: Vec<char> = left.chars().collect();
+    let right: Vec<char> = right.chars().collect();
+    let distance = levenshtein_distance(&left, &right);
+    1.0 - distance as f64 / left.len().max(right.len()) as f64
+}
+
+fn normalize_transcript(text: &str) -> String {
+    text.chars()
+        .filter(|character| character.is_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn levenshtein_distance(left: &[char], right: &[char]) -> usize {
+    let mut previous: Vec<usize> = (0..=right.len()).collect();
+    let mut current = vec![0; right.len() + 1];
+
+    for (left_index, left_character) in left.iter().enumerate() {
+        current[0] = left_index + 1;
+        for (right_index, right_character) in right.iter().enumerate() {
+            current[right_index + 1] = if left_character == right_character {
+                previous[right_index]
+            } else {
+                1 + previous[right_index]
+                    .min(previous[right_index + 1])
+                    .min(current[right_index])
+            };
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+
+    previous[right.len()]
 }
 
 // NOTE: get_transcript_history and get_recording_meeting_name functions
@@ -91,6 +196,7 @@ pub fn start_transcription_task<R: Runtime>(
 
             let worker_handle = tokio::spawn(async move {
                 info!("👷 Worker {} started", worker_id);
+                let mut recent_transcripts = VecDeque::<RecentTranscript>::new();
 
                 // PRE-VALIDATE model state to avoid repeated async calls per chunk
                 let initial_model_loaded = engine_clone.is_model_loaded().await;
@@ -142,6 +248,7 @@ pub fn start_transcription_task<R: Runtime>(
 
                             let chunk_timestamp = chunk.timestamp;
                             let chunk_duration = chunk.data.len() as f64 / chunk.sample_rate as f64;
+                            let transcript_source = TranscriptSource::from(chunk.device_type);
 
                             // Transcribe with provider-agnostic approach
                             match transcribe_chunk_with_provider(
@@ -191,10 +298,37 @@ pub fn start_transcription_task<R: Runtime>(
                                             info!("🔍 Speech already detected in this session, not re-emitting");
                                         }
 
-                                        // Generate sequence ID and calculate timestamps FIRST
-                                        let sequence_id = SEQUENCE_COUNTER.fetch_add(1, Ordering::SeqCst);
                                         let audio_start_time = chunk_timestamp; // Already in seconds from recording start
                                         let audio_end_time = chunk_timestamp + chunk_duration;
+
+                                        while recent_transcripts.len() >= 64 {
+                                            recent_transcripts.pop_front();
+                                        }
+
+                                        let sequence_id = match deduplication_decision(
+                                            &recent_transcripts,
+                                            &transcript,
+                                            transcript_source,
+                                            audio_start_time,
+                                            audio_end_time,
+                                        ) {
+                                            DeduplicationDecision::EmitNew => {
+                                                Some(SEQUENCE_COUNTER.fetch_add(1, Ordering::SeqCst))
+                                            }
+                                            DeduplicationDecision::ReplaceMicrophone(sequence_id) => {
+                                                recent_transcripts.retain(|candidate| {
+                                                    candidate.sequence_id != sequence_id
+                                                });
+                                                Some(sequence_id)
+                                            }
+                                            DeduplicationDecision::SuppressMicrophone => {
+                                                info!(
+                                                    "Suppressing likely microphone echo for system transcript at {:.2}s",
+                                                    audio_start_time
+                                                );
+                                                None
+                                            }
+                                        };
 
                                         // Save structured transcript segment to recording manager (only final results)
                                         // Save ALL segments (partial and final) to ensure complete JSON
@@ -205,26 +339,36 @@ pub fn start_transcription_task<R: Runtime>(
 
                                         // Emit transcript update with NEW recording-relative timestamps
 
-                                        let update = TranscriptUpdate {
-                                            text: transcript,
-                                            timestamp: format_current_timestamp(), // Wall-clock for reference
-                                            source: "Audio".to_string(),
-                                            sequence_id,
-                                            chunk_start_time: chunk_timestamp, // Legacy compatibility
-                                            is_partial,
-                                            confidence: confidence_opt.unwrap_or(0.85), // Default for providers without confidence
-                                            // NEW: Recording-relative timestamps for sync
-                                            audio_start_time,
-                                            audio_end_time,
-                                            duration: chunk_duration,
-                                        };
+                                        if let Some(sequence_id) = sequence_id {
+                                            recent_transcripts.push_back(RecentTranscript {
+                                                text: transcript.clone(),
+                                                source: transcript_source,
+                                                sequence_id,
+                                                start_time: audio_start_time,
+                                                end_time: audio_end_time,
+                                            });
 
-                                        if let Err(e) = app_clone.emit("transcript-update", &update)
-                                        {
-                                            error!(
-                                                "Worker {}: Failed to emit transcript update: {}",
-                                                worker_id, e
-                                            );
+                                            let update = TranscriptUpdate {
+                                                text: transcript,
+                                                timestamp: format_current_timestamp(), // Wall-clock for reference
+                                                source: transcript_source,
+                                                sequence_id,
+                                                chunk_start_time: chunk_timestamp, // Legacy compatibility
+                                                is_partial,
+                                                confidence: confidence_opt.unwrap_or(0.85), // Default for providers without confidence
+                                                // NEW: Recording-relative timestamps for sync
+                                                audio_start_time,
+                                                audio_end_time,
+                                                duration: chunk_duration,
+                                            };
+
+                                            if let Err(e) = app_clone.emit("transcript-update", &update)
+                                            {
+                                                error!(
+                                                    "Worker {}: Failed to emit transcript update: {}",
+                                                    worker_id, e
+                                                );
+                                            }
                                         }
                                         // PERFORMANCE: Removed verbose logging of every emission
                                     } else if !transcript.trim().is_empty() && should_log_this_chunk
@@ -593,4 +737,106 @@ fn format_recording_time(seconds: f64) -> String {
     let secs = total_seconds % 60;
 
     format!("[{:02}:{:02}]", minutes, secs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn recent(source: TranscriptSource) -> VecDeque<RecentTranscript> {
+        VecDeque::from([RecentTranscript {
+            text: "现在开始讨论发布计划".to_string(),
+            source,
+            sequence_id: 7,
+            start_time: 10.0,
+            end_time: 13.0,
+        }])
+    }
+
+    #[test]
+    fn transcript_source_uses_stable_wire_values() {
+        assert_eq!(
+            serde_json::to_string(&TranscriptSource::Microphone).unwrap(),
+            "\"mic\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TranscriptSource::SystemAudio).unwrap(),
+            "\"system\""
+        );
+    }
+
+    #[test]
+    fn system_audio_replaces_overlapping_microphone_echo() {
+        assert_eq!(
+            deduplication_decision(
+                &recent(TranscriptSource::Microphone),
+                "现在开始讨论，发布计划。",
+                TranscriptSource::SystemAudio,
+                10.1,
+                12.9,
+            ),
+            DeduplicationDecision::ReplaceMicrophone(7)
+        );
+    }
+
+    #[test]
+    fn microphone_echo_is_suppressed_after_system_audio() {
+        assert_eq!(
+            deduplication_decision(
+                &recent(TranscriptSource::SystemAudio),
+                "现在开始讨论发布计划",
+                TranscriptSource::Microphone,
+                10.2,
+                13.1,
+            ),
+            DeduplicationDecision::SuppressMicrophone
+        );
+    }
+
+    #[test]
+    fn different_or_non_overlapping_speech_is_preserved() {
+        assert_eq!(
+            deduplication_decision(
+                &recent(TranscriptSource::SystemAudio),
+                "我补充一个现场问题",
+                TranscriptSource::Microphone,
+                10.2,
+                13.1,
+            ),
+            DeduplicationDecision::EmitNew
+        );
+        assert_eq!(
+            deduplication_decision(
+                &recent(TranscriptSource::SystemAudio),
+                "现在开始讨论发布计划",
+                TranscriptSource::Microphone,
+                15.0,
+                18.0,
+            ),
+            DeduplicationDecision::EmitNew
+        );
+    }
+
+    #[test]
+    fn source_deduplication_tolerates_out_of_order_vad_completion() {
+        let mut history = recent(TranscriptSource::SystemAudio);
+        history.push_back(RecentTranscript {
+            text: "later unrelated microphone segment".to_string(),
+            source: TranscriptSource::Microphone,
+            sequence_id: 8,
+            start_time: 30.0,
+            end_time: 35.0,
+        });
+
+        assert_eq!(
+            deduplication_decision(
+                &history,
+                "现在开始讨论发布计划",
+                TranscriptSource::Microphone,
+                10.1,
+                13.1,
+            ),
+            DeduplicationDecision::SuppressMicrophone
+        );
+    }
 }

--- a/frontend/src-tauri/src/database/models.rs
+++ b/frontend/src-tauri/src/database/models.rs
@@ -35,6 +35,7 @@ pub struct Transcript {
     pub audio_start_time: Option<f64>,
     pub audio_end_time: Option<f64>,
     pub duration: Option<f64>,
+    pub speaker: Option<String>,
 }
 
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize)]

--- a/frontend/src-tauri/src/database/repositories/meeting.rs
+++ b/frontend/src-tauri/src/database/repositories/meeting.rs
@@ -92,6 +92,7 @@ impl MeetingsRepository {
                     audio_start_time: t.audio_start_time,
                     audio_end_time: t.audio_end_time,
                     duration: t.duration,
+                    source: t.speaker,
                 })
                 .collect::<Vec<_>>();
 

--- a/frontend/src-tauri/src/database/repositories/transcript.rs
+++ b/frontend/src-tauri/src/database/repositories/transcript.rs
@@ -47,8 +47,8 @@ impl TranscriptsRepository {
         for segment in transcripts {
             let transcript_id = format!("transcript-{}", Uuid::new_v4());
             let result = sqlx::query(
-                "INSERT INTO transcripts (id, meeting_id, transcript, timestamp, audio_start_time, audio_end_time, duration)
-                 VALUES (?, ?, ?, ?, ?, ?, ?)"
+                "INSERT INTO transcripts (id, meeting_id, transcript, timestamp, audio_start_time, audio_end_time, duration, speaker)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
             )
             .bind(&transcript_id)
             .bind(&meeting_id)
@@ -57,6 +57,7 @@ impl TranscriptsRepository {
             .bind(segment.audio_start_time)
             .bind(segment.audio_end_time)
             .bind(segment.duration)
+            .bind(&segment.source)
             .execute(&mut *transaction)
             .await;
 
@@ -142,5 +143,43 @@ impl TranscriptsRepository {
             }
             None => transcript.chars().take(200).collect(), // Fallback to the start of the transcript
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn saves_transcript_source_in_existing_speaker_column() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        let segments = vec![TranscriptSegment {
+            id: "source-test".to_string(),
+            text: "system audio".to_string(),
+            timestamp: "2026-07-17T00:00:00Z".to_string(),
+            audio_start_time: Some(1.0),
+            audio_end_time: Some(2.0),
+            duration: Some(1.0),
+            source: Some("system".to_string()),
+        }];
+
+        let meeting_id = TranscriptsRepository::save_transcript(
+            &pool,
+            "source test",
+            &segments,
+            None,
+        )
+        .await
+        .unwrap();
+        let speaker: Option<String> = sqlx::query_scalar(
+            "SELECT speaker FROM transcripts WHERE meeting_id = ?",
+        )
+        .bind(meeting_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(speaker.as_deref(), Some("system"));
     }
 }

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -61,6 +61,7 @@ export function TranscriptPanel({
       endTime: t.audio_end_time,
       text: t.text,
       confidence: t.confidence,
+      source: t.source,
     }));
   }, [transcripts, usePagination, segments]);
 

--- a/frontend/src/components/TranscriptSourceIndicator.tsx
+++ b/frontend/src/components/TranscriptSourceIndicator.tsx
@@ -1,4 +1,4 @@
-import { Mic, Volume2 } from 'lucide-react';
+import { Mic, Speaker } from 'lucide-react';
 import { TranscriptSource } from '@/types';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 
@@ -10,8 +10,8 @@ export function TranscriptSourceIndicator({ source }: TranscriptSourceIndicatorP
   if (!source) return null;
 
   const isMicrophone = source === 'mic';
-  const Icon = isMicrophone ? Mic : Volume2;
-  const label = isMicrophone ? 'Microphone' : 'System audio';
+  const Icon = isMicrophone ? Mic : Speaker;
+  const label = isMicrophone ? 'Mic' : 'Speaker';
 
   return (
     <Tooltip>

--- a/frontend/src/components/TranscriptSourceIndicator.tsx
+++ b/frontend/src/components/TranscriptSourceIndicator.tsx
@@ -1,0 +1,29 @@
+import { Mic, Volume2 } from 'lucide-react';
+import { TranscriptSource } from '@/types';
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
+
+interface TranscriptSourceIndicatorProps {
+  source?: TranscriptSource;
+}
+
+export function TranscriptSourceIndicator({ source }: TranscriptSourceIndicatorProps) {
+  if (!source) return null;
+
+  const isMicrophone = source === 'mic';
+  const Icon = isMicrophone ? Mic : Volume2;
+  const label = isMicrophone ? 'Microphone' : 'System audio';
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          aria-label={label}
+          className="inline-flex size-4 shrink-0 items-center justify-center text-gray-400"
+        >
+          <Icon aria-hidden="true" className="size-3.5" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/frontend/src/components/TranscriptView.tsx
+++ b/frontend/src/components/TranscriptView.tsx
@@ -6,6 +6,7 @@ import { ConfidenceIndicator } from './ConfidenceIndicator';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { RecordingStatusBar } from './RecordingStatusBar';
 import { motion, AnimatePresence } from 'framer-motion';
+import { TranscriptSourceIndicator } from './TranscriptSourceIndicator';
 
 interface TranscriptViewProps {
   transcripts: Transcript[];
@@ -282,28 +283,31 @@ export const TranscriptView: React.FC<TranscriptViewProps> = ({ transcripts, isR
             className="mb-3"
           >
             <div className="flex items-start gap-2">
-              <Tooltip>
-                <TooltipTrigger>
-                  <span className="text-xs text-gray-400 mt-1 flex-shrink-0 min-w-[50px]">
+              <div className="mt-1 flex min-w-[70px] flex-shrink-0 items-center gap-1">
+                <Tooltip>
+                  <TooltipTrigger>
+                    <span className="text-xs text-gray-400">
                     {transcript.audio_start_time !== undefined
                       ? formatRecordingTime(transcript.audio_start_time)
                       : transcript.timestamp}
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {transcript.duration !== undefined && (
-                    <span className="text-xs text-gray-400">
-                      {transcript.duration.toFixed(1)}s
-                      {transcript.confidence !== undefined && (
-                        <ConfidenceIndicator
-                          confidence={transcript.confidence}
-                          showIndicator={showConfidence}
-                        />
-                      )}
                     </span>
-                  )}
-                </TooltipContent>
-              </Tooltip>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {transcript.duration !== undefined && (
+                      <span className="text-xs text-gray-400">
+                        {transcript.duration.toFixed(1)}s
+                        {transcript.confidence !== undefined && (
+                          <ConfidenceIndicator
+                            confidence={transcript.confidence}
+                            showIndicator={showConfidence}
+                          />
+                        )}
+                      </span>
+                    )}
+                  </TooltipContent>
+                </Tooltip>
+                <TranscriptSourceIndicator source={transcript.source} />
+              </div>
               <div className="flex-1">
                 {isStreaming ? (
                   // Streaming transcript - show in bubble (full width)

--- a/frontend/src/components/VirtualizedTranscriptView.tsx
+++ b/frontend/src/components/VirtualizedTranscriptView.tsx
@@ -9,6 +9,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { RecordingStatusBar } from "./RecordingStatusBar";
 import { motion, AnimatePresence } from "framer-motion";
 import { TranscriptSegmentData } from "@/types";
+import { TranscriptSourceIndicator } from "./TranscriptSourceIndicator";
 
 export interface VirtualizedTranscriptViewProps {
     /** Transcript segments to display */
@@ -69,6 +70,7 @@ const TranscriptSegment = memo(function TranscriptSegment({
     timestamp,
     text,
     confidence,
+    source,
     isStreaming,
     showConfidence,
 }: {
@@ -76,6 +78,7 @@ const TranscriptSegment = memo(function TranscriptSegment({
     timestamp: number;
     text: string;
     confidence?: number;
+    source?: TranscriptSegmentData['source'];
     isStreaming: boolean;
     showConfidence: boolean;
 }) {
@@ -84,18 +87,21 @@ const TranscriptSegment = memo(function TranscriptSegment({
     return (
         <div id={`segment-${id}`} className="mb-3">
             <div className="flex items-start gap-2">
-                <Tooltip>
-                    <TooltipTrigger>
-                        <span className="text-xs text-gray-400 mt-1 flex-shrink-0 min-w-[50px]">
+                <div className="mt-1 flex min-w-[70px] flex-shrink-0 items-center gap-1">
+                    <Tooltip>
+                        <TooltipTrigger>
+                            <span className="text-xs text-gray-400">
                             {formatRecordingTime(timestamp)}
-                        </span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                        {confidence !== undefined && showConfidence && (
-                            <ConfidenceIndicator confidence={confidence} showIndicator={showConfidence} />
-                        )}
-                    </TooltipContent>
-                </Tooltip>
+                            </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            {confidence !== undefined && showConfidence && (
+                                <ConfidenceIndicator confidence={confidence} showIndicator={showConfidence} />
+                            )}
+                        </TooltipContent>
+                    </Tooltip>
+                    <TranscriptSourceIndicator source={source} />
+                </div>
                 <div className="flex-1">
                     {isStreaming ? (
                         <div className="bg-gray-100 border border-gray-200 rounded-lg px-3 py-2">
@@ -294,6 +300,7 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                                         timestamp={segment.timestamp}
                                         text={getDisplayText(segment)}
                                         confidence={segment.confidence}
+                                        source={segment.source}
                                         isStreaming={isStreaming}
                                         showConfidence={showConfidence}
                                     />
@@ -350,6 +357,7 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                                         timestamp={segment.timestamp}
                                         text={getDisplayText(segment)}
                                         confidence={segment.confidence}
+                                        source={segment.source}
                                         isStreaming={isStreaming}
                                         showConfidence={showConfidence}
                                     />

--- a/frontend/src/contexts/TranscriptContext.tsx
+++ b/frontend/src/contexts/TranscriptContext.tsx
@@ -244,24 +244,19 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
 
       if (allNewTranscripts.length > 0) {
         setTranscripts(prev => {
-          // Create a set of existing sequence_ids for deduplication
-          const existingSequenceIds = new Set(prev.map(t => t.sequence_id).filter(id => id !== undefined));
-
-          // Filter out any new transcripts that already exist
-          const uniqueNewTranscripts = allNewTranscripts.filter(transcript =>
-            transcript.sequence_id !== undefined && !existingSequenceIds.has(transcript.sequence_id)
+          const updatesBySequence = new Map(
+            allNewTranscripts
+              .filter(transcript => transcript.sequence_id !== undefined)
+              .map(transcript => [transcript.sequence_id!, transcript])
           );
-
-          // Only combine if we have unique new transcripts
-          if (uniqueNewTranscripts.length === 0) {
-            console.log('No unique transcripts to add - all were duplicates');
-            return prev; // No new unique transcripts to add
-          }
-
-          console.log(`Adding ${uniqueNewTranscripts.length} unique transcripts out of ${allNewTranscripts.length} received`);
-
-          // Merge with existing transcripts, maintaining chronological order
-          const combined = [...prev, ...uniqueNewTranscripts];
+          const combined = prev.map(transcript => {
+            if (transcript.sequence_id === undefined) return transcript;
+            const replacement = updatesBySequence.get(transcript.sequence_id);
+            if (!replacement) return transcript;
+            updatesBySequence.delete(transcript.sequence_id);
+            return replacement;
+          });
+          combined.push(...updatesBySequence.values());
 
           // Sort by chunk_start_time first, then by sequence_id
           return combined.sort((a, b) => {
@@ -296,10 +291,9 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
             buffer_size_before: transcriptBuffer.size
           });
 
-          // Check for duplicate sequence_id before processing
+          // A system-audio result may intentionally replace an earlier microphone echo.
           if (transcriptBuffer.has(update.sequence_id)) {
-            console.log('🚫 MAIN LISTENER: Duplicate sequence_id, skipping buffer:', update.sequence_id);
-            return;
+            console.log('Replacing buffered transcript:', update.sequence_id);
           }
 
           // Create transcript for buffer with NEW timestamp fields
@@ -315,6 +309,7 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
             audio_start_time: update.audio_start_time,
             audio_end_time: update.audio_end_time,
             duration: update.duration,
+            source: update.source,
           };
 
           // Add to buffer
@@ -383,6 +378,7 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
             audio_start_time: segment.audio_start_time,
             audio_end_time: segment.audio_end_time,
             duration: segment.duration,
+            source: segment.source,
           }));
 
           setTranscripts(formattedTranscripts);
@@ -424,22 +420,16 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
       audio_start_time: update.audio_start_time,
       audio_end_time: update.audio_end_time,
       duration: update.duration,
+      source: update.source,
     };
 
     setTranscripts(prev => {
       console.log('📊 Current transcripts count before update:', prev.length);
 
-      // Check if this transcript already exists
-      const exists = prev.some(
-        t => t.text === update.text && t.timestamp === update.timestamp
-      );
-      if (exists) {
-        console.log('🚫 Duplicate transcript detected, skipping:', update.text.substring(0, 30) + '...');
-        return prev;
-      }
-
-      // Add new transcript and sort by sequence_id to maintain order
-      const updated = [...prev, newTranscript];
+      const existingIndex = prev.findIndex(t => t.sequence_id === update.sequence_id);
+      const updated = existingIndex >= 0
+        ? prev.map((transcript, index) => index === existingIndex ? newTranscript : transcript)
+        : [...prev, newTranscript];
       const sorted = updated.sort((a, b) => (a.sequence_id || 0) - (b.sequence_id || 0));
 
       console.log('✅ Added new transcript. New count:', sorted.length);

--- a/frontend/src/hooks/usePaginatedTranscripts.ts
+++ b/frontend/src/hooks/usePaginatedTranscripts.ts
@@ -37,6 +37,7 @@ function convertTranscriptsToSegments(transcripts: Transcript[]): TranscriptSegm
         endTime: t.audio_end_time,
         text: t.text,
         confidence: t.confidence,
+        source: t.source,
     }));
 }
 

--- a/frontend/src/hooks/useTranscriptRecovery.ts
+++ b/frontend/src/hooks/useTranscriptRecovery.ts
@@ -166,13 +166,14 @@ export function useTranscriptRecovery(): UseTranscriptRecoveryReturn {
         id: t.id?.toString() || `${Date.now()}-${index}`,
         text: t.text,
         timestamp: t.timestamp,
-        sequence_id: t.sequenceId || index,
+        sequence_id: t.sequenceId ?? index,
         chunk_start_time: (t as any).chunk_start_time,
         is_partial: (t as any).is_partial || false,
         confidence: t.confidence,
         audio_start_time: (t as any).audio_start_time,
         audio_end_time: (t as any).audio_end_time,
         duration: (t as any).duration,
+        source: (t as any).source,
       }));
 
       // 6. Save to backend database using existing save utilities

--- a/frontend/src/services/indexedDBService.ts
+++ b/frontend/src/services/indexedDBService.ts
@@ -4,6 +4,8 @@
  * to enable recovery after app crashes or unexpected closures.
  */
 
+import type { TranscriptSource } from '@/types';
+
 // Database schema interfaces
 export interface MeetingMetadata {
   meetingId: string;          // Primary key: "meeting-{timestamp}"
@@ -26,13 +28,14 @@ export interface StoredTranscript {
   audio_start_time?: number;  // Recording-relative start time in seconds
   audio_end_time?: number;    // Recording-relative end time in seconds
   duration?: number;          // Duration in seconds
+  source?: TranscriptSource;
   [key: string]: any;         // Allow additional fields from TranscriptUpdate
 }
 
 class IndexedDBService {
   private db: IDBDatabase | null = null;
   private readonly DB_NAME = 'MeetilyRecoveryDB';
-  private readonly DB_VERSION = 1;
+  private readonly DB_VERSION = 2;
   private initPromise: Promise<void> | null = null;
 
   /**
@@ -73,14 +76,25 @@ class IndexedDBService {
             meetingsStore.createIndex('savedToSQLite', 'savedToSQLite', { unique: false });
           }
 
-          // Create transcripts store
+          // Create or upgrade the transcripts store.
+          let transcriptsStore: IDBObjectStore;
           if (!db.objectStoreNames.contains('transcripts')) {
-            const transcriptsStore = db.createObjectStore('transcripts', {
+            transcriptsStore = db.createObjectStore('transcripts', {
               keyPath: 'id',
               autoIncrement: true
             });
             transcriptsStore.createIndex('meetingId', 'meetingId', { unique: false });
             transcriptsStore.createIndex('storedAt', 'storedAt', { unique: false });
+          } else {
+            transcriptsStore = (event.target as IDBOpenDBRequest).transaction!
+              .objectStore('transcripts');
+          }
+          if (!transcriptsStore.indexNames.contains('meetingSequence')) {
+            transcriptsStore.createIndex(
+              'meetingSequence',
+              ['meetingId', 'sequenceId'],
+              { unique: false }
+            );
           }
         };
       } catch (error) {
@@ -234,6 +248,7 @@ class IndexedDBService {
       const storedTranscript: StoredTranscript = {
         ...transcript,
         meetingId,
+        sequenceId: transcript.sequence_id ?? transcript.sequenceId,
         storedAt: Date.now()
       };
 
@@ -241,9 +256,22 @@ class IndexedDBService {
       const transcriptsStore = transaction.objectStore('transcripts');
       const meetingsStore = transaction.objectStore('meetings');
 
-      // Save transcript
+      const existingKey = await new Promise<IDBValidKey | undefined>((resolve, reject) => {
+        const request = transcriptsStore
+          .index('meetingSequence')
+          .getKey([meetingId, storedTranscript.sequenceId]);
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+      if (existingKey !== undefined) {
+        storedTranscript.id = Number(existingKey);
+      }
+
+      // Insert a new transcript or replace a source-deduplicated segment.
       await new Promise<void>((resolve, reject) => {
-        const request = transcriptsStore.add(storedTranscript);
+        const request = existingKey === undefined
+          ? transcriptsStore.add(storedTranscript)
+          : transcriptsStore.put(storedTranscript);
         request.onsuccess = () => resolve();
         request.onerror = () => reject(request.error);
       });
@@ -257,7 +285,7 @@ class IndexedDBService {
 
       if (meeting) {
         meeting.lastUpdated = Date.now();
-        meeting.transcriptCount += 1;
+        if (existingKey === undefined) meeting.transcriptCount += 1;
         await new Promise<void>((resolve, reject) => {
           const request = meetingsStore.put(meeting);
           request.onsuccess = () => resolve();

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,6 +4,8 @@ export interface Message {
   timestamp: string;
 }
 
+export type TranscriptSource = 'mic' | 'system';
+
 export interface Transcript {
   id: string;
   text: string;
@@ -16,12 +18,13 @@ export interface Transcript {
   audio_start_time?: number; // Seconds from recording start (e.g., 125.3)
   audio_end_time?: number;   // Seconds from recording start (e.g., 128.6)
   duration?: number;          // Segment duration in seconds (e.g., 3.3)
+  source?: TranscriptSource;
 }
 
 export interface TranscriptUpdate {
   text: string;
   timestamp: string; // Wall-clock time for reference
-  source: string;
+  source: TranscriptSource;
   sequence_id: number;
   chunk_start_time: number; // Legacy field
   is_partial: boolean;
@@ -107,4 +110,5 @@ export interface TranscriptSegmentData {
   endTime?: number; // audio_end_time in seconds
   text: string;
   confidence?: number;
+  source?: TranscriptSource;
 }


### PR DESCRIPTION
## Description

Add deterministic transcript source attribution for live recordings:

- run independent VAD pipelines for microphone and system audio so provenance is preserved before transcription
- keep the existing mixed recording path unchanged
- persist stable `mic` / `system` source values through transcript events, meeting storage, JSON export, and IndexedDB
- show compact Mic / Speaker indicators in live, virtualized, and meeting-detail transcript views
- suppress likely microphone echo when overlapping system-audio text is substantially similar, preferring the system source

## Related Issue

Fixes #642

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] All tests pass

Validated on macOS arm64:

- `bun test` (8 passed)
- `bun run build`
- `LIBONNXRUNTIME_NO_PKG_CONFIG=1 cargo test -p meetily audio::transcription::worker::tests` (5 passed)
- `LIBONNXRUNTIME_NO_PKG_CONFIG=1 cargo test -p meetily database::repositories::transcript::tests` (1 passed)
- `LIBONNXRUNTIME_NO_PKG_CONFIG=1 cargo test -p meetily audio::pipeline::tests` (0 matching tests, command passed)
- `git diff --check origin/devtest...HEAD`

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)

The UI change is limited to compact source icons beside transcript rows.

## Additional Notes

This implements source attribution between the selected microphone and captured system audio. It is intentionally not full speaker diarization or speaker identity recognition. Imported audio and retranscription remain source-neutral because they do not carry separate input streams.
