### PR TITLE
Add Google Calendar integration and Google Meet auto-detect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3620,6 +3620,7 @@ dependencies = [
  "chrono",
  "cidre",
  "clap 4.6.1",
+ "core-foundation 0.9.4",
  "core-graphics 0.23.2",
  "cpal",
  "criterion",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -169,6 +169,7 @@ anyhow = "1.0"
 time = { version = "0.3", features = ["formatting"] }
 reqwest = { version = "0.11", features = ["multipart", "json"] }
 core-graphics = "0.23"
+core-foundation = "0.9"
 cidre = { git = "https://github.com/yury/cidre", rev = "a9587fa", features = ["av"] }
 dasp = "0.11.0"
 futures-channel = "0.3.31"

--- a/frontend/src-tauri/migrations/20260721000000_add_calendar_integration.sql
+++ b/frontend/src-tauri/migrations/20260721000000_add_calendar_integration.sql
@@ -1,0 +1,14 @@
+-- Migration: Add Google Calendar integration support
+
+-- Calendar-derived metadata on a meeting, written after a match against a Google Calendar event
+ALTER TABLE meetings ADD COLUMN calendar_event_id TEXT;
+ALTER TABLE meetings ADD COLUMN calendar_attendees TEXT; -- JSON array of {name, email}
+ALTER TABLE meetings ADD COLUMN calendar_meet_link TEXT;
+ALTER TABLE meetings ADD COLUMN calendar_start_time TEXT;
+ALTER TABLE meetings ADD COLUMN calendar_end_time TEXT;
+
+-- Google OAuth token bundle: {client_id, client_secret, access_token, refresh_token, token_expiry, scope}
+ALTER TABLE settings ADD COLUMN googleCalendarConfig TEXT;
+
+-- Phase B toggle: auto-start/stop recording on detected Google Meet calls
+ALTER TABLE settings ADD COLUMN autoDetectMeetEnabled INTEGER DEFAULT 0;

--- a/frontend/src-tauri/src/api/api.rs
+++ b/frontend/src-tauri/src/api/api.rs
@@ -123,6 +123,14 @@ pub struct MeetingDetails {
     pub created_at: String,
     pub updated_at: String,
     pub transcripts: Vec<MeetingTranscript>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub calendar_attendees: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub calendar_meet_link: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub calendar_start_time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub calendar_end_time: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -148,6 +156,14 @@ pub struct MeetingMetadata {
     pub updated_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub folder_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub calendar_attendees: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub calendar_meet_link: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub calendar_start_time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub calendar_end_time: Option<String>,
 }
 
 /// Paginated transcripts response with total count
@@ -828,6 +844,10 @@ pub async fn api_get_meeting_metadata<R: Runtime>(
                 created_at: meeting.created_at.0.to_rfc3339(),
                 updated_at: meeting.updated_at.0.to_rfc3339(),
                 folder_path: meeting.folder_path,
+                calendar_attendees: meeting.calendar_attendees,
+                calendar_meet_link: meeting.calendar_meet_link,
+                calendar_start_time: meeting.calendar_start_time,
+                calendar_end_time: meeting.calendar_end_time,
             })
         }
         Ok(None) => {

--- a/frontend/src-tauri/src/audio/permissions.rs
+++ b/frontend/src-tauri/src/audio/permissions.rs
@@ -144,6 +144,52 @@ pub async fn trigger_system_audio_permission_command() -> Result<bool, String> {
     .map_err(|e| e.to_string())
 }
 
+// The *real* macOS Screen Recording (TCC) permission — distinct from the "Audio Capture"
+// permission above despite the similar name. This one gates whether
+// `CGWindowListCopyWindowInfo` can return other apps' window titles (`kCGWindowName`),
+// which the Google Meet auto-detect feature needs to read browser tab titles.
+#[cfg(target_os = "macos")]
+extern "C" {
+    fn CGPreflightScreenCaptureAccess() -> bool;
+    fn CGRequestScreenCaptureAccess() -> bool;
+}
+
+#[cfg(target_os = "macos")]
+pub fn check_window_title_read_permission() -> bool {
+    unsafe { CGPreflightScreenCaptureAccess() }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn check_window_title_read_permission() -> bool {
+    true // Not required on other platforms; auto-detect is macOS-only anyway
+}
+
+/// Prompts the user for Screen Recording permission via macOS's built-in system dialog.
+/// Unlike Audio Capture, granting this does NOT require an app restart.
+#[cfg(target_os = "macos")]
+pub fn request_window_title_read_permission() -> bool {
+    info!("🔐 Requesting Screen Recording permission (for reading browser window titles)...");
+    unsafe { CGRequestScreenCaptureAccess() }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn request_window_title_read_permission() -> bool {
+    true
+}
+
+#[tauri::command]
+pub async fn check_window_title_read_permission_command() -> bool {
+    check_window_title_read_permission()
+}
+
+#[tauri::command]
+pub async fn request_window_title_read_permission_command() -> bool {
+    // CGRequestScreenCaptureAccess can block briefly showing the system dialog.
+    tokio::task::spawn_blocking(request_window_title_read_permission)
+        .await
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/frontend/src-tauri/src/calendar/client.rs
+++ b/frontend/src-tauri/src/calendar/client.rs
@@ -69,6 +69,9 @@ pub async fn list_meet_events(
             ("timeMax", time_max.to_rfc3339()),
             ("singleEvents", "true".to_string()),
             ("orderBy", "startTime".to_string()),
+            // Without this, Google omits `conferenceData` entirely from every event regardless
+            // of whether it has a Meet link — which silently broke all Meet-link matching.
+            ("conferenceDataVersion", "1".to_string()),
         ])
         .send()
         .await?;

--- a/frontend/src-tauri/src/calendar/client.rs
+++ b/frontend/src-tauri/src/calendar/client.rs
@@ -1,0 +1,116 @@
+// Minimal Google Calendar API v3 client — only what's needed to find Meet-linked events.
+
+use super::{Attendee, CalendarEvent};
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+const EVENTS_ENDPOINT: &str = "https://www.googleapis.com/calendar/v3/calendars/primary/events";
+
+#[derive(Debug, Deserialize)]
+struct EventsListResponse {
+    #[serde(default)]
+    items: Vec<RawEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawEvent {
+    id: String,
+    #[serde(default)]
+    summary: Option<String>,
+    start: RawEventTime,
+    end: RawEventTime,
+    #[serde(default)]
+    attendees: Vec<RawAttendee>,
+    #[serde(default, rename = "conferenceData")]
+    conference_data: Option<RawConferenceData>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawEventTime {
+    #[serde(rename = "dateTime")]
+    date_time: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawAttendee {
+    email: String,
+    #[serde(rename = "displayName")]
+    display_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawConferenceData {
+    #[serde(default, rename = "entryPoints")]
+    entry_points: Vec<RawEntryPoint>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawEntryPoint {
+    #[serde(rename = "entryPointType")]
+    entry_point_type: String,
+    uri: String,
+}
+
+/// Fetch Google Calendar events in `[time_min, time_max]` that carry a Google Meet link.
+/// Events without a video conferencing entry point (e.g. plain in-person events) are dropped —
+/// they're outside this integration's scope.
+pub async fn list_meet_events(
+    access_token: &str,
+    time_min: DateTime<Utc>,
+    time_max: DateTime<Utc>,
+) -> Result<Vec<CalendarEvent>> {
+    let client = reqwest::Client::new();
+    let response = client
+        .get(EVENTS_ENDPOINT)
+        .bearer_auth(access_token)
+        .query(&[
+            ("timeMin", time_min.to_rfc3339()),
+            ("timeMax", time_max.to_rfc3339()),
+            ("singleEvents", "true".to_string()),
+            ("orderBy", "startTime".to_string()),
+        ])
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        let text = response.text().await.unwrap_or_default();
+        return Err(anyhow!("Google Calendar API error: {}", text));
+    }
+
+    let parsed: EventsListResponse = response.json().await?;
+
+    let events = parsed
+        .items
+        .into_iter()
+        .filter_map(|raw| {
+            let start = raw.start.date_time?;
+            let end = raw.end.date_time?;
+            let meet_link = raw.conference_data.as_ref().and_then(|cd| {
+                cd.entry_points
+                    .iter()
+                    .find(|ep| ep.entry_point_type == "video")
+                    .map(|ep| ep.uri.clone())
+            });
+            meet_link.as_ref()?;
+
+            Some(CalendarEvent {
+                id: raw.id,
+                title: raw.summary.unwrap_or_else(|| "Untitled event".to_string()),
+                start_time: start,
+                end_time: end,
+                meet_link,
+                attendees: raw
+                    .attendees
+                    .into_iter()
+                    .map(|a| Attendee {
+                        name: a.display_name,
+                        email: a.email,
+                    })
+                    .collect(),
+            })
+        })
+        .collect();
+
+    Ok(events)
+}

--- a/frontend/src-tauri/src/calendar/commands.rs
+++ b/frontend/src-tauri/src/calendar/commands.rs
@@ -1,0 +1,188 @@
+use crate::calendar::{client, matcher, oauth, CalendarEvent};
+use crate::database::repositories::meeting::MeetingsRepository;
+use crate::database::repositories::setting::SettingsRepository;
+use crate::state::AppState;
+use chrono::Duration;
+use log::info;
+use serde::Serialize;
+use sqlx::SqlitePool;
+use std::sync::atomic::{AtomicBool, Ordering};
+use tauri::{AppHandle, Runtime};
+
+#[derive(Debug, Serialize)]
+pub struct CalendarConnectionStatus {
+    pub connected: bool,
+    pub scope: Option<String>,
+}
+
+/// Guards against overlapping OAuth flows — e.g. a page reload resetting the frontend's
+/// "connecting" state while a previous `calendar_start_oauth` call is still waiting (up to 3
+/// minutes) on its own loopback listener in the background. Without this, repeated clicks pile
+/// up stray listener threads and open a new browser tab each time.
+static OAUTH_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+/// Kick off the Google OAuth loopback flow: open the system browser for consent, catch the
+/// redirect locally, exchange the code for tokens, and persist them.
+#[tauri::command]
+pub async fn calendar_start_oauth<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    client_id: String,
+    client_secret: String,
+) -> Result<CalendarConnectionStatus, String> {
+    if OAUTH_IN_PROGRESS
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Err(
+            "A Google sign-in is already in progress. Finish it in the browser tab that opened, \
+             or wait up to 3 minutes for it to time out before trying again."
+                .to_string(),
+        );
+    }
+
+    let pool = state.db_manager.pool().clone();
+    let result = run_oauth_flow(pool, client_id, client_secret).await;
+    OAUTH_IN_PROGRESS.store(false, Ordering::SeqCst);
+    result
+}
+
+async fn run_oauth_flow(
+    pool: SqlitePool,
+    client_id: String,
+    client_secret: String,
+) -> Result<CalendarConnectionStatus, String> {
+    let (listener, port) = oauth::bind_loopback_listener()
+        .map_err(|e| format!("Failed to start local OAuth listener: {}", e))?;
+    let redirect_uri = format!("http://127.0.0.1:{}/callback", port);
+    let authorize_url = oauth::build_authorize_url(&client_id, &redirect_uri);
+
+    info!("Opening browser for Google Calendar OAuth consent");
+    crate::api::open_external_url(authorize_url)
+        .await
+        .map_err(|e| format!("Failed to open browser for Google sign-in: {}", e))?;
+
+    let code = tokio::task::spawn_blocking(move || {
+        oauth::wait_for_authorization_code(listener, std::time::Duration::from_secs(180))
+    })
+    .await
+    .map_err(|e| format!("OAuth listener task failed: {}", e))?
+    .map_err(|e| format!("Google sign-in was not completed: {}", e))?;
+
+    let config = oauth::exchange_code_for_tokens(&client_id, &client_secret, &code, &redirect_uri)
+        .await
+        .map_err(|e| format!("Failed to exchange authorization code: {}", e))?;
+
+    SettingsRepository::save_google_calendar_config(&pool, &config)
+        .await
+        .map_err(|e| format!("Failed to save Google Calendar credentials: {}", e))?;
+
+    info!("Google Calendar connected successfully");
+    Ok(CalendarConnectionStatus {
+        connected: true,
+        scope: config.scope,
+    })
+}
+
+#[tauri::command]
+pub async fn calendar_disconnect<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    SettingsRepository::clear_google_calendar_config(state.db_manager.pool())
+        .await
+        .map_err(|e| format!("Failed to disconnect Google Calendar: {}", e))
+}
+
+#[tauri::command]
+pub async fn calendar_get_connection_status<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+) -> Result<CalendarConnectionStatus, String> {
+    let config = SettingsRepository::get_google_calendar_config(state.db_manager.pool())
+        .await
+        .map_err(|e| format!("Failed to read Google Calendar config: {}", e))?;
+
+    Ok(match config {
+        Some(config) if config.is_connected() => CalendarConnectionStatus {
+            connected: true,
+            scope: config.scope,
+        },
+        _ => CalendarConnectionStatus {
+            connected: false,
+            scope: None,
+        },
+    })
+}
+
+/// Match a just-recorded meeting against Google Calendar and write attendee/title/meet-link
+/// metadata onto its row. Called by the frontend right after a transcript (and thus the
+/// meeting row) has been saved — meeting rows don't exist until then (see recording_commands.rs).
+/// Returns `Ok(None)` (not an error) when Calendar isn't connected or no event matches, since
+/// that's an expected, non-fatal outcome for meetings that weren't scheduled via Calendar.
+#[tauri::command]
+pub async fn api_save_meeting_calendar_metadata<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    meeting_id: String,
+) -> Result<Option<CalendarEvent>, String> {
+    let pool = state.db_manager.pool();
+
+    let meeting = MeetingsRepository::get_meeting_metadata(pool, &meeting_id)
+        .await
+        .map_err(|e| format!("Failed to load meeting: {}", e))?
+        .ok_or_else(|| format!("No meeting found with id {}", meeting_id))?;
+
+    let config = SettingsRepository::get_google_calendar_config(pool)
+        .await
+        .map_err(|e| format!("Failed to read Google Calendar config: {}", e))?;
+
+    let Some(config) = config.filter(|c| c.is_connected()) else {
+        return Ok(None);
+    };
+
+    let access_token = oauth::ensure_valid_access_token(pool, &config)
+        .await
+        .map_err(|e| format!("Failed to refresh Google Calendar access token: {}", e))?;
+
+    // A call may have started slightly before or after Meetily's recording did, so widen the
+    // fetch window generously, then match more tightly below.
+    let meeting_time = meeting.created_at.0;
+    let events = client::list_meet_events(
+        &access_token,
+        meeting_time - Duration::hours(2),
+        meeting_time + Duration::hours(2),
+    )
+    .await
+    .map_err(|e| format!("Failed to fetch Google Calendar events: {}", e))?;
+
+    let Some(matched) = matcher::find_matching_event(
+        &events,
+        meeting_time - Duration::minutes(15),
+        meeting_time + Duration::minutes(15),
+    ) else {
+        return Ok(None);
+    };
+
+    let attendees_json = serde_json::to_string(&matched.attendees)
+        .map_err(|e| format!("Failed to serialize attendees: {}", e))?;
+
+    MeetingsRepository::update_meeting_calendar_metadata(
+        pool,
+        &meeting_id,
+        &matched.id,
+        &attendees_json,
+        matched.meet_link.as_deref(),
+        &matched.start_time.to_rfc3339(),
+        &matched.end_time.to_rfc3339(),
+    )
+    .await
+    .map_err(|e| format!("Failed to save calendar metadata: {}", e))?;
+
+    // Only override the generic auto-generated title, never a name the user already set.
+    if meeting.title.starts_with("Meeting ") {
+        let _ = MeetingsRepository::update_meeting_title(pool, &meeting_id, &matched.title).await;
+    }
+
+    Ok(Some(matched.clone()))
+}

--- a/frontend/src-tauri/src/calendar/commands.rs
+++ b/frontend/src-tauri/src/calendar/commands.rs
@@ -145,22 +145,22 @@ pub async fn api_save_meeting_calendar_metadata<R: Runtime>(
         .await
         .map_err(|e| format!("Failed to refresh Google Calendar access token: {}", e))?;
 
-    // A call may have started slightly before or after Meetily's recording did, so widen the
-    // fetch window generously, then match more tightly below.
+    // `meeting.created_at` is set when the transcript is saved — i.e. roughly when the recording
+    // *stopped*, not when the meeting started (see transcript.rs's INSERT). For a long meeting
+    // that drift can be significant, so this window has to be wide enough to still contain the
+    // event's actual start; a narrow (e.g. ±15min) secondary filter would cause false "no match"
+    // results for anything longer than that. `find_matching_event`'s greatest-overlap scoring
+    // already picks the best candidate among whatever's fetched, so one generous window for both
+    // fetching and matching is both simpler and more correct than fetching wide then filtering
+    // tight.
     let meeting_time = meeting.created_at.0;
-    let events = client::list_meet_events(
-        &access_token,
-        meeting_time - Duration::hours(2),
-        meeting_time + Duration::hours(2),
-    )
-    .await
-    .map_err(|e| format!("Failed to fetch Google Calendar events: {}", e))?;
+    let window_start = meeting_time - Duration::hours(2);
+    let window_end = meeting_time + Duration::hours(2);
+    let events = client::list_meet_events(&access_token, window_start, window_end)
+        .await
+        .map_err(|e| format!("Failed to fetch Google Calendar events: {}", e))?;
 
-    let Some(matched) = matcher::find_matching_event(
-        &events,
-        meeting_time - Duration::minutes(15),
-        meeting_time + Duration::minutes(15),
-    ) else {
+    let Some(matched) = matcher::find_matching_event(&events, window_start, window_end) else {
         return Ok(None);
     };
 

--- a/frontend/src-tauri/src/calendar/matcher.rs
+++ b/frontend/src-tauri/src/calendar/matcher.rs
@@ -1,0 +1,65 @@
+use super::CalendarEvent;
+use chrono::{DateTime, Utc};
+
+/// Find the calendar event whose window overlaps `[window_start, window_end]` the most.
+/// Used both for post-recording metadata enrichment and (in the auto-detect path) for
+/// pre-filling a meeting title before recording starts.
+pub fn find_matching_event<'a>(
+    events: &'a [CalendarEvent],
+    window_start: DateTime<Utc>,
+    window_end: DateTime<Utc>,
+) -> Option<&'a CalendarEvent> {
+    events
+        .iter()
+        .filter(|event| event.start_time < window_end && event.end_time > window_start)
+        .max_by_key(|event| {
+            let overlap_start = event.start_time.max(window_start);
+            let overlap_end = event.end_time.min(window_end);
+            (overlap_end - overlap_start).num_seconds().max(0)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn event(id: &str, start_hour: u32, end_hour: u32) -> CalendarEvent {
+        CalendarEvent {
+            id: id.to_string(),
+            title: id.to_string(),
+            start_time: Utc.with_ymd_and_hms(2026, 1, 1, start_hour, 0, 0).unwrap(),
+            end_time: Utc.with_ymd_and_hms(2026, 1, 1, end_hour, 0, 0).unwrap(),
+            meet_link: None,
+            attendees: vec![],
+        }
+    }
+
+    #[test]
+    fn picks_the_event_with_greatest_overlap() {
+        let events = vec![event("standup", 9, 9), event("planning", 10, 12)];
+        // Widen the standup window slightly so it has a non-zero duration to compare against.
+        let events = vec![
+            CalendarEvent {
+                end_time: Utc.with_ymd_and_hms(2026, 1, 1, 9, 30, 0).unwrap(),
+                ..events[0].clone()
+            },
+            events[1].clone(),
+        ];
+
+        let window_start = Utc.with_ymd_and_hms(2026, 1, 1, 9, 45, 0).unwrap();
+        let window_end = Utc.with_ymd_and_hms(2026, 1, 1, 11, 0, 0).unwrap();
+
+        let matched = find_matching_event(&events, window_start, window_end).unwrap();
+        assert_eq!(matched.id, "planning");
+    }
+
+    #[test]
+    fn returns_none_when_no_event_overlaps() {
+        let events = vec![event("standup", 9, 10)];
+        let window_start = Utc.with_ymd_and_hms(2026, 1, 1, 14, 0, 0).unwrap();
+        let window_end = Utc.with_ymd_and_hms(2026, 1, 1, 15, 0, 0).unwrap();
+
+        assert!(find_matching_event(&events, window_start, window_end).is_none());
+    }
+}

--- a/frontend/src-tauri/src/calendar/mod.rs
+++ b/frontend/src-tauri/src/calendar/mod.rs
@@ -1,0 +1,43 @@
+pub mod client;
+pub mod commands;
+pub mod matcher;
+pub mod oauth;
+
+use serde::{Deserialize, Serialize};
+
+/// Google OAuth client credentials + token bundle for Calendar API access.
+/// Persisted as a single JSON blob in `settings.googleCalendarConfig`, mirroring
+/// how `CustomOpenAIConfig` is stored in `summary::CustomOpenAIConfig`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GoogleCalendarConfig {
+    pub client_id: String,
+    pub client_secret: String,
+    pub access_token: Option<String>,
+    pub refresh_token: Option<String>,
+    /// RFC3339 timestamp of access_token expiry
+    pub token_expiry: Option<String>,
+    pub scope: Option<String>,
+}
+
+impl GoogleCalendarConfig {
+    pub fn is_connected(&self) -> bool {
+        self.access_token.is_some() && self.refresh_token.is_some()
+    }
+}
+
+/// A Google Calendar event carrying a Google Meet link.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CalendarEvent {
+    pub id: String,
+    pub title: String,
+    pub start_time: chrono::DateTime<chrono::Utc>,
+    pub end_time: chrono::DateTime<chrono::Utc>,
+    pub meet_link: Option<String>,
+    pub attendees: Vec<Attendee>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Attendee {
+    pub name: Option<String>,
+    pub email: String,
+}

--- a/frontend/src-tauri/src/calendar/oauth.rs
+++ b/frontend/src-tauri/src/calendar/oauth.rs
@@ -1,0 +1,213 @@
+// Google OAuth 2.0 loopback flow ("installed app" flow, RFC 8252) for Calendar access.
+//
+// No OAuth plugin/dependency exists elsewhere in this codebase, so the redirect is caught
+// with a minimal single-request TCP listener on an OS-assigned 127.0.0.1 port instead of
+// pulling in a new crate. Desktop-type Google OAuth clients don't require pre-registering
+// that port, so this works without any redirect_uri allowlist configuration on Google's side.
+
+use super::GoogleCalendarConfig;
+use anyhow::{anyhow, Result};
+use chrono::{Duration, Utc};
+use log::{error, info};
+use serde::Deserialize;
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+
+pub const CALENDAR_SCOPE: &str = "https://www.googleapis.com/auth/calendar.readonly";
+const AUTH_ENDPOINT: &str = "https://accounts.google.com/o/oauth2/v2/auth";
+const TOKEN_ENDPOINT: &str = "https://oauth2.googleapis.com/token";
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    expires_in: i64,
+    #[serde(default)]
+    scope: Option<String>,
+}
+
+pub fn build_authorize_url(client_id: &str, redirect_uri: &str) -> String {
+    let mut url = url::Url::parse(AUTH_ENDPOINT).expect("AUTH_ENDPOINT is a valid URL");
+    url.query_pairs_mut()
+        .append_pair("client_id", client_id)
+        .append_pair("redirect_uri", redirect_uri)
+        .append_pair("response_type", "code")
+        .append_pair("scope", CALENDAR_SCOPE)
+        .append_pair("access_type", "offline")
+        .append_pair("prompt", "consent");
+    url.to_string()
+}
+
+/// Bind the loopback listener up front so the port is known before the browser opens.
+pub fn bind_loopback_listener() -> Result<(TcpListener, u16)> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    Ok((listener, port))
+}
+
+/// Blocks until Google's redirect delivers an authorization code, or `timeout` elapses.
+/// Must run in a blocking context (e.g. `tokio::task::spawn_blocking`).
+pub fn wait_for_authorization_code(
+    listener: TcpListener,
+    timeout: std::time::Duration,
+) -> Result<String> {
+    listener.set_nonblocking(true)?;
+    let deadline = std::time::Instant::now() + timeout;
+
+    loop {
+        if std::time::Instant::now() > deadline {
+            return Err(anyhow!("Timed out waiting for Google OAuth redirect"));
+        }
+
+        match listener.accept() {
+            Ok((mut stream, _addr)) => {
+                stream.set_nonblocking(false)?;
+                let mut reader = BufReader::new(stream.try_clone()?);
+                let mut request_line = String::new();
+                reader.read_line(&mut request_line)?;
+
+                // "GET /callback?code=XYZ&scope=... HTTP/1.1"
+                let path = request_line.split_whitespace().nth(1).unwrap_or("");
+                let query = path.split_once('?').map(|(_, q)| q).unwrap_or("");
+                let code = query
+                    .split('&')
+                    .find_map(|pair| pair.strip_prefix("code=").map(|c| c.to_string()));
+
+                let body = "<html><body>Meetily is connected to Google Calendar. \
+                             You can close this tab.</body></html>";
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: text/html\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes());
+
+                if let Some(code) = code {
+                    return Ok(code);
+                }
+                // No code on this request (e.g. a stray favicon.ico fetch) — keep waiting.
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(std::time::Duration::from_millis(200));
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+}
+
+pub async fn exchange_code_for_tokens(
+    client_id: &str,
+    client_secret: &str,
+    code: &str,
+    redirect_uri: &str,
+) -> Result<GoogleCalendarConfig> {
+    let client = reqwest::Client::new();
+    let params = [
+        ("client_id", client_id),
+        ("client_secret", client_secret),
+        ("code", code),
+        ("grant_type", "authorization_code"),
+        ("redirect_uri", redirect_uri),
+    ];
+
+    let response = client.post(TOKEN_ENDPOINT).form(&params).send().await?;
+    if !response.status().is_success() {
+        let text = response.text().await.unwrap_or_default();
+        error!("Google token exchange failed: {}", text);
+        return Err(anyhow!("Google token exchange failed: {}", text));
+    }
+
+    let token: TokenResponse = response.json().await?;
+    let refresh_token = token.refresh_token.ok_or_else(|| {
+        anyhow!(
+            "Google did not return a refresh_token. If you've connected before, revoke \
+             Meetily's access at https://myaccount.google.com/permissions and try again."
+        )
+    })?;
+
+    Ok(GoogleCalendarConfig {
+        client_id: client_id.to_string(),
+        client_secret: client_secret.to_string(),
+        access_token: Some(token.access_token),
+        refresh_token: Some(refresh_token),
+        token_expiry: Some((Utc::now() + Duration::seconds(token.expires_in)).to_rfc3339()),
+        scope: token.scope,
+    })
+}
+
+pub async fn refresh_access_token(config: &GoogleCalendarConfig) -> Result<GoogleCalendarConfig> {
+    let refresh_token = config
+        .refresh_token
+        .as_ref()
+        .ok_or_else(|| anyhow!("No refresh_token stored; reconnect Google Calendar"))?;
+
+    let client = reqwest::Client::new();
+    let params = [
+        ("client_id", config.client_id.as_str()),
+        ("client_secret", config.client_secret.as_str()),
+        ("refresh_token", refresh_token.as_str()),
+        ("grant_type", "refresh_token"),
+    ];
+
+    let response = client.post(TOKEN_ENDPOINT).form(&params).send().await?;
+    if !response.status().is_success() {
+        let text = response.text().await.unwrap_or_default();
+        error!("Google token refresh failed: {}", text);
+        return Err(anyhow!("Google token refresh failed: {}", text));
+    }
+
+    let token: TokenResponse = response.json().await?;
+
+    Ok(GoogleCalendarConfig {
+        client_id: config.client_id.clone(),
+        client_secret: config.client_secret.clone(),
+        access_token: Some(token.access_token),
+        refresh_token: Some(
+            token
+                .refresh_token
+                .unwrap_or_else(|| refresh_token.clone()),
+        ),
+        token_expiry: Some((Utc::now() + Duration::seconds(token.expires_in)).to_rfc3339()),
+        scope: token.scope.or_else(|| config.scope.clone()),
+    })
+}
+
+/// Returns a valid access token, refreshing (and persisting) it first if it's expired
+/// or about to expire.
+pub async fn ensure_valid_access_token(
+    pool: &sqlx::SqlitePool,
+    config: &GoogleCalendarConfig,
+) -> Result<String> {
+    let needs_refresh = match &config.token_expiry {
+        Some(expiry) => {
+            let expiry = chrono::DateTime::parse_from_rfc3339(expiry)
+                .map(|dt| dt.with_timezone(&Utc))
+                .unwrap_or_else(|_| Utc::now());
+            expiry <= Utc::now() + Duration::minutes(2)
+        }
+        None => true,
+    };
+
+    if !needs_refresh {
+        return config
+            .access_token
+            .clone()
+            .ok_or_else(|| anyhow!("No access_token stored; reconnect Google Calendar"));
+    }
+
+    info!("Refreshing Google Calendar access token");
+    let refreshed = refresh_access_token(config).await?;
+    let access_token = refreshed
+        .access_token
+        .clone()
+        .ok_or_else(|| anyhow!("Google refresh response did not include an access_token"))?;
+
+    crate::database::repositories::setting::SettingsRepository::save_google_calendar_config(
+        pool, &refreshed,
+    )
+    .await
+    .map_err(|e| anyhow!("Failed to persist refreshed Google token: {}", e))?;
+
+    Ok(access_token)
+}

--- a/frontend/src-tauri/src/calendar/oauth.rs
+++ b/frontend/src-tauri/src/calendar/oauth.rs
@@ -70,9 +70,11 @@ pub fn wait_for_authorization_code(
                 // "GET /callback?code=XYZ&scope=... HTTP/1.1"
                 let path = request_line.split_whitespace().nth(1).unwrap_or("");
                 let query = path.split_once('?').map(|(_, q)| q).unwrap_or("");
-                let code = query
-                    .split('&')
-                    .find_map(|pair| pair.strip_prefix("code=").map(|c| c.to_string()));
+                // The code can be percent-encoded (e.g. embedded `/` or `+`), so this must be
+                // decoded via a real query-string parser rather than a raw substring split.
+                let code = url::form_urlencoded::parse(query.as_bytes())
+                    .find(|(key, _)| key == "code")
+                    .map(|(_, value)| value.into_owned());
 
                 let body = "<html><body>Meetily is connected to Google Calendar. \
                              You can close this tab.</body></html>";

--- a/frontend/src-tauri/src/database/models.rs
+++ b/frontend/src-tauri/src/database/models.rs
@@ -106,6 +106,9 @@ pub struct Setting {
     #[sqlx(rename = "googleCalendarConfig")]
     #[serde(rename = "googleCalendarConfig")]
     pub google_calendar_config: Option<String>,
+    #[sqlx(rename = "autoDetectMeetEnabled")]
+    #[serde(rename = "autoDetectMeetEnabled")]
+    pub auto_detect_meet_enabled: Option<i64>,
 }
 
 impl Setting {

--- a/frontend/src-tauri/src/database/models.rs
+++ b/frontend/src-tauri/src/database/models.rs
@@ -9,6 +9,12 @@ pub struct MeetingModel {
     pub created_at: DateTimeUtc,
     pub updated_at: DateTimeUtc,
     pub folder_path: Option<String>,
+    pub calendar_event_id: Option<String>,
+    /// JSON array of {name, email}
+    pub calendar_attendees: Option<String>,
+    pub calendar_meet_link: Option<String>,
+    pub calendar_start_time: Option<String>,
+    pub calendar_end_time: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::Type)]
@@ -96,12 +102,23 @@ pub struct Setting {
     #[sqlx(rename = "customOpenAIConfig")]
     #[serde(rename = "customOpenAIConfig")]
     pub custom_openai_config: Option<String>,
+    /// Google OAuth token bundle for Calendar integration, stored as JSON
+    #[sqlx(rename = "googleCalendarConfig")]
+    #[serde(rename = "googleCalendarConfig")]
+    pub google_calendar_config: Option<String>,
 }
 
 impl Setting {
     /// Parse the custom OpenAI config from JSON string
     pub fn get_custom_openai_config(&self) -> Option<crate::summary::CustomOpenAIConfig> {
         self.custom_openai_config.as_ref().and_then(|json| {
+            serde_json::from_str(json).ok()
+        })
+    }
+
+    /// Parse the Google Calendar OAuth config from JSON string
+    pub fn get_google_calendar_config(&self) -> Option<crate::calendar::GoogleCalendarConfig> {
+        self.google_calendar_config.as_ref().and_then(|json| {
             serde_json::from_str(json).ok()
         })
     }

--- a/frontend/src-tauri/src/database/repositories/meeting.rs
+++ b/frontend/src-tauri/src/database/repositories/meeting.rs
@@ -62,7 +62,7 @@ impl MeetingsRepository {
 
         // Get meeting details
         let meeting: Option<MeetingModel> =
-            sqlx::query_as("SELECT id, title, created_at, updated_at, folder_path FROM meetings WHERE id = ?")
+            sqlx::query_as("SELECT id, title, created_at, updated_at, folder_path, calendar_event_id, calendar_attendees, calendar_meet_link, calendar_start_time, calendar_end_time FROM meetings WHERE id = ?")
                 .bind(meeting_id)
                 .fetch_optional(&mut *transaction)
                 .await?;
@@ -101,6 +101,10 @@ impl MeetingsRepository {
                 created_at: meeting.created_at.0.to_rfc3339(),
                 updated_at: meeting.updated_at.0.to_rfc3339(),
                 transcripts: meeting_transcripts,
+                calendar_attendees: meeting.calendar_attendees,
+                calendar_meet_link: meeting.calendar_meet_link,
+                calendar_start_time: meeting.calendar_start_time,
+                calendar_end_time: meeting.calendar_end_time,
             }))
         } else {
             transaction.rollback().await?;
@@ -120,12 +124,56 @@ impl MeetingsRepository {
         }
 
         let meeting: Option<MeetingModel> =
-            sqlx::query_as("SELECT id, title, created_at, updated_at, folder_path FROM meetings WHERE id = ?")
+            sqlx::query_as("SELECT id, title, created_at, updated_at, folder_path, calendar_event_id, calendar_attendees, calendar_meet_link, calendar_start_time, calendar_end_time FROM meetings WHERE id = ?")
                 .bind(meeting_id)
                 .fetch_optional(pool)
                 .await?;
 
         Ok(meeting)
+    }
+
+    /// Write calendar-derived metadata onto an existing meeting, matched by time window
+    /// against a Google Calendar event. Follows the same shape as `update_meeting_title`.
+    pub async fn update_meeting_calendar_metadata(
+        pool: &SqlitePool,
+        meeting_id: &str,
+        calendar_event_id: &str,
+        attendees_json: &str,
+        meet_link: Option<&str>,
+        start_time: &str,
+        end_time: &str,
+    ) -> Result<bool, SqlxError> {
+        if meeting_id.trim().is_empty() {
+            return Err(SqlxError::Protocol(
+                "meeting_id cannot be empty".to_string(),
+            ));
+        }
+
+        let now = Utc::now().naive_utc();
+
+        let rows_affected = sqlx::query(
+            r#"
+            UPDATE meetings SET
+                calendar_event_id = ?,
+                calendar_attendees = ?,
+                calendar_meet_link = ?,
+                calendar_start_time = ?,
+                calendar_end_time = ?,
+                updated_at = ?
+            WHERE id = ?
+            "#,
+        )
+        .bind(calendar_event_id)
+        .bind(attendees_json)
+        .bind(meet_link)
+        .bind(start_time)
+        .bind(end_time)
+        .bind(now)
+        .bind(meeting_id)
+        .execute(pool)
+        .await?;
+
+        Ok(rows_affected.rows_affected() > 0)
     }
 
     /// Get meeting transcripts with pagination support

--- a/frontend/src-tauri/src/database/repositories/setting.rs
+++ b/frontend/src-tauri/src/database/repositories/setting.rs
@@ -407,4 +407,32 @@ impl SettingsRepository {
             .await?;
         Ok(())
     }
+
+    pub async fn get_auto_detect_meet_enabled(
+        pool: &SqlitePool,
+    ) -> std::result::Result<bool, sqlx::Error> {
+        let value: Option<i64> =
+            sqlx::query_scalar("SELECT autoDetectMeetEnabled FROM settings WHERE id = '1' LIMIT 1")
+                .fetch_optional(pool)
+                .await?;
+        Ok(value.unwrap_or(0) != 0)
+    }
+
+    pub async fn set_auto_detect_meet_enabled(
+        pool: &SqlitePool,
+        enabled: bool,
+    ) -> std::result::Result<(), sqlx::Error> {
+        sqlx::query(
+            r#"
+            INSERT INTO settings (id, provider, model, whisperModel, autoDetectMeetEnabled)
+            VALUES ('1', 'openai', 'gpt-4o-2024-11-20', 'large-v3', $1)
+            ON CONFLICT(id) DO UPDATE SET
+                autoDetectMeetEnabled = excluded.autoDetectMeetEnabled
+            "#,
+        )
+        .bind(enabled as i64)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
 }

--- a/frontend/src-tauri/src/database/repositories/setting.rs
+++ b/frontend/src-tauri/src/database/repositories/setting.rs
@@ -345,4 +345,66 @@ impl SettingsRepository {
 
         Ok(())
     }
+
+    // ===== GOOGLE CALENDAR CONFIG METHODS =====
+
+    pub async fn get_google_calendar_config(
+        pool: &SqlitePool,
+    ) -> std::result::Result<Option<crate::calendar::GoogleCalendarConfig>, sqlx::Error> {
+        use sqlx::Row;
+
+        let row = sqlx::query("SELECT googleCalendarConfig FROM settings WHERE id = '1' LIMIT 1")
+            .fetch_optional(pool)
+            .await?;
+
+        match row {
+            Some(record) => {
+                let config_json: Option<String> = record.get("googleCalendarConfig");
+                if let Some(json) = config_json {
+                    let config: crate::calendar::GoogleCalendarConfig =
+                        serde_json::from_str(&json).map_err(|e| {
+                            sqlx::Error::Protocol(
+                                format!("Invalid JSON in googleCalendarConfig: {}", e).into(),
+                            )
+                        })?;
+                    Ok(Some(config))
+                } else {
+                    Ok(None)
+                }
+            }
+            None => Ok(None),
+        }
+    }
+
+    pub async fn save_google_calendar_config(
+        pool: &SqlitePool,
+        config: &crate::calendar::GoogleCalendarConfig,
+    ) -> std::result::Result<(), sqlx::Error> {
+        let config_json = serde_json::to_string(config).map_err(|e| {
+            sqlx::Error::Protocol(format!("Failed to serialize calendar config: {}", e).into())
+        })?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO settings (id, provider, model, whisperModel, googleCalendarConfig)
+            VALUES ('1', 'openai', 'gpt-4o-2024-11-20', 'large-v3', $1)
+            ON CONFLICT(id) DO UPDATE SET
+                googleCalendarConfig = excluded.googleCalendarConfig
+            "#,
+        )
+        .bind(config_json)
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn clear_google_calendar_config(
+        pool: &SqlitePool,
+    ) -> std::result::Result<(), sqlx::Error> {
+        sqlx::query("UPDATE settings SET googleCalendarConfig = NULL WHERE id = '1'")
+            .execute(pool)
+            .await?;
+        Ok(())
+    }
 }

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -38,6 +38,7 @@ pub(crate) use perf_trace;
 pub mod analytics;
 pub mod api;
 pub mod audio;
+pub mod calendar;
 pub mod config;
 pub mod console_utils;
 pub mod database;
@@ -530,6 +531,10 @@ pub fn run() {
             get_transcription_status,
             read_audio_file,
             save_transcript,
+            calendar::commands::calendar_start_oauth,
+            calendar::commands::calendar_disconnect,
+            calendar::commands::calendar_get_connection_status,
+            calendar::commands::api_save_meeting_calendar_metadata,
             analytics::commands::init_analytics,
             analytics::commands::disable_analytics,
             analytics::commands::track_event,

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -42,6 +42,7 @@ pub mod calendar;
 pub mod config;
 pub mod console_utils;
 pub mod database;
+pub mod meet_detection;
 pub mod notifications;
 pub mod ollama;
 pub mod onboarding;
@@ -426,6 +427,11 @@ pub fn run() {
                 log::error!("Failed to create system tray: {}", e);
             }
 
+            // Start the Google Meet auto-detect poller (macOS only; no-op elsewhere).
+            // Gated behind the `auto_detect_meet_enabled` setting, checked on every poll,
+            // so toggling it in Settings takes effect without restarting the app.
+            meet_detection::spawn_meet_detection_task(_app.handle().clone());
+
             // Initialize notification system with proper defaults
             log::info!("Initializing notification system...");
             let app_for_notif = _app.handle().clone();
@@ -535,6 +541,8 @@ pub fn run() {
             calendar::commands::calendar_disconnect,
             calendar::commands::calendar_get_connection_status,
             calendar::commands::api_save_meeting_calendar_metadata,
+            meet_detection::commands::calendar_toggle_auto_detect,
+            meet_detection::commands::calendar_get_auto_detect_enabled,
             analytics::commands::init_analytics,
             analytics::commands::disable_analytics,
             analytics::commands::track_event,
@@ -723,6 +731,8 @@ pub fn run() {
             audio::permissions::check_screen_recording_permission_command,
             audio::permissions::request_screen_recording_permission_command,
             audio::permissions::trigger_system_audio_permission_command,
+            audio::permissions::check_window_title_read_permission_command,
+            audio::permissions::request_window_title_read_permission_command,
             // Database import commands
             database::commands::check_first_launch,
             database::commands::select_legacy_database_path,

--- a/frontend/src-tauri/src/meet_detection/commands.rs
+++ b/frontend/src-tauri/src/meet_detection/commands.rs
@@ -1,0 +1,26 @@
+use crate::database::repositories::setting::SettingsRepository;
+use crate::state::AppState;
+use tauri::{AppHandle, Runtime};
+
+/// Toggle the "auto-detect Google Meet calls" setting read by `spawn_meet_detection_task`'s
+/// poll loop. Takes effect on the next poll — no app restart needed.
+#[tauri::command]
+pub async fn calendar_toggle_auto_detect<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    enabled: bool,
+) -> Result<(), String> {
+    SettingsRepository::set_auto_detect_meet_enabled(state.db_manager.pool(), enabled)
+        .await
+        .map_err(|e| format!("Failed to update auto-detect setting: {}", e))
+}
+
+#[tauri::command]
+pub async fn calendar_get_auto_detect_enabled<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+) -> Result<bool, String> {
+    SettingsRepository::get_auto_detect_meet_enabled(state.db_manager.pool())
+        .await
+        .map_err(|e| format!("Failed to read auto-detect setting: {}", e))
+}

--- a/frontend/src-tauri/src/meet_detection/mod.rs
+++ b/frontend/src-tauri/src/meet_detection/mod.rs
@@ -1,0 +1,156 @@
+pub mod commands;
+pub mod window_scan;
+
+use crate::audio::devices::{microphone, speakers};
+use crate::audio::recording_commands::{self, RecordingArgs};
+use crate::audio::recording_preferences;
+use crate::database::repositories::setting::SettingsRepository;
+use crate::state::AppState;
+use log::{debug, info, warn};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+use tauri::{AppHandle, Manager, Runtime};
+
+const POLL_INTERVAL: Duration = Duration::from_secs(5);
+/// Consecutive "no Meet window" polls to wait through before auto-stopping, so a brief tab
+/// switch or window-manager hiccup doesn't cut a call short. ~20s at a 5s poll interval.
+const STOP_DEBOUNCE_POLLS: u32 = 4;
+/// After a failed auto-start (e.g. no audio device available), wait this long before retrying
+/// rather than hammering it every poll for as long as the call stays open.
+const AUTO_START_RETRY_COOLDOWN: Duration = Duration::from_secs(60);
+
+/// Tracks whether the *current* recording was started by this detector, so auto-stop never
+/// touches a recording the user started manually for something other than a Meet call.
+static AUTO_STARTED_BY_DETECTION: AtomicBool = AtomicBool::new(false);
+
+/// Resolves which mic/system device names to record with, the same way the manual "Record"
+/// button's device selection ends up resolved before reaching the Rust side: prefer the user's
+/// saved device preference, falling back to the OS default. Unlike the manual flow, nothing in
+/// the frontend resolves this for an auto-triggered recording, so it has to happen here —
+/// passing `None`/`None` through leaves both mic and system audio unset and recording fails
+/// outright with "No audio streams could be created".
+async fn resolve_default_devices<R: Runtime>(app: &AppHandle<R>) -> (Option<String>, Option<String>) {
+    let prefs = recording_preferences::load_recording_preferences(app).await.ok();
+
+    // `parse_audio_device` (called downstream) requires the "(input)"/"(output)" suffix
+    // `AudioDevice`'s Display impl produces — a bare device name is rejected. Preferences are
+    // assumed to already be stored in that format, matching how the frontend saves them.
+    let mic_name = prefs
+        .as_ref()
+        .and_then(|p| p.preferred_mic_device.clone())
+        .or_else(|| microphone::default_input_device().ok().map(|d| d.to_string()));
+
+    let system_name = prefs
+        .as_ref()
+        .and_then(|p| p.preferred_system_device.clone())
+        .or_else(|| speakers::default_output_device().ok().map(|d| d.to_string()));
+
+    (mic_name, system_name)
+}
+
+/// Spawns the background poller that watches for an active Google Meet call and auto
+/// starts/stops Meetily's existing recording pipeline. The loop always runs (one settings
+/// read + one window scan every 5s) but only acts while `auto_detect_meet_enabled` is on,
+/// so flipping the Settings toggle takes effect without an app restart.
+pub fn spawn_meet_detection_task<R: Runtime>(app: AppHandle<R>) {
+    tauri::async_runtime::spawn(async move {
+        let mut consecutive_absent: u32 = 0;
+        let mut last_start_failure: Option<Instant> = None;
+
+        loop {
+            tokio::time::sleep(POLL_INTERVAL).await;
+
+            // AppState isn't registered until the DB is initialized, which on first launch is
+            // deferred until the user finishes onboarding (see database/setup.rs) — so unlike
+            // most command handlers, this loop can legitimately run before it exists.
+            let Some(state) = app.try_state::<AppState>() else {
+                continue;
+            };
+            let pool = state.db_manager.pool().clone();
+
+            let enabled = match SettingsRepository::get_auto_detect_meet_enabled(&pool).await {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!("Failed to read auto-detect-meet setting: {}", e);
+                    continue;
+                }
+            };
+
+            if !enabled {
+                consecutive_absent = 0;
+                continue;
+            }
+
+            if !crate::audio::permissions::check_window_title_read_permission() {
+                warn!(
+                    "[meet-detect] auto-detect is on but Screen Recording permission isn't \
+                     granted — window titles are invisible, so detection can never fire. \
+                     Grant it in System Settings > Privacy & Security > Screen Recording."
+                );
+            }
+
+            let meet_active = tokio::task::spawn_blocking(window_scan::scan_for_active_meet_call)
+                .await
+                .unwrap_or(false);
+            debug!("[meet-detect] poll: meet_active={}", meet_active);
+            let currently_recording = recording_commands::is_recording().await;
+
+            if meet_active {
+                consecutive_absent = 0;
+                let cooling_down = last_start_failure
+                    .is_some_and(|t| t.elapsed() < AUTO_START_RETRY_COOLDOWN);
+                if !currently_recording && !cooling_down {
+                    let (mic_name, system_name) = resolve_default_devices(&app).await;
+                    if mic_name.is_none() && system_name.is_none() {
+                        warn!(
+                            "[meet-detect] no microphone or system audio device available — \
+                             skipping auto-start"
+                        );
+                        last_start_failure = Some(Instant::now());
+                    } else {
+                        info!("Detected an active Google Meet call — auto-starting recording");
+                        match recording_commands::start_recording_with_devices_and_meeting(
+                            app.clone(),
+                            mic_name,
+                            system_name,
+                            None,
+                        )
+                        .await
+                        {
+                            Ok(()) => {
+                                AUTO_STARTED_BY_DETECTION.store(true, Ordering::SeqCst);
+                                last_start_failure = None;
+                            }
+                            Err(e) => {
+                                warn!("Auto-start recording failed: {}", e);
+                                last_start_failure = Some(Instant::now());
+                            }
+                        }
+                    }
+                }
+                continue;
+            }
+
+            if currently_recording && AUTO_STARTED_BY_DETECTION.load(Ordering::SeqCst) {
+                consecutive_absent += 1;
+                if consecutive_absent >= STOP_DEBOUNCE_POLLS {
+                    info!("Google Meet call no longer detected — auto-stopping recording");
+                    AUTO_STARTED_BY_DETECTION.store(false, Ordering::SeqCst);
+                    consecutive_absent = 0;
+                    if let Err(e) = recording_commands::stop_recording(
+                        app.clone(),
+                        RecordingArgs {
+                            save_path: String::new(),
+                        },
+                    )
+                    .await
+                    {
+                        warn!("Auto-stop recording failed: {}", e);
+                    }
+                }
+            } else {
+                consecutive_absent = 0;
+            }
+        }
+    });
+}

--- a/frontend/src-tauri/src/meet_detection/mod.rs
+++ b/frontend/src-tauri/src/meet_detection/mod.rs
@@ -18,6 +18,9 @@ const STOP_DEBOUNCE_POLLS: u32 = 4;
 /// After a failed auto-start (e.g. no audio device available), wait this long before retrying
 /// rather than hammering it every poll for as long as the call stays open.
 const AUTO_START_RETRY_COOLDOWN: Duration = Duration::from_secs(60);
+/// How often to re-log the missing-permission warning — otherwise it fires every single 5s
+/// poll for as long as the toggle is on and permission isn't granted, drowning out other logs.
+const PERMISSION_WARNING_INTERVAL: Duration = Duration::from_secs(300);
 
 /// Tracks whether the *current* recording was started by this detector, so auto-stop never
 /// touches a recording the user started manually for something other than a Meet call.
@@ -56,6 +59,7 @@ pub fn spawn_meet_detection_task<R: Runtime>(app: AppHandle<R>) {
     tauri::async_runtime::spawn(async move {
         let mut consecutive_absent: u32 = 0;
         let mut last_start_failure: Option<Instant> = None;
+        let mut last_permission_warning: Option<Instant> = None;
 
         loop {
             tokio::time::sleep(POLL_INTERVAL).await;
@@ -82,11 +86,16 @@ pub fn spawn_meet_detection_task<R: Runtime>(app: AppHandle<R>) {
             }
 
             if !crate::audio::permissions::check_window_title_read_permission() {
-                warn!(
-                    "[meet-detect] auto-detect is on but Screen Recording permission isn't \
-                     granted — window titles are invisible, so detection can never fire. \
-                     Grant it in System Settings > Privacy & Security > Screen Recording."
-                );
+                let should_warn = last_permission_warning
+                    .is_none_or(|t| t.elapsed() >= PERMISSION_WARNING_INTERVAL);
+                if should_warn {
+                    warn!(
+                        "[meet-detect] auto-detect is on but Screen Recording permission isn't \
+                         granted — window titles are invisible, so detection can never fire. \
+                         Grant it in System Settings > Privacy & Security > Screen Recording."
+                    );
+                    last_permission_warning = Some(Instant::now());
+                }
             }
 
             let meet_active = tokio::task::spawn_blocking(window_scan::scan_for_active_meet_call)

--- a/frontend/src-tauri/src/meet_detection/window_scan.rs
+++ b/frontend/src-tauri/src/meet_detection/window_scan.rs
@@ -1,0 +1,100 @@
+// Heuristic detection of an active Google Meet call via on-screen browser window titles.
+//
+// There is no public API to know "a Google Meet call is active" — this reads window titles
+// via CGWindowListCopyWindowInfo (Quartz Window Services) and pattern-matches them. It can
+// both miss real calls (e.g. a browser that doesn't put the call state in the title) and
+// false-positive (e.g. a Meet tab left open on the pre-join lobby). Treat it as a best-effort
+// signal, not a guarantee — this is why it's gated behind an opt-in settings toggle.
+
+#[cfg(target_os = "macos")]
+const BROWSER_OWNER_NAMES: &[&str] = &[
+    "Google Chrome",
+    "Safari",
+    "Firefox",
+    "Microsoft Edge",
+    "Arc",
+    "Brave Browser",
+];
+
+#[cfg(target_os = "macos")]
+fn looks_like_meet_call(title: &str) -> bool {
+    // Observed live: Chrome titles an active Meet call "Meet – <call-code> 🔊" (en-dash, not a
+    // hyphen). Match on the "meet" prefix alone rather than the exact separator, since Google
+    // can change punctuation without notice and other browsers may render it differently.
+    title.to_lowercase().starts_with("meet")
+}
+
+/// Returns `true` if a browser window's title currently looks like an active Google Meet call.
+/// Requires the real macOS Screen Recording permission (not the Core Audio "Audio Capture"
+/// permission this app already requests elsewhere) — without it, CGWindowListCopyWindowInfo
+/// returns window entries with no `kCGWindowName`, so this silently sees nothing and returns
+/// `false` rather than erroring.
+#[cfg(target_os = "macos")]
+pub fn scan_for_active_meet_call() -> bool {
+    use core_foundation::array::CFArray;
+    use core_foundation::base::{CFType, TCFType};
+    use core_foundation::dictionary::CFDictionary;
+    use core_foundation::string::{CFString, CFStringRef};
+    use core_graphics::window::{
+        kCGNullWindowID, kCGWindowListExcludeDesktopElements, kCGWindowListOptionOnScreenOnly,
+        kCGWindowName, kCGWindowOwnerName, CGWindowListCopyWindowInfo,
+    };
+    use std::os::raw::c_void;
+
+    // Reads a CFString value out of an untyped (void*, void*) dictionary by a known CFStringRef
+    // key. Dictionary entries from CGWindowListCopyWindowInfo aren't independently retained, so
+    // any string pulled out is re-wrapped with `wrap_under_get_rule` (borrow + retain) rather
+    // than treated as owned.
+    unsafe fn string_value(
+        dict: &CFDictionary<*const c_void, *const c_void>,
+        key: CFStringRef,
+    ) -> Option<String> {
+        dict.find(key as *const c_void)
+            .map(|value_ptr| CFString::wrap_under_get_rule(*value_ptr as CFStringRef).to_string())
+    }
+
+    let array_ref = unsafe {
+        CGWindowListCopyWindowInfo(
+            kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements,
+            kCGNullWindowID,
+        )
+    };
+    if array_ref.is_null() {
+        return false;
+    }
+    let windows: CFArray<CFType> = unsafe { TCFType::wrap_under_create_rule(array_ref) };
+
+    for item in windows.iter() {
+        let Some(dict) = item.downcast::<CFDictionary<*const c_void, *const c_void>>() else {
+            continue;
+        };
+
+        let owner_name = unsafe { string_value(&dict, kCGWindowOwnerName) };
+        let Some(owner_name) = owner_name else {
+            continue;
+        };
+        if !BROWSER_OWNER_NAMES.iter().any(|b| *b == owner_name) {
+            continue;
+        }
+
+        let window_title = unsafe { string_value(&dict, kCGWindowName) };
+        log::debug!(
+            "[meet-detect] browser window: owner={:?} title={:?}",
+            owner_name,
+            window_title
+        );
+        if let Some(title) = window_title {
+            if looks_like_meet_call(&title) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn scan_for_active_meet_call() -> bool {
+    // Auto-detect is macOS-only in this iteration; the settings toggle is a no-op elsewhere.
+    false
+}

--- a/frontend/src-tauri/src/summary/processor.rs
+++ b/frontend/src-tauri/src/summary/processor.rs
@@ -315,6 +315,7 @@ pub fn extract_meeting_name_from_markdown(markdown: &str) -> Option<String> {
 /// * `summary_language` - Optional BCP-47 tag (e.g. "en-GB") to force summary output language
 /// * `detected_transcript_language` - Optional detected transcript language BCP-47 tag
 /// * `cached_english` - Optional previously-generated English summary to skip pass 1 when translating
+/// * `meeting_metadata_block` - Optional pre-formatted `<meeting_metadata>` block (calendar title/attendees)
 ///
 /// # Returns
 /// Tuple of (final_summary_markdown, english_summary_markdown, number_of_chunks_processed)
@@ -340,6 +341,7 @@ pub async fn generate_meeting_summary(
     summary_language: Option<&str>,
     detected_transcript_language: Option<&str>,
     cached_english: Option<&str>,
+    meeting_metadata_block: Option<&str>,
 ) -> Result<(String, String, i64), String> {
     if let Some(token) = cancellation_token {
         if token.is_cancelled() {
@@ -485,6 +487,12 @@ pub async fn generate_meeting_summary(
         let mut final_user_prompt = format!(
             "<transcript_chunks>\n{content_to_summarize}\n</transcript_chunks>\n"
         );
+
+        if let Some(metadata_block) = meeting_metadata_block {
+            final_user_prompt.push('\n');
+            final_user_prompt.push_str(metadata_block);
+            final_user_prompt.push('\n');
+        }
 
         if !custom_prompt.is_empty() {
             final_user_prompt.push_str("\n\nUser Provided Context:\n\n<user_context>\n");

--- a/frontend/src-tauri/src/summary/service.rs
+++ b/frontend/src-tauri/src/summary/service.rs
@@ -504,6 +504,8 @@ impl SummaryService {
             }),
         };
 
+        let meeting_metadata_block = Self::build_calendar_metadata_block(&pool, &meeting_id).await;
+
         let client = reqwest::Client::new();
         let result = generate_meeting_summary(
             &client,
@@ -525,6 +527,7 @@ impl SummaryService {
             summary_language.as_deref(),
             detected_summary_language.as_deref(),
             cached_english.as_deref(),
+            meeting_metadata_block.as_deref(),
         )
         .await;
 
@@ -615,6 +618,42 @@ impl SummaryService {
                 meeting_id, e
             );
         }
+    }
+
+    /// Builds a `<meeting_metadata>` block from calendar-derived fields (title, attendees,
+    /// scheduled time) if a Google Calendar event was matched onto this meeting. Absent when
+    /// the meeting has no calendar match — most meetings, since Calendar integration is optional.
+    async fn build_calendar_metadata_block(pool: &SqlitePool, meeting_id: &str) -> Option<String> {
+        let meeting = MeetingsRepository::get_meeting_metadata(pool, meeting_id)
+            .await
+            .ok()
+            .flatten()?;
+
+        let attendees: Vec<String> = meeting
+            .calendar_attendees
+            .as_deref()
+            .and_then(|json| serde_json::from_str::<Vec<crate::calendar::Attendee>>(json).ok())
+            .map(|attendees| {
+                attendees
+                    .into_iter()
+                    .map(|a| a.name.unwrap_or(a.email))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        if attendees.is_empty() && meeting.calendar_start_time.is_none() {
+            return None;
+        }
+
+        let mut block = format!("<meeting_metadata>\nTitle: {}\n", meeting.title);
+        if !attendees.is_empty() {
+            block.push_str(&format!("Attendees: {}\n", attendees.join(", ")));
+        }
+        if let Some(start) = &meeting.calendar_start_time {
+            block.push_str(&format!("Scheduled start: {}\n", start));
+        }
+        block.push_str("</meeting_metadata>");
+        Some(block)
     }
 }
 

--- a/frontend/src-tauri/src/summary/service.rs
+++ b/frontend/src-tauri/src/summary/service.rs
@@ -641,7 +641,10 @@ impl SummaryService {
             })
             .unwrap_or_default();
 
-        if attendees.is_empty() && meeting.calendar_start_time.is_none() {
+        if attendees.is_empty()
+            && meeting.calendar_start_time.is_none()
+            && meeting.calendar_meet_link.is_none()
+        {
             return None;
         }
 
@@ -651,6 +654,12 @@ impl SummaryService {
         }
         if let Some(start) = &meeting.calendar_start_time {
             block.push_str(&format!("Scheduled start: {}\n", start));
+        }
+        if let Some(end) = &meeting.calendar_end_time {
+            block.push_str(&format!("Scheduled end: {}\n", end));
+        }
+        if let Some(meet_link) = &meeting.calendar_meet_link {
+            block.push_str(&format!("Meet link: {}\n", meet_link));
         }
         block.push_str("</meeting_metadata>");
         Some(block)

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
-import { ArrowLeft, Settings2, Mic, Database as DatabaseIcon, SparkleIcon, FlaskConical } from 'lucide-react';
+import { ArrowLeft, Settings2, Mic, Database as DatabaseIcon, SparkleIcon, FlaskConical, CalendarDays } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { invoke } from '@tauri-apps/api/core';
 import { motion } from 'framer-motion';
@@ -10,6 +10,7 @@ import { RecordingSettings } from '@/components/RecordingSettings';
 import { PreferenceSettings } from '@/components/PreferenceSettings';
 import { SummaryModelSettings } from '@/components/SummaryModelSettings';
 import { BetaSettings } from '@/components/BetaSettings';
+import { CalendarSettings } from '@/components/CalendarSettings';
 import { useConfig } from '@/contexts/ConfigContext';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 
@@ -19,6 +20,7 @@ const TABS = [
   { value: 'recording', label: 'Recordings', icon: Mic },
   { value: 'Transcriptionmodels', label: 'Transcription', icon: DatabaseIcon },
   { value: 'summaryModels', label: 'Summary', icon: SparkleIcon },
+  { value: 'calendar', label: 'Calendar', icon: CalendarDays },
   { value: 'beta', label: 'Beta', icon: FlaskConical }
 ] as const;
 
@@ -123,6 +125,9 @@ export default function SettingsPage() {
             </TabsContent>
             <TabsContent value="summaryModels">
               <SummaryModelSettings />
+            </TabsContent>
+            <TabsContent value="calendar">
+              <CalendarSettings />
             </TabsContent>
             <TabsContent value="beta" className="mt-6">
               <BetaSettings />

--- a/frontend/src/components/CalendarSettings.tsx
+++ b/frontend/src/components/CalendarSettings.tsx
@@ -1,0 +1,196 @@
+import React, { useState, useEffect } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { toast } from 'sonner';
+import { CalendarDays, ShieldCheck } from 'lucide-react';
+import { Switch } from '@/components/ui/switch';
+import { Input } from '@/components/ui/input';
+
+interface CalendarConnectionStatus {
+  connected: boolean;
+  scope: string | null;
+}
+
+export function CalendarSettings() {
+  const [loading, setLoading] = useState(true);
+  const [connecting, setConnecting] = useState(false);
+  const [status, setStatus] = useState<CalendarConnectionStatus>({ connected: false, scope: null });
+  const [autoDetect, setAutoDetect] = useState(false);
+  const [clientId, setClientId] = useState('');
+  const [clientSecret, setClientSecret] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [connectionStatus, autoDetectEnabled] = await Promise.all([
+          invoke<CalendarConnectionStatus>('calendar_get_connection_status'),
+          invoke<boolean>('calendar_get_auto_detect_enabled'),
+        ]);
+        setStatus(connectionStatus);
+        setAutoDetect(autoDetectEnabled);
+      } catch (error) {
+        console.error('Failed to load Google Calendar settings:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const handleConnect = async () => {
+    if (!clientId.trim() || !clientSecret.trim()) {
+      toast.error('Client ID and Client Secret are required');
+      return;
+    }
+
+    setConnecting(true);
+    try {
+      const result = await invoke<CalendarConnectionStatus>('calendar_start_oauth', {
+        clientId: clientId.trim(),
+        clientSecret: clientSecret.trim(),
+      });
+      setStatus(result);
+      setClientSecret('');
+      toast.success('Google Calendar connected');
+    } catch (error) {
+      console.error('Failed to connect Google Calendar:', error);
+      toast.error('Failed to connect Google Calendar', {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    try {
+      await invoke('calendar_disconnect');
+      setStatus({ connected: false, scope: null });
+      toast.success('Google Calendar disconnected');
+    } catch (error) {
+      console.error('Failed to disconnect Google Calendar:', error);
+      toast.error('Failed to disconnect Google Calendar');
+    }
+  };
+
+  const handleAutoDetectToggle = async (enabled: boolean) => {
+    if (enabled) {
+      try {
+        const hasPermission = await invoke<boolean>('check_window_title_read_permission_command');
+        if (!hasPermission) {
+          const granted = await invoke<boolean>('request_window_title_read_permission_command');
+          if (!granted) {
+            toast.error('Screen Recording permission is required', {
+              description: 'Meetily needs it to read browser window titles and detect Google Meet calls. Grant it in System Settings, then try again.',
+            });
+            return;
+          }
+        }
+      } catch (error) {
+        console.error('Failed to check/request Screen Recording permission:', error);
+        toast.error('Could not verify Screen Recording permission');
+        return;
+      }
+    }
+
+    setAutoDetect(enabled);
+    try {
+      await invoke('calendar_toggle_auto_detect', { enabled });
+    } catch (error) {
+      console.error('Failed to update auto-detect setting:', error);
+      setAutoDetect(!enabled);
+      toast.error('Failed to update setting');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="animate-pulse">
+        <div className="h-4 bg-gray-200 rounded w-1/4 mb-4"></div>
+        <div className="h-8 bg-gray-200 rounded mb-4"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-semibold mb-4">Google Calendar</h3>
+        <p className="text-sm text-gray-600 mb-6">
+          Connect Google Calendar so meetings recorded around a scheduled Google Meet call are
+          automatically tagged with the real title, attendees, and Meet link.
+        </p>
+      </div>
+
+      {status.connected ? (
+        <div className="flex items-center justify-between p-4 border rounded-lg bg-green-50">
+          <div className="flex items-center gap-3">
+            <ShieldCheck className="w-5 h-5 text-green-700" />
+            <div>
+              <div className="font-medium text-green-900">Connected</div>
+              <div className="text-sm text-green-700">
+                Meetily can read your calendar's Meet events (read-only access).
+              </div>
+            </div>
+          </div>
+          <button
+            onClick={handleDisconnect}
+            className="px-3 py-2 text-sm border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+          >
+            Disconnect
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-4 p-4 border rounded-lg">
+          <div className="flex items-center gap-3">
+            <CalendarDays className="w-5 h-5 text-gray-500" />
+            <div className="font-medium">Not connected</div>
+          </div>
+          <p className="text-sm text-gray-600">
+            Requires a Google Cloud project with the Calendar API enabled and an OAuth 2.0
+            Client ID of type &quot;Desktop app&quot;. Paste those credentials below, then sign in
+            when your browser opens.
+          </p>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700">Client ID</label>
+            <Input
+              value={clientId}
+              onChange={(e) => setClientId(e.target.value)}
+              placeholder="xxxxxxxxxxxx.apps.googleusercontent.com"
+              disabled={connecting}
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-700">Client Secret</label>
+            <Input
+              type="password"
+              value={clientSecret}
+              onChange={(e) => setClientSecret(e.target.value)}
+              placeholder="Client secret"
+              disabled={connecting}
+            />
+          </div>
+          <button
+            onClick={handleConnect}
+            disabled={connecting}
+            className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors disabled:opacity-50"
+          >
+            {connecting ? 'Waiting for sign-in in your browser…' : 'Connect Google Calendar'}
+          </button>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between p-4 border rounded-lg">
+        <div className="flex-1">
+          <div className="font-medium">Auto-detect Google Meet calls</div>
+          <div className="text-sm text-gray-600">
+            Automatically start recording when a Google Meet call is active in your browser, and
+            stop shortly after it ends. macOS only, and requires granting Meetily Screen
+            Recording permission to read browser window titles. Detection is heuristic
+            (title-based) — it does not always catch every call.
+          </div>
+        </div>
+        <Switch checked={autoDetect} onCheckedChange={handleAutoDetectToggle} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MeetingDetails/SummaryPanel.tsx
+++ b/frontend/src/components/MeetingDetails/SummaryPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Summary, SummaryResponse, Transcript } from '@/types';
+import { Summary, SummaryResponse, Transcript, CalendarAttendee } from '@/types';
 import { EditableTitle } from '@/components/EditableTitle';
 import { BlockNoteSummaryView, BlockNoteSummaryViewRef } from '@/components/AISummary/BlockNoteSummaryView';
 import { EmptyStateSummary } from '@/components/EmptyStateSummary';
@@ -10,7 +10,7 @@ import { SummaryUpdaterButtonGroup } from './SummaryUpdaterButtonGroup';
 import Analytics from '@/lib/analytics';
 import { useEffect, useRef, useState, RefObject } from 'react';
 import { toast } from 'sonner';
-import { Languages, ChevronDown } from 'lucide-react';
+import { Languages, ChevronDown, Users, Video } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
 import { LanguagePickerPopover } from '@/components/LanguagePickerPopover';
@@ -27,6 +27,8 @@ interface SummaryPanelProps {
     id: string;
     title: string;
     created_at: string;
+    calendar_attendees?: string;
+    calendar_meet_link?: string;
   };
   meetingTitle: string;
   onTitleChange: (title: string) => void;
@@ -115,6 +117,15 @@ export function SummaryPanel({
   } | null>(null);
   activeMeetingIdRef.current = meeting.id;
   const { addRecent } = useRecentLanguages();
+
+  const calendarAttendees: CalendarAttendee[] = (() => {
+    if (!meeting.calendar_attendees) return [];
+    try {
+      return JSON.parse(meeting.calendar_attendees) as CalendarAttendee[];
+    } catch {
+      return [];
+    }
+  })();
 
   const effectiveLangLabel = summaryLang ? labelForCode(summaryLang) : 'Auto';
   const isLocalFallbackLanguage = summaryLangStorage === 'local_fallback';
@@ -263,6 +274,28 @@ export function SummaryPanel({
           onFinishEditing={onFinishEditTitle}
           onChange={onTitleChange}
         /> */}
+
+        {(calendarAttendees.length > 0 || meeting.calendar_meet_link) && (
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-500 mb-2">
+            {calendarAttendees.length > 0 && (
+              <span className="flex items-center gap-1" title={calendarAttendees.map(a => a.name || a.email).join(', ')}>
+                <Users size={12} />
+                {calendarAttendees.length} attendee{calendarAttendees.length === 1 ? '' : 's'}
+              </span>
+            )}
+            {meeting.calendar_meet_link && (
+              <a
+                href={meeting.calendar_meet_link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 hover:text-blue-600"
+              >
+                <Video size={12} />
+                Meet link
+              </a>
+            )}
+          </div>
+        )}
 
         {/* Button groups - only show when summary exists */}
         {aiSummary && !isSummaryLoading && (

--- a/frontend/src/hooks/useRecordingStop.ts
+++ b/frontend/src/hooks/useRecordingStop.ts
@@ -265,6 +265,12 @@ export function useRecordingStop(
             throw new Error('No meeting ID received from save operation');
           }
 
+          try {
+            await storageService.syncCalendarMetadata(meetingId);
+          } catch (error) {
+            console.warn('Failed to sync Google Calendar metadata for meeting:', error);
+          }
+
           let shouldDetectSummaryLanguage = false;
           try {
             shouldDetectSummaryLanguage = !(await applyPinnedSummaryLanguageToMeeting(meetingId));

--- a/frontend/src/hooks/useTranscriptRecovery.ts
+++ b/frontend/src/hooks/useTranscriptRecovery.ts
@@ -185,6 +185,12 @@ export function useTranscriptRecovery(): UseTranscriptRecoveryReturn {
       const savedMeetingId = saveResponse.meeting_id;
 
       try {
+        await storageService.syncCalendarMetadata(savedMeetingId);
+      } catch (error) {
+        console.warn('Failed to sync Google Calendar metadata for recovered meeting:', error);
+      }
+
+      try {
         await applyPinnedSummaryLanguageToMeeting(savedMeetingId);
       } catch (error) {
         console.warn('Failed to apply pinned summary language to recovered meeting:', error);

--- a/frontend/src/services/storageService.ts
+++ b/frontend/src/services/storageService.ts
@@ -49,6 +49,16 @@ export class StorageService {
   }
 
   /**
+   * Match a just-saved meeting against Google Calendar and write attendee/title/meet-link
+   * metadata onto it. No-op (resolves without error) if Calendar isn't connected or no
+   * event matches the meeting's time window.
+   * @param meetingId - ID of the meeting to enrich
+   */
+  async syncCalendarMetadata(meetingId: string): Promise<void> {
+    await invoke('api_save_meeting_calendar_metadata', { meetingId });
+  }
+
+  /**
    * Get meeting details by ID
    * @param meetingId - ID of the meeting to fetch
    * @returns Promise with meeting details

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -86,12 +86,21 @@ export interface SummaryDataResponse {
 }
 
 // Pagination types for optimized transcript loading
+export interface CalendarAttendee {
+  name?: string;
+  email: string;
+}
+
 export interface MeetingMetadata {
   id: string;
   title: string;
   created_at: string;
   updated_at: string;
   folder_path?: string;
+  calendar_attendees?: string; // JSON-encoded CalendarAttendee[]
+  calendar_meet_link?: string;
+  calendar_start_time?: string;
+  calendar_end_time?: string;
 }
 
 export interface PaginatedTranscriptsResponse {


### PR DESCRIPTION
## Summary
- Connects Meetily to Google Calendar (OAuth 2.0 loopback flow, `calendar.readonly` scope) and matches recorded meetings against calendar events by time window, tagging matched meetings with the real event title, attendee list, and Google Meet link. That context is fed into the summary prompt so generated summaries can reference the actual agenda/attendees.
- Adds an opt-in "Auto-detect Google Meet calls" toggle that watches on-screen browser window titles (macOS only) for the pattern used while a Meet call is active, and auto-starts/stops Meetily's existing recording pipeline. No bot ever joins the call — this only triggers the same local audio capture a manual "Record" click would.
- New Settings → Calendar tab for connecting an account and enabling auto-detect.

## Known limitations (please read before reviewing)
- **Auto-detect is macOS-only** in this iteration. It's implemented via `CGWindowListCopyWindowInfo` (Quartz Window Services), gated behind the real macOS Screen Recording permission (distinct from this app's existing "Audio Capture" permission). No Windows/Linux equivalent yet — the settings toggle is a no-op on those platforms.
- **Window-title matching is heuristic, not a guarantee.** It pattern-matches browser tab titles (e.g. Chrome renders an active call as `"Meet – <call-code>"`) — it can miss calls if a browser doesn't reflect call state in the title, and can't perfectly distinguish an active call from a Meet tab sitting on a non-call page. It's opt-in and off by default for this reason.
- **The OAuth consent screen used for development is in Google's "Testing" mode**, restricted to specific test users, so it can't be tested end-to-end by reviewers out of the box. Each user brings their own Google Cloud OAuth client (Client ID + Secret entered in Settings → Calendar) — there's no shared/embedded client secret — so this isn't blocking for real usage, just for a reviewer trying it without their own GCP project.
- Calendar metadata enrichment only applies to meetings that overlap an event on the *connected* Google account's calendar; unrelated meetings just keep their generic auto-generated title with no error.

## Test plan
- [x] `cargo check` passes cleanly (both new modules, no new warnings beyond pre-existing ones)
- [x] `pnpm tsc --noEmit` passes cleanly
- [x] Unit tests for the calendar event time-window matcher (`calendar/matcher.rs`)
- [x] Manually verified end-to-end on macOS: OAuth connect flow (browser consent → token exchange → persisted), auto-detect correctly identifying a live Google Meet call, auto-start recording (mic + system audio), auto-stop ~20s after leaving the call, transcript/audio saved correctly
- [ ] Not yet tested: Calendar metadata actually landing on a meeting scheduled through Calendar (mechanism verified by code review / DB inspection, but not observed live end-to-end in this branch)
- [ ] Not tested on Windows/Linux (auto-detect is intentionally macOS-only; Calendar integration should be platform-agnostic but wasn't verified on those platforms)