### PR TITLE
feat(video): add desktop capture, editing, and browser tab recording

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,6 +1508,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3620,6 +3626,7 @@ dependencies = [
  "chrono",
  "cidre",
  "clap 4.6.1",
+ "core-foundation 0.9.4",
  "core-graphics 0.23.2",
  "cpal",
  "criterion",
@@ -3673,6 +3680,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -7240,6 +7248,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7512,6 +7532,24 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
 
 [[package]]
 name = "typeid"

--- a/edge-extension/README.md
+++ b/edge-extension/README.md
@@ -5,8 +5,12 @@ Unpacked Chrome/Edge extension for recording a selected browser tab with Meetily
 1. Open `chrome://extensions` in Chrome or `edge://extensions` in Edge.
 2. Enable **Developer mode**.
 3. Choose **Load unpacked** and select this directory.
-4. Before starting a meeting, focus the tab to record and click the extension.
-5. Select **Browser tab** in Meetily and begin recording.
+4. Focus the tab to record and open the extension.
+5. Choose **Select this tab**.
+6. Either choose **Start** for a standalone capture, or select **Browser tab** in
+   Meetily and begin a meeting recording.
 
 The extension only connects to Meetily on `127.0.0.1`. It has no internet host
-permissions and does not upload recordings.
+permissions and does not upload recordings. **Stop & save** finalizes the file;
+**Delete recording** discards the active or most recently saved standalone
+capture. Meeting recordings also stop and save automatically with the meeting.

--- a/edge-extension/README.md
+++ b/edge-extension/README.md
@@ -1,0 +1,12 @@
+# Meetily browser tab capture
+
+Unpacked Chrome/Edge extension for recording a selected browser tab with Meetily.
+
+1. Open `chrome://extensions` in Chrome or `edge://extensions` in Edge.
+2. Enable **Developer mode**.
+3. Choose **Load unpacked** and select this directory.
+4. Before starting a meeting, focus the tab to record and click the extension.
+5. Select **Browser tab** in Meetily and begin recording.
+
+The extension only connects to Meetily on `127.0.0.1`. It has no internet host
+permissions and does not upload recordings.

--- a/edge-extension/manifest.json
+++ b/edge-extension/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "Meetily Tab Capture",
+  "version": "0.1.0",
+  "description": "Records the Chrome or Edge tab you select while Meetily is recording.",
+  "permissions": [
+    "tabCapture",
+    "offscreen"
+  ],
+  "host_permissions": [
+    "ws://127.0.0.1:8179/*"
+  ],
+  "action": {
+    "default_title": "Select a browser tab for Meetily"
+  },
+  "background": {
+    "service_worker": "service-worker.js"
+  }
+}

--- a/edge-extension/manifest.json
+++ b/edge-extension/manifest.json
@@ -1,9 +1,10 @@
 {
   "manifest_version": 3,
   "name": "Meetily Tab Capture",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Records the Chrome or Edge tab you select while Meetily is recording.",
   "permissions": [
+    "activeTab",
     "tabCapture",
     "offscreen"
   ],
@@ -11,7 +12,8 @@
     "ws://127.0.0.1:8179/*"
   ],
   "action": {
-    "default_title": "Select a browser tab for Meetily"
+    "default_title": "Open Meetily tab capture controls",
+    "default_popup": "popup.html"
   },
   "background": {
     "service_worker": "service-worker.js"

--- a/edge-extension/offscreen.html
+++ b/edge-extension/offscreen.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Meetily Tab Capture</title>
+  </head>
+  <body>
+    <script src="offscreen.js"></script>
+  </body>
+</html>

--- a/edge-extension/offscreen.js
+++ b/edge-extension/offscreen.js
@@ -8,6 +8,10 @@ let mediaRecorder;
 let armedTitle;
 let audioContext;
 let chunkWrites = Promise.resolve();
+let releasingCapture = false;
+let captureOrigin;
+let discardOnStop = false;
+let lastResult;
 
 function connect() {
   clearTimeout(reconnectTimer);
@@ -19,13 +23,27 @@ function connect() {
     } else {
       send({ type: 'hello' });
     }
+    notifyState();
   });
   socket.addEventListener('message', async (event) => {
     const command = JSON.parse(event.data);
-    if (command.type === 'start') await startRecording();
-    if (command.type === 'stop') stopRecording();
+    if (command.type === 'start') {
+      await startRecording(command.origin || 'meeting');
+    } else if (command.type === 'stop') {
+      stopRecording(false);
+    } else if (command.type === 'saved') {
+      lastResult = `Saved ${command.filename}`;
+      notifyState();
+    } else if (command.type === 'discarded') {
+      lastResult = 'Recording deleted';
+      notifyState();
+    } else if (command.type === 'error') {
+      lastResult = command.message || 'Capture failed';
+      notifyState();
+    }
   });
   socket.addEventListener('close', () => {
+    notifyState();
     reconnectTimer = setTimeout(connect, 1000);
   });
   socket.addEventListener('error', () => socket.close());
@@ -34,15 +52,34 @@ function connect() {
 function send(message) {
   if (socket?.readyState === WebSocket.OPEN) {
     socket.send(JSON.stringify({ ...message, token: BRIDGE_TOKEN }));
+    return true;
   }
+  return false;
+}
+
+function currentStatus() {
+  return {
+    bridgeConnected: socket?.readyState === WebSocket.OPEN,
+    armed: Boolean(capturedStream?.active),
+    recording: mediaRecorder?.state === 'recording',
+    origin: captureOrigin || null,
+    title: armedTitle || null,
+    lastResult: lastResult || null,
+  };
+}
+
+function notifyState() {
+  chrome.runtime.sendMessage({
+    target: 'service-worker',
+    type: 'state',
+    status: currentStatus(),
+  }).catch(() => {});
 }
 
 async function arm(streamId, title) {
   if (mediaRecorder?.state === 'recording') {
-    throw new Error('Cannot change tabs while recording');
+    throw new Error('Stop the current recording before changing tabs');
   }
-  capturedStream?.getTracks().forEach((track) => track.stop());
-  if (audioContext) await audioContext.close();
 
   capturedStream = await navigator.mediaDevices.getUserMedia({
     audio: {
@@ -59,6 +96,7 @@ async function arm(streamId, title) {
     },
   });
   armedTitle = title;
+  lastResult = 'Tab selected';
 
   const audioTracks = capturedStream.getAudioTracks();
   if (audioTracks.length > 0) {
@@ -73,11 +111,33 @@ async function arm(streamId, title) {
     track.addEventListener('ended', disarm, { once: true });
   }
   send({ type: 'armed', title: armedTitle });
+  chrome.runtime.sendMessage({ target: 'service-worker', type: 'armed' }).catch(() => {});
+  notifyState();
 }
 
-async function startRecording() {
+async function releaseCapture() {
+  if (mediaRecorder?.state === 'recording') {
+    throw new Error('Stop the current recording before changing tabs');
+  }
+
+  releasingCapture = true;
+  capturedStream?.getTracks().forEach((track) => track.stop());
+  capturedStream = undefined;
+  armedTitle = undefined;
+  if (audioContext) {
+    await audioContext.close();
+    audioContext = undefined;
+  }
+  releasingCapture = false;
+  send({ type: 'disarmed' });
+  notifyState();
+}
+
+async function startRecording(origin) {
   if (!capturedStream?.active) {
-    send({ type: 'error', message: 'The armed tab is no longer available' });
+    lastResult = 'The selected tab is no longer available';
+    send({ type: 'error', message: lastResult });
+    notifyState();
     return;
   }
   if (mediaRecorder?.state === 'recording') return;
@@ -91,6 +151,9 @@ async function startRecording() {
     capturedStream,
     mimeType ? { mimeType, videoBitsPerSecond: 5_000_000 } : undefined,
   );
+  captureOrigin = origin;
+  discardOnStop = false;
+  lastResult = null;
   chunkWrites = Promise.resolve();
   mediaRecorder.addEventListener('dataavailable', (event) => {
     if (event.data.size > 0 && socket?.readyState === WebSocket.OPEN) {
@@ -101,34 +164,76 @@ async function startRecording() {
   });
   mediaRecorder.addEventListener('stop', async () => {
     await chunkWrites;
-    send({ type: 'complete' });
-    chrome.runtime.sendMessage({ target: 'service-worker', type: 'armed' });
+    send({ type: discardOnStop ? 'discard' : 'complete' });
+    lastResult = discardOnStop
+      ? 'Deleting recording…'
+      : captureOrigin === 'standalone'
+        ? 'Saving recording…'
+        : 'Saved with the meeting';
+    captureOrigin = undefined;
+    discardOnStop = false;
+    chrome.runtime.sendMessage({ target: 'service-worker', type: 'armed' }).catch(() => {});
+    notifyState();
   }, { once: true });
   mediaRecorder.start(1000);
-  chrome.runtime.sendMessage({ target: 'service-worker', type: 'recording' });
+  chrome.runtime.sendMessage({ target: 'service-worker', type: 'recording' }).catch(() => {});
+  notifyState();
 }
 
-function stopRecording() {
+function stopRecording(discard) {
   if (mediaRecorder?.state === 'recording') {
+    discardOnStop = discard;
     mediaRecorder.stop();
+  } else if (discard) {
+    send({ type: 'discard' });
+    lastResult = 'Deleting recording…';
+    notifyState();
   } else {
     send({ type: 'complete' });
   }
 }
 
 function disarm() {
+  if (releasingCapture) return;
   if (mediaRecorder?.state === 'recording') mediaRecorder.stop();
   capturedStream = undefined;
   armedTitle = undefined;
   send({ type: 'disarmed' });
-  chrome.runtime.sendMessage({ target: 'service-worker', type: 'disarmed' });
+  chrome.runtime.sendMessage({ target: 'service-worker', type: 'disarmed' }).catch(() => {});
+  notifyState();
 }
 
-chrome.runtime.onMessage.addListener((message) => {
-  if (message.target !== 'offscreen' || message.type !== 'arm') return;
-  arm(message.streamId, message.title).catch((error) => {
-    send({ type: 'error', message: error.message });
-  });
+async function handleMessage(message) {
+  if (message.type === 'release') {
+    await releaseCapture();
+  } else if (message.type === 'arm') {
+    await arm(message.streamId, message.title);
+  } else if (message.type === 'status') {
+    return currentStatus();
+  } else if (message.type === 'manual_start') {
+    if (!capturedStream?.active) throw new Error('Select a tab first');
+    if (!send({ type: 'manual_start' })) throw new Error('Open Meetily first');
+    lastResult = 'Starting recording…';
+    notifyState();
+  } else if (message.type === 'stop_user') {
+    if (mediaRecorder?.state !== 'recording') throw new Error('No recording is active');
+    stopRecording(false);
+  } else if (message.type === 'delete_user') {
+    stopRecording(true);
+  }
+  return currentStatus();
+}
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message.target !== 'offscreen') return;
+  handleMessage(message)
+    .then((status) => sendResponse({ ok: true, status }))
+    .catch((error) => {
+      lastResult = error.message;
+      notifyState();
+      sendResponse({ ok: false, error: error.message, status: currentStatus() });
+    });
+  return true;
 });
 
 connect();

--- a/edge-extension/offscreen.js
+++ b/edge-extension/offscreen.js
@@ -1,0 +1,134 @@
+const BRIDGE_URL = 'ws://127.0.0.1:8179';
+const BRIDGE_TOKEN = 'meetily-local-capture-v1-7d4f2c9a6e31b805';
+
+let socket;
+let reconnectTimer;
+let capturedStream;
+let mediaRecorder;
+let armedTitle;
+let audioContext;
+let chunkWrites = Promise.resolve();
+
+function connect() {
+  clearTimeout(reconnectTimer);
+  socket = new WebSocket(BRIDGE_URL);
+  socket.binaryType = 'arraybuffer';
+  socket.addEventListener('open', () => {
+    if (capturedStream?.active) {
+      send({ type: 'armed', title: armedTitle });
+    } else {
+      send({ type: 'hello' });
+    }
+  });
+  socket.addEventListener('message', async (event) => {
+    const command = JSON.parse(event.data);
+    if (command.type === 'start') await startRecording();
+    if (command.type === 'stop') stopRecording();
+  });
+  socket.addEventListener('close', () => {
+    reconnectTimer = setTimeout(connect, 1000);
+  });
+  socket.addEventListener('error', () => socket.close());
+}
+
+function send(message) {
+  if (socket?.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify({ ...message, token: BRIDGE_TOKEN }));
+  }
+}
+
+async function arm(streamId, title) {
+  if (mediaRecorder?.state === 'recording') {
+    throw new Error('Cannot change tabs while recording');
+  }
+  capturedStream?.getTracks().forEach((track) => track.stop());
+  if (audioContext) await audioContext.close();
+
+  capturedStream = await navigator.mediaDevices.getUserMedia({
+    audio: {
+      mandatory: {
+        chromeMediaSource: 'tab',
+        chromeMediaSourceId: streamId,
+      },
+    },
+    video: {
+      mandatory: {
+        chromeMediaSource: 'tab',
+        chromeMediaSourceId: streamId,
+      },
+    },
+  });
+  armedTitle = title;
+
+  const audioTracks = capturedStream.getAudioTracks();
+  if (audioTracks.length > 0) {
+    audioContext = new AudioContext();
+    const source = audioContext.createMediaStreamSource(
+      new MediaStream(audioTracks),
+    );
+    source.connect(audioContext.destination);
+  }
+
+  for (const track of capturedStream.getTracks()) {
+    track.addEventListener('ended', disarm, { once: true });
+  }
+  send({ type: 'armed', title: armedTitle });
+}
+
+async function startRecording() {
+  if (!capturedStream?.active) {
+    send({ type: 'error', message: 'The armed tab is no longer available' });
+    return;
+  }
+  if (mediaRecorder?.state === 'recording') return;
+
+  const mimeType = [
+    'video/webm;codecs=vp9,opus',
+    'video/webm;codecs=vp8,opus',
+    'video/webm',
+  ].find((candidate) => MediaRecorder.isTypeSupported(candidate));
+  mediaRecorder = new MediaRecorder(
+    capturedStream,
+    mimeType ? { mimeType, videoBitsPerSecond: 5_000_000 } : undefined,
+  );
+  chunkWrites = Promise.resolve();
+  mediaRecorder.addEventListener('dataavailable', (event) => {
+    if (event.data.size > 0 && socket?.readyState === WebSocket.OPEN) {
+      chunkWrites = chunkWrites.then(async () => {
+        socket.send(await event.data.arrayBuffer());
+      });
+    }
+  });
+  mediaRecorder.addEventListener('stop', async () => {
+    await chunkWrites;
+    send({ type: 'complete' });
+    chrome.runtime.sendMessage({ target: 'service-worker', type: 'armed' });
+  }, { once: true });
+  mediaRecorder.start(1000);
+  chrome.runtime.sendMessage({ target: 'service-worker', type: 'recording' });
+}
+
+function stopRecording() {
+  if (mediaRecorder?.state === 'recording') {
+    mediaRecorder.stop();
+  } else {
+    send({ type: 'complete' });
+  }
+}
+
+function disarm() {
+  if (mediaRecorder?.state === 'recording') mediaRecorder.stop();
+  capturedStream = undefined;
+  armedTitle = undefined;
+  send({ type: 'disarmed' });
+  chrome.runtime.sendMessage({ target: 'service-worker', type: 'disarmed' });
+}
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.target !== 'offscreen' || message.type !== 'arm') return;
+  arm(message.streamId, message.title).catch((error) => {
+    send({ type: 'error', message: error.message });
+  });
+});
+
+connect();

--- a/edge-extension/popup.css
+++ b/edge-extension/popup.css
@@ -1,0 +1,168 @@
+:root {
+  color-scheme: light dark;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  width: 320px;
+  margin: 0;
+  background: #f8fafc;
+}
+
+main {
+  padding: 16px;
+}
+
+header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+h1 {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.3;
+}
+
+header p,
+.footnote,
+#result {
+  margin: 4px 0 0;
+  color: #64748b;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+#status-dot {
+  width: 9px;
+  height: 9px;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: #f59e0b;
+}
+
+#status-dot.connected {
+  background: #10b981;
+}
+
+.tab-card {
+  display: grid;
+  gap: 7px;
+  padding: 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #fff;
+}
+
+.eyebrow {
+  color: #64748b;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+#tab-title {
+  overflow: hidden;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+button {
+  min-height: 34px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #fff;
+  color: #1e293b;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+button:hover:not(:disabled) {
+  background: #f1f5f9;
+}
+
+button:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+button:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+button.primary {
+  border-color: #2563eb;
+  background: #2563eb;
+  color: #fff;
+}
+
+button.primary:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+button.danger {
+  grid-column: 1 / -1;
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
+#result {
+  min-height: 31px;
+  margin-top: 10px;
+}
+
+.footnote {
+  padding-top: 10px;
+  border-top: 1px solid #e2e8f0;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root,
+  body {
+    background: #0f172a;
+    color: #f8fafc;
+  }
+
+  .tab-card,
+  button {
+    border-color: #334155;
+    background: #1e293b;
+    color: #f8fafc;
+  }
+
+  button:hover:not(:disabled) {
+    background: #334155;
+  }
+
+  header p,
+  .footnote,
+  #result,
+  .eyebrow {
+    color: #94a3b8;
+  }
+
+  .footnote {
+    border-color: #334155;
+  }
+}

--- a/edge-extension/popup.html
+++ b/edge-extension/popup.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Meetily Tab Capture</title>
+    <link rel="stylesheet" href="popup.css">
+  </head>
+  <body>
+    <main>
+      <header>
+        <div>
+          <h1>Meetily Tab Capture</h1>
+          <p id="connection">Checking Meetily…</p>
+        </div>
+        <span id="status-dot" aria-hidden="true"></span>
+      </header>
+
+      <section class="tab-card" aria-label="Selected tab">
+        <span class="eyebrow">Selected tab</span>
+        <strong id="tab-title">None</strong>
+        <button id="select-tab" type="button">Select this tab</button>
+      </section>
+
+      <section class="controls" aria-label="Recording controls">
+        <button id="start" class="primary" type="button">Start</button>
+        <button id="stop" type="button">Stop &amp; save</button>
+        <button id="delete" class="danger" type="button">Delete recording</button>
+      </section>
+
+      <p id="result" role="status">Select a tab to begin.</p>
+      <p class="footnote">
+        Standalone captures save to Movies/Meetily Captures. Meeting captures
+        save with the meeting and stop automatically.
+      </p>
+    </main>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/edge-extension/popup.js
+++ b/edge-extension/popup.js
@@ -1,0 +1,70 @@
+const connection = document.querySelector('#connection');
+const statusDot = document.querySelector('#status-dot');
+const tabTitle = document.querySelector('#tab-title');
+const result = document.querySelector('#result');
+const selectButton = document.querySelector('#select-tab');
+const startButton = document.querySelector('#start');
+const stopButton = document.querySelector('#stop');
+const deleteButton = document.querySelector('#delete');
+
+let latestStatus;
+let refreshing = false;
+
+function render(status = {}) {
+  latestStatus = status;
+  connection.textContent = status.bridgeConnected
+    ? status.recording
+      ? status.origin === 'meeting'
+        ? 'Meeting recording active'
+        : 'Standalone recording active'
+      : 'Meetily connected'
+    : 'Open Meetily to record';
+  statusDot.classList.toggle('connected', Boolean(status.bridgeConnected));
+  tabTitle.textContent = status.title || 'None';
+  selectButton.disabled = Boolean(status.recording);
+  startButton.disabled = !status.bridgeConnected || !status.armed || Boolean(status.recording);
+  stopButton.disabled = !status.recording;
+  const savedRecordingAvailable = status.lastResult?.startsWith('Saved ');
+  deleteButton.disabled = !status.bridgeConnected
+    || (!status.recording && !savedRecordingAvailable);
+  result.textContent = status.lastResult
+    || (status.armed
+      ? 'Ready. Start here or begin a meeting in Meetily.'
+      : 'Select a tab to begin.');
+}
+
+async function send(type) {
+  const response = await chrome.runtime.sendMessage({ target: 'popup', type });
+  if (!response?.ok) throw new Error(response?.error || 'Capture command failed');
+  render(response.status);
+}
+
+async function run(type) {
+  try {
+    result.textContent = 'Working…';
+    await send(type);
+  } catch (error) {
+    result.textContent = error.message;
+  }
+}
+
+async function refresh() {
+  if (refreshing) return;
+  refreshing = true;
+  try {
+    await send('status');
+  } catch (error) {
+    render(latestStatus);
+    result.textContent = error.message;
+  } finally {
+    refreshing = false;
+  }
+}
+
+selectButton.addEventListener('click', () => run('arm_current'));
+startButton.addEventListener('click', () => run('manual_start'));
+stopButton.addEventListener('click', () => run('stop_user'));
+deleteButton.addEventListener('click', () => run('delete_user'));
+
+refresh();
+window.setInterval(refresh, 750);

--- a/edge-extension/service-worker.js
+++ b/edge-extension/service-worker.js
@@ -10,37 +10,72 @@ async function ensureOffscreenDocument() {
     await chrome.offscreen.createDocument({
       url: OFFSCREEN_DOCUMENT,
       reasons: ['USER_MEDIA'],
-      justification: 'Record the exact tab selected by the user for a Meetily meeting',
+      justification: 'Record the exact tab selected by the user for Meetily',
     });
   }
 }
 
-chrome.action.onClicked.addListener(async (tab) => {
-  if (!tab.id) return;
+async function armCurrentTab() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab?.id) throw new Error('No active tab is available');
 
-  try {
-    await ensureOffscreenDocument();
-    const streamId = await chrome.tabCapture.getMediaStreamId({
-      targetTabId: tab.id,
-    });
-    await chrome.runtime.sendMessage({
-      target: 'offscreen',
-      type: 'arm',
-      streamId,
-      title: tab.title || 'Selected tab',
-    });
-    await chrome.action.setBadgeBackgroundColor({ color: '#2563eb' });
-    await chrome.action.setBadgeText({ text: 'ARM' });
-    await chrome.action.setTitle({ title: `Armed for Meetily: ${tab.title || 'Selected tab'}` });
-  } catch (error) {
-    console.error('Unable to arm tab capture', error);
-    await chrome.action.setBadgeBackgroundColor({ color: '#dc2626' });
-    await chrome.action.setBadgeText({ text: 'ERR' });
+  await ensureOffscreenDocument();
+  const releaseResult = await chrome.runtime.sendMessage({
+    target: 'offscreen',
+    type: 'release',
+  });
+  if (!releaseResult?.ok) {
+    throw new Error(releaseResult?.error || 'Unable to release the previous tab capture');
   }
-});
+  const streamId = await chrome.tabCapture.getMediaStreamId({
+    targetTabId: tab.id,
+  });
+  const armResult = await chrome.runtime.sendMessage({
+    target: 'offscreen',
+    type: 'arm',
+    streamId,
+    title: tab.title || 'Selected tab',
+  });
+  if (!armResult?.ok) {
+    throw new Error(armResult?.error || 'Unable to select this tab');
+  }
 
-chrome.runtime.onMessage.addListener((message) => {
+  await chrome.action.setBadgeBackgroundColor({ color: '#2563eb' });
+  await chrome.action.setBadgeText({ text: 'ARM' });
+  await chrome.action.setTitle({ title: `Selected for Meetily: ${tab.title || 'Selected tab'}` });
+  return armResult.status;
+}
+
+async function sendOffscreen(type) {
+  await ensureOffscreenDocument();
+  const result = await chrome.runtime.sendMessage({ target: 'offscreen', type });
+  if (!result?.ok) throw new Error(result?.error || 'Capture command failed');
+  return result.status;
+}
+
+async function handlePopupMessage(message) {
+  if (message.type === 'arm_current') return armCurrentTab();
+  if (message.type === 'status') return sendOffscreen('status');
+  if (message.type === 'manual_start') return sendOffscreen('manual_start');
+  if (message.type === 'stop_user') return sendOffscreen('stop_user');
+  if (message.type === 'delete_user') return sendOffscreen('delete_user');
+  throw new Error('Unknown capture command');
+}
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message.target === 'popup') {
+    handlePopupMessage(message)
+      .then((status) => sendResponse({ ok: true, status }))
+      .catch(async (error) => {
+        console.error('Meetily capture command failed', error);
+        await chrome.action.setBadgeBackgroundColor({ color: '#dc2626' });
+        await chrome.action.setBadgeText({ text: 'ERR' });
+        sendResponse({ ok: false, error: error.message });
+      });
+    return true;
+  }
   if (message.target !== 'service-worker') return;
+
   if (message.type === 'recording') {
     chrome.action.setBadgeBackgroundColor({ color: '#dc2626' });
     chrome.action.setBadgeText({ text: 'REC' });
@@ -49,6 +84,6 @@ chrome.runtime.onMessage.addListener((message) => {
     chrome.action.setBadgeText({ text: 'ARM' });
   } else if (message.type === 'disarmed') {
     chrome.action.setBadgeText({ text: '' });
-    chrome.action.setTitle({ title: 'Arm this tab for Meetily' });
+    chrome.action.setTitle({ title: 'Open Meetily tab capture controls' });
   }
 });

--- a/edge-extension/service-worker.js
+++ b/edge-extension/service-worker.js
@@ -1,0 +1,54 @@
+const OFFSCREEN_DOCUMENT = 'offscreen.html';
+
+async function ensureOffscreenDocument() {
+  const offscreenUrl = chrome.runtime.getURL(OFFSCREEN_DOCUMENT);
+  const contexts = await chrome.runtime.getContexts({
+    contextTypes: ['OFFSCREEN_DOCUMENT'],
+    documentUrls: [offscreenUrl],
+  });
+  if (contexts.length === 0) {
+    await chrome.offscreen.createDocument({
+      url: OFFSCREEN_DOCUMENT,
+      reasons: ['USER_MEDIA'],
+      justification: 'Record the exact tab selected by the user for a Meetily meeting',
+    });
+  }
+}
+
+chrome.action.onClicked.addListener(async (tab) => {
+  if (!tab.id) return;
+
+  try {
+    await ensureOffscreenDocument();
+    const streamId = await chrome.tabCapture.getMediaStreamId({
+      targetTabId: tab.id,
+    });
+    await chrome.runtime.sendMessage({
+      target: 'offscreen',
+      type: 'arm',
+      streamId,
+      title: tab.title || 'Selected tab',
+    });
+    await chrome.action.setBadgeBackgroundColor({ color: '#2563eb' });
+    await chrome.action.setBadgeText({ text: 'ARM' });
+    await chrome.action.setTitle({ title: `Armed for Meetily: ${tab.title || 'Selected tab'}` });
+  } catch (error) {
+    console.error('Unable to arm tab capture', error);
+    await chrome.action.setBadgeBackgroundColor({ color: '#dc2626' });
+    await chrome.action.setBadgeText({ text: 'ERR' });
+  }
+});
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.target !== 'service-worker') return;
+  if (message.type === 'recording') {
+    chrome.action.setBadgeBackgroundColor({ color: '#dc2626' });
+    chrome.action.setBadgeText({ text: 'REC' });
+  } else if (message.type === 'armed') {
+    chrome.action.setBadgeBackgroundColor({ color: '#2563eb' });
+    chrome.action.setBadgeText({ text: 'ARM' });
+  } else if (message.type === 'disarmed') {
+    chrome.action.setBadgeText({ text: '' });
+    chrome.action.setTitle({ title: 'Arm this tab for Meetily' });
+  }
+});

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -100,6 +100,7 @@ nnnoiseless = "0.5"
 # NOTE: whisper-rs is declared in platform-specific sections below (macOS/Windows/Linux)
 # to ensure correct GPU features are enabled per platform
 futures-util = "0.3"
+tokio-tungstenite = "0.24"
 silero_rs = { git = "https://github.com/emotechlab/silero-rs", rev = "26a6460", package = "silero" }
 
 # Parakeet (ONNX-based fast transcription) dependencies
@@ -169,6 +170,7 @@ anyhow = "1.0"
 time = { version = "0.3", features = ["formatting"] }
 reqwest = { version = "0.11", features = ["multipart", "json"] }
 core-graphics = "0.23"
+core-foundation = "0.9"
 cidre = { git = "https://github.com/yury/cidre", rev = "a9587fa", features = ["av"] }
 dasp = "0.11.0"
 futures-channel = "0.3.31"

--- a/frontend/src-tauri/Info.plist
+++ b/frontend/src-tauri/Info.plist
@@ -5,7 +5,7 @@
     <key>NSMicrophoneUsageDescription</key>
     <string>This application needs access to your microphone to record meeting audio.</string>
     <key>NSScreenCaptureUsageDescription</key>
-    <string>This application needs screen recording permission to capture system audio during meetings.</string>
+    <string>This application needs screen recording permission to capture system audio and a display or window you choose during meetings.</string>
     <key>NSAudioCaptureUsageDescription</key>
     <string>This application needs permission to capture system audio output for meeting transcription and recording.</string>
     <key>com.apple.security.device.audio-input</key>

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -558,6 +558,8 @@ pub fn run() {
             video_capture::get_video_capture_status,
             video_capture::get_meeting_video_path,
             video_capture::list_capture_windows,
+            video_capture::trim_meeting_video,
+            video_capture::restore_original_meeting_video,
             read_audio_file,
             save_transcript,
             analytics::commands::init_analytics,

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -53,13 +53,14 @@ pub mod state;
 pub mod summary;
 pub mod tray;
 pub mod utils;
+pub mod video_capture;
 pub mod whisper_engine;
 
 use audio::{list_audio_devices, AudioDevice, trigger_audio_permission};
 use log::{error as log_error, info as log_info};
 use notifications::commands::NotificationManagerState;
 use std::sync::Arc;
-use tauri::{AppHandle, Manager, Runtime};
+use tauri::{AppHandle, Emitter, Manager, Runtime};
 use tokio::sync::RwLock;
 
 static RECORDING_FLAG: AtomicBool = AtomicBool::new(false);
@@ -114,6 +115,24 @@ async fn start_recording<R: Runtime>(
 
             log_info!("Recording started successfully");
 
+            if let Ok(Some(folder)) =
+                audio::recording_commands::get_meeting_folder_path().await
+            {
+                if let Err(error) =
+                    video_capture::start_for_meeting(std::path::Path::new(&folder)).await
+                {
+                    let _ = audio::recording_commands::stop_recording(
+                        app.clone(),
+                        audio::recording_commands::RecordingArgs {
+                            save_path: String::new(),
+                        },
+                    )
+                    .await;
+                    RECORDING_FLAG.store(false, Ordering::SeqCst);
+                    return Err(format!("Failed to start video capture: {error}"));
+                }
+            }
+
             // Show recording started notification through NotificationManager
             // This respects user's notification preferences
             let notification_manager_state = app.state::<NotificationManagerState<R>>();
@@ -144,6 +163,12 @@ async fn start_recording<R: Runtime>(
 #[tauri::command]
 async fn stop_recording<R: Runtime>(app: AppHandle<R>, args: RecordingArgs) -> Result<(), String> {
     log_info!("Attempting to stop recording...");
+
+    let video_result = video_capture::stop_active_capture().await;
+    if let Err(error) = &video_result {
+        log_error!("Video capture could not be finalized: {}", error);
+        let _ = app.emit("video-capture-error", error.clone());
+    }
 
     // Check the actual audio recording system state instead of the flag
     if !audio::recording_commands::is_recording().await {
@@ -418,6 +443,7 @@ pub fn run() {
         .manage(audio::init_system_audio_state())
         .manage(summary::summary_engine::ModelManagerState(Arc::new(tokio::sync::Mutex::new(None))))
         .setup(|_app| {
+            video_capture::start_bridge();
             log::info!("Application setup complete");
 
             // Initialize system tray
@@ -528,6 +554,10 @@ pub fn run() {
             stop_recording,
             is_recording,
             get_transcription_status,
+            video_capture::set_video_capture_mode,
+            video_capture::get_video_capture_status,
+            video_capture::get_meeting_video_path,
+            video_capture::list_capture_windows,
             read_audio_file,
             save_transcript,
             analytics::commands::init_analytics,

--- a/frontend/src-tauri/src/video_capture.rs
+++ b/frontend/src-tauri/src/video_capture.rs
@@ -9,7 +9,7 @@ use std::{
     },
 };
 use tokio::{
-    fs::File,
+    fs::{self, File},
     io::{AsyncWriteExt, BufWriter},
     net::{TcpListener, TcpStream},
     process::{Child, Command},
@@ -53,8 +53,14 @@ pub struct CaptureWindow {
 }
 
 enum ActiveCapture {
-    Screen { child: Child, output_path: PathBuf },
-    BrowserTab { output_path: PathBuf },
+    Screen {
+        child: Child,
+        output_path: PathBuf,
+    },
+    BrowserTab {
+        output_path: PathBuf,
+        standalone: bool,
+    },
 }
 
 struct BridgeState {
@@ -64,6 +70,7 @@ struct BridgeState {
     tab_title: Mutex<Option<String>>,
     window_id: Mutex<Option<u32>>,
     active: Mutex<Option<ActiveCapture>>,
+    last_saved: Mutex<Option<PathBuf>>,
     writer: Mutex<Option<BufWriter<File>>>,
     commands: broadcast::Sender<String>,
     completed: Notify,
@@ -78,6 +85,7 @@ static STATE: LazyLock<Arc<BridgeState>> = LazyLock::new(|| {
         tab_title: Mutex::new(None),
         window_id: Mutex::new(None),
         active: Mutex::new(None),
+        last_saved: Mutex::new(None),
         writer: Mutex::new(None),
         commands,
         completed: Notify::new(),
@@ -195,6 +203,76 @@ async fn handle_extension_message(text: &str) {
                     log::error!("Failed flushing browser video: {error}");
                 }
             }
+            let standalone_output = {
+                let mut active = STATE.active.lock().await;
+                match active.as_ref() {
+                    Some(ActiveCapture::BrowserTab {
+                        output_path,
+                        standalone: true,
+                    }) => {
+                        let output_path = output_path.clone();
+                        active.take();
+                        Some(output_path)
+                    }
+                    _ => None,
+                }
+            };
+            if let Some(output_path) = standalone_output {
+                match validate_video(&output_path) {
+                    Ok(()) => {
+                        *STATE.last_saved.lock().await = Some(output_path.clone());
+                        let filename = output_path
+                            .file_name()
+                            .and_then(|name| name.to_str())
+                            .unwrap_or("Meetily tab recording.webm");
+                        let _ = STATE.commands.send(
+                            serde_json::json!({
+                                "type": "saved",
+                                "filename": filename,
+                            })
+                            .to_string(),
+                        );
+                    }
+                    Err(error) => {
+                        let _ = fs::remove_file(&output_path).await;
+                        let _ = STATE.commands.send(
+                            serde_json::json!({
+                                "type": "error",
+                                "message": error,
+                            })
+                            .to_string(),
+                        );
+                    }
+                }
+            }
+            STATE.completed.notify_one();
+        }
+        Some("manual_start") => {
+            if let Err(error) = start_standalone_browser_capture().await {
+                let _ = STATE.commands.send(
+                    serde_json::json!({
+                        "type": "error",
+                        "message": error,
+                    })
+                    .to_string(),
+                );
+            }
+        }
+        Some("discard") => {
+            match discard_browser_capture().await {
+                Ok(()) => {
+                    let _ = STATE.commands.send(r#"{"type":"discarded"}"#.to_string());
+                }
+                Err(error) => {
+                    let _ = STATE.commands.send(
+                        serde_json::json!({
+                            "type": "error",
+                            "message": error,
+                        })
+                        .to_string(),
+                    );
+                }
+            }
             STATE.completed.notify_one();
         }
         Some("error") => {
@@ -256,16 +334,11 @@ pub fn get_meeting_video_path(folder_path: String) -> Option<String> {
 #[cfg(target_os = "macos")]
 #[tauri::command]
 pub fn list_capture_windows() -> Vec<CaptureWindow> {
-    use core_foundation::{
-        base::TCFType,
-        number::CFNumber,
-        string::CFString,
-    };
+    use core_foundation::{base::TCFType, number::CFNumber, string::CFString};
     use core_graphics::window::{
-        create_description_from_array, create_window_list, kCGNullWindowID,
-        kCGWindowLayer, kCGWindowListExcludeDesktopElements,
-        kCGWindowListOptionOnScreenOnly, kCGWindowName, kCGWindowNumber,
-        kCGWindowOwnerName,
+        create_description_from_array, create_window_list, kCGNullWindowID, kCGWindowLayer,
+        kCGWindowListExcludeDesktopElements, kCGWindowListOptionOnScreenOnly, kCGWindowName,
+        kCGWindowNumber, kCGWindowOwnerName,
     };
 
     let options = kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements;
@@ -340,8 +413,8 @@ async fn start_screen_capture(meeting_folder: &Path) -> Result<(), String> {
 }
 
 async fn start_window_capture(meeting_folder: &Path) -> Result<(), String> {
-    let window_id = (*STATE.window_id.lock().await)
-        .ok_or_else(|| "Choose a window to record".to_string())?;
+    let window_id =
+        (*STATE.window_id.lock().await).ok_or_else(|| "Choose a window to record".to_string())?;
     let output_path = meeting_folder.join("video.mov");
     let child = Command::new("/usr/sbin/screencapture")
         .args(["-v", "-l", &window_id.to_string(), "-x"])
@@ -356,6 +429,9 @@ async fn start_window_capture(meeting_folder: &Path) -> Result<(), String> {
 }
 
 async fn start_browser_capture(meeting_folder: &Path) -> Result<(), String> {
+    if STATE.active.lock().await.is_some() {
+        return Err("Stop the current tab recording before starting a meeting".to_string());
+    }
     if !STATE.connected.load(Ordering::SeqCst) {
         return Err("Browser capture extension is not connected".to_string());
     }
@@ -370,14 +446,88 @@ async fn start_browser_capture(meeting_folder: &Path) -> Result<(), String> {
     *STATE.writer.lock().await = Some(BufWriter::new(file));
     *STATE.active.lock().await = Some(ActiveCapture::BrowserTab {
         output_path: output_path.clone(),
+        standalone: false,
     });
     STATE
         .commands
-        .send(r#"{"type":"start"}"#.to_string())
+        .send(r#"{"type":"start","origin":"meeting"}"#.to_string())
         .map_err(|_| {
             "Browser capture extension disconnected before recording started".to_string()
         })?;
     Ok(())
+}
+
+async fn start_standalone_browser_capture() -> Result<(), String> {
+    if STATE.active.lock().await.is_some() {
+        return Err("A Meetily video capture is already active".to_string());
+    }
+    if !STATE.connected.load(Ordering::SeqCst) {
+        return Err("Meetily is not running".to_string());
+    }
+    if !STATE.tab_armed.load(Ordering::SeqCst) {
+        return Err("Select a tab before starting".to_string());
+    }
+
+    let capture_dir = dirs::video_dir()
+        .or_else(dirs::document_dir)
+        .ok_or_else(|| "Could not locate a local video folder".to_string())?
+        .join("Meetily Captures");
+    fs::create_dir_all(&capture_dir)
+        .await
+        .map_err(|error| format!("Failed creating Meetily Captures: {error}"))?;
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| format!("System clock error: {error}"))?
+        .as_secs();
+    let output_path = capture_dir.join(format!("meetily-tab-{timestamp}.webm"));
+    let file = File::create(&output_path)
+        .await
+        .map_err(|error| format!("Failed creating browser video: {error}"))?;
+
+    *STATE.writer.lock().await = Some(BufWriter::new(file));
+    *STATE.active.lock().await = Some(ActiveCapture::BrowserTab {
+        output_path,
+        standalone: true,
+    });
+    STATE
+        .commands
+        .send(r#"{"type":"start","origin":"standalone"}"#.to_string())
+        .map_err(|_| {
+            "Browser capture extension disconnected before recording started".to_string()
+        })?;
+    Ok(())
+}
+
+async fn discard_browser_capture() -> Result<(), String> {
+    if let Some(mut writer) = STATE.writer.lock().await.take() {
+        writer
+            .flush()
+            .await
+            .map_err(|error| format!("Failed closing browser video: {error}"))?;
+    }
+
+    let output_path = {
+        let mut active = STATE.active.lock().await;
+        match active.as_ref() {
+            Some(ActiveCapture::BrowserTab { output_path, .. }) => {
+                let output_path = output_path.clone();
+                active.take();
+                Some(output_path)
+            }
+            Some(ActiveCapture::Screen { .. }) => {
+                return Err("The extension cannot delete a macOS screen recording".to_string());
+            }
+            None => STATE.last_saved.lock().await.take(),
+        }
+    };
+    let Some(output_path) = output_path else {
+        return Err("There is no tab recording to delete".to_string());
+    };
+    match fs::remove_file(&output_path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!("Failed deleting tab recording: {error}")),
+    }
 }
 
 pub async fn stop_active_capture() -> Result<Option<PathBuf>, String> {
@@ -411,7 +561,7 @@ pub async fn stop_active_capture() -> Result<Option<PathBuf>, String> {
             validate_video(&output_path)?;
             Ok(Some(output_path))
         }
-        Some(ActiveCapture::BrowserTab { output_path }) => {
+        Some(ActiveCapture::BrowserTab { output_path, .. }) => {
             let completed = STATE.completed.notified();
             STATE
                 .commands

--- a/frontend/src-tauri/src/video_capture.rs
+++ b/frontend/src-tauri/src/video_capture.rs
@@ -1,0 +1,473 @@
+use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use std::{
+    path::{Path, PathBuf},
+    process::Stdio,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, LazyLock,
+    },
+};
+use tokio::{
+    fs::File,
+    io::{AsyncWriteExt, BufWriter},
+    net::{TcpListener, TcpStream},
+    process::{Child, Command},
+    sync::{broadcast, Mutex, Notify},
+    time::{timeout, Duration},
+};
+use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+const BRIDGE_ADDRESS: &str = "127.0.0.1:8179";
+const BRIDGE_TOKEN: &str = "meetily-local-capture-v1-7d4f2c9a6e31b805";
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum VideoCaptureMode {
+    Off,
+    Screen,
+    Window,
+    BrowserTab,
+}
+
+impl Default for VideoCaptureMode {
+    fn default() -> Self {
+        Self::Off
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct VideoCaptureStatus {
+    pub mode: VideoCaptureMode,
+    pub bridge_connected: bool,
+    pub tab_armed: bool,
+    pub tab_title: Option<String>,
+    pub recording: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CaptureWindow {
+    pub id: u32,
+    pub app: String,
+    pub title: String,
+}
+
+enum ActiveCapture {
+    Screen { child: Child, output_path: PathBuf },
+    BrowserTab { output_path: PathBuf },
+}
+
+struct BridgeState {
+    mode: Mutex<VideoCaptureMode>,
+    connected: AtomicBool,
+    tab_armed: AtomicBool,
+    tab_title: Mutex<Option<String>>,
+    window_id: Mutex<Option<u32>>,
+    active: Mutex<Option<ActiveCapture>>,
+    writer: Mutex<Option<BufWriter<File>>>,
+    commands: broadcast::Sender<String>,
+    completed: Notify,
+}
+
+static STATE: LazyLock<Arc<BridgeState>> = LazyLock::new(|| {
+    let (commands, _) = broadcast::channel(16);
+    Arc::new(BridgeState {
+        mode: Mutex::new(VideoCaptureMode::Off),
+        connected: AtomicBool::new(false),
+        tab_armed: AtomicBool::new(false),
+        tab_title: Mutex::new(None),
+        window_id: Mutex::new(None),
+        active: Mutex::new(None),
+        writer: Mutex::new(None),
+        commands,
+        completed: Notify::new(),
+    })
+});
+
+pub fn start_bridge() {
+    tauri::async_runtime::spawn(async {
+        let listener = match TcpListener::bind(BRIDGE_ADDRESS).await {
+            Ok(listener) => listener,
+            Err(error) => {
+                log::error!("Unable to start browser capture bridge: {error}");
+                return;
+            }
+        };
+        log::info!("Browser capture bridge listening on {BRIDGE_ADDRESS}");
+        loop {
+            match listener.accept().await {
+                Ok((stream, _)) => {
+                    tauri::async_runtime::spawn(handle_extension(stream));
+                }
+                Err(error) => log::warn!("Browser capture bridge accept failed: {error}"),
+            }
+        }
+    });
+}
+
+async fn handle_extension(stream: TcpStream) {
+    let websocket = match accept_async(stream).await {
+        Ok(socket) => socket,
+        Err(error) => {
+            log::warn!("Rejected browser capture bridge connection: {error}");
+            return;
+        }
+    };
+    let (mut outgoing, mut incoming) = websocket.split();
+    let mut commands = STATE.commands.subscribe();
+    let mut authorized = false;
+
+    loop {
+        tokio::select! {
+            command = commands.recv(), if authorized => {
+                match command {
+                    Ok(command) => {
+                        if outgoing.send(Message::Text(command)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(_) => break,
+                }
+            }
+            message = incoming.next() => {
+                match message {
+                    Some(Ok(Message::Text(text))) => {
+                        if is_authorized_message(&text) {
+                            authorized = true;
+                            STATE.connected.store(true, Ordering::SeqCst);
+                            handle_extension_message(&text).await;
+                        } else {
+                            break;
+                        }
+                    }
+                    Some(Ok(Message::Binary(bytes))) if authorized => {
+                        let mut writer = STATE.writer.lock().await;
+                        if let Some(writer) = writer.as_mut() {
+                            if let Err(error) = writer.write_all(&bytes).await {
+                                log::error!("Failed writing browser video chunk: {error}");
+                            }
+                        }
+                    }
+                    Some(Ok(Message::Close(_))) | None | Some(Err(_)) => break,
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    STATE.connected.store(false, Ordering::SeqCst);
+    STATE.tab_armed.store(false, Ordering::SeqCst);
+    *STATE.tab_title.lock().await = None;
+}
+
+fn is_authorized_message(text: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(text)
+        .ok()
+        .and_then(|message| {
+            message
+                .get("token")
+                .and_then(|value| value.as_str())
+                .map(|token| token == BRIDGE_TOKEN)
+        })
+        .unwrap_or(false)
+}
+
+async fn handle_extension_message(text: &str) {
+    let Ok(message) = serde_json::from_str::<serde_json::Value>(text) else {
+        return;
+    };
+    match message.get("type").and_then(|value| value.as_str()) {
+        Some("armed") => {
+            STATE.tab_armed.store(true, Ordering::SeqCst);
+            *STATE.tab_title.lock().await = message
+                .get("title")
+                .and_then(|value| value.as_str())
+                .map(ToOwned::to_owned);
+        }
+        Some("disarmed") => {
+            STATE.tab_armed.store(false, Ordering::SeqCst);
+            *STATE.tab_title.lock().await = None;
+        }
+        Some("complete") => {
+            if let Some(mut writer) = STATE.writer.lock().await.take() {
+                if let Err(error) = writer.flush().await {
+                    log::error!("Failed flushing browser video: {error}");
+                }
+            }
+            STATE.completed.notify_one();
+        }
+        Some("error") => {
+            log::error!(
+                "Browser capture extension error: {}",
+                message
+                    .get("message")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("unknown error")
+            );
+            STATE.completed.notify_one();
+        }
+        _ => {}
+    }
+}
+
+#[tauri::command]
+pub async fn set_video_capture_mode(
+    mode: VideoCaptureMode,
+    window_id: Option<u32>,
+) -> Result<(), String> {
+    if STATE.active.lock().await.is_some() {
+        return Err("Cannot change video source while recording".to_string());
+    }
+    if mode == VideoCaptureMode::Window && window_id.is_none() {
+        return Err("Choose a window to record".to_string());
+    }
+    *STATE.mode.lock().await = mode;
+    *STATE.window_id.lock().await = window_id;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn get_video_capture_status() -> VideoCaptureStatus {
+    VideoCaptureStatus {
+        mode: *STATE.mode.lock().await,
+        bridge_connected: STATE.connected.load(Ordering::SeqCst),
+        tab_armed: STATE.tab_armed.load(Ordering::SeqCst),
+        tab_title: STATE.tab_title.lock().await.clone(),
+        recording: STATE.active.lock().await.is_some(),
+    }
+}
+
+#[tauri::command]
+pub fn get_meeting_video_path(folder_path: String) -> Option<String> {
+    [
+        Path::new(&folder_path).join("video.mov"),
+        Path::new(&folder_path).join("video.webm"),
+    ]
+    .into_iter()
+    .find(|path| {
+        std::fs::metadata(path)
+            .map(|metadata| metadata.is_file() && metadata.len() >= 1024)
+            .unwrap_or(false)
+    })
+    .map(|path| path.to_string_lossy().to_string())
+}
+
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn list_capture_windows() -> Vec<CaptureWindow> {
+    use core_foundation::{
+        base::TCFType,
+        number::CFNumber,
+        string::CFString,
+    };
+    use core_graphics::window::{
+        create_description_from_array, create_window_list, kCGNullWindowID,
+        kCGWindowLayer, kCGWindowListExcludeDesktopElements,
+        kCGWindowListOptionOnScreenOnly, kCGWindowName, kCGWindowNumber,
+        kCGWindowOwnerName,
+    };
+
+    let options = kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements;
+    let Some(ids) = create_window_list(options, kCGNullWindowID) else {
+        return Vec::new();
+    };
+    let Some(descriptions) = create_description_from_array(ids) else {
+        return Vec::new();
+    };
+
+    let number_key = unsafe { CFString::wrap_under_get_rule(kCGWindowNumber) };
+    let layer_key = unsafe { CFString::wrap_under_get_rule(kCGWindowLayer) };
+    let owner_key = unsafe { CFString::wrap_under_get_rule(kCGWindowOwnerName) };
+    let name_key = unsafe { CFString::wrap_under_get_rule(kCGWindowName) };
+
+    descriptions
+        .iter()
+        .filter_map(|description| {
+            let layer = description
+                .find(&layer_key)?
+                .downcast::<CFNumber>()?
+                .to_i32()?;
+            if layer != 0 {
+                return None;
+            }
+            let id = description
+                .find(&number_key)?
+                .downcast::<CFNumber>()?
+                .to_i64()? as u32;
+            let app = description
+                .find(&owner_key)?
+                .downcast::<CFString>()?
+                .to_string();
+            let title = description
+                .find(&name_key)
+                .and_then(|value| value.downcast::<CFString>())
+                .map(|value| value.to_string())
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| app.clone());
+            Some(CaptureWindow { id, app, title })
+        })
+        .collect()
+}
+
+#[cfg(not(target_os = "macos"))]
+#[tauri::command]
+pub fn list_capture_windows() -> Vec<CaptureWindow> {
+    Vec::new()
+}
+
+pub async fn start_for_meeting(meeting_folder: &Path) -> Result<(), String> {
+    match *STATE.mode.lock().await {
+        VideoCaptureMode::Off => Ok(()),
+        VideoCaptureMode::Screen => start_screen_capture(meeting_folder).await,
+        VideoCaptureMode::Window => start_window_capture(meeting_folder).await,
+        VideoCaptureMode::BrowserTab => start_browser_capture(meeting_folder).await,
+    }
+}
+
+async fn start_screen_capture(meeting_folder: &Path) -> Result<(), String> {
+    let output_path = meeting_folder.join("video.mov");
+    let child = Command::new("/usr/sbin/screencapture")
+        .args(["-v", "-U", "-J", "video", "-x"])
+        .arg(&output_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| format!("Failed to open the macOS screen picker: {error}"))?;
+    *STATE.active.lock().await = Some(ActiveCapture::Screen { child, output_path });
+    Ok(())
+}
+
+async fn start_window_capture(meeting_folder: &Path) -> Result<(), String> {
+    let window_id = (*STATE.window_id.lock().await)
+        .ok_or_else(|| "Choose a window to record".to_string())?;
+    let output_path = meeting_folder.join("video.mov");
+    let child = Command::new("/usr/sbin/screencapture")
+        .args(["-v", "-l", &window_id.to_string(), "-x"])
+        .arg(&output_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| format!("Failed to record the selected window: {error}"))?;
+    *STATE.active.lock().await = Some(ActiveCapture::Screen { child, output_path });
+    Ok(())
+}
+
+async fn start_browser_capture(meeting_folder: &Path) -> Result<(), String> {
+    if !STATE.connected.load(Ordering::SeqCst) {
+        return Err("Browser capture extension is not connected".to_string());
+    }
+    if !STATE.tab_armed.load(Ordering::SeqCst) {
+        return Err("Choose a tab by clicking the Meetily Capture extension first".to_string());
+    }
+
+    let output_path = meeting_folder.join("video.webm");
+    let file = File::create(&output_path)
+        .await
+        .map_err(|error| format!("Failed creating browser video: {error}"))?;
+    *STATE.writer.lock().await = Some(BufWriter::new(file));
+    *STATE.active.lock().await = Some(ActiveCapture::BrowserTab {
+        output_path: output_path.clone(),
+    });
+    STATE
+        .commands
+        .send(r#"{"type":"start"}"#.to_string())
+        .map_err(|_| {
+            "Browser capture extension disconnected before recording started".to_string()
+        })?;
+    Ok(())
+}
+
+pub async fn stop_active_capture() -> Result<Option<PathBuf>, String> {
+    match STATE.active.lock().await.take() {
+        None => Ok(None),
+        Some(ActiveCapture::Screen {
+            mut child,
+            output_path,
+        }) => {
+            let already_finished = child
+                .try_wait()
+                .map_err(|error| format!("Failed checking screen capture: {error}"))?
+                .is_some();
+            if !already_finished {
+                let pid = child
+                    .id()
+                    .ok_or_else(|| "Screen capture process has no process ID".to_string())?;
+                let status = Command::new("/bin/kill")
+                    .args(["-INT", &pid.to_string()])
+                    .status()
+                    .await
+                    .map_err(|error| format!("Failed stopping screen capture: {error}"))?;
+                if !status.success() {
+                    return Err("macOS screen capture did not accept the stop signal".to_string());
+                }
+            }
+            timeout(Duration::from_secs(10), child.wait())
+                .await
+                .map_err(|_| "Timed out finalizing screen video".to_string())?
+                .map_err(|error| format!("Failed finalizing screen video: {error}"))?;
+            validate_video(&output_path)?;
+            Ok(Some(output_path))
+        }
+        Some(ActiveCapture::BrowserTab { output_path }) => {
+            let completed = STATE.completed.notified();
+            STATE
+                .commands
+                .send(r#"{"type":"stop"}"#.to_string())
+                .map_err(|_| "Browser capture extension disconnected before stop".to_string())?;
+            timeout(Duration::from_secs(10), completed)
+                .await
+                .map_err(|_| "Timed out finalizing browser video".to_string())?;
+            if let Some(mut writer) = STATE.writer.lock().await.take() {
+                writer
+                    .flush()
+                    .await
+                    .map_err(|error| format!("Failed flushing browser video: {error}"))?;
+            }
+            validate_video(&output_path)?;
+            Ok(Some(output_path))
+        }
+    }
+}
+
+fn validate_video(path: &Path) -> Result<(), String> {
+    let metadata =
+        std::fs::metadata(path).map_err(|error| format!("Video was not created: {error}"))?;
+    if metadata.len() < 1024 {
+        return Err("Video capture ended before any usable frames were saved".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn video_modes_use_stable_wire_names() {
+        assert_eq!(
+            serde_json::to_string(&VideoCaptureMode::BrowserTab).unwrap(),
+            "\"browser_tab\""
+        );
+        assert_eq!(
+            serde_json::from_str::<VideoCaptureMode>("\"screen\"").unwrap(),
+            VideoCaptureMode::Screen
+        );
+    }
+
+    #[test]
+    fn rejects_empty_video_files() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        assert!(validate_video(file.path()).is_err());
+    }
+
+    #[test]
+    fn browser_bridge_rejects_messages_without_the_pairing_token() {
+        assert!(!is_authorized_message(r#"{"type":"hello"}"#));
+        assert!(is_authorized_message(&format!(
+            r#"{{"type":"hello","token":"{BRIDGE_TOKEN}"}}"#
+        )));
+    }
+}

--- a/frontend/src-tauri/src/video_capture.rs
+++ b/frontend/src-tauri/src/video_capture.rs
@@ -344,9 +344,108 @@ pub async fn get_video_capture_status() -> VideoCaptureStatus {
 
 #[tauri::command]
 pub fn get_meeting_video_path(folder_path: String) -> Option<String> {
+    find_preferred_video(Path::new(&folder_path)).map(|path| path.to_string_lossy().to_string())
+}
+
+#[tauri::command]
+pub async fn trim_meeting_video(
+    folder_path: String,
+    start_seconds: f64,
+    end_seconds: f64,
+) -> Result<String, String> {
+    validate_trim_range(start_seconds, end_seconds)?;
+
+    let folder = PathBuf::from(folder_path);
+    let input_path = find_preferred_video(&folder)
+        .ok_or_else(|| "The meeting video could not be found".to_string())?;
+    let output_path = folder.join("video-trimmed.mp4");
+    let temporary_path = folder.join("video-trimmed.tmp.mp4");
+    let ffmpeg_path = crate::audio::ffmpeg::find_ffmpeg_path()
+        .ok_or_else(|| "FFmpeg is required to trim meeting videos".to_string())?;
+    let duration = end_seconds - start_seconds;
+    let start_arg = format!("{start_seconds:.3}");
+    let duration_arg = format!("{duration:.3}");
+
+    let output = Command::new(ffmpeg_path)
+        .args(["-hide_banner", "-loglevel", "error", "-y", "-i"])
+        .arg(&input_path)
+        .args([
+            "-ss",
+            &start_arg,
+            "-t",
+            &duration_arg,
+            "-map",
+            "0:v:0",
+            "-map",
+            "0:a?",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryfast",
+            "-crf",
+            "20",
+            "-c:a",
+            "aac",
+            "-movflags",
+            "+faststart",
+        ])
+        .arg(&temporary_path)
+        .output()
+        .await
+        .map_err(|error| format!("Failed to start FFmpeg: {error}"))?;
+
+    if !output.status.success() {
+        let _ = fs::remove_file(&temporary_path).await;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "FFmpeg could not trim the video: {}",
+            stderr.trim()
+        ));
+    }
+    if let Err(error) = validate_video(&temporary_path) {
+        let _ = fs::remove_file(&temporary_path).await;
+        return Err(error);
+    }
+    if output_path.exists() {
+        fs::remove_file(&output_path)
+            .await
+            .map_err(|error| format!("Failed replacing the previous trim: {error}"))?;
+    }
+    fs::rename(&temporary_path, &output_path)
+        .await
+        .map_err(|error| format!("Failed saving the trimmed video: {error}"))?;
+    Ok(output_path.to_string_lossy().to_string())
+}
+
+#[tauri::command]
+pub async fn restore_original_meeting_video(folder_path: String) -> Result<String, String> {
+    let folder = PathBuf::from(folder_path);
+    let trimmed_path = folder.join("video-trimmed.mp4");
+    match fs::remove_file(&trimmed_path).await {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(format!("Failed removing the trimmed video: {error}")),
+    }
+    find_original_video(&folder)
+        .map(|path| path.to_string_lossy().to_string())
+        .ok_or_else(|| "The original meeting video could not be found".to_string())
+}
+
+fn find_original_video(folder: &Path) -> Option<PathBuf> {
+    [folder.join("video.mov"), folder.join("video.webm")]
+        .into_iter()
+        .find(|path| {
+            std::fs::metadata(path)
+                .map(|metadata| metadata.is_file() && metadata.len() >= 1024)
+                .unwrap_or(false)
+        })
+}
+
+fn find_preferred_video(folder: &Path) -> Option<PathBuf> {
     [
-        Path::new(&folder_path).join("video.mov"),
-        Path::new(&folder_path).join("video.webm"),
+        folder.join("video-trimmed.mp4"),
+        folder.join("video.mov"),
+        folder.join("video.webm"),
     ]
     .into_iter()
     .find(|path| {
@@ -354,7 +453,19 @@ pub fn get_meeting_video_path(folder_path: String) -> Option<String> {
             .map(|metadata| metadata.is_file() && metadata.len() >= 1024)
             .unwrap_or(false)
     })
-    .map(|path| path.to_string_lossy().to_string())
+}
+
+fn validate_trim_range(start_seconds: f64, end_seconds: f64) -> Result<(), String> {
+    if !start_seconds.is_finite() || !end_seconds.is_finite() {
+        return Err("Trim points must be finite numbers".to_string());
+    }
+    if start_seconds < 0.0 || end_seconds <= start_seconds {
+        return Err("The trim end must be after the trim start".to_string());
+    }
+    if end_seconds - start_seconds < 0.1 {
+        return Err("Keep at least 0.1 seconds of video".to_string());
+    }
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]
@@ -654,5 +765,13 @@ mod tests {
         )));
         assert!(!is_allowed_extension_origin(Some("https://example.com")));
         assert!(!is_allowed_extension_origin(None));
+    }
+
+    #[test]
+    fn trim_ranges_require_positive_finite_duration() {
+        assert!(validate_trim_range(1.0, 5.0).is_ok());
+        assert!(validate_trim_range(-1.0, 5.0).is_err());
+        assert!(validate_trim_range(5.0, 5.0).is_err());
+        assert!(validate_trim_range(0.0, f64::INFINITY).is_err());
     }
 }

--- a/frontend/src-tauri/src/video_capture.rs
+++ b/frontend/src-tauri/src/video_capture.rs
@@ -16,7 +16,14 @@ use tokio::{
     sync::{broadcast, Mutex, Notify},
     time::{timeout, Duration},
 };
-use tokio_tungstenite::{accept_async, tungstenite::Message};
+use tokio_tungstenite::{
+    accept_hdr_async,
+    tungstenite::{
+        handshake::server::{ErrorResponse, Request, Response},
+        http::StatusCode,
+        Message,
+    },
+};
 
 const BRIDGE_ADDRESS: &str = "127.0.0.1:8179";
 const BRIDGE_TOKEN: &str = "meetily-local-capture-v1-7d4f2c9a6e31b805";
@@ -114,7 +121,22 @@ pub fn start_bridge() {
 }
 
 async fn handle_extension(stream: TcpStream) {
-    let websocket = match accept_async(stream).await {
+    let websocket = match accept_hdr_async(stream, |request: &Request, response: Response| {
+        let origin = request
+            .headers()
+            .get("origin")
+            .and_then(|value| value.to_str().ok());
+        if is_allowed_extension_origin(origin) {
+            Ok(response)
+        } else {
+            Err(ErrorResponse::builder()
+                .status(StatusCode::FORBIDDEN)
+                .body(Some("Browser extension origin required".to_string()))
+                .expect("valid WebSocket rejection response"))
+        }
+    })
+    .await
+    {
         Ok(socket) => socket,
         Err(error) => {
             log::warn!("Rejected browser capture bridge connection: {error}");
@@ -167,6 +189,10 @@ async fn handle_extension(stream: TcpStream) {
     STATE.connected.store(false, Ordering::SeqCst);
     STATE.tab_armed.store(false, Ordering::SeqCst);
     *STATE.tab_title.lock().await = None;
+}
+
+fn is_allowed_extension_origin(origin: Option<&str>) -> bool {
+    origin.is_some_and(|value| value.starts_with("chrome-extension://"))
 }
 
 fn is_authorized_message(text: &str) -> bool {
@@ -619,5 +645,14 @@ mod tests {
         assert!(is_authorized_message(&format!(
             r#"{{"type":"hello","token":"{BRIDGE_TOKEN}"}}"#
         )));
+    }
+
+    #[test]
+    fn browser_bridge_only_accepts_chromium_extension_origins() {
+        assert!(is_allowed_extension_origin(Some(
+            "chrome-extension://abcdefghijklmnop"
+        )));
+        assert!(!is_allowed_extension_origin(Some("https://example.com")));
+        assert!(!is_allowed_extension_origin(None));
     }
 }

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -32,7 +32,8 @@
             "assetProtocol": {
                 "enable": true,
                 "scope": [
-                    "$APPDATA/**"
+                    "$APPDATA/**",
+                    "$VIDEO/**"
                 ]
             },
             "capabilities": [

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -21,6 +21,7 @@ import { TranscriptRecovery } from '@/components/TranscriptRecovery';
 import { indexedDBService } from '@/services/indexedDBService';
 import { toast } from 'sonner';
 import { useRouter } from 'next/navigation';
+import { VideoCaptureSelector } from '@/components/VideoCaptureSelector';
 
 export default function Home() {
   // Local page state (not moved to contexts)
@@ -232,6 +233,7 @@ export default function Home() {
               >
                 <div className="w-2/3 max-w-[750px] flex justify-center">
                   <div className="bg-white rounded-full shadow-lg flex items-center">
+                    <VideoCaptureSelector disabled={recordingState.isRecording || isProcessingStop} />
                     <RecordingControls
                       isRecording={recordingState.isRecording}
                       onRecordingStop={(callApi = true) => handleRecordingStop(callApi)}

--- a/frontend/src/components/MeetingDetails/MeetingVideo.tsx
+++ b/frontend/src/components/MeetingDetails/MeetingVideo.tsx
@@ -1,12 +1,47 @@
 'use client';
 
-import { convertFileSrc } from '@tauri-apps/api/core';
-import { invoke } from '@tauri-apps/api/core';
-import { Video } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { convertFileSrc, invoke } from '@tauri-apps/api/core';
+import {
+  FolderOpen,
+  Loader2,
+  Play,
+  RotateCcw,
+  Save,
+  Scissors,
+  SkipBack,
+  SkipForward,
+  Video,
+  X,
+} from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
 
-export function MeetingVideo({ folderPath }: { folderPath?: string | null }) {
+function formatTime(seconds: number) {
+  if (!Number.isFinite(seconds)) return '0:00';
+  const minutes = Math.floor(seconds / 60);
+  const remainder = Math.floor(seconds % 60);
+  return `${minutes}:${remainder.toString().padStart(2, '0')}`;
+}
+
+export function MeetingVideo({
+  folderPath,
+  onOpenFolder,
+}: {
+  folderPath?: string | null;
+  onOpenFolder?: () => Promise<void>;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
   const [videoPath, setVideoPath] = useState<string | null>(null);
+  const [duration, setDuration] = useState(0);
+  const [trimStart, setTrimStart] = useState(0);
+  const [trimEnd, setTrimEnd] = useState(0);
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isPreviewing, setIsPreviewing] = useState(false);
+  const [revision, setRevision] = useState(0);
+
+  const isTrimmed = videoPath?.endsWith('video-trimmed.mp4') ?? false;
 
   useEffect(() => {
     let active = true;
@@ -24,20 +59,231 @@ export function MeetingVideo({ folderPath }: { folderPath?: string | null }) {
     };
   }, [folderPath]);
 
+  const resetSelection = (nextDuration = duration) => {
+    setTrimStart(0);
+    setTrimEnd(nextDuration);
+    setIsPreviewing(false);
+  };
+
+  const setStartFromPlayhead = () => {
+    const currentTime = videoRef.current?.currentTime ?? 0;
+    setTrimStart(Math.min(currentTime, Math.max(0, trimEnd - 0.1)));
+  };
+
+  const setEndFromPlayhead = () => {
+    const currentTime = videoRef.current?.currentTime ?? duration;
+    setTrimEnd(Math.max(currentTime, Math.min(duration, trimStart + 0.1)));
+  };
+
+  const previewSelection = async () => {
+    const video = videoRef.current;
+    if (!video) return;
+    video.currentTime = trimStart;
+    try {
+      setIsPreviewing(true);
+      await video.play();
+    } catch (error) {
+      setIsPreviewing(false);
+      toast.error('Could not preview the selection', { description: String(error) });
+    }
+  };
+
+  const saveTrim = async () => {
+    if (!folderPath) return;
+    setIsSaving(true);
+    try {
+      const path = await invoke<string>('trim_meeting_video', {
+        folderPath,
+        startSeconds: trimStart,
+        endSeconds: trimEnd,
+      });
+      setVideoPath(path);
+      setRevision((value) => value + 1);
+      setIsEditing(false);
+      toast.success('Trimmed video saved', {
+        description: 'The original recording is still available.',
+      });
+    } catch (error) {
+      toast.error('Could not trim the video', { description: String(error) });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const restoreOriginal = async () => {
+    if (!folderPath) return;
+    setIsSaving(true);
+    try {
+      const path = await invoke<string>('restore_original_meeting_video', { folderPath });
+      setVideoPath(path);
+      setRevision((value) => value + 1);
+      setIsEditing(false);
+      toast.success('Original video restored');
+    } catch (error) {
+      toast.error('Could not restore the original', { description: String(error) });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
   if (!videoPath) return null;
 
   return (
     <section className="border-b border-gray-200 bg-white p-3">
-      <div className="mb-2 flex items-center gap-2 text-xs font-medium text-gray-700">
-        <Video size={15} className="text-blue-600" />
-        Meeting video
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2 text-xs font-medium text-gray-700">
+          <Video size={15} className="shrink-0 text-blue-600" />
+          <span className="truncate">{isTrimmed ? 'Trimmed meeting video' : 'Meeting video'}</span>
+          {duration > 0 && <span className="text-gray-400">{formatTime(duration)}</span>}
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          {onOpenFolder && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={onOpenFolder}
+              title="Open meeting folder"
+            >
+              <FolderOpen />
+              <span className="sr-only">Open meeting folder</span>
+            </Button>
+          )}
+          {isTrimmed && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={isSaving}
+              onClick={restoreOriginal}
+              title="Restore the untouched original video"
+            >
+              <RotateCcw />
+              Restore
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant={isEditing ? 'secondary' : 'ghost'}
+            size="sm"
+            disabled={isSaving || duration <= 0}
+            onClick={() => {
+              resetSelection();
+              setIsEditing((value) => !value);
+            }}
+            title="Trim meeting video"
+          >
+            <Scissors />
+            Trim
+          </Button>
+        </div>
       </div>
+
       <video
+        key={`${videoPath}-${revision}`}
+        ref={videoRef}
         controls
         preload="metadata"
         className="aspect-video w-full rounded-lg bg-black"
         src={convertFileSrc(videoPath)}
+        onLoadedMetadata={(event) => {
+          const nextDuration = event.currentTarget.duration;
+          setDuration(nextDuration);
+          resetSelection(nextDuration);
+        }}
+        onTimeUpdate={(event) => {
+          if (isPreviewing && event.currentTarget.currentTime >= trimEnd) {
+            event.currentTarget.pause();
+            setIsPreviewing(false);
+          }
+        }}
+        onPause={() => setIsPreviewing(false)}
       />
+
+      {isEditing && (
+        <div className="mt-3 space-y-3 rounded-lg border border-gray-200 bg-gray-50 p-3">
+          <div className="flex items-center justify-between text-xs">
+            <span className="font-medium text-gray-700">Keep selection</span>
+            <span className="tabular-nums text-gray-500">
+              {formatTime(trimStart)} – {formatTime(trimEnd)}
+              {' · '}
+              {formatTime(Math.max(0, trimEnd - trimStart))}
+            </span>
+          </div>
+
+          <label className="grid grid-cols-[42px_1fr_46px] items-center gap-2 text-[11px] text-gray-600">
+            Start
+            <input
+              type="range"
+              min={0}
+              max={Math.max(0, duration)}
+              step={0.1}
+              value={trimStart}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                setTrimStart(Math.min(value, Math.max(0, trimEnd - 0.1)));
+              }}
+              className="accent-blue-600"
+            />
+            <span className="text-right tabular-nums">{formatTime(trimStart)}</span>
+          </label>
+
+          <label className="grid grid-cols-[42px_1fr_46px] items-center gap-2 text-[11px] text-gray-600">
+            End
+            <input
+              type="range"
+              min={0}
+              max={Math.max(0, duration)}
+              step={0.1}
+              value={trimEnd}
+              onChange={(event) => {
+                const value = Number(event.target.value);
+                setTrimEnd(Math.max(value, Math.min(duration, trimStart + 0.1)));
+              }}
+              className="accent-blue-600"
+            />
+            <span className="text-right tabular-nums">{formatTime(trimEnd)}</span>
+          </label>
+
+          <div className="grid grid-cols-2 gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={setStartFromPlayhead}>
+              <SkipBack />
+              Start here
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={setEndFromPlayhead}>
+              <SkipForward />
+              End here
+            </Button>
+          </div>
+
+          <div className="flex flex-wrap justify-end gap-2">
+            <Button type="button" variant="ghost" size="sm" onClick={() => setIsEditing(false)}>
+              <X />
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={isSaving}
+              onClick={previewSelection}
+            >
+              <Play />
+              Preview
+            </Button>
+            <Button
+              type="button"
+              variant="blue"
+              size="sm"
+              disabled={isSaving || trimEnd - trimStart < 0.1}
+              onClick={saveTrim}
+            >
+              {isSaving ? <Loader2 className="animate-spin" /> : <Save />}
+              Save trim
+            </Button>
+          </div>
+        </div>
+      )}
     </section>
   );
 }

--- a/frontend/src/components/MeetingDetails/MeetingVideo.tsx
+++ b/frontend/src/components/MeetingDetails/MeetingVideo.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { convertFileSrc } from '@tauri-apps/api/core';
+import { invoke } from '@tauri-apps/api/core';
+import { Video } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+export function MeetingVideo({ folderPath }: { folderPath?: string | null }) {
+  const [videoPath, setVideoPath] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    if (!folderPath) {
+      setVideoPath(null);
+      return;
+    }
+    invoke<string | null>('get_meeting_video_path', { folderPath })
+      .then((path) => {
+        if (active) setVideoPath(path);
+      })
+      .catch((error) => console.error('Failed to find meeting video', error));
+    return () => {
+      active = false;
+    };
+  }, [folderPath]);
+
+  if (!videoPath) return null;
+
+  return (
+    <section className="border-b border-gray-200 bg-white p-3">
+      <div className="mb-2 flex items-center gap-2 text-xs font-medium text-gray-700">
+        <Video size={15} className="text-blue-600" />
+        Meeting video
+      </div>
+      <video
+        controls
+        preload="metadata"
+        className="aspect-video w-full rounded-lg bg-black"
+        src={convertFileSrc(videoPath)}
+      />
+    </section>
+  );
+}

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -79,7 +79,10 @@ export function TranscriptPanel({
         />
       </div>
 
-      <MeetingVideo folderPath={meetingFolderPath} />
+      <MeetingVideo
+        folderPath={meetingFolderPath}
+        onOpenFolder={onOpenMeetingFolder}
+      />
 
       {/* Transcript content - use virtualized view for better performance */}
       <div className="flex-1 overflow-hidden pb-4">

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -5,6 +5,7 @@ import { TranscriptView } from '@/components/TranscriptView';
 import { VirtualizedTranscriptView } from '@/components/VirtualizedTranscriptView';
 import { TranscriptButtonGroup } from './TranscriptButtonGroup';
 import { useMemo } from 'react';
+import { MeetingVideo } from './MeetingVideo';
 
 interface TranscriptPanelProps {
   transcripts: Transcript[];
@@ -77,6 +78,8 @@ export function TranscriptPanel({
           onRefetchTranscripts={onRefetchTranscripts}
         />
       </div>
+
+      <MeetingVideo folderPath={meetingFolderPath} />
 
       {/* Transcript content - use virtualized view for better performance */}
       <div className="flex-1 overflow-hidden pb-4">

--- a/frontend/src/components/VideoCaptureSelector.tsx
+++ b/frontend/src/components/VideoCaptureSelector.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import { Monitor, Video, VideoOff } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+type VideoCaptureMode = 'off' | 'screen' | 'window' | 'browser_tab';
+
+interface CaptureWindow {
+  id: number;
+  app: string;
+  title: string;
+}
+
+interface VideoCaptureStatus {
+  mode: VideoCaptureMode;
+  bridge_connected: boolean;
+  tab_armed: boolean;
+  tab_title: string | null;
+  recording: boolean;
+}
+
+const STORAGE_KEY = 'meetily-video-capture-mode';
+const WINDOW_STORAGE_KEY = 'meetily-video-capture-window';
+
+export function VideoCaptureSelector({ disabled }: { disabled: boolean }) {
+  const [mode, setMode] = useState<VideoCaptureMode>('off');
+  const [status, setStatus] = useState<VideoCaptureStatus | null>(null);
+  const [windows, setWindows] = useState<CaptureWindow[]>([]);
+  const [windowId, setWindowId] = useState<number | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as VideoCaptureMode | null;
+    const storedWindowId = Number(localStorage.getItem(WINDOW_STORAGE_KEY)) || null;
+    const initial = stored && ['off', 'screen', 'window', 'browser_tab'].includes(stored)
+      ? stored
+      : 'off';
+    const validInitial = initial === 'window' && !storedWindowId ? 'off' : initial;
+    setMode(validInitial);
+    setWindowId(storedWindowId);
+    invoke('set_video_capture_mode', {
+      mode: validInitial,
+      windowId: validInitial === 'window' ? storedWindowId : null,
+    }).catch(console.error);
+    invoke<CaptureWindow[]>('list_capture_windows')
+      .then(setWindows)
+      .catch((error) => console.error('Failed to list capture windows', error));
+  }, []);
+
+  useEffect(() => {
+    const unlisten = listen<string>('video-capture-error', (event) => {
+      toast.error('Meeting audio was saved, but video capture failed', {
+        description: event.payload,
+        duration: 8000,
+      });
+    });
+    return () => {
+      unlisten.then((stopListening) => stopListening());
+    };
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    const refresh = async () => {
+      try {
+        const next = await invoke<VideoCaptureStatus>('get_video_capture_status');
+        if (active) setStatus(next);
+      } catch (error) {
+        console.error('Failed to read video capture status', error);
+      }
+    };
+    refresh();
+    const timer = window.setInterval(refresh, 1000);
+    return () => {
+      active = false;
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  const updateMode = async (next: VideoCaptureMode) => {
+    const selectedWindowId = next === 'window'
+      ? windowId || windows[0]?.id || null
+      : null;
+    try {
+      await invoke('set_video_capture_mode', { mode: next, windowId: selectedWindowId });
+      setMode(next);
+      if (selectedWindowId) {
+        setWindowId(selectedWindowId);
+        localStorage.setItem(WINDOW_STORAGE_KEY, String(selectedWindowId));
+      }
+      localStorage.setItem(STORAGE_KEY, next);
+      if (next === 'screen') {
+        toast.info('The macOS display or area picker will open when recording starts');
+      } else if (next === 'window') {
+        toast.info('The selected window will be recorded for the whole meeting');
+      } else if (next === 'browser_tab') {
+        toast.info('Focus a tab and click the Meetily Tab Capture extension to arm it');
+      }
+    } catch (error) {
+      toast.error('Could not change video source', { description: String(error) });
+    }
+  };
+
+  const updateWindow = async (nextWindowId: number) => {
+    try {
+      await invoke('set_video_capture_mode', { mode: 'window', windowId: nextWindowId });
+      setWindowId(nextWindowId);
+      localStorage.setItem(WINDOW_STORAGE_KEY, String(nextWindowId));
+    } catch (error) {
+      toast.error('Could not select that window', { description: String(error) });
+    }
+  };
+
+  const Icon = mode === 'off' ? VideoOff : ['screen', 'window'].includes(mode) ? Monitor : Video;
+  const browserReady = status?.bridge_connected && status?.tab_armed;
+
+  return (
+    <div className="flex items-center gap-2 border-r border-gray-200 px-3">
+      <Icon size={17} className={mode === 'off' ? 'text-gray-400' : 'text-blue-600'} />
+      <div className="flex flex-col">
+        <label htmlFor="video-capture-mode" className="sr-only">Video capture source</label>
+        <select
+          id="video-capture-mode"
+          value={mode}
+          disabled={disabled}
+          onChange={(event) => updateMode(event.target.value as VideoCaptureMode)}
+          className="max-w-[150px] bg-transparent text-xs font-medium text-gray-700 outline-none disabled:opacity-60"
+          title="Video capture source"
+        >
+          <option value="off">Audio only</option>
+          <option value="window">Exact window</option>
+          <option value="screen">Display / area</option>
+          <option value="browser_tab">Browser tab</option>
+        </select>
+        {mode === 'window' && (
+          <select
+            value={windowId || ''}
+            disabled={disabled || windows.length === 0}
+            onChange={(event) => updateWindow(Number(event.target.value))}
+            className="max-w-[180px] bg-transparent text-[10px] text-blue-600 outline-none disabled:text-amber-600"
+            title="Window to record"
+          >
+            {windows.length === 0 && <option value="">No windows found</option>}
+            {windows.map((window) => (
+              <option key={window.id} value={window.id}>
+                {window.app}: {window.title}
+              </option>
+            ))}
+          </select>
+        )}
+        {mode === 'browser_tab' && (
+          <span
+            className={`max-w-[150px] truncate text-[10px] ${
+              browserReady ? 'text-emerald-600' : 'text-amber-600'
+            }`}
+            title={status?.tab_title || undefined}
+          >
+            {browserReady ? status?.tab_title || 'Tab armed' : 'Click extension to arm'}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/VideoCaptureSelector.tsx
+++ b/frontend/src/components/VideoCaptureSelector.tsx
@@ -24,6 +24,9 @@ interface VideoCaptureStatus {
 
 const STORAGE_KEY = 'meetily-video-capture-mode';
 const WINDOW_STORAGE_KEY = 'meetily-video-capture-window';
+const WINDOW_LABEL_STORAGE_KEY = 'meetily-video-capture-window-label';
+
+const windowLabel = (window: CaptureWindow) => `${window.app}\u0000${window.title}`;
 
 export function VideoCaptureSelector({ disabled }: { disabled: boolean }) {
   const [mode, setMode] = useState<VideoCaptureMode>('off');
@@ -32,21 +35,40 @@ export function VideoCaptureSelector({ disabled }: { disabled: boolean }) {
   const [windowId, setWindowId] = useState<number | null>(null);
 
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY) as VideoCaptureMode | null;
-    const storedWindowId = Number(localStorage.getItem(WINDOW_STORAGE_KEY)) || null;
-    const initial = stored && ['off', 'screen', 'window', 'browser_tab'].includes(stored)
-      ? stored
-      : 'off';
-    const validInitial = initial === 'window' && !storedWindowId ? 'off' : initial;
-    setMode(validInitial);
-    setWindowId(storedWindowId);
-    invoke('set_video_capture_mode', {
-      mode: validInitial,
-      windowId: validInitial === 'window' ? storedWindowId : null,
-    }).catch(console.error);
-    invoke<CaptureWindow[]>('list_capture_windows')
-      .then(setWindows)
-      .catch((error) => console.error('Failed to list capture windows', error));
+    let active = true;
+    const initialize = async () => {
+      try {
+        const availableWindows = await invoke<CaptureWindow[]>('list_capture_windows');
+        if (!active) return;
+
+        setWindows(availableWindows);
+        const stored = localStorage.getItem(STORAGE_KEY) as VideoCaptureMode | null;
+        const storedWindowId = Number(localStorage.getItem(WINDOW_STORAGE_KEY)) || null;
+        const storedWindowLabel = localStorage.getItem(WINDOW_LABEL_STORAGE_KEY);
+        const selectedWindow = availableWindows.find(
+          (window) => storedWindowLabel && windowLabel(window) === storedWindowLabel,
+        ) || availableWindows.find((window) => window.id === storedWindowId)
+          || availableWindows[0]
+          || null;
+        const initial = stored && ['off', 'screen', 'window', 'browser_tab'].includes(stored)
+          ? stored
+          : 'off';
+        const validInitial = initial === 'window' && !selectedWindow ? 'off' : initial;
+
+        setMode(validInitial);
+        setWindowId(selectedWindow?.id || null);
+        await invoke('set_video_capture_mode', {
+          mode: validInitial,
+          windowId: validInitial === 'window' ? selectedWindow?.id || null : null,
+        });
+      } catch (error) {
+        console.error('Failed to initialize video capture', error);
+      }
+    };
+    initialize();
+    return () => {
+      active = false;
+    };
   }, []);
 
   useEffect(() => {
@@ -89,15 +111,12 @@ export function VideoCaptureSelector({ disabled }: { disabled: boolean }) {
       if (selectedWindowId) {
         setWindowId(selectedWindowId);
         localStorage.setItem(WINDOW_STORAGE_KEY, String(selectedWindowId));
+        const selectedWindow = windows.find((window) => window.id === selectedWindowId);
+        if (selectedWindow) {
+          localStorage.setItem(WINDOW_LABEL_STORAGE_KEY, windowLabel(selectedWindow));
+        }
       }
       localStorage.setItem(STORAGE_KEY, next);
-      if (next === 'screen') {
-        toast.info('The macOS display or area picker will open when recording starts');
-      } else if (next === 'window') {
-        toast.info('The selected window will be recorded for the whole meeting');
-      } else if (next === 'browser_tab') {
-        toast.info('Focus a tab and click the Meetily Tab Capture extension to arm it');
-      }
     } catch (error) {
       toast.error('Could not change video source', { description: String(error) });
     }
@@ -108,6 +127,10 @@ export function VideoCaptureSelector({ disabled }: { disabled: boolean }) {
       await invoke('set_video_capture_mode', { mode: 'window', windowId: nextWindowId });
       setWindowId(nextWindowId);
       localStorage.setItem(WINDOW_STORAGE_KEY, String(nextWindowId));
+      const selectedWindow = windows.find((window) => window.id === nextWindowId);
+      if (selectedWindow) {
+        localStorage.setItem(WINDOW_LABEL_STORAGE_KEY, windowLabel(selectedWindow));
+      }
     } catch (error) {
       toast.error('Could not select that window', { description: String(error) });
     }
@@ -158,6 +181,11 @@ export function VideoCaptureSelector({ disabled }: { disabled: boolean }) {
             title={status?.tab_title || undefined}
           >
             {browserReady ? status?.tab_title || 'Tab armed' : 'Click extension to arm'}
+          </span>
+        )}
+        {mode === 'screen' && (
+          <span className="max-w-[150px] truncate text-[10px] text-blue-600">
+            Picker opens when recording starts
           </span>
         )}
       </div>


### PR DESCRIPTION
## Description
- Add desktop meeting video capture for macOS display or window sources, with native playback in meeting details.
- Add an in-app trim editor with start/end sliders, playhead-based in/out points, selection preview, save, restore-original, and open-folder actions.
- Keep trimming non-destructive: the editor writes video-trimmed.mp4 and preserves the original recording. Repeated edits use the currently preferred trim, while Restore returns to the untouched source.
- Add a Manifest V3 companion extension for Chrome and Edge tab capture, including tab selection, standalone recording, stop/save, and delete controls.
- Persist the selected capture source across restarts.
- Restrict the localhost WebSocket bridge to Chromium extension origins and require its protocol token.

## Related Issue
No linked issue.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other

## Testing
- [ ] Unit tests executed
- [ ] Manual testing performed for this PR preparation
- [ ] Full build executed
- [x] Static JavaScript syntax checks passed for service-worker.js, offscreen.js, and popup.js
- [x] Extension manifest JSON validation passed
- [x] Rust source formatting and parse check passed for video_capture.rs
- [x] Changed TSX files passed isolated TypeScript transpilation
- [x] Git whitespace and conflict-marker checks passed

Per request, verification was limited to static checks; no build or runtime artifact checks were performed.

## Documentation
- [x] Documentation updated
- [ ] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Uses existing UI primitives and Lucide icons
- [x] Updated extension README
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots
Not captured because verification was limited to static checks.

## Additional Notes
Desktop display and exact-window capture use the macOS screencapture facility. Video trimming uses the existing FFmpeg discovery path and encodes the selected range to H.264/AAC MP4. Browser tab capture supports Chromium browsers through the unpacked extension in edge-extension.