### PR TITLE
fix: preserve short Whisper transcripts

### DIFF
--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -17,6 +17,11 @@ static SEQUENCE_COUNTER: AtomicU64 = AtomicU64::new(0);
 // Speech detection flag - reset per recording session
 static SPEECH_DETECTED_EMITTED: AtomicBool = AtomicBool::new(false);
 
+// Confidence is preserved as metadata, but emission depends only on transcript content.
+fn should_emit_transcript(transcript: &str, _confidence: Option<f32>) -> bool {
+    !transcript.trim().is_empty()
+}
+
 /// Reset the speech detected flag for a new recording session
 pub fn reset_speech_detected_flag() {
     SPEECH_DETECTED_EMITTED.store(false, Ordering::SeqCst);
@@ -152,24 +157,15 @@ pub fn start_transcription_task<R: Runtime>(
                             .await
                             {
                                 Ok((transcript, confidence_opt, is_partial)) => {
-                                    // Provider-aware confidence threshold
-                                    let confidence_threshold = match &engine_clone {
-                                        TranscriptionEngine::Whisper(_) | TranscriptionEngine::Provider(_) => 0.3,
-                                        TranscriptionEngine::Parakeet(_) => 0.0, // Parakeet has no confidence, accept all
-                                    };
-
                                     let confidence_str = match confidence_opt {
                                         Some(c) => format!("{:.2}", c),
                                         None => "N/A".to_string(),
                                     };
 
-                                    info!("🔍 Worker {} transcription result: text='{}', confidence={}, partial={}, threshold={:.2}",
-                                          worker_id, transcript, confidence_str, is_partial, confidence_threshold);
+                                    info!("🔍 Worker {} transcription result: text='{}', confidence={}, partial={}",
+                                          worker_id, transcript, confidence_str, is_partial);
 
-                                    // Check confidence threshold (or accept if no confidence provided)
-                                    let meets_threshold = confidence_opt.map_or(true, |c| c >= confidence_threshold);
-
-                                    if !transcript.trim().is_empty() && meets_threshold {
+                                    if should_emit_transcript(&transcript, confidence_opt) {
                                         // PERFORMANCE: Only log transcription results, not every processing step
                                         info!("✅ Worker {} transcribed: {} (confidence: {}, partial: {})",
                                               worker_id, transcript, confidence_str, is_partial);
@@ -227,12 +223,6 @@ pub fn start_transcription_task<R: Runtime>(
                                             );
                                         }
                                         // PERFORMANCE: Removed verbose logging of every emission
-                                    } else if !transcript.trim().is_empty() && should_log_this_chunk
-                                    {
-                                        // PERFORMANCE: Only log low-confidence results occasionally
-                                        if let Some(c) = confidence_opt {
-                                            info!("Worker {} low-confidence transcription (confidence: {:.2}), skipping", worker_id, c);
-                                        }
                                     }
                                 }
                                 Err(e) => {
@@ -593,4 +583,19 @@ fn format_recording_time(seconds: f64) -> String {
     let secs = total_seconds % 60;
 
     format!("[{:02}:{:02}]", minutes, secs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_emit_transcript;
+
+    #[test]
+    fn accepts_short_nonempty_transcript_regardless_of_confidence() {
+        assert!(should_emit_transcript("да", Some(0.14)));
+    }
+
+    #[test]
+    fn rejects_whitespace_only_transcript() {
+        assert!(!should_emit_transcript("   ", Some(1.0)));
+    }
 }

--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -590,8 +590,20 @@ mod tests {
     use super::should_emit_transcript;
 
     #[test]
-    fn accepts_short_nonempty_transcript_regardless_of_confidence() {
-        assert!(should_emit_transcript("да", Some(0.14)));
+    fn accepts_short_nonempty_transcripts_regardless_of_confidence() {
+        for (transcript, confidence) in [
+            ("OK", 0.12),
+            ("Yes", 0.13),
+            ("No", 0.12),
+            ("Sure", 0.14),
+            ("Got it", 0.16),
+            ("Thanks", 0.16),
+        ] {
+            assert!(
+                should_emit_transcript(transcript, Some(confidence)),
+                "expected short transcript '{transcript}' to be emitted"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

Preserve short, non-empty live transcription results instead of dropping them based on the current confidence-like value.

The Whisper engine derives this value from decoded text length rather than acoustic or token probabilities. The live worker treated it as a calibrated score and rejected results below `0.3`, so valid short utterances could disappear. Common examples include `OK` (approximately `0.12`), `Yes` (`0.13`), `No` (`0.12`), `Sure` (`0.14`), `Got it` (`0.16`), and `Thanks` (`0.16`).

This change keeps confidence in transcript metadata but bases emission on whether the returned transcript contains text. Empty and whitespace-only results remain filtered out.

Regression tests cover all six short English examples and the whitespace-only case.

## Related Issue

Fixes #675

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [x] Unit tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass

Validated with:

```text
cargo test -p meetily --lib audio::transcription::worker::tests
2 passed, 0 failed

cargo test -p meetily --lib -- --skip audio::device_detection::tests::test_calculate_buffer_timeout_bluetooth
189 passed, 0 failed, 3 ignored, 1 filtered out
```

The unfiltered suite still has the pre-existing Bluetooth duration precision failure in `test_calculate_buffer_timeout_bluetooth` (`159.999996ms` vs `160ms`). This PR does not change that module.

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [x] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)

Not applicable; this change does not affect the UI.

## Additional Notes

The regression test was written first and observed failing before the production change. It now checks six short English replies whose former text-length confidence values all fall below the worker's old `0.3` cutoff.
