### PR TITLE
feat(summary): add MiniMax as a first-class summary provider

### DIFF
--- a/frontend/src-tauri/migrations/20260729000000_add_minimax_api_key.sql
+++ b/frontend/src-tauri/migrations/20260729000000_add_minimax_api_key.sql
@@ -1,0 +1,2 @@
+-- Add MiniMax API key storage for the OpenAI-compatible summary provider
+ALTER TABLE settings ADD COLUMN minimaxApiKey TEXT;

--- a/frontend/src-tauri/src/database/models.rs
+++ b/frontend/src-tauri/src/database/models.rs
@@ -89,6 +89,9 @@ pub struct Setting {
     #[sqlx(rename = "openRouterApiKey")]
     #[serde(rename = "openRouterApiKey")]
     pub open_router_api_key: Option<String>,
+    #[sqlx(rename = "minimaxApiKey")]
+    #[serde(rename = "minimaxApiKey")]
+    pub minimax_api_key: Option<String>,
     #[sqlx(rename = "ollamaEndpoint")]
     #[serde(rename = "ollamaEndpoint")]
     pub ollama_endpoint: Option<String>,

--- a/frontend/src-tauri/src/database/repositories/setting.rs
+++ b/frontend/src-tauri/src/database/repositories/setting.rs
@@ -25,7 +25,7 @@ pub struct SaveTranscriptConfigRequest {
 pub struct SettingsRepository;
 
 // Transcript providers: localWhisper, deepgram, elevenLabs, groq, openai
-// Summary providers: openai, claude, ollama, groq, added openrouter
+// Summary providers: openai, claude, ollama, groq, openrouter, minimax
 // NOTE: Handle data exclusion in the higher layer as this is database abstraction layer(using SELECT *)
 
 impl SettingsRepository {
@@ -85,6 +85,7 @@ impl SettingsRepository {
             "ollama" => "ollamaApiKey",
             "groq" => "groqApiKey",
             "openrouter" => "openRouterApiKey",
+            "minimax" => "minimaxApiKey",
             "builtin-ai" => return Ok(()), // No API key needed
             _ => {
                 return Err(sqlx::Error::Protocol(
@@ -123,6 +124,7 @@ impl SettingsRepository {
             "groq" => "groqApiKey",
             "claude" => "anthropicApiKey",
             "openrouter" => "openRouterApiKey",
+            "minimax" => "minimaxApiKey",
             "builtin-ai" => return Ok(None), // No API key needed
             _ => {
                 return Err(sqlx::Error::Protocol(
@@ -249,6 +251,7 @@ impl SettingsRepository {
             "groq" => "groqApiKey",
             "claude" => "anthropicApiKey",
             "openrouter" => "openRouterApiKey",
+            "minimax" => "minimaxApiKey",
             "builtin-ai" => return Ok(()), // No API key needed
             _ => {
                 return Err(sqlx::Error::Protocol(

--- a/frontend/src-tauri/src/summary/llm_client.rs
+++ b/frontend/src-tauri/src/summary/llm_client.rs
@@ -7,6 +7,21 @@ use tracing::info;
 
 const REQUEST_TIMEOUT_DURATION: Duration = Duration::from_secs(300);
 
+/// MiniMax OpenAI-compatible base URLs by region.
+const MINIMAX_GLOBAL_BASE_URL: &str = "https://api.minimax.io/v1";
+const MINIMAX_CN_BASE_URL: &str = "https://api.minimaxi.com/v1";
+/// Region used for MiniMax summary dispatch by default.
+const MINIMAX_DEFAULT_REGION: &str = "global";
+
+/// Resolve the MiniMax OpenAI-compatible base URL for a region.
+/// Any unrecognized region falls back to the global endpoint.
+fn minimax_base_url(region: &str) -> &'static str {
+    match region.to_lowercase().as_str() {
+        "cn" | "cn_zh" | "china" => MINIMAX_CN_BASE_URL,
+        _ => MINIMAX_GLOBAL_BASE_URL,
+    }
+}
+
 // Generic structure for OpenAI-compatible API chat messages
 #[derive(Debug, Serialize)]
 pub struct ChatMessage {
@@ -71,6 +86,7 @@ pub enum LLMProvider {
     Groq,
     Ollama,
     OpenRouter,
+    MiniMax,
     BuiltInAI,
     CustomOpenAI,
 }
@@ -84,6 +100,7 @@ impl LLMProvider {
             "groq" => Ok(Self::Groq),
             "ollama" => Ok(Self::Ollama),
             "openrouter" => Ok(Self::OpenRouter),
+            "minimax" => Ok(Self::MiniMax),
             "builtin-ai" | "local-llama" | "localllama" => Ok(Self::BuiltInAI),
             "custom-openai" => Ok(Self::CustomOpenAI),
             _ => Err(format!("Unsupported LLM provider: {}", s)),
@@ -159,6 +176,10 @@ pub async fn generate_summary(
         ),
         LLMProvider::OpenRouter => (
             "https://openrouter.ai/api/v1/chat/completions".to_string(),
+            header::HeaderMap::new(),
+        ),
+        LLMProvider::MiniMax => (
+            format!("{}/chat/completions", minimax_base_url(MINIMAX_DEFAULT_REGION)),
             header::HeaderMap::new(),
         ),
         LLMProvider::Ollama => {
@@ -341,6 +362,32 @@ fn provider_name(provider: &LLMProvider) -> &str {
         LLMProvider::Ollama => "Ollama",
         LLMProvider::BuiltInAI => "Built-in AI",
         LLMProvider::OpenRouter => "OpenRouter",
+        LLMProvider::MiniMax => "MiniMax",
         LLMProvider::CustomOpenAI => "Custom OpenAI",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{minimax_base_url, provider_name, LLMProvider};
+
+    #[test]
+    fn parses_minimax_provider() {
+        assert_eq!(LLMProvider::from_str("minimax"), Ok(LLMProvider::MiniMax));
+        assert_eq!(LLMProvider::from_str("MiniMax"), Ok(LLMProvider::MiniMax));
+    }
+
+    #[test]
+    fn exposes_minimax_provider_name() {
+        assert_eq!(provider_name(&LLMProvider::MiniMax), "MiniMax");
+    }
+
+    #[test]
+    fn resolves_minimax_regional_base_urls() {
+        assert_eq!(minimax_base_url("global"), "https://api.minimax.io/v1");
+        assert_eq!(minimax_base_url("cn_zh"), "https://api.minimaxi.com/v1");
+        assert_eq!(minimax_base_url("cn"), "https://api.minimaxi.com/v1");
+        // Unknown regions fall back to the global endpoint.
+        assert_eq!(minimax_base_url("unknown"), "https://api.minimax.io/v1");
     }
 }

--- a/frontend/src-tauri/src/summary/mod.rs
+++ b/frontend/src-tauri/src/summary/mod.rs
@@ -1,7 +1,7 @@
 /// Summary module - handles all meeting summary generation functionality
 ///
 /// This module contains:
-/// - LLM client for communicating with various AI providers (OpenAI, Claude, Groq, Ollama, OpenRouter, CustomOpenAI)
+/// - LLM client for communicating with various AI providers (OpenAI, Claude, Groq, Ollama, OpenRouter, MiniMax, CustomOpenAI)
 /// - Processor for chunking transcripts and generating summaries
 /// - Service layer for orchestrating summary generation
 /// - Templates for structured meeting summary generation

--- a/frontend/src/app/_components/SettingsModal.tsx
+++ b/frontend/src/app/_components/SettingsModal.tsx
@@ -106,6 +106,7 @@ export function SettingsModals({
                       <option value="builtin-ai">Built-in AI</option>
                       <option value="claude">Claude</option>
                       <option value="groq">Groq</option>
+                      <option value="minimax">MiniMax</option>
                       <option value="ollama">Ollama</option>
                       <option value="openrouter">OpenRouter</option>
                       <option value="openai">OpenAI</option>

--- a/frontend/src/components/ModelSettingsModal.tsx
+++ b/frontend/src/components/ModelSettingsModal.tsx
@@ -31,7 +31,7 @@ import { cn, isOllamaNotInstalledError } from '@/lib/utils';
 import { toast } from 'sonner';
 
 export interface ModelConfig {
-  provider: 'ollama' | 'groq' | 'claude' | 'openai' | 'openrouter' | 'builtin-ai' | 'custom-openai';
+  provider: 'ollama' | 'groq' | 'claude' | 'openai' | 'openrouter' | 'minimax' | 'builtin-ai' | 'custom-openai';
   model: string;
   whisperModel: string;
   apiKey?: string | null;
@@ -99,6 +99,11 @@ const GROQ_FALLBACK_MODELS = [
   'llama-3.1-70b-versatile',
   'mixtral-8x7b-32768',
   'gemma2-9b-it',
+];
+
+const MINIMAX_FALLBACK_MODELS = [
+  'MiniMax-M3',
+  'MiniMax-M2.7',
 ];
 
 interface ModelSettingsModalProps {
@@ -229,6 +234,7 @@ export function ModelSettingsModal({
     groq: groqModels.length > 0 ? groqModels : GROQ_FALLBACK_MODELS,
     openai: openaiModels.length > 0 ? openaiModels : OPENAI_FALLBACK_MODELS,
     openrouter: openRouterModels.map((m) => m.id),
+    minimax: MINIMAX_FALLBACK_MODELS,
     'builtin-ai': builtinAiModels.map((m) => m.name),
     'custom-openai': customOpenAIModel ? [customOpenAIModel] : [], // User specifies model manually
   };
@@ -237,7 +243,8 @@ export function ModelSettingsModal({
     modelConfig.provider === 'claude' ||
     modelConfig.provider === 'groq' ||
     modelConfig.provider === 'openai' ||
-    modelConfig.provider === 'openrouter';
+    modelConfig.provider === 'openrouter' ||
+    modelConfig.provider === 'minimax';
 
   // Check if Ollama endpoint has changed but models haven't been fetched yet
   const ollamaEndpointChanged = modelConfig.provider === 'ollama' &&
@@ -878,6 +885,7 @@ export function ModelSettingsModal({
                 <SelectItem value="claude">Claude</SelectItem>
                 <SelectItem value="custom-openai">Custom Server (OpenAI)</SelectItem>
                 <SelectItem value="groq">Groq</SelectItem>
+                <SelectItem value="minimax">MiniMax</SelectItem>
                 <SelectItem value="ollama">Ollama</SelectItem>
                 <SelectItem value="openai">OpenAI</SelectItem>
                 <SelectItem value="openrouter">OpenRouter</SelectItem>

--- a/frontend/src/contexts/ConfigContext.tsx
+++ b/frontend/src/contexts/ConfigContext.tsx
@@ -82,6 +82,7 @@ interface ConfigContextType {
     groq: string | null;
     openai: string | null;
     openrouter: string | null;
+    minimax: string | null;
   };
   updateProviderApiKey: (provider: string, apiKey: string | null) => void;
 
@@ -119,11 +120,13 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     groq: string | null;
     openai: string | null;
     openrouter: string | null;
+    minimax: string | null;
   }>({
     claude: null,
     groq: null,
     openai: null,
     openrouter: null,
+    minimax: null,
   });
 
   // Ollama models list and error state
@@ -295,7 +298,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const loadAllApiKeys = async () => {
       try {
-        const providers = ['claude', 'groq', 'openai', 'openrouter'];
+        const providers = ['claude', 'groq', 'openai', 'openrouter', 'minimax'];
         const keys = await Promise.all(
           providers.map(p =>
             invoke<string>('api_get_api_key', { provider: p })
@@ -308,6 +311,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
           groq: keys[1],
           openai: keys[2],
           openrouter: keys[3],
+          minimax: keys[4],
         });
         console.log('[ConfigContext] Loaded provider API keys');
       } catch (error) {
@@ -367,6 +371,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     claude: ['claude-3-5-sonnet-latest'],
     groq: ['llama-3.3-70b-versatile'],
     openrouter: [],
+    minimax: ['MiniMax-M3', 'MiniMax-M2.7'],
     openai: ['gpt-4', 'gpt-4-turbo', 'gpt-3.5-turbo'],
     'builtin-ai': [],
     'custom-openai': [],

--- a/frontend/src/services/configService.ts
+++ b/frontend/src/services/configService.ts
@@ -9,7 +9,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { TranscriptModelProps } from '@/components/TranscriptSettings';
 
 export interface ModelConfig {
-  provider: 'ollama' | 'groq' | 'claude' | 'openrouter' | 'openai' | 'builtin-ai' | 'custom-openai';
+  provider: 'ollama' | 'groq' | 'claude' | 'openrouter' | 'minimax' | 'openai' | 'builtin-ai' | 'custom-openai';
   model: string;
   whisperModel: string;
   /**


### PR DESCRIPTION
Reason: MiniMax was missing from the summary provider enum, dispatch, preset models, and settings UI.

## Summary
- Add MiniMax as a first-class summary provider that reuses the existing OpenAI-compatible chat completions request path.
- Resolve the MiniMax base URL by region, defaulting to the global endpoint (`https://api.minimax.io/v1`) with the CN endpoint (`https://api.minimaxi.com/v1`) wired through the same resolver.
- Persist MiniMax API keys in a dedicated `minimaxApiKey` settings column with a matching migration.
- Surface MiniMax in the summary model settings UI with the `MiniMax-M3` and `MiniMax-M2.7` preset models.

## Changes
- `frontend/src-tauri/src/summary/llm_client.rs`: add the `MiniMax` provider variant, string parsing, a regional base-URL resolver, the dispatch arm, the provider-name label, and unit tests.
- `frontend/src-tauri/src/database/models.rs`, `frontend/src-tauri/src/database/repositories/setting.rs`, and `frontend/src-tauri/migrations/20260729000000_add_minimax_api_key.sql`: store and route the MiniMax API key.
- `frontend/src-tauri/src/summary/mod.rs`: update the module provider list.
- `frontend/src/contexts/ConfigContext.tsx`, `frontend/src/components/ModelSettingsModal.tsx`, `frontend/src/app/_components/SettingsModal.tsx`, and `frontend/src/services/configService.ts`: add the provider option, preset models, API-key wiring, and the provider type union.

## Validation
- `pnpm install --no-frozen-lockfile --ignore-scripts`
- `pnpm run build` — compiled successfully and type checking passed.
- `git diff --cached --check`

## Notes
- `pnpm exec tsc --noEmit` reports only a pre-existing `bun:test` type-resolution error in `tests/lib/blocknote-markdown.test.ts`, which is unrelated to this change; the application build itself type-checks cleanly.
- The Rust workspace could not be compiled in this environment because `cargo` and the `cmake` dependency required by `whisper-rs-sys` are unavailable; the new provider mirrors the existing OpenAI-compatible provider pattern and ships with unit tests.
- No README or documentation changes.
