### PR TITLE
fix(recording): honor the selected save folder

### DIFF
--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -20,13 +20,17 @@ use uuid::Uuid;
 use super::audio_processing::create_meeting_folder;
 use super::common::{create_transcript_segments, split_segment_at_silence, write_transcripts_json};
 use super::constants::AUDIO_EXTENSIONS;
-use super::recording_preferences::get_default_recordings_folder;
+use super::recording_preferences::load_recording_preferences;
 
 /// Global flag to track if import is in progress
 static IMPORT_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
 /// Global flag to signal cancellation
 static IMPORT_CANCELLED: AtomicBool = AtomicBool::new(false);
+
+fn create_import_meeting_folder(base_folder: &PathBuf, title: &str) -> Result<PathBuf> {
+    create_meeting_folder(base_folder, title, false)
+}
 
 /// RAII guard for IMPORT_IN_PROGRESS flag
 /// Ensures flag is cleared even if import panics or returns early
@@ -339,8 +343,8 @@ async fn run_import<R: Runtime>(
     }
 
     // Create meeting folder
-    let base_folder = get_default_recordings_folder();
-    let meeting_folder = create_meeting_folder(&base_folder, &title, false)?;
+    let base_folder = load_recording_preferences(&app).await?.save_folder;
+    let meeting_folder = create_import_meeting_folder(&base_folder, &title)?;
 
     // Copy audio file to meeting folder
     emit_progress(&app, "copying", 10, "Copying audio file...");
@@ -1007,6 +1011,30 @@ pub async fn is_import_in_progress_command() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn import_root_creates_meeting_beneath_selected_folder() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory");
+        let selected_root = temp_dir.path().join("knowledge-base");
+
+        let meeting_folder = create_import_meeting_folder(&selected_root, "Imported Meeting")
+            .expect("create import meeting folder");
+
+        assert!(meeting_folder.starts_with(&selected_root));
+        assert!(meeting_folder.is_dir());
+    }
+
+    #[test]
+    fn import_root_rejects_existing_file() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory");
+        let file_root = temp_dir.path().join("not-a-directory");
+        std::fs::write(&file_root, b"file").expect("create file root");
+
+        let result = create_import_meeting_folder(&file_root, "Rejected Import");
+
+        assert!(result.is_err());
+        assert!(file_root.is_file());
+    }
 
     #[test]
     fn test_audio_extensions() {

--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 use super::audio_processing::create_meeting_folder;
 use super::common::{create_transcript_segments, split_segment_at_silence, write_transcripts_json};
 use super::constants::AUDIO_EXTENSIONS;
-use super::recording_preferences::load_recording_preferences;
+use super::recording_preferences::{load_recording_preferences, RecordingPreferences};
 
 /// Global flag to track if import is in progress
 static IMPORT_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
@@ -30,6 +30,10 @@ static IMPORT_CANCELLED: AtomicBool = AtomicBool::new(false);
 
 fn create_import_meeting_folder(base_folder: &PathBuf, title: &str) -> Result<PathBuf> {
     create_meeting_folder(base_folder, title, false)
+}
+
+fn capture_import_save_folder(preferences: &RecordingPreferences) -> PathBuf {
+    preferences.save_folder.clone()
 }
 
 /// RAII guard for IMPORT_IN_PROGRESS flag
@@ -257,6 +261,7 @@ fn extract_duration_from_metadata(path: &Path) -> Result<f64> {
 /// Start import of an audio file
 pub async fn start_import<R: Runtime>(
     app: AppHandle<R>,
+    save_folder: PathBuf,
     source_path: String,
     title: String,
     language: Option<String>,
@@ -272,6 +277,7 @@ pub async fn start_import<R: Runtime>(
     let use_parakeet = provider.as_deref() == Some("parakeet");
     let result = run_import(
         app.clone(),
+        save_folder,
         source_path,
         title,
         language,
@@ -314,6 +320,7 @@ pub async fn start_import<R: Runtime>(
 /// Internal function to run import
 async fn run_import<R: Runtime>(
     app: AppHandle<R>,
+    save_folder: PathBuf,
     source_path: String,
     title: String,
     language: Option<String>,
@@ -343,8 +350,7 @@ async fn run_import<R: Runtime>(
     }
 
     // Create meeting folder
-    let base_folder = load_recording_preferences(&app).await?.save_folder;
-    let meeting_folder = create_import_meeting_folder(&base_folder, &title)?;
+    let meeting_folder = create_import_meeting_folder(&save_folder, &title)?;
 
     // Copy audio file to meeting folder
     emit_progress(&app, "copying", 10, "Copying audio file...");
@@ -978,9 +984,23 @@ pub async fn start_import_audio_command<R: Runtime>(
         return Err("Import already in progress".to_string());
     }
 
+    let preferences = load_recording_preferences(&app)
+        .await
+        .map_err(|error| format!("Failed to load recording preferences: {}", error))?;
+    let save_folder = capture_import_save_folder(&preferences);
+
     // Spawn import in background
     tauri::async_runtime::spawn(async move {
-        let result = start_import(app, source_path, title, language, model, provider).await;
+        let result = start_import(
+            app,
+            save_folder,
+            source_path,
+            title,
+            language,
+            model,
+            provider,
+        )
+        .await;
 
         if let Err(e) = result {
             error!("Import failed: {}", e);
@@ -1034,6 +1054,21 @@ mod tests {
 
         assert!(result.is_err());
         assert!(file_root.is_file());
+    }
+
+    #[test]
+    fn import_save_folder_snapshot_is_not_changed_by_later_preferences() {
+        let first_root = std::env::temp_dir().join("first-import-root");
+        let second_root = std::env::temp_dir().join("second-import-root");
+        let mut preferences = super::super::recording_preferences::RecordingPreferences {
+            save_folder: first_root.clone(),
+            ..Default::default()
+        };
+
+        let captured = capture_import_save_folder(&preferences);
+        preferences.save_folder = second_root;
+
+        assert_eq!(captured, first_root);
     }
 
     #[test]

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -113,16 +113,26 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
     let mut manager = RecordingManager::new();
 
     // Load recording preferences to get auto_save AND device preferences
-    let (auto_save, preferred_mic_name, preferred_system_name) =
+    let (auto_save, save_folder, preferred_mic_name, preferred_system_name) =
         match super::recording_preferences::load_recording_preferences(&app).await {
             Ok(prefs) => {
                 info!("📋 Loaded recording preferences: auto_save={}, preferred_mic={:?}, preferred_system={:?}",
                       prefs.auto_save, prefs.preferred_mic_device, prefs.preferred_system_device);
-                (prefs.auto_save, prefs.preferred_mic_device, prefs.preferred_system_device)
+                (
+                    prefs.auto_save,
+                    prefs.save_folder,
+                    prefs.preferred_mic_device,
+                    prefs.preferred_system_device,
+                )
             }
             Err(e) => {
                 warn!("Failed to load recording preferences, using defaults: {}", e);
-                (true, None, None)
+                (
+                    true,
+                    super::recording_preferences::get_default_recordings_folder(),
+                    None,
+                    None,
+                )
             }
         };
 
@@ -225,6 +235,7 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
         )
     });
     manager.set_meeting_name(Some(effective_meeting_name));
+    manager.set_save_folder(save_folder);
 
     // Set up error callback
     let app_for_error = app.clone();
@@ -376,16 +387,20 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
     let mut manager = RecordingManager::new();
 
     // Load recording preferences to check auto_save setting
-    let auto_save = match super::recording_preferences::load_recording_preferences(&app).await {
-        Ok(prefs) => {
-            info!("📋 Loaded recording preferences: auto_save={}", prefs.auto_save);
-            prefs.auto_save
-        }
-        Err(e) => {
-            warn!("Failed to load recording preferences, defaulting to auto_save=true: {}", e);
-            true // Default to saving if preferences can't be loaded
-        }
-    };
+    let (auto_save, save_folder) =
+        match super::recording_preferences::load_recording_preferences(&app).await {
+            Ok(prefs) => {
+                info!("📋 Loaded recording preferences: auto_save={}", prefs.auto_save);
+                (prefs.auto_save, prefs.save_folder)
+            }
+            Err(e) => {
+                warn!("Failed to load recording preferences, defaulting to auto_save=true: {}", e);
+                (
+                    true,
+                    super::recording_preferences::get_default_recordings_folder(),
+                )
+            }
+        };
 
     // Always ensure a meeting name is set so incremental saver initializes
     let effective_meeting_name = meeting_name.clone().unwrap_or_else(|| {
@@ -396,6 +411,7 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
         )
     });
     manager.set_meeting_name(Some(effective_meeting_name));
+    manager.set_save_folder(save_folder);
 
     // Set up error callback
     let app_for_error = app.clone();

--- a/frontend/src-tauri/src/audio/recording_manager.rs
+++ b/frontend/src-tauri/src/audio/recording_manager.rs
@@ -74,7 +74,7 @@ impl RecordingManager {
         // CRITICAL FIX: Create recording sender for pre-mixed audio from pipeline
         // Pipeline will mix mic + system audio professionally and send to this channel
         // Pass auto_save to control whether audio checkpoints are created
-        let recording_sender = self.recording_saver.start_accumulation(auto_save);
+        let recording_sender = self.recording_saver.start_accumulation(auto_save)?;
 
         // Start recording state first
         self.state.start_recording()?;
@@ -434,6 +434,11 @@ impl RecordingManager {
         self.recording_saver.set_meeting_name(name);
     }
 
+    /// Set the persisted root used for this recording session.
+    pub fn set_save_folder(&mut self, save_folder: std::path::PathBuf) {
+        self.recording_saver.set_save_folder(save_folder);
+    }
+
     /// Add a structured transcript segment to be saved later
     pub fn add_transcript_segment(&self, segment: super::recording_saver::TranscriptSegment) {
         self.recording_saver.add_transcript_segment(segment);
@@ -611,5 +616,26 @@ impl Drop for RecordingManager {
     fn drop(&mut self) {
         // Note: Can't call async cleanup in Drop, but streams have their own Drop implementations
         self.state.cleanup();
+    }
+}
+
+#[cfg(test)]
+mod recording_root_failure_tests {
+    use super::RecordingManager;
+
+    #[tokio::test]
+    async fn invalid_recording_root_does_not_start_recording_state() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory");
+        let file_root = temp_dir.path().join("not-a-directory");
+        std::fs::write(&file_root, b"file").expect("create file root");
+        let mut manager = RecordingManager::new();
+        manager.set_meeting_name(Some("Rejected Root".to_string()));
+        manager.set_save_folder(file_root);
+
+        let result = manager.start_recording(None, None, true).await;
+
+        assert!(result.is_err());
+        assert!(!manager.is_recording());
+        assert!(manager.get_meeting_folder().is_none());
     }
 }

--- a/frontend/src-tauri/src/audio/recording_preferences.rs
+++ b/frontend/src-tauri/src/audio/recording_preferences.rs
@@ -124,6 +124,14 @@ fn persist_preferences_value(
     Ok(())
 }
 
+fn merge_recording_save_folder(
+    mut preferences: RecordingPreferences,
+    save_folder: PathBuf,
+) -> RecordingPreferences {
+    preferences.save_folder = save_folder;
+    preferences
+}
+
 /// Generate a unique filename for a recording
 pub fn generate_recording_filename(format: &str) -> String {
     let now = chrono::Utc::now();
@@ -243,6 +251,50 @@ pub async fn set_recording_preferences<R: Runtime>(
     save_recording_preferences(&app, &preferences)
         .await
         .map_err(|e| format!("Failed to save recording preferences: {}", e))
+}
+
+#[tauri::command]
+pub async fn set_recording_save_folder<R: Runtime>(
+    app: AppHandle<R>,
+    save_folder: String,
+) -> Result<RecordingPreferences, String> {
+    serialize_save_transaction(|| async {
+        let store = app
+            .store("recording_preferences.json")
+            .map_err(|e| anyhow::anyhow!("Failed to access store: {}", e))?;
+        let previous_value = store.get("preferences");
+        let latest_preferences = match previous_value.as_ref() {
+            Some(value) => serde_json::from_value::<RecordingPreferences>(value.clone())
+                .map_err(|e| anyhow::anyhow!("Failed to deserialize preferences: {}", e))?,
+            None => RecordingPreferences::default(),
+        };
+        let preferences =
+            merge_recording_save_folder(latest_preferences, PathBuf::from(save_folder));
+
+        persist_preferences_value(
+            &preferences,
+            previous_value,
+            |value| match value {
+                Some(value) => store.set("preferences", value),
+                None => {
+                    store.delete("preferences");
+                }
+            },
+            || {
+                store
+                    .save()
+                    .map_err(|error| anyhow::anyhow!("Failed to save store to disk: {}", error))
+            },
+        )?;
+
+        if let Err(error) = app.emit("recording-preferences-updated", &preferences) {
+            warn!("Failed to emit recording preferences update: {}", error);
+        }
+
+        Ok(preferences)
+    })
+    .await
+    .map_err(|e| format!("Failed to save recording folder: {}", e))
 }
 
 #[tauri::command]
@@ -463,7 +515,10 @@ pub async fn get_audio_backend_info() -> Result<Vec<BackendInfo>, String> {
 
 #[cfg(test)]
 mod persistence_tests {
-    use super::{persist_preferences_value, serialize_save_transaction, RecordingPreferences};
+    use super::{
+        merge_recording_save_folder, persist_preferences_value, serialize_save_transaction,
+        RecordingPreferences,
+    };
     use serde_json::{json, Value};
     use std::cell::{Cell, RefCell};
     use std::sync::{
@@ -471,6 +526,30 @@ mod persistence_tests {
         Arc,
     };
     use tokio::sync::{Mutex, Notify};
+
+    #[test]
+    fn folder_only_update_preserves_latest_preferences() {
+        let mut latest = RecordingPreferences::default();
+        latest.auto_save = false;
+        latest.file_format = "wav".to_string();
+        latest.preferred_mic_device = Some("Latest microphone".to_string());
+        latest.preferred_system_device = Some("Latest system audio".to_string());
+        let selected_folder = std::env::temp_dir().join("selected-recordings");
+
+        let updated = merge_recording_save_folder(latest, selected_folder.clone());
+
+        assert_eq!(updated.save_folder, selected_folder);
+        assert!(!updated.auto_save);
+        assert_eq!(updated.file_format, "wav");
+        assert_eq!(
+            updated.preferred_mic_device.as_deref(),
+            Some("Latest microphone")
+        );
+        assert_eq!(
+            updated.preferred_system_device.as_deref(),
+            Some("Latest system audio")
+        );
+    }
 
     #[test]
     fn invalid_directory_is_rejected_before_store_mutation() {

--- a/frontend/src-tauri/src/audio/recording_preferences.rs
+++ b/frontend/src-tauri/src/audio/recording_preferences.rs
@@ -1,7 +1,9 @@
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
+use std::future::Future;
 use std::path::PathBuf;
-use tauri::{AppHandle, Runtime};
+use tauri::{AppHandle, Emitter, Runtime};
+use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_store::StoreExt;
 
 use anyhow::Result;
@@ -10,6 +12,17 @@ use log::error;
 
 #[cfg(target_os = "macos")]
 use crate::audio::capture::AudioCaptureBackend;
+
+static RECORDING_PREFERENCES_SAVE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+async fn serialize_save_transaction<T, F, Fut>(transaction: F) -> Result<T>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    let _guard = RECORDING_PREFERENCES_SAVE_LOCK.lock().await;
+    transaction().await
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RecordingPreferences {
@@ -78,10 +91,36 @@ pub fn get_default_recordings_folder() -> PathBuf {
 
 /// Ensure the recordings directory exists
 pub fn ensure_recordings_directory(path: &PathBuf) -> Result<()> {
-    if !path.exists() {
+    if path.exists() {
+        if !path.is_dir() {
+            return Err(anyhow::anyhow!(
+                "Recording save path is not a directory: {}",
+                path.display()
+            ));
+        }
+    } else {
         std::fs::create_dir_all(path)?;
         info!("Created recordings directory: {:?}", path);
     }
+    Ok(())
+}
+
+fn persist_preferences_value(
+    preferences: &RecordingPreferences,
+    previous_value: Option<serde_json::Value>,
+    mut update_store: impl FnMut(Option<serde_json::Value>),
+    save_store: impl FnOnce() -> Result<()>,
+) -> Result<()> {
+    ensure_recordings_directory(&preferences.save_folder)?;
+    let preferences_value = serde_json::to_value(preferences)
+        .map_err(|error| anyhow::anyhow!("Failed to serialize preferences: {}", error))?;
+
+    update_store(Some(preferences_value));
+    if let Err(error) = save_store() {
+        update_store(previous_value);
+        return Err(error);
+    }
+
     Ok(())
 }
 
@@ -143,22 +182,34 @@ pub async fn save_recording_preferences<R: Runtime>(
           preferences.save_folder, preferences.auto_save, preferences.file_format,
           preferences.preferred_mic_device, preferences.preferred_system_device);
 
-    // Get or create store
-    let store = app
-        .store("recording_preferences.json")
-        .map_err(|e| anyhow::anyhow!("Failed to access store: {}", e))?;
+    serialize_save_transaction(|| async {
+        let store = app
+            .store("recording_preferences.json")
+            .map_err(|e| anyhow::anyhow!("Failed to access store: {}", e))?;
+        let previous_value = store.get("preferences");
 
-    // Serialize preferences to JSON value
-    let prefs_value = serde_json::to_value(preferences)
-        .map_err(|e| anyhow::anyhow!("Failed to serialize preferences: {}", e))?;
+        persist_preferences_value(
+            preferences,
+            previous_value,
+            |value| match value {
+                Some(value) => store.set("preferences", value),
+                None => {
+                    store.delete("preferences");
+                }
+            },
+            || {
+                store
+                    .save()
+                    .map_err(|error| anyhow::anyhow!("Failed to save store to disk: {}", error))
+            },
+        )?;
 
-    // Save to store
-    store.set("preferences", prefs_value);
-
-    // Persist to disk
-    store
-        .save()
-        .map_err(|e| anyhow::anyhow!("Failed to save store to disk: {}", e))?;
+        if let Err(error) = app.emit("recording-preferences-updated", preferences) {
+            warn!("Failed to emit recording preferences update: {}", error);
+        }
+        Ok(())
+    })
+    .await?;
 
     info!("Successfully persisted recording preferences to disk");
 
@@ -170,9 +221,6 @@ pub async fn save_recording_preferences<R: Runtime>(
             crate::audio::capture::set_current_backend(backend);
         }
     }
-
-    // Ensure the directory exists
-    ensure_recordings_directory(&preferences.save_folder)?;
 
     Ok(())
 }
@@ -245,13 +293,41 @@ pub async fn open_recordings_folder<R: Runtime>(app: AppHandle<R>) -> Result<(),
 
 #[tauri::command]
 pub async fn select_recording_folder<R: Runtime>(
-    _app: AppHandle<R>,
+    app: AppHandle<R>,
 ) -> Result<Option<String>, String> {
-    // Use Tauri's dialog to select folder
-    // For now, return None - this would need to be implemented with tauri-plugin-dialog
-    // when it's available in the Cargo.toml
-    warn!("Folder selection not yet implemented - using dialog plugin");
-    Ok(None)
+    let start_dir = load_recording_preferences(&app)
+        .await
+        .map(|preferences| preferences.save_folder)
+        .unwrap_or_else(|error| {
+            warn!(
+                "Failed to load recording preferences before folder selection: {}",
+                error
+            );
+            get_default_recordings_folder()
+        });
+
+    let selected = tauri::async_runtime::spawn_blocking(move || {
+        let dialog = app.dialog().file();
+        if start_dir.is_dir() {
+            dialog.set_directory(start_dir).blocking_pick_folder()
+        } else {
+            dialog.blocking_pick_folder()
+        }
+    })
+    .await
+    .map_err(|error| format!("Folder dialog task failed: {}", error))?;
+
+    selected
+        .map(|path| {
+            path.into_path()
+                .map_err(|error| format!("Selected folder is not a filesystem path: {}", error))
+                .and_then(|path| {
+                    path.into_os_string().into_string().map_err(|_| {
+                        "Selected folder path contains unsupported characters".to_string()
+                    })
+                })
+        })
+        .transpose()
 }
 
 // Backend selection commands
@@ -385,3 +461,161 @@ pub async fn get_audio_backend_info() -> Result<Vec<BackendInfo>, String> {
     }
 }
 
+#[cfg(test)]
+mod persistence_tests {
+    use super::{persist_preferences_value, serialize_save_transaction, RecordingPreferences};
+    use serde_json::{json, Value};
+    use std::cell::{Cell, RefCell};
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+    use tokio::sync::{Mutex, Notify};
+
+    #[test]
+    fn invalid_directory_is_rejected_before_store_mutation() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory");
+        let file_path = temp_dir.path().join("not-a-directory");
+        std::fs::write(&file_path, b"file").expect("create file root");
+        let preferences = RecordingPreferences {
+            save_folder: file_path,
+            ..RecordingPreferences::default()
+        };
+        let mutations = RefCell::new(Vec::<Option<Value>>::new());
+        let save_called = Cell::new(false);
+
+        let result = persist_preferences_value(
+            &preferences,
+            None,
+            |value| mutations.borrow_mut().push(value),
+            || {
+                save_called.set(true);
+                Ok(())
+            },
+        );
+
+        assert!(result.is_err());
+        assert!(mutations.borrow().is_empty());
+        assert!(!save_called.get());
+    }
+
+    #[test]
+    fn save_failure_restores_previous_in_memory_value() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory");
+        let preferences = RecordingPreferences {
+            save_folder: temp_dir.path().join("selected"),
+            ..RecordingPreferences::default()
+        };
+        let previous = json!({"save_folder": "/tmp/previous"});
+        let mutations = RefCell::new(Vec::<Option<Value>>::new());
+
+        let result = persist_preferences_value(
+            &preferences,
+            Some(previous.clone()),
+            |value| mutations.borrow_mut().push(value),
+            || Err(anyhow::anyhow!("simulated disk save failure")),
+        );
+
+        assert!(result.is_err());
+        let mutations = mutations.into_inner();
+        assert_eq!(mutations.len(), 2);
+        assert_eq!(
+            mutations[0],
+            Some(serde_json::to_value(&preferences).expect("serialize preferences"))
+        );
+        assert_eq!(mutations[1], Some(previous));
+    }
+
+    #[test]
+    fn save_failure_removes_new_value_when_store_was_empty() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory");
+        let preferences = RecordingPreferences {
+            save_folder: temp_dir.path().join("selected"),
+            ..RecordingPreferences::default()
+        };
+        let mutations = RefCell::new(Vec::<Option<Value>>::new());
+
+        let result = persist_preferences_value(
+            &preferences,
+            None,
+            |value| mutations.borrow_mut().push(value),
+            || Err(anyhow::anyhow!("simulated disk save failure")),
+        );
+
+        assert!(result.is_err());
+        let mutations = mutations.into_inner();
+        assert_eq!(mutations.len(), 2);
+        assert_eq!(
+            mutations[0],
+            Some(serde_json::to_value(&preferences).expect("serialize preferences"))
+        );
+        assert_eq!(mutations[1], None);
+    }
+
+    #[tokio::test]
+    async fn concurrent_save_failure_cannot_rollback_a_successful_transaction() {
+        #[derive(Default)]
+        struct SimulatedStore {
+            cache: Option<&'static str>,
+            durable: Option<&'static str>,
+        }
+
+        let store = Arc::new(Mutex::new(SimulatedStore::default()));
+        let first_entered = Arc::new(Notify::new());
+        let release_first = Arc::new(Notify::new());
+        let second_attempting = Arc::new(Notify::new());
+        let second_entered = Arc::new(AtomicBool::new(false));
+
+        let successful = {
+            let store = store.clone();
+            let first_entered = first_entered.clone();
+            let release_first = release_first.clone();
+            tokio::spawn(async move {
+                serialize_save_transaction(|| async move {
+                    store.lock().await.cache = Some("successful");
+                    first_entered.notify_one();
+                    release_first.notified().await;
+                    store.lock().await.durable = Some("successful");
+                    Ok::<_, anyhow::Error>("successful")
+                })
+                .await
+            })
+        };
+
+        first_entered.notified().await;
+        let failed = {
+            let store = store.clone();
+            let second_attempting = second_attempting.clone();
+            let second_entered = second_entered.clone();
+            tokio::spawn(async move {
+                second_attempting.notify_one();
+                serialize_save_transaction(|| async move {
+                    second_entered.store(true, Ordering::SeqCst);
+                    let previous = store.lock().await.cache;
+                    store.lock().await.cache = Some("failed");
+                    store.lock().await.cache = previous;
+                    Err::<&'static str, _>(anyhow::anyhow!("save failed for failed payload"))
+                })
+                .await
+            })
+        };
+
+        second_attempting.notified().await;
+        tokio::task::yield_now().await;
+        assert!(!second_entered.load(Ordering::SeqCst));
+        release_first.notify_one();
+
+        assert_eq!(
+            successful.await.expect("successful task").unwrap(),
+            "successful"
+        );
+        let failed_error = failed
+            .await
+            .expect("failed task")
+            .expect_err("second transaction must fail");
+        assert!(failed_error.to_string().contains("failed payload"));
+        let store = store.lock().await;
+        assert_eq!(store.cache, Some("successful"));
+        assert_eq!(store.durable, Some("successful"));
+    }
+}

--- a/frontend/src-tauri/src/audio/recording_preferences.rs
+++ b/frontend/src-tauri/src/audio/recording_preferences.rs
@@ -24,6 +24,15 @@ where
     transaction().await
 }
 
+async fn serialize_preferences_read<T, F, Fut>(read: F) -> Result<T>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    let _guard = RECORDING_PREFERENCES_SAVE_LOCK.lock().await;
+    read().await
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RecordingPreferences {
     pub save_folder: PathBuf,
@@ -143,42 +152,45 @@ pub fn generate_recording_filename(format: &str) -> String {
 pub async fn load_recording_preferences<R: Runtime>(
     app: &AppHandle<R>,
 ) -> Result<RecordingPreferences> {
-    // Try to load from Tauri store
-    let store = match app.store("recording_preferences.json") {
-        Ok(store) => store,
-        Err(e) => {
-            warn!("Failed to access store: {}, using defaults", e);
-            return Ok(RecordingPreferences::default());
-        }
-    };
-
-    // Try to get the preferences from store
-    let prefs = if let Some(value) = store.get("preferences") {
-        match serde_json::from_value::<RecordingPreferences>(value.clone()) {
-            Ok(mut p) => {
-                info!("Loaded recording preferences from store");
-                // Update macOS backend to current value if needed
-                #[cfg(target_os = "macos")]
-                {
-                    let backend = crate::audio::capture::get_current_backend();
-                    p.system_audio_backend = Some(backend.to_string());
-                }
-                p
-            }
+    serialize_preferences_read(|| async {
+        // Try to load from Tauri store
+        let store = match app.store("recording_preferences.json") {
+            Ok(store) => store,
             Err(e) => {
-                warn!("Failed to deserialize preferences: {}, using defaults", e);
-                RecordingPreferences::default()
+                warn!("Failed to access store: {}, using defaults", e);
+                return Ok(RecordingPreferences::default());
             }
-        }
-    } else {
-        info!("No stored preferences found, using defaults");
-        RecordingPreferences::default()
-    };
+        };
 
-    info!("Loaded recording preferences: save_folder={:?}, auto_save={}, format={}, mic={:?}, system={:?}",
-          prefs.save_folder, prefs.auto_save, prefs.file_format,
-          prefs.preferred_mic_device, prefs.preferred_system_device);
-    Ok(prefs)
+        // Try to get the preferences from store
+        let prefs = if let Some(value) = store.get("preferences") {
+            match serde_json::from_value::<RecordingPreferences>(value.clone()) {
+                Ok(mut p) => {
+                    info!("Loaded recording preferences from store");
+                    // Update macOS backend to current value if needed
+                    #[cfg(target_os = "macos")]
+                    {
+                        let backend = crate::audio::capture::get_current_backend();
+                        p.system_audio_backend = Some(backend.to_string());
+                    }
+                    p
+                }
+                Err(e) => {
+                    warn!("Failed to deserialize preferences: {}, using defaults", e);
+                    RecordingPreferences::default()
+                }
+            }
+        } else {
+            info!("No stored preferences found, using defaults");
+            RecordingPreferences::default()
+        };
+
+        info!("Loaded recording preferences: save_folder={:?}, auto_save={}, format={}, mic={:?}, system={:?}",
+              prefs.save_folder, prefs.auto_save, prefs.file_format,
+              prefs.preferred_mic_device, prefs.preferred_system_device);
+        Ok(prefs)
+    })
+    .await
 }
 
 /// Save recording preferences to store
@@ -516,8 +528,8 @@ pub async fn get_audio_backend_info() -> Result<Vec<BackendInfo>, String> {
 #[cfg(test)]
 mod persistence_tests {
     use super::{
-        merge_recording_save_folder, persist_preferences_value, serialize_save_transaction,
-        RecordingPreferences,
+        merge_recording_save_folder, persist_preferences_value, serialize_preferences_read,
+        serialize_save_transaction, RecordingPreferences,
     };
     use serde_json::{json, Value};
     use std::cell::{Cell, RefCell};
@@ -526,6 +538,50 @@ mod persistence_tests {
         Arc,
     };
     use tokio::sync::{Mutex, Notify};
+
+    #[tokio::test]
+    async fn preference_read_waits_for_failed_save_rollback() {
+        let cached_folder = Arc::new(Mutex::new("previous"));
+        let save_entered = Arc::new(Notify::new());
+        let release_save = Arc::new(Notify::new());
+        let read_entered = Arc::new(AtomicBool::new(false));
+
+        let failed_save = {
+            let cached_folder = cached_folder.clone();
+            let save_entered = save_entered.clone();
+            let release_save = release_save.clone();
+            tokio::spawn(async move {
+                serialize_save_transaction(|| async move {
+                    *cached_folder.lock().await = "staged";
+                    save_entered.notify_one();
+                    release_save.notified().await;
+                    *cached_folder.lock().await = "previous";
+                    Err::<(), _>(anyhow::anyhow!("simulated save failure"))
+                })
+                .await
+            })
+        };
+
+        save_entered.notified().await;
+        let read = {
+            let cached_folder = cached_folder.clone();
+            let read_entered = read_entered.clone();
+            tokio::spawn(async move {
+                serialize_preferences_read(|| async move {
+                    read_entered.store(true, Ordering::SeqCst);
+                    Ok::<_, anyhow::Error>(*cached_folder.lock().await)
+                })
+                .await
+            })
+        };
+
+        tokio::task::yield_now().await;
+        assert!(!read_entered.load(Ordering::SeqCst));
+        release_save.notify_one();
+
+        assert!(failed_save.await.expect("save task").is_err());
+        assert_eq!(read.await.expect("read task").unwrap(), "previous");
+    }
 
     #[test]
     fn folder_only_update_preserves_latest_preferences() {

--- a/frontend/src-tauri/src/audio/recording_saver.rs
+++ b/frontend/src-tauri/src/audio/recording_saver.rs
@@ -55,6 +55,7 @@ pub struct RecordingSaver {
     transcript_segments: Arc<Mutex<Vec<TranscriptSegment>>>,
     chunk_receiver: Option<mpsc::UnboundedReceiver<AudioChunk>>,
     is_saving: Arc<Mutex<bool>>,
+    save_folder: PathBuf,
 }
 
 impl RecordingSaver {
@@ -67,12 +68,18 @@ impl RecordingSaver {
             transcript_segments: Arc::new(Mutex::new(Vec::new())),
             chunk_receiver: None,
             is_saving: Arc::new(Mutex::new(false)),
+            save_folder: super::recording_preferences::get_default_recordings_folder(),
         }
     }
 
     /// Set the meeting name for this recording session
     pub fn set_meeting_name(&mut self, name: Option<String>) {
         self.meeting_name = name;
+    }
+
+    /// Set the persisted root used for new meeting folders.
+    pub fn set_save_folder(&mut self, save_folder: PathBuf) {
+        self.save_folder = save_folder;
     }
 
     /// Set device information in metadata
@@ -137,40 +144,26 @@ impl RecordingSaver {
     ///
     /// # Arguments
     /// * `auto_save` - If true, creates checkpoints and enables saving. If false, audio chunks are discarded.
-    pub fn start_accumulation(&mut self, auto_save: bool) -> mpsc::UnboundedSender<AudioChunk> {
+    pub fn start_accumulation(&mut self, auto_save: bool) -> Result<mpsc::UnboundedSender<AudioChunk>> {
         if auto_save {
             info!("Initializing incremental audio saver for recording (auto-save ENABLED)");
         } else {
             info!("Starting recording without audio saving (auto-save DISABLED - transcripts only)");
         }
 
-        // Create channel for receiving audio chunks
-        let (sender, receiver) = mpsc::unbounded_channel::<AudioChunk>();
-        self.chunk_receiver = Some(receiver);
-
-        // Initialize meeting folder and incremental saver ONLY if auto_save is enabled
-        if auto_save {
-            if let Some(name) = self.meeting_name.clone() {
-                match self.initialize_meeting_folder(&name, true) {
-                    Ok(()) => info!("Successfully initialized meeting folder with checkpoints"),
-                    Err(e) => {
-                        error!("Failed to initialize meeting folder: {}", e);
-                        // Continue anyway - will use fallback flat structure
-                    }
-                }
-            }
-        } else {
-            // When auto_save is false, still create meeting folder for transcripts/metadata
-            // but skip .checkpoints directory
-            if let Some(name) = self.meeting_name.clone() {
-                match self.initialize_meeting_folder(&name, false) {
-                    Ok(()) => info!("Successfully initialized meeting folder (transcripts only)"),
-                    Err(e) => {
-                        error!("Failed to initialize meeting folder: {}", e);
-                    }
-                }
+        // Initialize the output folder before starting any recording work.
+        if let Some(name) = self.meeting_name.clone() {
+            self.initialize_meeting_folder(&name, auto_save)?;
+            if auto_save {
+                info!("Successfully initialized meeting folder with checkpoints");
+            } else {
+                info!("Successfully initialized meeting folder (transcripts only)");
             }
         }
+
+        // Create the channel only after the output folder is ready.
+        let (sender, receiver) = mpsc::unbounded_channel::<AudioChunk>();
+        self.chunk_receiver = Some(receiver);
 
         // Start accumulation task
         let is_saving_clone = self.is_saving.clone();
@@ -219,7 +212,7 @@ impl RecordingSaver {
             *is_saving = true;
         }
 
-        sender
+        Ok(sender)
     }
 
     /// Initialize meeting folder structure and metadata
@@ -228,11 +221,8 @@ impl RecordingSaver {
     /// * `meeting_name` - Name of the meeting
     /// * `create_checkpoints` - Whether to create .checkpoints/ directory and IncrementalAudioSaver
     fn initialize_meeting_folder(&mut self, meeting_name: &str, create_checkpoints: bool) -> Result<()> {
-        // Load preferences to get base recordings folder
-        let base_folder = super::recording_preferences::get_default_recordings_folder();
-
         // Create meeting folder structure (with or without .checkpoints/ subdirectory)
-        let meeting_folder = create_meeting_folder(&base_folder, meeting_name, create_checkpoints)?;
+        let meeting_folder = create_meeting_folder(&self.save_folder, meeting_name, create_checkpoints)?;
 
         // Only initialize incremental saver if checkpoints are needed (auto_save is true)
         if create_checkpoints {
@@ -481,5 +471,27 @@ impl RecordingSaver {
 impl Default for RecordingSaver {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod recording_root_tests {
+    use super::RecordingSaver;
+
+    #[tokio::test]
+    async fn meeting_artifacts_are_created_under_selected_root() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory");
+        let selected_root = temp_dir.path().join("knowledge-base");
+        let mut saver = RecordingSaver::new();
+
+        saver.set_save_folder(selected_root.clone());
+        saver.set_meeting_name(Some("Folder Contract".to_string()));
+        let _sender = saver.start_accumulation(false).expect("start accumulation");
+        saver.add_transcript_chunk("Stored with the meeting".to_string());
+
+        let meeting_folder = saver.get_meeting_folder().expect("meeting folder");
+        assert!(meeting_folder.starts_with(&selected_root));
+        assert!(meeting_folder.join("metadata.json").is_file());
+        assert!(meeting_folder.join("transcripts.json").is_file());
     }
 }

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -683,6 +683,7 @@ pub fn run() {
             openrouter::get_openrouter_models,
             audio::recording_preferences::get_recording_preferences,
             audio::recording_preferences::set_recording_preferences,
+            audio::recording_preferences::set_recording_save_folder,
             audio::recording_preferences::get_default_recordings_folder_path,
             audio::recording_preferences::open_recordings_folder,
             audio::recording_preferences::select_recording_folder,

--- a/frontend/src/components/RecordingSettings.tsx
+++ b/frontend/src/components/RecordingSettings.tsx
@@ -1,10 +1,12 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
 import { FolderOpen } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { DeviceSelection, SelectedDevices } from '@/components/DeviceSelection';
 import Analytics from '@/lib/analytics';
 import { toast } from 'sonner';
+import { useConfig } from '@/contexts/ConfigContext';
 
 export interface RecordingPreferences {
   save_folder: string;
@@ -19,6 +21,7 @@ interface RecordingSettingsProps {
 }
 
 export function RecordingSettings({ onSave }: RecordingSettingsProps) {
+  const { updateRecordingSaveFolder } = useConfig();
   const [preferences, setPreferences] = useState<RecordingPreferences>({
     save_folder: '',
     auto_save: true,
@@ -26,22 +29,35 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
     preferred_mic_device: null,
     preferred_system_device: null
   });
+  const preferencesRef = useRef(preferences);
+  const chooserBusyRef = useRef(false);
+  const savingRef = useRef(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [choosingFolder, setChoosingFolder] = useState(false);
   const [showRecordingNotification, setShowRecordingNotification] = useState(true);
+  const controlsBusy = saving || choosingFolder;
+
+  const updatePreferences = (next: RecordingPreferences) => {
+    preferencesRef.current = next;
+    setPreferences(next);
+  };
 
   // Load recording preferences on component mount
   useEffect(() => {
     const loadPreferences = async () => {
       try {
         const prefs = await invoke<RecordingPreferences>('get_recording_preferences');
-        setPreferences(prefs);
+        updatePreferences(prefs);
       } catch (error) {
         console.error('Failed to load recording preferences:', error);
         // If loading fails, get default folder path
         try {
           const defaultPath = await invoke<string>('get_default_recordings_folder_path');
-          setPreferences(prev => ({ ...prev, save_folder: defaultPath }));
+          updatePreferences({
+            ...preferencesRef.current,
+            save_folder: defaultPath,
+          });
         } catch (defaultError) {
           console.error('Failed to get default folder path:', defaultError);
         }
@@ -51,6 +67,33 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
     };
 
     loadPreferences();
+  }, []);
+
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+
+    import('@tauri-apps/api/event')
+      .then(({ listen }) =>
+        listen<RecordingPreferences>('recording-preferences-updated', (event) => {
+          updatePreferences(event.payload);
+        }),
+      )
+      .then((cleanup) => {
+        if (disposed) {
+          cleanup();
+        } else {
+          unlisten = cleanup;
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to listen for recording preference updates:', error);
+      });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
   }, []);
 
   // Load recording notification preference
@@ -69,8 +112,8 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
   }, []);
 
   const handleAutoSaveToggle = async (enabled: boolean) => {
-    const newPreferences = { ...preferences, auto_save: enabled };
-    setPreferences(newPreferences);
+    const newPreferences = { ...preferencesRef.current, auto_save: enabled };
+    updatePreferences(newPreferences);
     await savePreferences(newPreferences);
 
     // Track auto-save setting change
@@ -81,11 +124,11 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
 
   const handleDeviceChange = async (devices: SelectedDevices) => {
     const newPreferences = {
-      ...preferences,
+      ...preferencesRef.current,
       preferred_mic_device: devices.micDevice,
       preferred_system_device: devices.systemDevice
     };
-    setPreferences(newPreferences);
+    updatePreferences(newPreferences);
     await savePreferences(newPreferences);
 
     // Track default device preference changes
@@ -101,6 +144,54 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
       await invoke('open_recordings_folder');
     } catch (error) {
       console.error('Failed to open recordings folder:', error);
+      toast.error('Failed to open recordings folder', {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  const handleChooseFolder = async () => {
+    if (chooserBusyRef.current || savingRef.current) return;
+    chooserBusyRef.current = true;
+    setChoosingFolder(true);
+    try {
+      const selectedFolder = await invoke<string | null>('select_recording_folder');
+      if (!selectedFolder) return;
+
+      savingRef.current = true;
+      setSaving(true);
+      let persistedPreferences: RecordingPreferences;
+      try {
+        persistedPreferences = await invoke<RecordingPreferences>(
+          'set_recording_save_folder',
+          { saveFolder: selectedFolder },
+        );
+      } catch (error) {
+        console.error('Failed to save recording folder:', error);
+        toast.error('Failed to save recording folder', {
+          description: error instanceof Error ? error.message : String(error),
+        });
+        return;
+      } finally {
+        savingRef.current = false;
+        setSaving(false);
+      }
+
+      updatePreferences(persistedPreferences);
+      updateRecordingSaveFolder(persistedPreferences.save_folder);
+      onSave?.(persistedPreferences);
+      toast.success('Recording folder saved');
+      await Analytics.track('recording_save_folder_changed', {
+        folder_selected: 'true',
+      });
+    } catch (error) {
+      console.error('Failed to choose recordings folder:', error);
+      toast.error('Failed to choose recording folder', {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      chooserBusyRef.current = false;
+      setChoosingFolder(false);
     }
   };
 
@@ -122,6 +213,7 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
   };
 
   const savePreferences = async (prefs: RecordingPreferences) => {
+    savingRef.current = true;
     setSaving(true);
     try {
       await invoke('set_recording_preferences', { preferences: prefs });
@@ -139,6 +231,7 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
         description: error instanceof Error ? error.message : String(error)
       });
     } finally {
+      savingRef.current = false;
       setSaving(false);
     }
   };
@@ -172,7 +265,7 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
         <Switch
           checked={preferences.auto_save}
           onCheckedChange={handleAutoSaveToggle}
-          disabled={saving}
+          disabled={controlsBusy}
         />
       </div>
 
@@ -184,13 +277,28 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
             <div className="text-sm text-gray-600 mb-3 break-all">
               {preferences.save_folder || 'Default folder'}
             </div>
-            <button
-              onClick={handleOpenFolder}
-              className="flex items-center gap-2 px-3 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
-            >
-              <FolderOpen className="w-4 h-4" />
-              Open Folder
-            </button>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleOpenFolder}
+                disabled={controlsBusy}
+              >
+                <FolderOpen className="w-4 h-4" />
+                Open Folder
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleChooseFolder}
+                disabled={controlsBusy}
+              >
+                <FolderOpen className="w-4 h-4" />
+                Choose Folder
+              </Button>
+            </div>
           </div>
 
           <div className="p-4 border rounded-lg bg-blue-50">
@@ -224,6 +332,7 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
         <Switch
           checked={showRecordingNotification}
           onCheckedChange={handleNotificationToggle}
+          disabled={controlsBusy}
         />
       </div>
 
@@ -242,7 +351,7 @@ export function RecordingSettings({ onSave }: RecordingSettingsProps) {
                 systemDevice: preferences.preferred_system_device
               }}
               onDeviceChange={handleDeviceChange}
-              disabled={saving}
+              disabled={controlsBusy}
             />
           </div>
         </div>

--- a/frontend/src/contexts/ConfigContext.tsx
+++ b/frontend/src/contexts/ConfigContext.tsx
@@ -91,6 +91,7 @@ interface ConfigContextType {
   isLoadingPreferences: boolean;
   loadPreferences: () => Promise<void>;
   updateNotificationSettings: (settings: NotificationSettings) => Promise<void>;
+  updateRecordingSaveFolder: (saveFolder: string) => void;
 }
 
 const ConfigContext = createContext<ConfigContextType | undefined>(undefined);
@@ -174,6 +175,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
   const [isLoadingPreferences, setIsLoadingPreferences] = useState(false);
   const preferencesLoadedRef = useRef(false);
   const isLoadingRef = useRef(false);
+  const pendingRecordingSaveFolderRef = useRef<string | null>(null);
 
   // Load Ollama models (uses saved endpoint, re-runs when endpoint changes after config load)
   useEffect(() => {
@@ -437,17 +439,19 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
       }
 
       // Load storage locations
-      const [dbDir, modelsDir, recordingsDir] = await Promise.all([
+      const [dbDir, modelsDir, recordingPreferences] = await Promise.all([
         invoke<string>('get_database_directory'),
         invoke<string>('whisper_get_models_directory'),
-        invoke<string>('get_default_recordings_folder_path')
+        invoke<{ save_folder: string }>('get_recording_preferences')
       ]);
 
       setStorageLocations({
         database: dbDir,
         models: modelsDir,
-        recordings: recordingsDir
+        recordings:
+          pendingRecordingSaveFolderRef.current ?? recordingPreferences.save_folder
       });
+      pendingRecordingSaveFolderRef.current = null;
 
       // Mark as loaded
       preferencesLoadedRef.current = true;
@@ -468,6 +472,13 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
       console.error('[ConfigContext] Failed to update notification settings:', error);
       throw error; // Re-throw so component can handle error
     }
+  }, []);
+
+  const updateRecordingSaveFolder = useCallback((saveFolder: string) => {
+    pendingRecordingSaveFolderRef.current = saveFolder;
+    setStorageLocations(previous =>
+      previous ? { ...previous, recordings: saveFolder } : previous,
+    );
   }, []);
 
   // Wrapper for setSelectedLanguage that persists to localStorage and syncs to Rust
@@ -507,6 +518,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     isLoadingPreferences,
     loadPreferences,
     updateNotificationSettings,
+    updateRecordingSaveFolder,
   }), [
     modelConfig,
     isAutoSummary,
@@ -529,6 +541,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     isLoadingPreferences,
     loadPreferences,
     updateNotificationSettings,
+    updateRecordingSaveFolder,
   ]);
 
   return (


### PR DESCRIPTION
## Description

Adds a native **Choose Folder** action next to **Open Folder** and makes the persisted recording root apply to all future live recordings and future audio imports.

### Behavior

- Existing meetings keep their stored `folder_path` and are not moved.
- New live recordings capture the selected root when recording starts.
- New audio imports capture the selected root before the background import starts.
- Invalid or unavailable configured roots fail before recording/import output begins; there is no silent fallback to the default folder.
- Folder changes are validated and persisted transactionally, with rollback and serialized reads/writes.
- The folder-only command reloads the latest preferences under the lock, so unrelated device and auto-save settings are preserved.
- The UI changes only after persistence succeeds, blocks duplicate/racing controls, and reports picker/save/open errors.
- Analytics records only `folder_selected: true`; no filesystem path is sent.

## Related Issue

Fixes #481

Related to #516. This PR covers the same live-recording and import paths while adding transactional persistence, fail-fast destination handling, race protection, privacy-safe analytics, and focused tests.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] All feature tests pass

Clean `upstream/devtest` branch:

- 6 recording-preference persistence/concurrency tests passed.
- 2 live-recording root tests passed.
- 3 import-root/snapshot tests passed.
- `pnpm run build` passed.

Source build with browser-test infrastructure:

- Full Rust suite: 204 passed, 0 failed, 3 ignored.
- Playwright: 14 passed (folder contract plus settings/theme regression).
- `pnpm exec tsc --noEmit` passed.
- `pnpm run build` passed.

Known upstream baseline checks outside this diff:

- The full `devtest` Rust suite has one exact-duration float assertion failure: `159.999996ms != 160ms` in `audio::device_detection::tests::test_calculate_buffer_timeout_bluetooth`. This PR does not modify that file.
- Direct project-wide `tsc --noEmit` on `devtest` reports the existing missing `bun:test` declaration in `tests/lib/blocknote-markdown.test.ts`; the production Next.js build passes type checking.

## Documentation

- [ ] Documentation updated
- [x] No documentation needed

## Checklist

- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments/tests for non-obvious concurrency behavior
- [x] README update is not needed
