### PR TITLE
fix(ui/summary): meeting-details layout and Ollama reasoning strip (#592)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,6 +96,7 @@
         }
     },
     "devDependencies": {
+        "@tailwindcss/container-queries": "^0.1.1",
         "@tailwindcss/typography": "^0.5.15",
         "@tauri-apps/cli": "^2.1.0",
         "@tauri-apps/plugin-fs": "~2.4.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  prosemirror-model: 1.25.3
+  prosemirror-state: 1.4.3
+  prosemirror-view: 1.41.3
+  prosemirror-transform: 1.10.4
+  prosemirror-tables: 1.8.1
+
 importers:
 
   .:
@@ -180,6 +187,9 @@ importers:
         specifier: ^3.25.71
         version: 3.25.76
     devDependencies:
+      '@tailwindcss/container-queries':
+        specifier: ^0.1.1
+        version: 0.1.1(tailwindcss@3.4.19)
       '@tailwindcss/typography':
         specifier: ^0.5.15
         version: 0.5.19(tailwindcss@3.4.19)
@@ -1557,6 +1567,11 @@ packages:
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
 
+  '@tailwindcss/container-queries@0.1.1':
+    resolution: {integrity: sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==}
+    peerDependencies:
+      tailwindcss: '>=3.2.0'
+
   '@tailwindcss/typography@0.5.19':
     resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
     peerDependencies:
@@ -2930,10 +2945,10 @@ packages:
       '@types/hast': ^3.0.0
       highlight.js: ^11.9.0
       lowlight: ^3.1.0
-      prosemirror-model: ^1.19.3
-      prosemirror-state: ^1.4.3
-      prosemirror-transform: ^1.8.0
-      prosemirror-view: ^1.32.4
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.3
       refractor: ^5.0.0
       sugar-high: ^0.6.1 || ^0.7.0 || ^0.8.0 || ^0.9.0
     peerDependenciesMeta:
@@ -2979,9 +2994,9 @@ packages:
   prosemirror-paste-rules@3.0.0:
     resolution: {integrity: sha512-p2ayp2xtSTtDPZutoxZyK6UKJhJk0hEpIfdfVYfd3DSENE1Lyrcg96pju+ClgwXlTjPUykXx5DrsfRbHCY+gGQ==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-schema-basic@1.2.4:
     resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
@@ -2995,9 +3010,9 @@ packages:
   prosemirror-suggest@3.0.0:
     resolution: {integrity: sha512-cEYnJHOAnQ+ET7PKY1tY8SMSpyR2rQAuYfPEmVtet0V9exgHAeiaSEzyBcCSeLesxXJRIv8b9cofyqoqyMjlEw==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-tables@1.8.1:
     resolution: {integrity: sha512-DAgDoUYHCcc6tOGpLVPSU1k84kCUWTWnfWX3UDy2Delv4ryH0KqTD6RBI6k4yi9j9I8gl3j8MkPpRD/vWPZbug==}
@@ -3005,9 +3020,9 @@ packages:
   prosemirror-trailing-node@3.0.0:
     resolution: {integrity: sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-transform@1.10.4:
     resolution: {integrity: sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==}
@@ -3448,9 +3463,9 @@ packages:
     resolution: {integrity: sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     peerDependencies:
-      prosemirror-model: ^1.7.1
-      prosemirror-state: ^1.2.3
-      prosemirror-view: ^1.9.10
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
       y-protocols: ^1.0.1
       yjs: ^13.5.38
 
@@ -5242,6 +5257,10 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
       tslib: 2.8.1
+
+  '@tailwindcss/container-queries@0.1.1(tailwindcss@3.4.19)':
+    dependencies:
+      tailwindcss: 3.4.19
 
   '@tailwindcss/typography@0.5.19(tailwindcss@3.4.19)':
     dependencies:

--- a/frontend/src-tauri/src/summary/llm_client.rs
+++ b/frontend/src-tauri/src/summary/llm_client.rs
@@ -27,6 +27,44 @@ pub struct ChatRequest {
     pub top_p: Option<f32>,
 }
 
+/// Build OpenAI-compat JSON body.
+///
+/// Ollama thinking/reasoning stays enabled (no `reasoning_effort: none`) so
+/// capable models can reason; Meetily strips reasoning from the saved summary
+/// and surfaces it to the UI separately.
+pub fn build_openai_compat_chat_body(
+    provider: &LLMProvider,
+    model_name: &str,
+    system_prompt: &str,
+    user_prompt: &str,
+    max_tokens: Option<u32>,
+    temperature: Option<f32>,
+    top_p: Option<f32>,
+) -> serde_json::Value {
+    let (max_tokens_val, temperature_val, top_p_val) = if *provider == LLMProvider::CustomOpenAI {
+        (max_tokens, temperature, top_p)
+    } else {
+        (None, None, None)
+    };
+
+    serde_json::json!(ChatRequest {
+        model: model_name.to_string(),
+        messages: vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: system_prompt.to_string(),
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: user_prompt.to_string(),
+            }
+        ],
+        max_tokens: max_tokens_val,
+        temperature: temperature_val,
+        top_p: top_p_val,
+    })
+}
+
 // Generic structure for OpenAI-compatible API chat responses
 #[derive(Deserialize, Debug)]
 pub struct ChatResponse {
@@ -41,6 +79,9 @@ pub struct Choice {
 #[derive(Deserialize, Debug)]
 pub struct MessageContent {
     pub content: String,
+    /// Ollama thinking models may return reasoning separately from content.
+    #[serde(default)]
+    pub reasoning: Option<String>,
 }
 
 // Claude-specific request structure
@@ -218,29 +259,15 @@ pub async fn generate_summary(
 
     // Build request body based on provider
     let request_body = if provider != &LLMProvider::Claude {
-        // For CustomOpenAI, apply optional parameters if provided
-        let (max_tokens_val, temperature_val, top_p_val) = if provider == &LLMProvider::CustomOpenAI {
-            (max_tokens, temperature, top_p)
-        } else {
-            (None, None, None)
-        };
-
-        serde_json::json!(ChatRequest {
-            model: model_name.to_string(),
-            messages: vec![
-                ChatMessage {
-                    role: "system".to_string(),
-                    content: system_prompt.to_string(),
-                },
-                ChatMessage {
-                    role: "user".to_string(),
-                    content: user_prompt.to_string(),
-                }
-            ],
-            max_tokens: max_tokens_val,
-            temperature: temperature_val,
-            top_p: top_p_val,
-        })
+        build_openai_compat_chat_body(
+            provider,
+            model_name,
+            system_prompt,
+            user_prompt,
+            max_tokens,
+            temperature,
+            top_p,
+        )
     } else {
         serde_json::json!(ClaudeRequest {
             system: system_prompt.to_string(),
@@ -321,14 +348,57 @@ pub async fn generate_summary(
 
         info!("🐞 LLM Response received from {}", provider_name(provider));
 
-        let content = chat_response
+        let message = &chat_response
             .choices
             .get(0)
             .ok_or("No content in LLM response")?
-            .message
-            .content
-            .trim();
-        Ok(content.to_string())
+            .message;
+        let content = message.content.trim();
+        // Fold separate reasoning into <think> so existing cleaners can extract it
+        // and the UI can be notified that reasoning was present.
+        if let Some(reasoning) = message
+            .reasoning
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            Ok(format!("<think>\n{reasoning}\n</think>\n{content}"))
+        } else {
+            Ok(content.to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ollama_body_leaves_reasoning_enabled() {
+        let body = build_openai_compat_chat_body(
+            &LLMProvider::Ollama,
+            "qwen3.5:9b",
+            "sys",
+            "user",
+            None,
+            None,
+            None,
+        );
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn openai_body_omits_reasoning_effort() {
+        let body = build_openai_compat_chat_body(
+            &LLMProvider::OpenAI,
+            "gpt-4o",
+            "sys",
+            "user",
+            None,
+            None,
+            None,
+        );
+        assert!(body.get("reasoning_effort").is_none());
     }
 }
 

--- a/frontend/src-tauri/src/summary/processor.rs
+++ b/frontend/src-tauri/src/summary/processor.rs
@@ -5,12 +5,154 @@ use regex::Regex;
 use reqwest::Client;
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 // Compile regex once and reuse (significant performance improvement for repeated calls)
 static THINKING_TAG_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(?s)<think(?:ing)?>.*?</think(?:ing)?>").unwrap()
+    // Capture inner reasoning text from closed think tags
+    Regex::new(r"(?is)<think(?:ing)?>(.*?)</think(?:ing)?>").unwrap()
 });
+
+static OPEN_THINK_TAG_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?i)<think(?:ing)?>").unwrap()
+});
+
+static HEADING_LINE_START_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\n(#{1,6}\s)").unwrap()
+});
+
+fn strip_unclosed_think_tags(text: &str) -> (String, Option<String>) {
+    let Some(open_match) = OPEN_THINK_TAG_REGEX.find(text) else {
+        return (text.to_string(), None);
+    };
+
+    let prefix = &text[..open_match.start()];
+    let after_open = &text[open_match.end()..];
+
+    if let Some(m) = HEADING_LINE_START_REGEX.find(after_open) {
+        let reasoning = after_open[..m.start()].trim();
+        let summary = &after_open[m.start() + 1..];
+        let cleaned = format!("{}{}", prefix, summary).trim().to_string();
+        let reasoning = (!reasoning.is_empty()).then(|| reasoning.to_string());
+        return (cleaned, reasoning);
+    }
+
+    let reasoning = after_open.trim();
+    let reasoning = (!reasoning.is_empty()).then(|| reasoning.to_string());
+    (prefix.trim().to_string(), reasoning)
+}
+
+/// Leading meta/CoT headings/phrases seen with thinking models (issue #592).
+static LEADING_COT_LINE_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"(?i)^(#{1,6}\s*)?(Thinking|Self-Correction|Decision Strategy|Strict Interpretation|Wait\.{0,3}|Actually checking.*)$",
+    )
+    .unwrap()
+});
+
+fn strip_leading_plaintext_cot(text: &str) -> (String, Option<String>) {
+    let mut lines = text.lines().peekable();
+    let mut cot_lines = Vec::new();
+    while let Some(line) = lines.peek() {
+        let t = line.trim();
+        if t.is_empty() || LEADING_COT_LINE_REGEX.is_match(t) {
+            if !t.is_empty() {
+                cot_lines.push(t.to_string());
+            }
+            lines.next();
+            continue;
+        }
+        break;
+    }
+    let cleaned = lines.collect::<Vec<_>>().join("\n").trim().to_string();
+    let reasoning = (!cot_lines.is_empty()).then(|| cot_lines.join("\n"));
+    (cleaned, reasoning)
+}
+
+/// Result of cleaning LLM markdown, including any extracted reasoning text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CleanedLlmMarkdown {
+    pub markdown: String,
+    pub reasoning: Option<String>,
+}
+
+fn merge_reasoning(parts: &[Option<String>]) -> Option<String> {
+    let joined = parts
+        .iter()
+        .filter_map(|p| p.as_deref())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    (!joined.is_empty()).then_some(joined)
+}
+
+/// Cleans markdown and returns any stripped reasoning for the UI.
+pub fn clean_llm_markdown_detailed(markdown: &str) -> CleanedLlmMarkdown {
+    let original = markdown.to_string();
+
+    let mut think_parts = Vec::new();
+    for caps in THINKING_TAG_REGEX.captures_iter(markdown) {
+        if let Some(inner) = caps.get(1) {
+            let t = inner.as_str().trim();
+            if !t.is_empty() {
+                think_parts.push(t.to_string());
+            }
+        }
+    }
+    let closed_reasoning = (!think_parts.is_empty()).then(|| think_parts.join("\n\n"));
+
+    let without_closed = THINKING_TAG_REGEX.replace_all(markdown, "");
+    let (without_thinking, unclosed_reasoning) = strip_unclosed_think_tags(&without_closed);
+    let (without_cot, cot_reasoning) = strip_leading_plaintext_cot(&without_thinking);
+    let trimmed = without_cot.trim();
+
+    let reasoning = merge_reasoning(&[closed_reasoning, unclosed_reasoning, cot_reasoning]);
+
+    if trimmed.is_empty() {
+        warn!("clean_llm_markdown_output produced empty output; keeping original");
+        return CleanedLlmMarkdown {
+            markdown: original,
+            reasoning: None,
+        };
+    }
+
+    const PREFIXES: &[&str] = &["```markdown\n", "```\n"];
+    const SUFFIX: &str = "```";
+    for prefix in PREFIXES {
+        if trimmed.starts_with(prefix) && trimmed.ends_with(SUFFIX) {
+            let content = &trimmed[prefix.len()..trimmed.len() - SUFFIX.len()];
+            let c = content.trim();
+            if c.is_empty() {
+                warn!("clean_llm_markdown_output fence strip emptied content; keeping original");
+                return CleanedLlmMarkdown {
+                    markdown: original,
+                    reasoning: None,
+                };
+            }
+            return CleanedLlmMarkdown {
+                markdown: c.to_string(),
+                reasoning,
+            };
+        }
+    }
+
+    CleanedLlmMarkdown {
+        markdown: trimmed.to_string(),
+        reasoning,
+    }
+}
+
+/// Cleans markdown output from LLM by removing thinking tags and code fences
+///
+/// # Arguments
+/// * `markdown` - Raw markdown output from LLM
+///
+/// # Returns
+/// Cleaned markdown string
+pub fn clean_llm_markdown_output(markdown: &str) -> String {
+    clean_llm_markdown_detailed(markdown).markdown
+}
 
 const ENGLISH_BASE_SUMMARY_INSTRUCTION: &str =
     "**Write the summary/report in English regardless of transcript language; non-English prose is invalid.**";
@@ -136,13 +278,13 @@ fn translation_system_prompt(target_language: &str) -> String {
 
 fn build_chunk_summary_user_prompt(chunk: &str) -> String {
     format!(
-        "{ENGLISH_BASE_SUMMARY_INSTRUCTION}\n\nProvide a concise but comprehensive summary of the following transcript chunk. Capture all key points, decisions, action items, and mentioned individuals.\n\n<transcript_chunk>\n{chunk}\n</transcript_chunk>"
+        "{ENGLISH_BASE_SUMMARY_INSTRUCTION}\n\nProvide a concise but comprehensive summary of the following transcript chunk. Capture all key points, decisions, action items, and mentioned individuals. Do not include reasoning, self-correction, or meta-commentary — output only the summary content.\n\n<transcript_chunk>\n{chunk}\n</transcript_chunk>"
     )
 }
 
 fn build_combine_summary_user_prompt(combined_text: &str) -> String {
     format!(
-        "{ENGLISH_BASE_SUMMARY_INSTRUCTION}\n\nThe following are consecutive summaries of a meeting. Combine them into a single, coherent, and detailed narrative summary that retains all important details, organized logically.\n\n<summaries>\n{combined_text}\n</summaries>"
+        "{ENGLISH_BASE_SUMMARY_INSTRUCTION}\n\nThe following are consecutive summaries of a meeting. Combine them into a single, coherent, and detailed narrative summary that retains all important details, organized logically. Do not include reasoning, self-correction, or meta-commentary — output only the summary content.\n\n<summaries>\n{combined_text}\n</summaries>"
     )
 }
 
@@ -160,7 +302,8 @@ fn build_final_report_system_prompt(
 4. Fill each template section per its instructions.
 5. If a section has no relevant info, write "None noted in this section."
 6. Output **only** the completed Markdown report.
-7. If unsure about something, omit it.
+7. Do not include reasoning, thinking, self-correction, decision strategy, or any meta-commentary sections — output only the completed Markdown report.
+8. If unsure about something, omit it.
 
 **SECTION-SPECIFIC INSTRUCTIONS:**
 {section_instructions}
@@ -251,35 +394,6 @@ pub fn chunk_text(text: &str, chunk_size_tokens: usize, overlap_tokens: usize) -
     chunks
 }
 
-/// Cleans markdown output from LLM by removing thinking tags and code fences
-///
-/// # Arguments
-/// * `markdown` - Raw markdown output from LLM
-///
-/// # Returns
-/// Cleaned markdown string
-pub fn clean_llm_markdown_output(markdown: &str) -> String {
-    // Remove <think>...</think> or <thinking>...</thinking> blocks using cached regex
-    let without_thinking = THINKING_TAG_REGEX.replace_all(markdown, "");
-
-    let trimmed = without_thinking.trim();
-
-    // List of possible language identifiers for code blocks
-    const PREFIXES: &[&str] = &["```markdown\n", "```\n"];
-    const SUFFIX: &str = "```";
-
-    for prefix in PREFIXES {
-        if trimmed.starts_with(prefix) && trimmed.ends_with(SUFFIX) {
-            // Extract content between the fences
-            let content = &trimmed[prefix.len()..trimmed.len() - SUFFIX.len()];
-            return content.trim().to_string();
-        }
-    }
-
-    // If no fences found, return the trimmed string
-    trimmed.to_string()
-}
-
 /// Extracts meeting name from the first heading in markdown
 ///
 /// # Arguments
@@ -317,9 +431,10 @@ pub fn extract_meeting_name_from_markdown(markdown: &str) -> Option<String> {
 /// * `cached_english` - Optional previously-generated English summary to skip pass 1 when translating
 ///
 /// # Returns
-/// Tuple of (final_summary_markdown, english_summary_markdown, number_of_chunks_processed)
+/// Tuple of (final_summary_markdown, english_summary_markdown, number_of_chunks_processed, stripped_reasoning)
 /// where english_summary_markdown is the canonical AI-generated English summary
-/// (equals final_summary_markdown when target language is English)
+/// (equals final_summary_markdown when target language is English).
+/// `stripped_reasoning` is present when model thinking/CoT was removed from the summary.
 pub async fn generate_meeting_summary(
     client: &Client,
     provider: &LLMProvider,
@@ -340,7 +455,7 @@ pub async fn generate_meeting_summary(
     summary_language: Option<&str>,
     detected_transcript_language: Option<&str>,
     cached_english: Option<&str>,
-) -> Result<(String, String, i64), String> {
+) -> Result<(String, String, i64, Option<String>), String> {
     if let Some(token) = cancellation_token {
         if token.is_cancelled() {
             return Err("Summary generation was cancelled".to_string());
@@ -354,13 +469,13 @@ pub async fn generate_meeting_summary(
     let total_tokens = rough_token_count(text);
     info!("Transcript length: {} tokens", total_tokens);
 
-    let (mut english_markdown, successful_chunk_count) = if let Some(cached) =
+    let (mut english_markdown, successful_chunk_count, mut stripped_reasoning) = if let Some(cached) =
         resolve_cached_english(cached_english, summary_language)
     {
         info!("✓ Using cached English summary ({} chars), skipping pass 1", cached.len());
-        (cached.to_string(), 1_i64)
+        (cached.to_string(), 1_i64, None)
     } else {
-        let content_to_summarize: String;
+        let mut content_to_summarize: String;
         let successful_chunk_count: i64;
 
         // Strategy: Use single-pass for cloud providers or short transcripts
@@ -417,7 +532,7 @@ pub async fn generate_meeting_summary(
                 .await
                 {
                     Ok(summary) => {
-                        chunk_summaries.push(summary);
+                        chunk_summaries.push(clean_llm_markdown_output(&summary));
                         info!("✓ Chunk {}/{} processed successfully", i + 1, num_chunks);
                     }
                     Err(e) => {
@@ -452,7 +567,7 @@ pub async fn generate_meeting_summary(
                 let combined_text = chunk_summaries.join("\n---\n");
                 let system_prompt_combine = "You are an expert at synthesizing meeting summaries.";
                 let user_prompt_combine = build_combine_summary_user_prompt(&combined_text);
-                generate_summary(
+                let combined = generate_summary(
                     client,
                     provider,
                     model_name,
@@ -467,9 +582,10 @@ pub async fn generate_meeting_summary(
                     app_data_dir,
                     cancellation_token,
                 )
-                .await?
+                .await?;
+                clean_llm_markdown_output(&combined)
             } else {
-                chunk_summaries.remove(0)
+                chunk_summaries.remove(0) // already cleaned on push
             };
         }
 
@@ -517,10 +633,14 @@ pub async fn generate_meeting_summary(
         )
         .await?;
 
-        let english_markdown = clean_llm_markdown_output(&raw_markdown);
-        info!("Summary pass completed ({} chars)", english_markdown.len());
+        let cleaned = clean_llm_markdown_detailed(&raw_markdown);
+        info!(
+            "Summary pass completed ({} chars, reasoning_stripped={})",
+            cleaned.markdown.len(),
+            cleaned.reasoning.is_some()
+        );
 
-        (english_markdown, successful_chunk_count)
+        (cleaned.markdown, successful_chunk_count, cleaned.reasoning)
     };
 
     let final_markdown = match resolve_final_language_action(summary_language, detected_transcript_language) {
@@ -542,7 +662,11 @@ pub async fn generate_meeting_summary(
             )
             .await
             {
-                Ok(translated) => translated,
+                Ok(translated) => {
+                    let cleaned = clean_llm_markdown_detailed(&translated);
+                    stripped_reasoning = merge_reasoning(&[stripped_reasoning, cleaned.reasoning]);
+                    cleaned.markdown
+                }
                 Err(e) => return Err(format!("Translation to {} failed: {}", name, e)),
             }
         }
@@ -569,14 +693,21 @@ pub async fn generate_meeting_summary(
                 )
                 .await,
             )?;
-            english_markdown = normalized.clone();
-            normalized
+            let cleaned = clean_llm_markdown_detailed(&normalized);
+            stripped_reasoning = merge_reasoning(&[stripped_reasoning, cleaned.reasoning]);
+            english_markdown = cleaned.markdown.clone();
+            cleaned.markdown
         }
         FinalLanguageAction::ReturnEnglish => english_markdown.clone(),
     };
 
     info!("Summary generation completed successfully");
-    Ok((final_markdown, english_markdown, successful_chunk_count))
+    Ok((
+        final_markdown,
+        english_markdown,
+        successful_chunk_count,
+        stripped_reasoning,
+    ))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -734,6 +865,24 @@ mod tests {
     }
 
     #[test]
+    fn final_report_prompt_forbids_reasoning_output() {
+        let prompt = build_final_report_system_prompt("Fill", "# Title");
+        assert!(prompt.to_lowercase().contains("no reasoning")
+            || prompt.contains("meta-commentary")
+            || prompt.contains("self-correction"));
+    }
+
+    #[test]
+    fn chunk_prompt_forbids_reasoning_output() {
+        let prompt = build_chunk_summary_user_prompt("x");
+        assert!(
+            prompt.contains("Do not include reasoning")
+                || prompt.contains("meta-commentary")
+                || prompt.contains("self-correction")
+        );
+    }
+
+    #[test]
     fn english_base_instruction_marks_non_english_prose_invalid_without_bloat() {
         assert!(ENGLISH_BASE_SUMMARY_INSTRUCTION.contains("non-English prose is invalid"));
         assert!(ENGLISH_BASE_SUMMARY_INSTRUCTION.len() <= 120);
@@ -852,5 +1001,49 @@ mod tests {
     fn underscore_locale_variant_returns_none() {
         // OS locale APIs (notably macOS) may emit "en_GB" with underscore.
         assert_eq!(resolve_cached_english(Some("body"), Some("en_GB")), None);
+    }
+
+    #[test]
+    fn clean_detailed_returns_stripped_reasoning() {
+        let input = "<think>internal plan</think>\n# Meeting\nHello";
+        let cleaned = clean_llm_markdown_detailed(input);
+        assert_eq!(cleaned.markdown, "# Meeting\nHello");
+        assert_eq!(cleaned.reasoning.as_deref(), Some("internal plan"));
+    }
+
+    #[test]
+    fn clean_strips_think_tags() {
+        let input = "<think>internal</think>\n# Meeting\nHello";
+        assert_eq!(clean_llm_markdown_output(input), "# Meeting\nHello");
+    }
+
+    #[test]
+    fn clean_strips_unclosed_think_tag() {
+        let input = "<think>still thinking\n# Meeting\nHello";
+        let out = clean_llm_markdown_output(input);
+        assert!(!out.contains("<think>"));
+        assert!(out.contains("# Meeting"));
+    }
+
+    #[test]
+    fn clean_strips_leading_plaintext_cot() {
+        let input = "Thinking\n\nSelf-Correction\nActually checking...\n\n# Key Decisions\n- Ship it\n";
+        let out = clean_llm_markdown_output(input);
+        assert!(!out.contains("Self-Correction"));
+        assert!(out.starts_with("# Key Decisions") || out.contains("# Key Decisions"));
+        assert!(out.contains("Ship it"));
+    }
+
+    #[test]
+    fn clean_preserves_clean_summary() {
+        let input = "# Standup\n\n## Action Items\n- Alice: deploy\n";
+        assert_eq!(clean_llm_markdown_output(input), input.trim());
+    }
+
+    #[test]
+    fn clean_empty_after_strip_keeps_original() {
+        let input = "<think>only thinking</think>";
+        // After strip, content is empty/whitespace → keep original (safety)
+        assert_eq!(clean_llm_markdown_output(input), input);
     }
 }

--- a/frontend/src-tauri/src/summary/service.rs
+++ b/frontend/src-tauri/src/summary/service.rs
@@ -139,15 +139,29 @@ fn build_summary_result_json(
     english_markdown: &str,
     source: SummaryCacheSource,
     output_language: Option<&str>,
+    stripped_reasoning: Option<&str>,
 ) -> serde_json::Value {
-    serde_json::json!({
+    let reasoning = stripped_reasoning
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let reasoning_stripped = reasoning.is_some();
+
+    let mut value = serde_json::json!({
         "markdown": strip_title_if_present(final_markdown),
         ENGLISH_CACHE_FIELD: EnglishSummaryCache {
             markdown: english_markdown.to_string(),
             source,
             output_language: normalise_summary_language_for_cache(output_language),
         },
-    })
+        "reasoning_stripped": reasoning_stripped,
+    });
+
+    if let Some(reasoning) = reasoning {
+        value["reasoning"] = serde_json::Value::String(reasoning);
+    }
+
+    value
 }
 
 /// Parses a `summary_processes.result` JSON blob and extracts a cached English
@@ -534,7 +548,7 @@ impl SummaryService {
         Self::cleanup_cancellation_token(&meeting_id);
 
         match result {
-            Ok((final_markdown, english_markdown, num_chunks)) => {
+            Ok((final_markdown, english_markdown, num_chunks, stripped_reasoning)) => {
                 info!(
                     "✓ Successfully processed {} chunks for meeting_id: {}. Duration: {:.2}s",
                     num_chunks, meeting_id, duration
@@ -559,6 +573,7 @@ impl SummaryService {
                     &english_markdown,
                     cache_source,
                     summary_language.as_deref(),
+                    stripped_reasoning.as_deref(),
                 );
 
                 // Update database with completed status
@@ -764,6 +779,7 @@ mod tests {
             "# Meeting\n## Points\nHello",
             source.clone(),
             Some("fr"),
+            None,
         )
         .to_string();
 
@@ -781,6 +797,7 @@ mod tests {
             "# Meeting\n## Points\nHello",
             source.clone(),
             Some("fr"),
+            None,
         )
         .to_string();
 
@@ -799,6 +816,7 @@ mod tests {
             "# Meeting\n## Points\nHello",
             source,
             Some("fr"),
+            None,
         )
         .to_string();
 
@@ -919,6 +937,7 @@ mod tests {
             "# Meeting\n## Points\nHello",
             source.clone(),
             Some("fr"),
+            None,
         )
         .to_string();
 
@@ -941,6 +960,7 @@ mod tests {
             "# Meeting\n## Points\nHello",
             source.clone(),
             Some("fr"),
+            None,
         )
         .to_string();
 
@@ -962,6 +982,7 @@ mod tests {
             "# English Title\n## Decisions\nDone",
             sample_cache_source(),
             Some("fr"),
+            None,
         );
 
         assert_eq!(result["markdown"], "## Decisions\nDone");

--- a/frontend/src/app/meeting-details/page-content.tsx
+++ b/frontend/src/app/meeting-details/page-content.tsx
@@ -8,6 +8,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { toast } from 'sonner';
 import { TranscriptPanel } from '@/components/MeetingDetails/TranscriptPanel';
 import { SummaryPanel } from '@/components/MeetingDetails/SummaryPanel';
+import { MeetingDetailsSplitView, type MeetingDetailsTab } from '@/components/MeetingDetails/MeetingDetailsSplitView';
 import { ModelConfig } from '@/components/ModelSettingsModal';
 
 // Custom hooks
@@ -57,6 +58,7 @@ export default function PageContent({
   const [customPrompt, setCustomPrompt] = useState<string>('');
   const [isRecording] = useState(false);
   const [summaryResponse] = useState<SummaryResponse | null>(null);
+  const [activeTab, setActiveTab] = useState<MeetingDetailsTab>('transcript');
 
   // Ref to store the modal open function from SummaryGeneratorButtonGroup
   const openModelSettingsRef = useRef<(() => void) | null>(null);
@@ -139,6 +141,12 @@ export default function PageContent({
     Analytics.trackPageView('meeting_details');
   }, []);
 
+  useEffect(() => {
+    if (meetingData.aiSummary || summaryGeneration.summaryStatus === 'completed') {
+      setActiveTab('summary');
+    }
+  }, [meetingData.aiSummary, summaryGeneration.summaryStatus]);
+
   // Auto-generate summary when flag is set
   useEffect(() => {
     let cancelled = false;
@@ -168,64 +176,70 @@ export default function PageContent({
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3, ease: 'easeOut' }}
-      className="flex flex-col h-screen bg-gray-50"
+      className="flex flex-col h-screen min-w-0 bg-gray-50"
     >
-      <div className="flex flex-1 overflow-hidden">
-        <TranscriptPanel
-          transcripts={meetingData.transcripts}
-          customPrompt={customPrompt}
-          onPromptChange={setCustomPrompt}
-          onCopyTranscript={copyOperations.handleCopyTranscript}
-          onOpenMeetingFolder={meetingOperations.handleOpenMeetingFolder}
-          isRecording={isRecording}
-          disableAutoScroll={true}
-          // Pagination props for efficient loading
-          usePagination={true}
-          segments={segments}
-          hasMore={hasMore}
-          isLoadingMore={isLoadingMore}
-          totalCount={totalCount}
-          loadedCount={loadedCount}
-          onLoadMore={onLoadMore}
-          // Retranscription props
-          meetingId={meeting.id}
-          meetingFolderPath={meeting.folder_path}
-          onRefetchTranscripts={onRefetchTranscripts}
-        />
-        <SummaryPanel
-          meeting={meeting}
-          meetingTitle={meetingData.meetingTitle}
-          onTitleChange={meetingData.handleTitleChange}
-          isEditingTitle={meetingData.isEditingTitle}
-          onStartEditTitle={() => meetingData.setIsEditingTitle(true)}
-          onFinishEditTitle={() => meetingData.setIsEditingTitle(false)}
-          isTitleDirty={meetingData.isTitleDirty}
-          summaryRef={meetingData.blockNoteSummaryRef}
-          isSaving={meetingData.isSaving}
-          onSaveAll={meetingData.saveAllChanges}
-          onCopySummary={copyOperations.handleCopySummary}
-          onOpenFolder={meetingOperations.handleOpenMeetingFolder}
-          aiSummary={meetingData.aiSummary}
-          summaryStatus={summaryGeneration.summaryStatus}
-          transcripts={meetingData.transcripts}
-          modelConfig={modelConfig}
-          setModelConfig={setModelConfig}
-          onSaveModelConfig={handleSaveModelConfig}
-          onGenerateSummary={summaryGeneration.handleGenerateSummary}
-          onStopGeneration={summaryGeneration.handleStopGeneration}
-          customPrompt={customPrompt}
-          summaryResponse={summaryResponse}
-          onSaveSummary={meetingData.handleSaveSummary}
-          onSummaryChange={meetingData.handleSummaryChange}
-          onDirtyChange={meetingData.setIsSummaryDirty}
-          summaryError={summaryGeneration.summaryError}
-          onRegenerateSummary={summaryGeneration.handleRegenerateSummary}
-          getSummaryStatusMessage={summaryGeneration.getSummaryStatusMessage}
-          availableTemplates={templates.availableTemplates}
-          selectedTemplate={templates.selectedTemplate}
-          onTemplateSelect={templates.handleTemplateSelection}
-          isModelConfigLoading={false}
-          onOpenModelSettings={handleRegisterModalOpen}
+      <div className="flex flex-1 min-w-0 overflow-hidden">
+        <MeetingDetailsSplitView
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
+          transcript={
+            <TranscriptPanel
+              transcripts={meetingData.transcripts}
+              customPrompt={customPrompt}
+              onPromptChange={setCustomPrompt}
+              onCopyTranscript={copyOperations.handleCopyTranscript}
+              onOpenMeetingFolder={meetingOperations.handleOpenMeetingFolder}
+              isRecording={isRecording}
+              disableAutoScroll={true}
+              usePagination={true}
+              segments={segments}
+              hasMore={hasMore}
+              isLoadingMore={isLoadingMore}
+              totalCount={totalCount}
+              loadedCount={loadedCount}
+              onLoadMore={onLoadMore}
+              meetingId={meeting.id}
+              meetingFolderPath={meeting.folder_path}
+              onRefetchTranscripts={onRefetchTranscripts}
+            />
+          }
+          summary={
+            <SummaryPanel
+              meeting={meeting}
+              meetingTitle={meetingData.meetingTitle}
+              onTitleChange={meetingData.handleTitleChange}
+              isEditingTitle={meetingData.isEditingTitle}
+              onStartEditTitle={() => meetingData.setIsEditingTitle(true)}
+              onFinishEditTitle={() => meetingData.setIsEditingTitle(false)}
+              isTitleDirty={meetingData.isTitleDirty}
+              summaryRef={meetingData.blockNoteSummaryRef}
+              isSaving={meetingData.isSaving}
+              onSaveAll={meetingData.saveAllChanges}
+              onCopySummary={copyOperations.handleCopySummary}
+              onOpenFolder={meetingOperations.handleOpenMeetingFolder}
+              aiSummary={meetingData.aiSummary}
+              summaryStatus={summaryGeneration.summaryStatus}
+              transcripts={meetingData.transcripts}
+              modelConfig={modelConfig}
+              setModelConfig={setModelConfig}
+              onSaveModelConfig={handleSaveModelConfig}
+              onGenerateSummary={summaryGeneration.handleGenerateSummary}
+              onStopGeneration={summaryGeneration.handleStopGeneration}
+              customPrompt={customPrompt}
+              summaryResponse={summaryResponse}
+              onSaveSummary={meetingData.handleSaveSummary}
+              onSummaryChange={meetingData.handleSummaryChange}
+              onDirtyChange={meetingData.setIsSummaryDirty}
+              summaryError={summaryGeneration.summaryError}
+              onRegenerateSummary={summaryGeneration.handleRegenerateSummary}
+              getSummaryStatusMessage={summaryGeneration.getSummaryStatusMessage}
+              availableTemplates={templates.availableTemplates}
+              selectedTemplate={templates.selectedTemplate}
+              onTemplateSelect={templates.handleTemplateSelection}
+              isModelConfigLoading={false}
+              onOpenModelSettings={handleRegisterModalOpen}
+            />
+          }
         />
       </div>
     </motion.div>

--- a/frontend/src/components/Logo.tsx
+++ b/frontend/src/components/Logo.tsx
@@ -5,34 +5,60 @@ import { VisuallyHidden } from "./ui/visually-hidden";
 import { About } from "./About";
 
 interface LogoProps {
-    isCollapsed: boolean;
+  isCollapsed: boolean;
 }
 
-const Logo = React.forwardRef<HTMLButtonElement, LogoProps>(({ isCollapsed }, ref) => {
-  return (
-    <Dialog aria-describedby={undefined}>
-      {isCollapsed ? (
-        <DialogTrigger asChild>
-          <button ref={ref} className="flex items-center justify-start mb-2 cursor-pointer bg-transparent border-none p-0 hover:opacity-80 transition-opacity">
-            <Image src="/logo-collapsed.png" alt="Logo" width={40} height={32} />
-          </button>
-        </DialogTrigger>
-      ) : (
-        <DialogTrigger asChild>
-          <span className="text-lg text-center border rounded-full bg-blue-50 border-white font-semibold text-gray-700 mb-2 block items-center cursor-pointer hover:opacity-80 transition-opacity">
-            <span>Meetily</span>
-          </span>
-        </DialogTrigger>
-      )}
-      <DialogContent>
-        <VisuallyHidden>
-          <DialogTitle>About Meetily</DialogTitle>
-        </VisuallyHidden>
-        <About />
-      </DialogContent>
-    </Dialog>
-  );
-});
+const Logo = React.forwardRef<HTMLButtonElement, LogoProps>(
+  ({ isCollapsed }, ref) => {
+    return (
+      <Dialog aria-describedby={undefined}>
+        {isCollapsed ? (
+          <DialogTrigger asChild>
+            <button
+              ref={ref}
+              type="button"
+              className="flex items-center justify-center mb-2 cursor-pointer bg-transparent border-none p-0 hover:opacity-80 transition-opacity"
+              aria-label="About Meetily"
+            >
+              <Image
+                src="/logo-collapsed.png"
+                alt="Meetily"
+                width={40}
+                height={40}
+                className="object-contain"
+                priority
+              />
+            </button>
+          </DialogTrigger>
+        ) : (
+          <DialogTrigger asChild>
+            <button
+              ref={ref}
+              type="button"
+              className="mb-2 flex w-full cursor-pointer items-center justify-center bg-transparent border-none p-0 hover:opacity-80 transition-opacity"
+              aria-label="About Meetily"
+            >
+              <Image
+                src="/logo.png"
+                alt="Meetily"
+                width={137}
+                height={48}
+                className="h-9 w-auto object-contain"
+                priority
+              />
+            </button>
+          </DialogTrigger>
+        )}
+        <DialogContent>
+          <VisuallyHidden>
+            <DialogTitle>About Meetily</DialogTitle>
+          </VisuallyHidden>
+          <About />
+        </DialogContent>
+      </Dialog>
+    );
+  },
+);
 
 Logo.displayName = "Logo";
 

--- a/frontend/src/components/MainContent/index.tsx
+++ b/frontend/src/components/MainContent/index.tsx
@@ -11,12 +11,12 @@ const MainContent: React.FC<MainContentProps> = ({ children }) => {
   const { isCollapsed } = useSidebar();
 
   return (
-    <main 
-      className={`flex-1 transition-all duration-300 ${
+    <main
+      className={`flex-1 min-w-0 overflow-hidden transition-all duration-300 ${
         isCollapsed ? 'ml-16' : 'ml-64'
       }`}
     >
-      <div className="pl-8">
+      <div className="pl-8 min-w-0 w-full max-w-full overflow-hidden">
         {children}
       </div>
     </main>

--- a/frontend/src/components/MeetingDetails/MeetingDetailsSplitView.tsx
+++ b/frontend/src/components/MeetingDetails/MeetingDetailsSplitView.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { FileText, Sparkles } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+
+const STORAGE_KEY = 'meetily.meetingDetails.transcriptPaneRatio';
+const DEFAULT_RATIO = 0.3;
+const MIN_RATIO = 0.2;
+const MAX_RATIO = 0.5;
+
+const TABS = [
+  { value: 'transcript' as const, label: 'Transcript', icon: FileText },
+  { value: 'summary' as const, label: 'Summary', icon: Sparkles },
+];
+
+function readStoredRatio(): number {
+  if (typeof window === 'undefined') return DEFAULT_RATIO;
+  const raw = localStorage.getItem(STORAGE_KEY);
+  const n = raw == null ? NaN : Number(raw);
+  if (!Number.isFinite(n) || n < MIN_RATIO || n > MAX_RATIO) return DEFAULT_RATIO;
+  return n;
+}
+
+export type MeetingDetailsTab = 'transcript' | 'summary';
+
+interface MeetingDetailsSplitViewProps {
+  transcript: ReactNode;
+  summary: ReactNode;
+  activeTab: MeetingDetailsTab;
+  onTabChange: (tab: MeetingDetailsTab) => void;
+}
+
+/**
+ * Desktop: side-by-side panes with a light, hover-emphasized drag separator.
+ * Small screens: Settings-style Transcript / Summary tabs (one panel mounted).
+ */
+export function MeetingDetailsSplitView({
+  transcript,
+  summary,
+  activeTab,
+  onTabChange,
+}: MeetingDetailsSplitViewProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [ratio, setRatio] = useState(DEFAULT_RATIO);
+  const [isDesktop, setIsDesktop] = useState(true);
+  const [underlineStyle, setUnderlineStyle] = useState({ left: 0, width: 0 });
+  const dragging = useRef(false);
+
+  useEffect(() => {
+    setRatio(readStoredRatio());
+  }, []);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(min-width: 768px)');
+    const updateLayout = () => setIsDesktop(mediaQuery.matches);
+
+    updateLayout();
+    mediaQuery.addEventListener('change', updateLayout);
+    return () => mediaQuery.removeEventListener('change', updateLayout);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (isDesktop) return;
+    const activeIndex = TABS.findIndex((tab) => tab.value === activeTab);
+    const activeTabElement = tabRefs.current[activeIndex];
+    if (activeTabElement) {
+      const { offsetLeft, offsetWidth } = activeTabElement;
+      setUnderlineStyle({ left: offsetLeft, width: offsetWidth });
+    }
+  }, [activeTab, isDesktop]);
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    dragging.current = true;
+    (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+  }, []);
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    if (!dragging.current || !containerRef.current) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const next = (e.clientX - rect.left) / rect.width;
+    const clamped = Math.min(MAX_RATIO, Math.max(MIN_RATIO, next));
+    setRatio(clamped);
+  }, []);
+
+  const onPointerUp = useCallback(() => {
+    if (!dragging.current) return;
+    dragging.current = false;
+    setRatio((r) => {
+      localStorage.setItem(STORAGE_KEY, String(r));
+      return r;
+    });
+  }, []);
+
+  if (isDesktop) {
+    return (
+      <div
+        ref={containerRef}
+        className="flex flex-1 min-w-0 overflow-hidden"
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+      >
+        <div
+          className="min-w-0 h-full flex flex-col overflow-hidden"
+          style={{ width: `${ratio * 100}%`, flexShrink: 0 }}
+        >
+          {transcript}
+        </div>
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-valuenow={Math.round(ratio * 100)}
+          aria-valuemin={Math.round(MIN_RATIO * 100)}
+          aria-valuemax={Math.round(MAX_RATIO * 100)}
+          aria-label="Resize transcript and summary"
+          tabIndex={0}
+          className="group relative z-10 flex w-2 flex-shrink-0 cursor-col-resize items-stretch justify-center"
+          onPointerDown={onPointerDown}
+        >
+          <div
+            className="h-full w-px bg-gray-200 transition-[width,background-color] duration-150 ease-out group-hover:w-1 group-hover:bg-blue-400 group-active:w-1 group-active:bg-blue-500"
+          />
+        </div>
+        <div className="flex-1 min-w-0 h-full flex flex-col overflow-hidden">
+          {summary}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 min-w-0 flex-col overflow-hidden">
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => onTabChange(v as MeetingDetailsTab)}
+        className="flex flex-1 min-w-0 flex-col overflow-hidden"
+      >
+        <div className="bg-white px-2 shrink-0">
+          <TabsList className="bg-transparent relative rounded-none border-b border-gray-200 p-0 h-auto w-full justify-start">
+            {TABS.map((tab, index) => {
+              const Icon = tab.icon;
+              return (
+                <TabsTrigger
+                  key={tab.value}
+                  value={tab.value}
+                  ref={(el) => {
+                    tabRefs.current[index] = el;
+                  }}
+                  className="flex items-center gap-2 px-6 py-4 bg-transparent rounded-none border-0 data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:shadow-none text-gray-600 hover:text-gray-900 relative z-10"
+                >
+                  <Icon className="w-4 h-4" />
+                  {tab.label}
+                </TabsTrigger>
+              );
+            })}
+            <motion.div
+              className="absolute bottom-0 z-20 h-0.5 bg-blue-600"
+              layoutId="meeting-details-underline"
+              style={{ left: underlineStyle.left, width: underlineStyle.width }}
+              transition={{ type: 'spring', stiffness: 400, damping: 40 }}
+            />
+          </TabsList>
+        </div>
+        <div className="flex-1 min-h-0 min-w-0 overflow-hidden">
+          {activeTab === 'transcript' ? transcript : summary}
+        </div>
+      </Tabs>
+    </div>
+  );
+}

--- a/frontend/src/components/MeetingDetails/SummaryGeneratorButtonGroup.tsx
+++ b/frontend/src/components/MeetingDetails/SummaryGeneratorButtonGroup.tsx
@@ -249,21 +249,21 @@ export function SummaryGeneratorButtonGroup({
         <Button
           variant="outline"
           size="sm"
-          className="bg-gradient-to-r from-red-50 to-orange-50 hover:from-red-100 hover:to-orange-100 border-red-200 xl:px-4"
+          className="bg-gradient-to-r from-red-50 to-orange-50 hover:from-red-100 hover:to-orange-100 border-red-200 @[40rem]:px-4"
           onClick={() => {
             Analytics.trackButtonClick('stop_summary_generation', 'meeting_details');
             onStopGeneration();
           }}
           title="Stop summary generation"
         >
-          <Square className="xl:mr-2" size={18} fill="currentColor" />
-          <span className="hidden lg:inline xl:inline">Stop</span>
+          <Square className="@[40rem]:mr-2" size={18} fill="currentColor" />
+          <span className="hidden @[40rem]:inline">Stop</span>
         </Button>
       ) : (
         <Button
           variant="outline"
           size="sm"
-          className="bg-gradient-to-r from-blue-50 to-purple-50 hover:from-blue-100 hover:to-purple-100 border-blue-200 xl:px-4"
+          className="bg-gradient-to-r from-blue-50 to-purple-50 hover:from-blue-100 hover:to-purple-100 border-blue-200 @[40rem]:px-4"
           onClick={() => {
             Analytics.trackButtonClick('generate_summary', 'meeting_details');
             checkOllamaModelsAndGenerate();
@@ -279,13 +279,13 @@ export function SummaryGeneratorButtonGroup({
         >
           {isCheckingModels || isModelConfigLoading ? (
             <>
-              <Loader2 className="animate-spin xl:mr-2" size={18} />
-              <span className="hidden xl:inline">Processing...</span>
+              <Loader2 className="animate-spin @[40rem]:mr-2" size={18} />
+              <span className="hidden @[40rem]:inline">Processing...</span>
             </>
           ) : (
             <>
-              <Sparkles className="xl:mr-2" size={18} />
-              <span className="hidden lg:inline xl:inline">{hasSummary ? 'Regenerate Summary' : 'Generate Summary'}</span>
+              <Sparkles className="@[40rem]:mr-2" size={18} />
+              <span className="hidden @[40rem]:inline">{hasSummary ? 'Regenerate' : 'Generate'}</span>
             </>
           )}
         </Button>
@@ -302,7 +302,7 @@ export function SummaryGeneratorButtonGroup({
             title="Summary Settings"
           >
             <Settings />
-            <span className="hidden lg:inline">AI Model</span>
+            <span className="hidden @[40rem]:inline">AI Model</span>
           </Button>
         </DialogTrigger>
         <DialogContent
@@ -334,7 +334,7 @@ export function SummaryGeneratorButtonGroup({
               title="Select summary template"
             >
               <FileText />
-              <span className="hidden lg:inline">Template</span>
+              <span className="hidden @[40rem]:inline">Template</span>
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">

--- a/frontend/src/components/MeetingDetails/SummaryPanel.tsx
+++ b/frontend/src/components/MeetingDetails/SummaryPanel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Summary, SummaryResponse, Transcript } from '@/types';
-import { EditableTitle } from '@/components/EditableTitle';
 import { BlockNoteSummaryView, BlockNoteSummaryViewRef } from '@/components/AISummary/BlockNoteSummaryView';
 import { EmptyStateSummary } from '@/components/EmptyStateSummary';
 import { ModelConfig } from '@/components/ModelSettingsModal';
@@ -21,6 +20,7 @@ import {
   saveMeetingSummaryLanguage,
   SummaryLanguageStorage,
 } from '@/lib/summary-language-preferences';
+import { cn } from '@/lib/utils';
 
 interface SummaryPanelProps {
   meeting: {
@@ -60,6 +60,7 @@ interface SummaryPanelProps {
   onTemplateSelect: (templateId: string, templateName: string) => void;
   isModelConfigLoading?: boolean;
   onOpenModelSettings?: (openFn: () => void) => void;
+  className?: string;
 }
 
 export function SummaryPanel({
@@ -95,7 +96,8 @@ export function SummaryPanel({
   selectedTemplate,
   onTemplateSelect,
   isModelConfigLoading = false,
-  onOpenModelSettings
+  onOpenModelSettings,
+  className,
 }: SummaryPanelProps) {
   const [summaryLang, setSummaryLang] = useState<string | null>(null);
   const [summaryLangStorage, setSummaryLangStorage] = useState<SummaryLanguageStorage>('metadata');
@@ -234,7 +236,7 @@ export function SummaryPanel({
           aria-label="Set summary language"
         >
           <Languages size={18} />
-          <span className="hidden lg:inline">{effectiveLangLabel}</span>
+          <span className="hidden @[40rem]:inline">{effectiveLangLabel}</span>
           <ChevronDown size={14} className="text-gray-400" />
         </Button>
       </PopoverTrigger>
@@ -253,42 +255,31 @@ export function SummaryPanel({
   );
 
   return (
-    <div className="flex-1 min-w-0 flex flex-col bg-white overflow-hidden">
-      {/* Title area */}
+    <div className={cn("flex-1 min-w-0 flex flex-col bg-white overflow-hidden h-full w-full @container", className)}>
+      {/* Top-level actions — always visible, same pattern as TranscriptPanel */}
       <div className="p-4 border-b border-gray-200">
-        {/* <EditableTitle
-          title={meetingTitle}
-          isEditing={isEditingTitle}
-          onStartEditing={onStartEditTitle}
-          onFinishEditing={onFinishEditTitle}
-          onChange={onTitleChange}
-        /> */}
+        <div className="flex items-center justify-center w-full min-w-0 gap-2 flex-wrap">
+          <div className="flex-shrink-0 min-w-0">
+            <SummaryGeneratorButtonGroup
+              modelConfig={modelConfig}
+              setModelConfig={setModelConfig}
+              onSaveModelConfig={onSaveModelConfig}
+              onGenerateSummary={onGenerateSummary}
+              onStopGeneration={onStopGeneration}
+              customPrompt={customPrompt}
+              summaryStatus={summaryStatus}
+              availableTemplates={availableTemplates}
+              selectedTemplate={selectedTemplate}
+              onTemplateSelect={onTemplateSelect}
+              hasTranscripts={transcripts.length > 0}
+              hasSummary={!!aiSummary}
+              isModelConfigLoading={isModelConfigLoading}
+              onOpenModelSettings={onOpenModelSettings}
+              languageSlot={transcripts.length > 0 || !!aiSummary ? languageSlot : undefined}
+            />
+          </div>
 
-        {/* Button groups - only show when summary exists */}
-        {aiSummary && !isSummaryLoading && (
-          <div className="flex items-center justify-center w-full pt-0 gap-2">
-            {/* Left-aligned: Summary Generator Button Group */}
-            <div className="flex-shrink-0">
-              <SummaryGeneratorButtonGroup
-                modelConfig={modelConfig}
-                setModelConfig={setModelConfig}
-                onSaveModelConfig={onSaveModelConfig}
-                onGenerateSummary={onGenerateSummary}
-                onStopGeneration={onStopGeneration}
-                customPrompt={customPrompt}
-                summaryStatus={summaryStatus}
-                availableTemplates={availableTemplates}
-                selectedTemplate={selectedTemplate}
-                onTemplateSelect={onTemplateSelect}
-                hasTranscripts={transcripts.length > 0}
-                hasSummary={!!aiSummary}
-                isModelConfigLoading={isModelConfigLoading}
-                onOpenModelSettings={onOpenModelSettings}
-                languageSlot={languageSlot}
-              />
-            </div>
-
-            {/* Right-aligned: Summary Updater Button Group */}
+          {aiSummary && !isSummaryLoading && (
             <div className="flex-shrink-0">
               <SummaryUpdaterButtonGroup
                 isSaving={isSaving}
@@ -303,69 +294,25 @@ export function SummaryPanel({
                 hasSummary={!!aiSummary}
               />
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
 
       {isSummaryLoading ? (
-        <div className="flex flex-col h-full">
-          {/* Show button group during generation */}
-          <div className="flex items-center justify-center pt-8 pb-4">
-            <SummaryGeneratorButtonGroup
-              modelConfig={modelConfig}
-              setModelConfig={setModelConfig}
-              onSaveModelConfig={onSaveModelConfig}
-              onGenerateSummary={onGenerateSummary}
-              onStopGeneration={onStopGeneration}
-              customPrompt={customPrompt}
-              summaryStatus={summaryStatus}
-              availableTemplates={availableTemplates}
-              selectedTemplate={selectedTemplate}
-              onTemplateSelect={onTemplateSelect}
-              hasTranscripts={transcripts.length > 0}
-              isModelConfigLoading={isModelConfigLoading}
-              onOpenModelSettings={onOpenModelSettings}
-            />
-          </div>
-          {/* Loading spinner */}
-          <div className="flex items-center justify-center flex-1">
-            <div className="text-center">
-              <div className="inline-block animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500 mb-4"></div>
-              <p className="text-gray-600">Generating AI Summary...</p>
-            </div>
+        <div className="flex items-center justify-center flex-1">
+          <div className="text-center">
+            <div className="inline-block animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500 mb-4"></div>
+            <p className="text-gray-600">Generating AI Summary...</p>
           </div>
         </div>
       ) : !aiSummary ? (
-        <div className="flex flex-col h-full">
-          {/* Centered Summary Generator Button Group when no summary */}
-          <div className="flex items-center justify-center gap-2 pt-8 pb-4">
-            <SummaryGeneratorButtonGroup
-              modelConfig={modelConfig}
-              setModelConfig={setModelConfig}
-              onSaveModelConfig={onSaveModelConfig}
-              onGenerateSummary={onGenerateSummary}
-              onStopGeneration={onStopGeneration}
-              customPrompt={customPrompt}
-              summaryStatus={summaryStatus}
-              availableTemplates={availableTemplates}
-              selectedTemplate={selectedTemplate}
-              onTemplateSelect={onTemplateSelect}
-              hasTranscripts={transcripts.length > 0}
-              hasSummary={false}
-              isModelConfigLoading={isModelConfigLoading}
-              onOpenModelSettings={onOpenModelSettings}
-              languageSlot={transcripts.length > 0 ? languageSlot : undefined}
-            />
-          </div>
-          {/* Empty state message */}
-          <EmptyStateSummary
-            onGenerate={() => onGenerateSummary(customPrompt)}
-            hasModel={modelConfig.provider !== null && modelConfig.model !== null}
-            isGenerating={isSummaryLoading}
-          />
-        </div>
-      ) : transcripts?.length > 0 && (
-        <div className="flex-1 overflow-y-auto min-h-0">
+        <EmptyStateSummary
+          onGenerate={() => onGenerateSummary(customPrompt)}
+          hasModel={modelConfig.provider !== null && modelConfig.model !== null}
+          isGenerating={isSummaryLoading}
+        />
+      ) : (
+        <div className="flex-1 overflow-y-auto overflow-x-auto min-h-0">
           {summaryResponse && (
             <div className="fixed bottom-0 left-0 right-0 bg-white shadow-lg p-4 max-h-1/3 overflow-y-auto">
               <h3 className="text-lg font-semibold mb-2">Meeting Summary</h3>

--- a/frontend/src/components/MeetingDetails/SummaryUpdaterButtonGroup.tsx
+++ b/frontend/src/components/MeetingDetails/SummaryUpdaterButtonGroup.tsx
@@ -41,12 +41,12 @@ export function SummaryUpdaterButtonGroup({
         {isSaving ? (
           <>
             <Loader2 className="animate-spin" />
-            <span className="hidden lg:inline">Saving...</span>
+            <span className="hidden @[40rem]:inline">Saving...</span>
           </>
         ) : (
           <>
             <Save />
-            <span className="hidden lg:inline">Save</span>
+            <span className="hidden @[40rem]:inline">Save</span>
           </>
         )}
       </Button>
@@ -64,7 +64,7 @@ export function SummaryUpdaterButtonGroup({
         className="cursor-pointer"
       >
         <Copy />
-        <span className="hidden lg:inline">Copy</span>
+        <span className="hidden @[40rem]:inline">Copy</span>
       </Button>
 
       {/* Find button */}
@@ -81,7 +81,7 @@ export function SummaryUpdaterButtonGroup({
           className="cursor-pointer"
         >
           <Search />
-          <span className="hidden lg:inline">Find</span>
+          <span className="hidden @[40rem]:inline">Find</span>
         </Button>
       )} */}
     </ButtonGroup>

--- a/frontend/src/components/MeetingDetails/TranscriptButtonGroup.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptButtonGroup.tsx
@@ -51,36 +51,36 @@ export function TranscriptButtonGroup({
           title={transcriptCount === 0 ? 'No transcript available' : 'Copy Transcript'}
         >
           <Copy />
-          <span className="hidden lg:inline">Copy</span>
+          <span className="hidden @[20rem]:inline">Copy</span>
         </Button>
 
         <Button
           size="sm"
           variant="outline"
-          className="xl:px-4"
+          className="@[20rem]:px-4"
           onClick={() => {
             Analytics.trackButtonClick('open_recording_folder', 'meeting_details');
             onOpenMeetingFolder();
           }}
           title="Open Recording Folder"
         >
-          <FolderOpen className="xl:mr-2" size={18} />
-          <span className="hidden lg:inline">Recording</span>
+          <FolderOpen className="@[20rem]:mr-2" size={18} />
+          <span className="hidden @[20rem]:inline">Recording</span>
         </Button>
 
         {betaFeatures.importAndRetranscribe && meetingId && meetingFolderPath && (
           <Button
             size="sm"
             variant="outline"
-            className="bg-gradient-to-r from-blue-50 to-purple-50 hover:from-blue-100 hover:to-purple-100 border-blue-200 xl:px-4"
+            className="bg-gradient-to-r from-blue-50 to-purple-50 hover:from-blue-100 hover:to-purple-100 border-blue-200 @[20rem]:px-4"
             onClick={() => {
               Analytics.trackButtonClick('enhance_transcript', 'meeting_details');
               setShowRetranscribeDialog(true);
             }}
             title="Retranscribe to enhance your recorded audio"
           >
-            <RefreshCw className="xl:mr-2" size={18} />
-            <span className="hidden lg:inline">Enhance</span>
+            <RefreshCw className="@[20rem]:mr-2" size={18} />
+            <span className="hidden @[20rem]:inline">Enhance</span>
           </Button>
         )}
       </ButtonGroup>

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -5,6 +5,7 @@ import { TranscriptView } from '@/components/TranscriptView';
 import { VirtualizedTranscriptView } from '@/components/VirtualizedTranscriptView';
 import { TranscriptButtonGroup } from './TranscriptButtonGroup';
 import { useMemo } from 'react';
+import { cn } from '@/lib/utils';
 
 interface TranscriptPanelProps {
   transcripts: Transcript[];
@@ -23,6 +24,7 @@ interface TranscriptPanelProps {
   totalCount?: number;
   loadedCount?: number;
   onLoadMore?: () => void;
+  className?: string;
 
   // Retranscription props
   meetingId?: string;
@@ -45,6 +47,7 @@ export function TranscriptPanel({
   totalCount,
   loadedCount,
   onLoadMore,
+  className,
   meetingId,
   meetingFolderPath,
   onRefetchTranscripts,
@@ -65,7 +68,7 @@ export function TranscriptPanel({
   }, [transcripts, usePagination, segments]);
 
   return (
-    <div className="hidden md:flex md:w-1/4 lg:w-1/3 min-w-0 border-r border-gray-200 bg-white flex-col relative shrink-0">
+    <div className={cn("flex h-full min-w-0 w-full bg-white flex-col relative @container", className)}>
       {/* Title area */}
       <div className="p-4 border-b border-gray-200">
         <TranscriptButtonGroup

--- a/frontend/src/hooks/meeting-details/useSummaryGeneration.ts
+++ b/frontend/src/hooks/meeting-details/useSummaryGeneration.ts
@@ -274,12 +274,22 @@ export function useSummaryGeneration({
           // Check if backend returned markdown format (new flow)
           if (pollingResult.data.markdown) {
             console.log('Received markdown format from backend');
-            setAiSummary({ markdown: pollingResult.data.markdown } as any);
+            setAiSummary({
+              markdown: pollingResult.data.markdown,
+              ...(pollingResult.data.reasoning_stripped
+                ? {
+                    reasoning_stripped: true,
+                    reasoning: pollingResult.data.reasoning,
+                  }
+                : {}),
+            } as any);
             setSummaryStatus('completed');
 
             // Show success toast
             toast.success('Summary generated successfully!', {
-              description: 'Your meeting summary is ready',
+              description: pollingResult.data.reasoning_stripped
+                ? 'Your meeting summary is ready. Model reasoning was filtered out of the notes.'
+                : 'Your meeting summary is ready',
               duration: 4000,
             });
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -85,5 +85,8 @@ module.exports = {
   		}
   	}
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [
+    require("tailwindcss-animate"),
+    require("@tailwindcss/container-queries"),
+  ],
 }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -29,5 +29,6 @@ export default {
   },
   plugins: [
     require('@tailwindcss/typography'),
+    require('@tailwindcss/container-queries'),
   ],
 } satisfies Config;


### PR DESCRIPTION
## Description
Fixes meeting-details layout and Ollama thinking-model summary handling for #592.

**UI / layout**
- Adds a resizable transcript/summary split view (`MeetingDetailsSplitView`) with Settings-style tabs
- Keeps summary actions in the top toolbar when the summary is empty
- Uses container queries so action label sizing follows panel width
- Minor Logo / MainContent adjustments for the new layout

**Summary / Ollama**
- Leaves Ollama reasoning enabled (does not send `reasoning_effort: none`) so thinking models can reason
- Strips reasoning from the saved notes summary
- Surfaces `reasoning_stripped` / `reasoning` to the frontend and notifies the user when reasoning was filtered out
- Folds separate Ollama `reasoning` into `<think>` so existing cleaners can extract it

## Related Issue
Fixes #592

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] All tests pass

### Manual test plan
- [ ] Open meeting details: transcript/summary split is resizable; tabs match Settings-style behavior
- [ ] Empty summary: generate actions stay in the top toolbar
- [ ] Narrow/wide panels: action labels size correctly via container queries
- [ ] Generate summary with a non-thinking Ollama model: summary looks normal; no “reasoning filtered” toast
- [ ] Generate summary with a thinking Ollama model (e.g. qwen3): notes exclude thinking text; toast notes reasoning was filtered
- [ ] Confirm saved summary in the meeting does not retain `<think>` / raw reasoning blocks

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)
[Add before/after screenshots of the meeting-details split layout]

## Additional Notes
Commits on this branch:
- `6e2a8ef` — `fix(ui): meeting-details split layout, toolbars, and container queries`
- `2f28bb8` — `fix(summary): keep Ollama reasoning enabled and strip it for notes`

Base branch: `devtest` (not `main`), per CONTRIBUTING.md.