### PR TITLE
feat: support API ASR and custom local Whisper paths

### DIFF
--- a/frontend/src-tauri/migrations/20260724000000_add_asr_provider_config.sql
+++ b/frontend/src-tauri/migrations/20260724000000_add_asr_provider_config.sql
@@ -1,0 +1,3 @@
+ALTER TABLE transcript_settings ADD COLUMN endpoint TEXT;
+ALTER TABLE transcript_settings ADD COLUMN customApiKey TEXT;
+ALTER TABLE transcript_settings ADD COLUMN whisperModelPath TEXT;

--- a/frontend/src-tauri/src/api/api.rs
+++ b/frontend/src-tauri/src/api/api.rs
@@ -101,6 +101,9 @@ pub struct TranscriptConfig {
     pub model: String,
     #[serde(rename = "apiKey")]
     pub api_key: Option<String>,
+    pub endpoint: Option<String>,
+    #[serde(rename = "whisperModelPath")]
+    pub whisper_model_path: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -109,6 +112,9 @@ pub struct SaveTranscriptConfigRequest {
     pub model: String,
     #[serde(rename = "apiKey")]
     pub api_key: Option<String>,
+    pub endpoint: Option<String>,
+    #[serde(rename = "whisperModelPath")]
+    pub whisper_model_path: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -619,6 +625,8 @@ pub async fn api_get_transcript_config<R: Runtime>(
                         provider: config.provider,
                         model: config.model,
                         api_key,
+                        endpoint: config.endpoint,
+                        whisper_model_path: config.whisper_model_path,
                     }))
                 }
                 Err(e) => {
@@ -637,6 +645,8 @@ pub async fn api_get_transcript_config<R: Runtime>(
                 provider: "parakeet".to_string(),
                 model: crate::config::DEFAULT_PARAKEET_MODEL.to_string(),
                 api_key: None,
+                endpoint: None,
+                whisper_model_path: None,
             }))
         }
         Err(e) => {
@@ -653,6 +663,8 @@ pub async fn api_save_transcript_config<R: Runtime>(
     provider: String,
     model: String,
     api_key: Option<String>,
+    endpoint: Option<String>,
+    whisper_model_path: Option<String>,
     _auth_token: Option<String>,
 ) -> Result<serde_json::Value, String> {
     log_info!(
@@ -661,7 +673,16 @@ pub async fn api_save_transcript_config<R: Runtime>(
     );
     let pool = state.db_manager.pool();
 
-    if let Err(e) = SettingsRepository::save_transcript_config(pool, &provider, &model).await {
+    let endpoint = endpoint.filter(|value| !value.trim().is_empty());
+    let whisper_model_path = whisper_model_path.filter(|value| !value.trim().is_empty());
+
+    if let Err(e) = SettingsRepository::save_transcript_config(
+        pool,
+        &provider,
+        &model,
+        endpoint.as_deref(),
+        whisper_model_path.as_deref(),
+    ).await {
         log_error!("Failed to save transcript config: {}", e);
         return Err(e.to_string());
     }

--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -2,6 +2,7 @@
 
 use crate::api::TranscriptSegment;
 use crate::audio::decoder::{decode_audio_file, decode_audio_file_with_progress};
+use crate::audio::transcription::TranscriptionEngine;
 use crate::audio::vad::get_speech_chunks_with_progress;
 use crate::config::{DEFAULT_WHISPER_MODEL, DEFAULT_PARAKEET_MODEL};
 use crate::parakeet_engine::ParakeetEngine;
@@ -330,6 +331,7 @@ async fn run_import<R: Runtime>(
 
     // Determine which provider to use (default to whisper)
     let use_parakeet = provider.as_deref() == Some("parakeet");
+    let use_api = provider.as_deref() == Some("openaiCompatible");
 
     emit_progress(&app, "copying", 5, "Creating meeting folder...");
 
@@ -508,13 +510,29 @@ async fn run_import<R: Runtime>(
     emit_progress(&app, "transcribing", 30, "Loading transcription engine...");
 
     // Initialize the appropriate engine
-    let whisper_engine = if !use_parakeet && total_segments > 0 {
+    let whisper_engine = if !use_parakeet && !use_api && total_segments > 0 {
         Some(get_or_init_whisper(&app, model.as_deref()).await?)
     } else {
         None
     };
     let parakeet_engine = if use_parakeet && total_segments > 0 {
         Some(get_or_init_parakeet(&app, model.as_deref()).await?)
+    } else {
+        None
+    };
+    let api_provider = if use_api && total_segments > 0 {
+        match crate::audio::transcription::get_or_init_transcription_engine(&app)
+            .await
+            .map_err(anyhow::Error::msg)?
+        {
+            TranscriptionEngine::Provider(provider) => Some(provider),
+            engine => {
+                return Err(anyhow!(
+                    "Configured API transcription returned the '{}' engine",
+                    engine.provider_name()
+                ))
+            }
+        }
     } else {
         None
     };
@@ -586,6 +604,14 @@ async fn run_import<R: Runtime>(
                 .await
                 .map_err(|e| anyhow!("Parakeet transcription failed on segment {}: {}", i, e))?;
             (text, 0.9f32)
+        } else if use_api {
+            let result = api_provider
+                .as_ref()
+                .unwrap()
+                .transcribe(segment.samples.clone(), language.clone())
+                .await
+                .map_err(|e| anyhow!("API transcription failed on segment {}: {}", i, e))?;
+            (result.text, result.confidence.unwrap_or(0.0))
         } else {
             let engine = whisper_engine.as_ref().unwrap();
             let (text, conf, _) = engine

--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -1,6 +1,7 @@
 // Retranscription module - allows re-processing stored audio with different settings
 
 use crate::audio::decoder::decode_audio_file;
+use crate::audio::transcription::TranscriptionEngine;
 use crate::audio::vad::get_speech_chunks_with_progress;
 use super::common::{create_transcript_segments, split_segment_at_silence, write_transcripts_json};
 use super::constants::AUDIO_EXTENSIONS;
@@ -182,6 +183,7 @@ async fn run_retranscription<R: Runtime>(
 
     // Determine which provider to use (default to whisper)
     let use_parakeet = provider.as_deref() == Some("parakeet");
+    let use_api = provider.as_deref() == Some("openaiCompatible");
 
     info!(
         "Starting retranscription for meeting {} with language {:?}, model {:?}, provider {:?}",
@@ -299,13 +301,29 @@ async fn run_retranscription<R: Runtime>(
     emit_progress(&app, &meeting_id, "transcribing", 25, "Loading transcription engine...");
 
     // Initialize the appropriate engine once (not per-segment)
-    let whisper_engine = if !use_parakeet {
+    let whisper_engine = if !use_parakeet && !use_api {
         Some(get_or_init_whisper(&app, model.as_deref()).await?)
     } else {
         None
     };
     let parakeet_engine = if use_parakeet {
         Some(get_or_init_parakeet(&app, model.as_deref()).await?)
+    } else {
+        None
+    };
+    let api_provider = if use_api {
+        match crate::audio::transcription::get_or_init_transcription_engine(&app)
+            .await
+            .map_err(anyhow::Error::msg)?
+        {
+            TranscriptionEngine::Provider(provider) => Some(provider),
+            engine => {
+                return Err(anyhow!(
+                    "Configured API transcription returned the '{}' engine",
+                    engine.provider_name()
+                ))
+            }
+        }
     } else {
         None
     };
@@ -375,6 +393,14 @@ async fn run_retranscription<R: Runtime>(
                 .await
                 .map_err(|e| anyhow!("Parakeet transcription failed on segment {}: {}", i, e))?;
             (text, 0.9f32)
+        } else if use_api {
+            let result = api_provider
+                .as_ref()
+                .unwrap()
+                .transcribe(segment.samples.clone(), language.clone())
+                .await
+                .map_err(|e| anyhow!("API transcription failed on segment {}: {}", i, e))?;
+            (result.text, result.confidence.unwrap_or(0.0))
         } else {
             let engine = whisper_engine.as_ref().unwrap();
             let (text, conf, _) = engine

--- a/frontend/src-tauri/src/audio/transcription/engine.rs
+++ b/frontend/src-tauri/src/audio/transcription/engine.rs
@@ -74,6 +74,8 @@ pub async fn validate_transcription_model_ready<R: Runtime>(app: &AppHandle<R>) 
                 provider: "parakeet".to_string(),
                 model: crate::config::DEFAULT_PARAKEET_MODEL.to_string(),
                 api_key: None,
+                endpoint: None,
+                whisper_model_path: None,
             }
         }
         Err(e) => {
@@ -82,6 +84,8 @@ pub async fn validate_transcription_model_ready<R: Runtime>(app: &AppHandle<R>) 
                 provider: "parakeet".to_string(),
                 model: crate::config::DEFAULT_PARAKEET_MODEL.to_string(),
                 api_key: None,
+                endpoint: None,
+                whisper_model_path: None,
             }
         }
     };
@@ -135,10 +139,19 @@ pub async fn validate_transcription_model_ready<R: Runtime>(app: &AppHandle<R>) 
                 }
             }
         }
+        "openaiCompatible" => {
+            if config.endpoint.as_deref().map(str::trim).filter(|value| !value.is_empty()).is_none() {
+                return Err("Configure an OpenAI-compatible ASR endpoint before recording.".to_string());
+            }
+            if config.model.trim().is_empty() {
+                return Err("Configure an ASR model before recording.".to_string());
+            }
+            Ok(())
+        }
         other => {
             warn!("❌ Unsupported transcription provider for local recording: {}", other);
             Err(format!(
-                "Provider '{}' is not supported for local transcription. Please select 'localWhisper' or 'parakeet'.",
+                "Provider '{}' is not supported for transcription. Please select Local Whisper, Parakeet, or OpenAI-compatible ASR.",
                 other
             ))
         }
@@ -170,6 +183,8 @@ pub async fn get_or_init_transcription_engine<R: Runtime>(
                 provider: "parakeet".to_string(),
                 model: crate::config::DEFAULT_PARAKEET_MODEL.to_string(),
                 api_key: None,
+                endpoint: None,
+                whisper_model_path: None,
             }
         }
         Err(e) => {
@@ -178,6 +193,8 @@ pub async fn get_or_init_transcription_engine<R: Runtime>(
                 provider: "parakeet".to_string(),
                 model: crate::config::DEFAULT_PARAKEET_MODEL.to_string(),
                 api_key: None,
+                endpoint: None,
+                whisper_model_path: None,
             }
         }
     };
@@ -211,6 +228,19 @@ pub async fn get_or_init_transcription_engine<R: Runtime>(
                     Err("Parakeet engine not initialized. This should not happen after validation.".to_string())
                 }
             }
+        }
+        "openaiCompatible" => {
+            let endpoint = config.endpoint
+                .ok_or_else(|| "OpenAI-compatible ASR endpoint is not configured".to_string())?;
+            let provider = crate::audio::transcription::OpenAiCompatibleProvider::new(
+                crate::audio::transcription::OpenAiCompatibleConfig {
+                    endpoint,
+                    api_key: config.api_key,
+                    model: config.model,
+                    request_timeout: std::time::Duration::from_secs(300),
+                },
+            )?;
+            Ok(TranscriptionEngine::Provider(Arc::new(provider)))
         }
         "localWhisper" | _ => {
             info!("🎤 Initializing Whisper transcription engine");
@@ -255,7 +285,7 @@ pub async fn get_or_init_whisper<R: Runtime>(
                         config.provider, config.model
                     );
                     if config.provider == "localWhisper" && !config.model.is_empty() {
-                        Some(config.model)
+                        Some((config.model, config.whisper_model_path))
                     } else {
                         None
                     }
@@ -271,8 +301,14 @@ pub async fn get_or_init_whisper<R: Runtime>(
             };
 
             // If loaded model matches config, reuse it
-            if let Some(ref expected_model) = configured_model {
-                if current_model == *expected_model {
+            if let Some((ref expected_model, ref expected_path)) = configured_model {
+                let path_matches = match expected_path {
+                    Some(path) if !path.trim().is_empty() => engine
+                        .is_model_loaded_from_path(std::path::Path::new(path))
+                        .await,
+                    _ => true,
+                };
+                if current_model == *expected_model && path_matches {
                     info!(
                         "✅ Loaded model '{}' matches saved config, reusing",
                         current_model
@@ -321,7 +357,7 @@ pub async fn get_or_init_whisper<R: Runtime>(
     };
 
     // Get model configuration from API
-    let model_to_load =
+    let (model_to_load, custom_model_path) =
         match crate::api::api::api_get_transcript_config(app.clone(), app.clone().state(), None)
             .await
         {
@@ -332,7 +368,7 @@ pub async fn get_or_init_whisper<R: Runtime>(
                 );
                 if config.provider == "localWhisper" {
                     info!("Using model from API config: {}", config.model);
-                    config.model
+                    (config.model, config.whisper_model_path)
                 } else {
                     // Non-Whisper provider (e.g., parakeet) - this function shouldn't be called
                     return Err(format!(
@@ -343,18 +379,26 @@ pub async fn get_or_init_whisper<R: Runtime>(
             }
             Ok(None) => {
                 info!("No transcript config found in API, falling back to 'small'");
-                "small".to_string()
+                ("small".to_string(), None)
             }
             Err(e) => {
                 warn!(
                     "Failed to get transcript config from API: {}, falling back to 'small'",
                     e
                 );
-                "small".to_string()
+                ("small".to_string(), None)
             }
         };
 
     info!("Selected model to load: {}", model_to_load);
+
+    if let Some(model_path) = custom_model_path.filter(|path| !path.trim().is_empty()) {
+        engine
+            .load_model_from_path(&model_to_load, std::path::Path::new(&model_path))
+            .await
+            .map_err(|error| error.to_string())?;
+        return Ok(engine);
+    }
 
     // Discover available models to check if the desired model is downloaded
     let models = engine

--- a/frontend/src-tauri/src/audio/transcription/mod.rs
+++ b/frontend/src-tauri/src/audio/transcription/mod.rs
@@ -7,11 +7,13 @@ pub mod whisper_provider;
 pub mod parakeet_provider;
 pub mod engine;
 pub mod worker;
+pub mod openai_compatible_provider;
 
 // Re-export commonly used types
 pub use provider::{TranscriptionError, TranscriptionProvider, TranscriptResult};
 pub use whisper_provider::WhisperProvider;
 pub use parakeet_provider::ParakeetProvider;
+pub use openai_compatible_provider::{OpenAiCompatibleConfig, OpenAiCompatibleProvider};
 pub use engine::{
     TranscriptionEngine,
     validate_transcription_model_ready,

--- a/frontend/src-tauri/src/audio/transcription/openai_compatible_provider.rs
+++ b/frontend/src-tauri/src/audio/transcription/openai_compatible_provider.rs
@@ -1,0 +1,257 @@
+use super::provider::{TranscriptResult, TranscriptionError, TranscriptionProvider};
+use async_trait::async_trait;
+use reqwest::multipart::{Form, Part};
+use serde::Deserialize;
+use std::time::Duration;
+
+#[derive(Clone, Debug)]
+pub struct OpenAiCompatibleConfig {
+    pub endpoint: String,
+    pub api_key: Option<String>,
+    pub model: String,
+    pub request_timeout: Duration,
+}
+
+pub struct OpenAiCompatibleProvider {
+    config: OpenAiCompatibleConfig,
+    client: reqwest::Client,
+}
+
+#[derive(Debug, Deserialize)]
+struct TranscriptionResponse {
+    #[serde(default)]
+    text: String,
+}
+
+impl OpenAiCompatibleProvider {
+    pub fn new(config: OpenAiCompatibleConfig) -> Result<Self, String> {
+        let client = reqwest::Client::builder()
+            .timeout(config.request_timeout)
+            .build()
+            .map_err(|error| format!("Failed to create ASR HTTP client: {error}"))?;
+        Ok(Self { config, client })
+    }
+
+    fn transcription_url(endpoint: &str) -> String {
+        let endpoint = endpoint.trim().trim_end_matches('/');
+        if endpoint.ends_with("/audio/transcriptions") {
+            endpoint.to_string()
+        } else if endpoint.ends_with("/v1") {
+            format!("{endpoint}/audio/transcriptions")
+        } else {
+            format!("{endpoint}/v1/audio/transcriptions")
+        }
+    }
+
+    fn wav_pcm16_mono(samples: &[f32], sample_rate: u32) -> Vec<u8> {
+        let data_size = (samples.len() * 2) as u32;
+        let mut wav = Vec::with_capacity(44 + data_size as usize);
+        wav.extend_from_slice(b"RIFF");
+        wav.extend_from_slice(&(36 + data_size).to_le_bytes());
+        wav.extend_from_slice(b"WAVEfmt ");
+        wav.extend_from_slice(&16_u32.to_le_bytes());
+        wav.extend_from_slice(&1_u16.to_le_bytes());
+        wav.extend_from_slice(&1_u16.to_le_bytes());
+        wav.extend_from_slice(&sample_rate.to_le_bytes());
+        wav.extend_from_slice(&(sample_rate * 2).to_le_bytes());
+        wav.extend_from_slice(&2_u16.to_le_bytes());
+        wav.extend_from_slice(&16_u16.to_le_bytes());
+        wav.extend_from_slice(b"data");
+        wav.extend_from_slice(&data_size.to_le_bytes());
+        for sample in samples {
+            let pcm = ((*sample).clamp(-1.0, 1.0) * 32767.0).round() as i16;
+            wav.extend_from_slice(&pcm.to_le_bytes());
+        }
+        wav
+    }
+}
+
+#[async_trait]
+impl TranscriptionProvider for OpenAiCompatibleProvider {
+    async fn transcribe(
+        &self,
+        audio: Vec<f32>,
+        language: Option<String>,
+    ) -> Result<TranscriptResult, TranscriptionError> {
+        if self.config.endpoint.trim().is_empty() {
+            return Err(TranscriptionError::EngineFailed(
+                "OpenAI-compatible ASR endpoint is not configured".to_string(),
+            ));
+        }
+        if self.config.model.trim().is_empty() {
+            return Err(TranscriptionError::EngineFailed(
+                "OpenAI-compatible ASR model is not configured".to_string(),
+            ));
+        }
+
+        let wav = Self::wav_pcm16_mono(&audio, 16_000);
+        let file = Part::bytes(wav)
+            .file_name("meetily-chunk.wav")
+            .mime_str("audio/wav")
+            .map_err(|error| TranscriptionError::EngineFailed(error.to_string()))?;
+        let mut form = Form::new()
+            .part("file", file)
+            .text("model", self.config.model.clone())
+            .text("response_format", "json");
+        if let Some(language) = language.filter(|value| !value.is_empty() && value != "auto") {
+            form = form.text("language", language);
+        }
+
+        let mut request = self
+            .client
+            .post(Self::transcription_url(&self.config.endpoint))
+            .multipart(form);
+        if let Some(api_key) = self
+            .config
+            .api_key
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            request = request.bearer_auth(api_key);
+        }
+
+        let response = request.send().await.map_err(|error| {
+            TranscriptionError::EngineFailed(format!("ASR request failed: {error}"))
+        })?;
+        let status = response.status();
+        let body = response.text().await.map_err(|error| {
+            TranscriptionError::EngineFailed(format!("Failed to read ASR response: {error}"))
+        })?;
+        if !status.is_success() {
+            let message: String = body.chars().take(300).collect();
+            return Err(TranscriptionError::EngineFailed(format!(
+                "ASR service returned HTTP {}: {}",
+                status.as_u16(),
+                message
+            )));
+        }
+
+        let response: TranscriptionResponse = serde_json::from_str(&body).map_err(|error| {
+            TranscriptionError::EngineFailed(format!(
+                "ASR service returned an invalid transcription response: {error}"
+            ))
+        })?;
+        Ok(TranscriptResult {
+            text: response.text,
+            confidence: None,
+            is_partial: false,
+        })
+    }
+
+    async fn is_model_loaded(&self) -> bool {
+        !self.config.endpoint.trim().is_empty() && !self.config.model.trim().is_empty()
+    }
+
+    async fn get_current_model(&self) -> Option<String> {
+        (!self.config.model.trim().is_empty()).then(|| self.config.model.clone())
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "OpenAI-compatible ASR"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OpenAiCompatibleConfig, OpenAiCompatibleProvider};
+    use crate::audio::transcription::provider::TranscriptionProvider;
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    #[test]
+    fn resolves_base_and_full_transcription_urls() {
+        assert_eq!(
+            OpenAiCompatibleProvider::transcription_url("https://api.openai.com"),
+            "https://api.openai.com/v1/audio/transcriptions"
+        );
+        assert_eq!(
+            OpenAiCompatibleProvider::transcription_url("http://localhost:8000/v1/"),
+            "http://localhost:8000/v1/audio/transcriptions"
+        );
+        assert_eq!(
+            OpenAiCompatibleProvider::transcription_url(
+                "https://example.test/v1/audio/transcriptions"
+            ),
+            "https://example.test/v1/audio/transcriptions"
+        );
+    }
+
+    #[test]
+    fn encodes_valid_pcm_wav_header() {
+        let wav = OpenAiCompatibleProvider::wav_pcm16_mono(&[0.0, 1.0, -1.0], 16_000);
+        assert_eq!(&wav[0..4], b"RIFF");
+        assert_eq!(&wav[8..12], b"WAVE");
+        assert_eq!(&wav[36..40], b"data");
+        assert_eq!(wav.len(), 50);
+    }
+
+    #[tokio::test]
+    async fn sends_openai_compatible_multipart_request() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 4096];
+            loop {
+                let count = socket.read(&mut buffer).await.unwrap();
+                if count == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..count]);
+                let header_end = request
+                    .windows(4)
+                    .position(|window| window == b"\r\n\r\n")
+                    .map(|position| position + 4);
+                let Some(header_end) = header_end else {
+                    continue;
+                };
+                let headers = String::from_utf8_lossy(&request[..header_end]);
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        line.to_ascii_lowercase()
+                            .strip_prefix("content-length:")
+                            .and_then(|value| value.trim().parse::<usize>().ok())
+                    })
+                    .unwrap();
+                if request.len() >= header_end + content_length {
+                    break;
+                }
+            }
+
+            let request_text = String::from_utf8_lossy(&request);
+            assert!(request_text.starts_with("POST /v1/audio/transcriptions HTTP/1.1"));
+            assert!(request_text.contains("authorization: Bearer test-key"));
+            assert!(request_text.contains("name=\"file\""));
+            assert!(request_text.contains("name=\"model\""));
+            assert!(request_text.contains("whisper-test"));
+            assert!(request_text.contains("name=\"language\""));
+            assert!(request_text.contains("en"));
+
+            let body = r#"{"text":"mocked transcript"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let provider = OpenAiCompatibleProvider::new(OpenAiCompatibleConfig {
+            endpoint: format!("http://{address}"),
+            api_key: Some("test-key".to_string()),
+            model: "whisper-test".to_string(),
+            request_timeout: Duration::from_secs(5),
+        })
+        .unwrap();
+        let result = provider
+            .transcribe(vec![0.0; 320], Some("en".to_string()))
+            .await
+            .unwrap();
+
+        assert_eq!(result.text, "mocked transcript");
+        server.await.unwrap();
+    }
+}

--- a/frontend/src-tauri/src/database/commands.rs
+++ b/frontend/src-tauri/src/database/commands.rs
@@ -209,6 +209,8 @@ pub async fn initialize_fresh_database(app: AppHandle) -> Result<(), String> {
         pool,
         "parakeet",
         crate::config::DEFAULT_PARAKEET_MODEL,
+        None,
+        None,
     ).await {
         error!("Failed to set default transcription model config: {}", e);
     }

--- a/frontend/src-tauri/src/database/models.rs
+++ b/frontend/src-tauri/src/database/models.rs
@@ -127,4 +127,11 @@ pub struct TranscriptSetting {
     #[sqlx(rename = "openaiApiKey")]
     #[serde(rename = "openaiApiKey")]
     pub openai_api_key: Option<String>,
+    pub endpoint: Option<String>,
+    #[sqlx(rename = "customApiKey")]
+    #[serde(rename = "customApiKey")]
+    pub custom_api_key: Option<String>,
+    #[sqlx(rename = "whisperModelPath")]
+    #[serde(rename = "whisperModelPath")]
+    pub whisper_model_path: Option<String>,
 }

--- a/frontend/src-tauri/src/database/repositories/setting.rs
+++ b/frontend/src-tauri/src/database/repositories/setting.rs
@@ -154,18 +154,24 @@ impl SettingsRepository {
         pool: &SqlitePool,
         provider: &str,
         model: &str,
+        endpoint: Option<&str>,
+        whisper_model_path: Option<&str>,
     ) -> std::result::Result<(), sqlx::Error> {
         sqlx::query(
             r#"
-            INSERT INTO transcript_settings (id, provider, model)
-            VALUES ('1', $1, $2)
+            INSERT INTO transcript_settings (id, provider, model, endpoint, whisperModelPath)
+            VALUES ('1', $1, $2, $3, $4)
             ON CONFLICT(id) DO UPDATE SET
                 provider = excluded.provider,
-                model = excluded.model
+                model = excluded.model,
+                endpoint = excluded.endpoint,
+                whisperModelPath = excluded.whisperModelPath
             "#,
         )
         .bind(provider)
         .bind(model)
+        .bind(endpoint)
+        .bind(whisper_model_path)
         .execute(pool)
         .await?;
 
@@ -184,6 +190,7 @@ impl SettingsRepository {
             "elevenLabs" => "elevenLabsApiKey",
             "groq" => "groqApiKey",
             "openai" => "openaiApiKey",
+            "openaiCompatible" => "customApiKey",
             _ => {
                 return Err(sqlx::Error::Protocol(
                     format!("Invalid provider: {}", provider).into(),
@@ -216,6 +223,7 @@ impl SettingsRepository {
             "elevenLabs" => "elevenLabsApiKey",
             "groq" => "groqApiKey",
             "openai" => "openaiApiKey",
+            "openaiCompatible" => "customApiKey",
             _ => {
                 return Err(sqlx::Error::Protocol(
                     format!("Invalid provider: {}", provider).into(),

--- a/frontend/src-tauri/src/onboarding.rs
+++ b/frontend/src-tauri/src/onboarding.rs
@@ -196,6 +196,8 @@ pub async fn complete_onboarding<R: Runtime>(
         pool,
         "parakeet",
         crate::config::DEFAULT_PARAKEET_MODEL,
+        None,
+        None,
     ).await {
         error!("Failed to save transcription model config: {}", e);
         return Err(format!("Failed to save transcription model config: {}", e));

--- a/frontend/src-tauri/src/whisper_engine/commands.rs
+++ b/frontend/src-tauri/src/whisper_engine/commands.rs
@@ -286,51 +286,40 @@ pub async fn whisper_validate_model_ready_with_config<R: tauri::Runtime>(
     };
 
     if let Some(engine) = engine {
-        // Check if a model is currently loaded
-        if engine.is_model_loaded().await {
-            if let Some(current_model) = engine.get_current_model().await {
-                log::info!("Model already loaded: {}", current_model);
-                return Ok(current_model);
-            }
+        let config = crate::api::api::api_get_transcript_config(app.clone(), app.state(), None)
+            .await
+            .map_err(|error| format!("Failed to read Whisper configuration: {error}"))?
+            .ok_or_else(|| "Whisper configuration is missing".to_string())?;
+        if config.provider != "localWhisper" {
+            return Err(format!("Whisper validation requested for '{}' provider", config.provider));
         }
 
-        // No model loaded - try to load user's configured model from transcript config
-        let model_to_load = match crate::api::api::api_get_transcript_config(
-            app.clone(),
-            app.state(),
-            None,
-        )
-        .await
-        {
-            Ok(Some(config)) => {
-                log::info!(
-                    "Got transcript config from API - provider: {}, model: {}",
-                    config.provider,
-                    config.model
-                );
-                if config.provider == "localWhisper" && !config.model.is_empty() {
-                    log::info!("Using user's configured model: {}", config.model);
-                    Some(config.model)
-                } else {
-                    log::info!(
-                        "API config uses non-local provider ({}) or empty model, will auto-select",
-                        config.provider
-                    );
-                    None
+        let model_to_load = (!config.model.trim().is_empty()).then_some(config.model);
+        let custom_model_path = config.whisper_model_path.filter(|path| !path.trim().is_empty());
+        let desired_model = model_to_load.clone().unwrap_or_else(|| "custom-whisper".to_string());
+
+        if engine.is_model_loaded().await {
+            if engine.get_current_model().await.as_deref() == Some(desired_model.as_str()) {
+                let path_matches = match custom_model_path.as_deref() {
+                    Some(path) => engine
+                        .is_model_loaded_from_path(std::path::Path::new(path))
+                        .await,
+                    None => true,
+                };
+                if path_matches {
+                    return Ok(desired_model);
                 }
             }
-            Ok(None) => {
-                log::info!("No transcript config found in API, will auto-select model");
-                None
-            }
-            Err(e) => {
-                log::warn!(
-                    "Failed to get transcript config from API: {}, will auto-select model",
-                    e
-                );
-                None
-            }
-        };
+            engine.unload_model().await;
+        }
+
+        if let Some(model_path) = custom_model_path {
+            engine
+                .load_model_from_path(&desired_model, std::path::Path::new(&model_path))
+                .await
+                .map_err(|error| error.to_string())?;
+            return Ok(desired_model);
+        }
 
         // Check available models
         let models = engine

--- a/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
+++ b/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
@@ -37,6 +37,7 @@ pub struct WhisperEngine {
     models_dir: PathBuf,
     current_context: Arc<RwLock<Option<WhisperContext>>>,
     current_model: Arc<RwLock<Option<String>>>,
+    current_model_path: Arc<RwLock<Option<PathBuf>>>,
     available_models: Arc<RwLock<HashMap<String, ModelInfo>>>,
     // State tracking for smart logging
     last_transcription_was_short: Arc<RwLock<bool>>,
@@ -153,6 +154,7 @@ impl WhisperEngine {
             models_dir,
             current_context: Arc::new(RwLock::new(None)),
             current_model: Arc::new(RwLock::new(None)),
+            current_model_path: Arc::new(RwLock::new(None)),
             available_models: Arc::new(RwLock::new(HashMap::new())),
             // Initialize state tracking
             last_transcription_was_short: Arc::new(RwLock::new(false)),
@@ -259,73 +261,16 @@ impl WhisperEngine {
     }
     
     pub async fn load_model(&self, model_name: &str) -> Result<()> {
-        let models = self.available_models.read().await;
-        let model_info = models.get(model_name)
-            .ok_or_else(|| anyhow!("Model {} not found", model_name))?;
+        let model_info = {
+            let models = self.available_models.read().await;
+            models.get(model_name)
+                .cloned()
+                .ok_or_else(|| anyhow!("Model {} not found", model_name))?
+        };
 
         match model_info.status {
             ModelStatus::Available => {
-                // FIX 5: Check if this model is already loaded
-                if let Some(current_model) = self.current_model.read().await.as_ref() {
-                    if current_model == model_name {
-                        log::info!("Model {} is already loaded, skipping reload", model_name);
-                        return Ok(());
-                    }
-
-                    // FIX 5: Unload current model before loading new one
-                    log::info!("Unloading current model '{}' before loading '{}'", current_model, model_name);
-                    self.unload_model().await;
-                }
-
-                log::info!("Loading model: {}", model_name);
-
-                // PERFORMANCE OPTIMIZATION: Use comprehensive hardware profile for optimal GPU configuration
-                let hardware_profile = crate::audio::HardwareProfile::detect();
-                let adaptive_config = hardware_profile.get_whisper_config();
-                let acceleration = whisper_context_acceleration_for(
-                    WhisperCompiledBackend::current(),
-                    hardware_profile.gpu_type,
-                    hardware_profile.performance_tier,
-                );
-
-                let context_param = WhisperContextParameters {
-                    use_gpu: acceleration.use_gpu,
-                    gpu_device: acceleration.gpu_device,
-                    flash_attn: acceleration.flash_attn,
-                    ..Default::default()
-                };
-
-                log::info!(
-                    "Whisper acceleration decision: compiled_backend={} runtime_detected_gpu={:?} use_gpu={} flash_attn={} gpu_device={}",
-                    acceleration.compiled_backend.as_str(),
-                    acceleration.runtime_detected_gpu,
-                    acceleration.use_gpu,
-                    acceleration.flash_attn,
-                    acceleration.gpu_device,
-                );
-
-                // PERFORMANCE: Suppress verbose C library logs during model loading
-                // This hides the excessive Metal/GGML initialization logs in release builds
-                let ctx = {
-                    // let _suppressor = crate::whisper_engine::StderrSuppressor::new();
-
-                    // Load whisper context with hardware-optimized parameters
-                    WhisperContext::new_with_params(&model_info.path.to_string_lossy(), context_param)
-                        .map_err(|e| anyhow!("Failed to load model {}: {}", model_name, e))?
-                    // Suppressor dropped here, stderr restored
-                };
-
-                // Update current context and model
-                *self.current_context.write().await = Some(ctx);
-                *self.current_model.write().await = Some(model_name.to_string());
-
-                // Enhanced acceleration status reporting
-                let acceleration_status = acceleration.status_label();
-
-                log::info!("Successfully loaded model: {} with {} (Performance Tier: {:?}, Beam Size: {}, Threads: {:?})",
-                          model_name, acceleration_status, hardware_profile.performance_tier,
-                          adaptive_config.beam_size, adaptive_config.max_threads);
-                Ok(())
+                self.load_model_from_path(model_name, &model_info.path).await
             },
             ModelStatus::Missing => {
                 Err(anyhow!("Model {} is not downloaded", model_name))
@@ -342,6 +287,56 @@ impl WhisperEngine {
         }
     }
 
+    /// Load a whisper.cpp GGML model from any local file path.
+    pub async fn load_model_from_path(&self, model_name: &str, model_path: &std::path::Path) -> Result<()> {
+        let model_path = model_path.canonicalize()
+            .map_err(|error| anyhow!("Could not access model file '{}': {}", model_path.display(), error))?;
+        if !model_path.is_file() {
+            return Err(anyhow!("Whisper model path must point to a file"));
+        }
+        self.validate_model_file(&model_path).await.map_err(|_| {
+            anyhow!(
+                "Unsupported Whisper model format at '{}'. Meetily requires a whisper.cpp GGML model file (usually ggml-*.bin); convert safetensors or PyTorch models first.",
+                model_path.display()
+            )
+        })?;
+
+        if self.current_model.read().await.as_deref() == Some(model_name)
+            && self.current_model_path.read().await.as_deref() == Some(model_path.as_path()) {
+            log::info!("Model {} is already loaded, skipping reload", model_name);
+            return Ok(());
+        }
+        let current_model = self.current_model.read().await.clone();
+        if let Some(current_model) = current_model {
+            log::info!("Unloading current model '{}' before loading '{}'", current_model, model_name);
+            self.unload_model().await;
+        }
+
+        let hardware_profile = crate::audio::HardwareProfile::detect();
+        let adaptive_config = hardware_profile.get_whisper_config();
+        let acceleration = whisper_context_acceleration_for(
+            WhisperCompiledBackend::current(),
+            hardware_profile.gpu_type,
+            hardware_profile.performance_tier,
+        );
+        let context_param = WhisperContextParameters {
+            use_gpu: acceleration.use_gpu,
+            gpu_device: acceleration.gpu_device,
+            flash_attn: acceleration.flash_attn,
+            ..Default::default()
+        };
+        let ctx = WhisperContext::new_with_params(&model_path.to_string_lossy(), context_param)
+            .map_err(|error| anyhow!("Failed to load model {}: {}", model_name, error))?;
+        *self.current_context.write().await = Some(ctx);
+        *self.current_model.write().await = Some(model_name.to_string());
+        *self.current_model_path.write().await = Some(model_path);
+
+        log::info!("Successfully loaded model: {} with {} (Performance Tier: {:?}, Beam Size: {}, Threads: {:?})",
+                  model_name, acceleration.status_label(), hardware_profile.performance_tier,
+                  adaptive_config.beam_size, adaptive_config.max_threads);
+        Ok(())
+    }
+
     pub async fn unload_model(&self) -> bool  {
         let mut ctx_guard = self.current_context.write().await;
         let unloaded = ctx_guard.take().is_some();
@@ -351,6 +346,7 @@ impl WhisperEngine {
 
         let mut model_name_guard = self.current_model.write().await;
         model_name_guard.take();
+        self.current_model_path.write().await.take();
 
         unloaded
     }
@@ -358,9 +354,16 @@ impl WhisperEngine {
     pub async fn get_current_model(&self) -> Option<String> {
         self.current_model.read().await.clone()
     }
-    
+
     pub async fn is_model_loaded(&self) -> bool {
         self.current_context.read().await.is_some()
+    }
+
+    pub async fn is_model_loaded_from_path(&self, model_path: &std::path::Path) -> bool {
+        let Ok(model_path) = fs::canonicalize(model_path).await else {
+            return false;
+        };
+        self.current_model_path.read().await.as_deref() == Some(model_path.as_path())
     }
     
     // Enhanced function to clean repetitive text patterns and meaningless outputs
@@ -808,7 +811,7 @@ impl WhisperEngine {
     }
 
     /// Validate if a model file is a valid GGML file by checking its header
-    async fn validate_model_file(&self, model_path: &PathBuf) -> Result<()> {
+    async fn validate_model_file(&self, model_path: &std::path::Path) -> Result<()> {
         use tokio::io::AsyncReadExt;
 
         let mut file = fs::File::open(model_path).await
@@ -820,11 +823,11 @@ impl WhisperEngine {
             .map_err(|e| anyhow!("Failed to read model file header: {}", e))?;
 
         // Check for GGML magic number (various versions and endianness)
-        if buffer.starts_with(b"ggml") || buffer.starts_with(b"GGUF") || buffer.starts_with(b"ggmf") ||
+        if buffer.starts_with(b"ggml") || buffer.starts_with(b"ggmf") ||
            buffer.starts_with(b"lmgg") || buffer.starts_with(b"FUGU") || buffer.starts_with(b"fmgg") {
             Ok(())
         } else {
-            Err(anyhow!("Invalid model file: missing GGML/GGUF magic number. Found: {:?}",
+            Err(anyhow!("Invalid model file: missing GGML magic number. Found: {:?}",
                        String::from_utf8_lossy(&buffer[..4])))
         }
     }

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -41,7 +41,9 @@ export default function SettingsPage() {
           setTranscriptModelConfig({
             provider: config.provider || 'localWhisper',
             model: config.model || 'large-v3',
-            apiKey: config.apiKey || null
+            apiKey: config.apiKey || null,
+            endpoint: config.endpoint || null,
+            whisperModelPath: config.whisperModelPath || null
           });
         }
       } catch (error) {

--- a/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
+++ b/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
@@ -395,7 +395,8 @@ export function ImportAudioDialog({
                                   key={`${model.provider}:${model.name}`}
                                   value={`${model.provider}:${model.name}`}
                                 >
-                                  {model.displayName} ({Math.round(model.size_mb)} MB)
+                                  {model.displayName}
+                                  {model.provider !== 'openaiCompatible' && ` (${Math.round(model.size_mb)} MB)`}
                                 </SelectItem>
                               ))}
                             </SelectContent>

--- a/frontend/src/components/LanguageSelection.tsx
+++ b/frontend/src/components/LanguageSelection.tsx
@@ -118,7 +118,7 @@ interface LanguageSelectionProps {
   selectedLanguage: string;
   onLanguageChange: (language: string) => void;
   disabled?: boolean;
-  provider?: 'localWhisper' | 'parakeet' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
+  provider?: 'localWhisper' | 'parakeet' | 'openaiCompatible' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
 }
 
 export function LanguageSelection({

--- a/frontend/src/components/MeetingDetails/RetranscribeDialog.tsx
+++ b/frontend/src/components/MeetingDetails/RetranscribeDialog.tsx
@@ -349,7 +349,8 @@ export function RetranscribeDialog({
                 <SelectContent>
                   {availableModels.map((model) => (
                     <SelectItem key={`${model.provider}:${model.name}`} value={`${model.provider}:${model.name}`}>
-                      {model.displayName} ({Math.round(model.size_mb)} MB)
+                      {model.displayName}
+                      {model.provider !== 'openaiCompatible' && ` (${Math.round(model.size_mb)} MB)`}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/frontend/src/components/Sidebar/index.tsx
+++ b/frontend/src/components/Sidebar/index.tsx
@@ -215,7 +215,9 @@ const Sidebar: React.FC = () => {
       const payload = {
         provider: configToSave.provider,
         model: configToSave.model,
-        apiKey: configToSave.apiKey ?? null
+        apiKey: configToSave.apiKey ?? null,
+        endpoint: configToSave.endpoint ?? null,
+        whisperModelPath: configToSave.whisperModelPath ?? null
       };
       console.log('Saving transcript config with payload:', payload);
 
@@ -223,6 +225,8 @@ const Sidebar: React.FC = () => {
         provider: payload.provider,
         model: payload.model,
         apiKey: payload.apiKey,
+        endpoint: payload.endpoint,
+        whisperModelPath: payload.whisperModelPath,
       });
 
 

--- a/frontend/src/components/TranscriptSettings.tsx
+++ b/frontend/src/components/TranscriptSettings.tsx
@@ -8,11 +8,18 @@ import { Eye, EyeOff, Lock, Unlock } from 'lucide-react';
 import { ModelManager } from './WhisperModelManager';
 import { ParakeetModelManager } from './ParakeetModelManager';
 
+const providerLabels: Partial<Record<TranscriptModelProps['provider'], string>> = {
+    parakeet: 'Parakeet (recommended)',
+    localWhisper: 'Local Whisper',
+    openaiCompatible: 'OpenAI-compatible ASR API',
+};
 
 export interface TranscriptModelProps {
-    provider: 'localWhisper' | 'parakeet' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
+    provider: 'localWhisper' | 'parakeet' | 'openaiCompatible' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
     model: string;
     apiKey?: string | null;
+    endpoint?: string | null;
+    whisperModelPath?: string | null;
 }
 
 export interface TranscriptSettingsProps {
@@ -58,7 +65,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
         groq: ['llama-3.3-70b-versatile'],
         openai: ['gpt-4o'],
     };
-    const requiresApiKey = transcriptModelConfig.provider === 'deepgram' || transcriptModelConfig.provider === 'elevenLabs' || transcriptModelConfig.provider === 'openai' || transcriptModelConfig.provider === 'groq';
+    const requiresApiKey = uiProvider === 'openaiCompatible' || transcriptModelConfig.provider === 'deepgram' || transcriptModelConfig.provider === 'elevenLabs' || transcriptModelConfig.provider === 'openai' || transcriptModelConfig.provider === 'groq';
 
     const handleInputClick = () => {
         if (isApiKeyLocked) {
@@ -73,12 +80,29 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
         setTranscriptModelConfig({
             ...transcriptModelConfig,
             provider: 'localWhisper', // Ensure provider is set correctly
-            model: modelName
+            model: modelName,
+            whisperModelPath: null
         });
         // Close modal after selection
         if (onModelSelect) {
             onModelSelect();
         }
+    };
+
+    const saveConfiguration = async () => {
+        const config = {
+            ...transcriptModelConfig,
+            provider: uiProvider,
+            apiKey: apiKey || null,
+        };
+        await invoke('api_save_transcript_config', {
+            provider: config.provider,
+            model: config.model,
+            apiKey: config.apiKey,
+            endpoint: config.endpoint || null,
+            whisperModelPath: config.whisperModelPath || null,
+        });
+        setTranscriptModelConfig(config);
     };
 
     const handleParakeetModelSelect = (modelName: string) => {
@@ -112,17 +136,21 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 onValueChange={(value) => {
                                     const provider = value as TranscriptModelProps['provider'];
                                     setUiProvider(provider);
+                                    setTranscriptModelConfig({ ...transcriptModelConfig, provider });
                                     if (provider !== 'localWhisper' && provider !== 'parakeet') {
                                         fetchApiKey(provider);
                                     }
                                 }}
                             >
                                 <SelectTrigger className='focus:ring-1 focus:ring-blue-500 focus:border-blue-500'>
-                                    <SelectValue placeholder="Select provider" />
+                                    <SelectValue placeholder="Select provider">
+                                        {providerLabels[uiProvider] || uiProvider}
+                                    </SelectValue>
                                 </SelectTrigger>
                                 <SelectContent>
-                                    <SelectItem value="parakeet">⚡ Parakeet (Recommended - Real-time / Accurate)</SelectItem>
-                                    <SelectItem value="localWhisper">🏠 Local Whisper (High Accuracy)</SelectItem>
+                                    <SelectItem value="parakeet">Parakeet (recommended)</SelectItem>
+                                    <SelectItem value="localWhisper">Local Whisper</SelectItem>
+                                    <SelectItem value="openaiCompatible">OpenAI-compatible ASR API</SelectItem>
                                     {/* <SelectItem value="deepgram">☁️ Deepgram (Backup)</SelectItem>
                                     <SelectItem value="elevenLabs">☁️ ElevenLabs</SelectItem>
                                     <SelectItem value="groq">☁️ Groq</SelectItem>
@@ -130,7 +158,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 </SelectContent>
                             </Select>
 
-                            {uiProvider !== 'localWhisper' && uiProvider !== 'parakeet' && (
+                            {uiProvider !== 'localWhisper' && uiProvider !== 'parakeet' && uiProvider !== 'openaiCompatible' && (
                                 <Select
                                     value={transcriptModelConfig.model}
                                     onValueChange={(value) => {
@@ -159,6 +187,26 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 onModelSelect={handleWhisperModelSelect}
                                 autoSave={true}
                             />
+                            <div className="mt-4 space-y-2">
+                                <Label htmlFor="whisper-model-path">Custom GGML model file</Label>
+                                <Input
+                                    id="whisper-model-path"
+                                    value={transcriptModelConfig.whisperModelPath || ''}
+                                    onChange={(event) => setTranscriptModelConfig({
+                                        ...transcriptModelConfig,
+                                        provider: 'localWhisper',
+                                        model: event.target.value.split(/[\\/]/).pop()?.replace(/\.bin$/i, '') || 'custom-whisper',
+                                        whisperModelPath: event.target.value,
+                                    })}
+                                    placeholder="/path/to/ggml-model.bin"
+                                />
+                                <p className="text-xs text-gray-500">
+                                    Absolute paths are supported. The file must be a whisper.cpp GGML model; safetensors and PyTorch folders require conversion.
+                                </p>
+                                <Button type="button" variant="outline" onClick={saveConfiguration}>
+                                    Save custom model path
+                                </Button>
+                            </div>
                         </div>
                     )}
 
@@ -169,6 +217,37 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 onModelSelect={handleParakeetModelSelect}
                                 autoSave={true}
                             />
+                        </div>
+                    )}
+
+                    {uiProvider === 'openaiCompatible' && (
+                        <div className="space-y-4">
+                            <div>
+                                <Label htmlFor="asr-endpoint">ASR endpoint or base URL</Label>
+                                <Input
+                                    id="asr-endpoint"
+                                    value={transcriptModelConfig.endpoint || ''}
+                                    onChange={(event) => setTranscriptModelConfig({
+                                        ...transcriptModelConfig,
+                                        provider: 'openaiCompatible',
+                                        endpoint: event.target.value,
+                                    })}
+                                    placeholder="https://api.openai.com/v1"
+                                />
+                            </div>
+                            <div>
+                                <Label htmlFor="asr-model">ASR model</Label>
+                                <Input
+                                    id="asr-model"
+                                    value={transcriptModelConfig.model}
+                                    onChange={(event) => setTranscriptModelConfig({
+                                        ...transcriptModelConfig,
+                                        provider: 'openaiCompatible',
+                                        model: event.target.value,
+                                    })}
+                                    placeholder="gpt-4o-mini-transcribe"
+                                />
+                            </div>
                         </div>
                     )}
 
@@ -184,7 +263,14 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                     className={`pr-24 focus:ring-1 focus:ring-blue-500 focus:border-blue-500 ${isApiKeyLocked ? 'bg-gray-100 cursor-not-allowed' : ''
                                         }`}
                                     value={apiKey || ''}
-                                    onChange={(e) => setApiKey(e.target.value)}
+                                    onChange={(e) => {
+                                        setApiKey(e.target.value);
+                                        setTranscriptModelConfig({
+                                            ...transcriptModelConfig,
+                                            provider: uiProvider,
+                                            apiKey: e.target.value,
+                                        });
+                                    }}
                                     disabled={isApiKeyLocked}
                                     onClick={handleInputClick}
                                     placeholder="Enter your API key"
@@ -219,14 +305,16 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                             </div>
                         </div>
                     )}
+                    {uiProvider === 'openaiCompatible' && (
+                        <Button type="button" onClick={saveConfiguration}>
+                            Save ASR service
+                        </Button>
+                    )}
                 </div>
             </div>
         </div >
     )
 }
-
-
-
 
 
 

--- a/frontend/src/contexts/ConfigContext.tsx
+++ b/frontend/src/contexts/ConfigContext.tsx
@@ -201,7 +201,9 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
           setTranscriptModelConfig({
             provider: config.provider || 'parakeet',
             model: config.model || 'parakeet-tdt-0.6b-v3-int8',
-            apiKey: config.apiKey || null
+            apiKey: config.apiKey || null,
+            endpoint: config.endpoint || null,
+            whisperModelPath: config.whisperModelPath || null
           });
         }
       } catch (error) {

--- a/frontend/src/hooks/useRecordingStart.ts
+++ b/frontend/src/hooks/useRecordingStart.ts
@@ -34,7 +34,7 @@ export function useRecordingStart(
 
   const { clearTranscripts, setMeetingTitle } = useTranscripts();
   const { setIsMeetingActive } = useSidebar();
-  const { selectedDevices } = useConfig();
+  const { selectedDevices, transcriptModelConfig } = useConfig();
   const { setStatus } = useRecordingState();
 
   // Generate meeting title with timestamp
@@ -49,8 +49,11 @@ export function useRecordingStart(
     return `Meeting ${day}_${month}_${year}_${hours}_${minutes}_${seconds}`;
   }, []);
 
-  // Check if Parakeet transcription model is ready
-  const checkParakeetReady = useCallback(async (): Promise<boolean> => {
+  // Local Parakeet needs an on-disk model. Other providers are validated by Rust.
+  const checkTranscriptionReady = useCallback(async (): Promise<boolean> => {
+    if (transcriptModelConfig.provider !== 'parakeet') {
+      return true;
+    }
     try {
       await invoke('parakeet_init');
       const hasModels = await invoke<boolean>('parakeet_has_available_models');
@@ -59,7 +62,7 @@ export function useRecordingStart(
       console.error('Failed to check Parakeet status:', error);
       return false;
     }
-  }, []);
+  }, [transcriptModelConfig.provider]);
 
   // Check if any model is currently downloading
   const checkIfModelDownloading = useCallback(async (): Promise<boolean> => {
@@ -85,8 +88,8 @@ export function useRecordingStart(
       console.log('handleRecordingStart called - checking Parakeet model status');
 
       // Check if Parakeet transcription model is ready before starting
-      const parakeetReady = await checkParakeetReady();
-      if (!parakeetReady) {
+      const transcriptionReady = await checkTranscriptionReady();
+      if (!transcriptionReady) {
         const isDownloading = await checkIfModelDownloading();
         if (isDownloading) {
           toast.info('Model download in progress', {
@@ -141,7 +144,7 @@ export function useRecordingStart(
       // Re-throw so RecordingControls can handle device-specific errors
       throw error;
     }
-  }, [generateMeetingTitle, setMeetingTitle, setIsRecording, clearTranscripts, setIsMeetingActive, checkParakeetReady, checkIfModelDownloading, selectedDevices, showModal, setStatus]);
+  }, [generateMeetingTitle, setMeetingTitle, setIsRecording, clearTranscripts, setIsMeetingActive, checkTranscriptionReady, checkIfModelDownloading, selectedDevices, showModal, setStatus]);
 
   // Check for autoStartRecording flag and start recording automatically
   useEffect(() => {
@@ -154,8 +157,8 @@ export function useRecordingStart(
           sessionStorage.removeItem('autoStartRecording'); // Clear the flag
 
           // Check if Parakeet transcription model is ready before starting
-          const parakeetReady = await checkParakeetReady();
-          if (!parakeetReady) {
+          const transcriptionReady = await checkTranscriptionReady();
+          if (!transcriptionReady) {
             const isDownloading = await checkIfModelDownloading();
             if (isDownloading) {
               toast.info('Model download in progress', {
@@ -224,7 +227,7 @@ export function useRecordingStart(
     setIsRecording,
     clearTranscripts,
     setIsMeetingActive,
-    checkParakeetReady,
+    checkTranscriptionReady,
     checkIfModelDownloading,
     showModal,
     setStatus,
@@ -242,8 +245,8 @@ export function useRecordingStart(
       setIsAutoStarting(true);
 
       // Check if Parakeet transcription model is ready before starting
-      const parakeetReady = await checkParakeetReady();
-      if (!parakeetReady) {
+      const transcriptionReady = await checkTranscriptionReady();
+      if (!transcriptionReady) {
         const isDownloading = await checkIfModelDownloading();
         if (isDownloading) {
           toast.info('Model download in progress', {
@@ -313,7 +316,7 @@ export function useRecordingStart(
     setIsRecording,
     clearTranscripts,
     setIsMeetingActive,
-    checkParakeetReady,
+    checkTranscriptionReady,
     checkIfModelDownloading,
     showModal,
     setStatus,

--- a/frontend/src/hooks/useTranscriptionModels.ts
+++ b/frontend/src/hooks/useTranscriptionModels.ts
@@ -8,7 +8,7 @@ export interface RawModelInfo {
 }
 
 export interface ModelOption {
-  provider: 'whisper' | 'parakeet';
+  provider: 'whisper' | 'parakeet' | 'openaiCompatible';
   name: string;
   displayName: string;
   size_mb: number;
@@ -20,7 +20,7 @@ interface TranscriptModelConfig {
 }
 
 /**
- * Custom hook for fetching and managing transcription models (Whisper and Parakeet).
+ * Custom hook for fetching and managing local and API transcription models.
  *
  * This hook centralizes the model fetching logic that was previously duplicated
  * in ImportAudioDialog and RetranscribeDialog components.
@@ -77,6 +77,15 @@ export function useTranscriptionModels(transcriptModelConfig: TranscriptModelCon
       console.error('Failed to fetch Parakeet models:', err);
     }
 
+    if (transcriptModelConfig?.provider === 'openaiCompatible' && transcriptModelConfig.model) {
+      allModels.push({
+        provider: 'openaiCompatible',
+        name: transcriptModelConfig.model,
+        displayName: `API: ${transcriptModelConfig.model}`,
+        size_mb: 0,
+      });
+    }
+
     setAvailableModels(allModels);
 
     // Set default model based on user's saved configuration
@@ -88,7 +97,10 @@ export function useTranscriptionModels(transcriptModelConfig: TranscriptModelCon
     const configuredMatch = allModels.find(
       (m) =>
         (configuredProvider === 'localWhisper' && m.provider === 'whisper' && m.name === configuredModel) ||
-        (configuredProvider === 'parakeet' && m.provider === 'parakeet' && m.name === configuredModel)
+        (configuredProvider === 'parakeet' && m.provider === 'parakeet' && m.name === configuredModel) ||
+        (configuredProvider === 'openaiCompatible' &&
+          m.provider === 'openaiCompatible' &&
+          m.name === configuredModel)
     );
 
     // Only set default model if user hasn't manually selected one


### PR DESCRIPTION
## Description

Adds two configurable transcription paths:

- An OpenAI-compatible ASR provider using the standard multipart `/v1/audio/transcriptions` contract. Users can configure the endpoint/base URL, model, and optional API key.
- A custom local Whisper model file path. Meetily accepts any accessible whisper.cpp GGML file instead of requiring it to live in the managed model directory.

Configuration is persisted in `transcript_settings`, recording readiness is provider-aware, and changing a custom model path reloads the correct file even when the model label is unchanged.

## Related Issue

Closes #301
Relates to #493

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] All tests pass

Focused verification:

- `cargo check -p meetily --lib -j 2`
- `cargo test -p meetily openai_compatible_provider --lib -j 2` — 3 passed
- SQLite migration smoke test for all three new columns
- Settings UI verified at 1280x900 and 800x900 for both API ASR and custom local-model configurations

The full frontend TypeScript check remains blocked by five pre-existing errors in `BlockNoteSummaryView.tsx`, `ModelSettingsModal.tsx`, `ParakeetModelManager.tsx`, `WhisperModelManager.tsx`, and the existing `bun:test` import.

## Documentation

- [ ] Documentation updated
- [x] No documentation needed

The settings UI includes format guidance for custom model files. Unsupported safetensors/PyTorch paths return an actionable conversion message.

## Checklist

- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [x] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)

Manually verified locally at desktop and narrow viewports; no layout overlap, truncation, or unreachable controls observed.

## Additional Notes

- API tests use a local mock server; no external API calls are made.
- API keys remain optional so unauthenticated self-hosted OpenAI-compatible services work.
- Custom local files must be whisper.cpp GGML model files. Other formats need conversion before loading.
