### PR TITLE
Fix: stop dropping transcripts below confidence threshold (#675)

### DIFF
--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -23,6 +23,12 @@ pub fn reset_speech_detected_flag() {
     info!("🔍 SPEECH_DETECTED_EMITTED reset to: {}", SPEECH_DETECTED_EMITTED.load(Ordering::SeqCst));
 }
 
+/// Returns true if the transcript text is non-trivial and should be emitted.
+/// Filters empty/whitespace-only text; no confidence gating is applied.
+fn should_emit_transcript(text: &str) -> bool {
+    !text.trim().is_empty()
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TranscriptUpdate {
     pub text: String,
@@ -152,24 +158,15 @@ pub fn start_transcription_task<R: Runtime>(
                             .await
                             {
                                 Ok((transcript, confidence_opt, is_partial)) => {
-                                    // Provider-aware confidence threshold
-                                    let confidence_threshold = match &engine_clone {
-                                        TranscriptionEngine::Whisper(_) | TranscriptionEngine::Provider(_) => 0.3,
-                                        TranscriptionEngine::Parakeet(_) => 0.0, // Parakeet has no confidence, accept all
-                                    };
-
                                     let confidence_str = match confidence_opt {
                                         Some(c) => format!("{:.2}", c),
                                         None => "N/A".to_string(),
                                     };
 
-                                    info!("🔍 Worker {} transcription result: text='{}', confidence={}, partial={}, threshold={:.2}",
-                                          worker_id, transcript, confidence_str, is_partial, confidence_threshold);
+                                    info!("🔍 Worker {} transcription result: text='{}', confidence={}, partial={}",
+                worker_id, transcript, confidence_str, is_partial);
 
-                                    // Check confidence threshold (or accept if no confidence provided)
-                                    let meets_threshold = confidence_opt.map_or(true, |c| c >= confidence_threshold);
-
-                                    if !transcript.trim().is_empty() && meets_threshold {
+                                    if should_emit_transcript(&transcript) {
                                         // PERFORMANCE: Only log transcription results, not every processing step
                                         info!("✅ Worker {} transcribed: {} (confidence: {}, partial: {})",
                                               worker_id, transcript, confidence_str, is_partial);
@@ -227,12 +224,6 @@ pub fn start_transcription_task<R: Runtime>(
                                             );
                                         }
                                         // PERFORMANCE: Removed verbose logging of every emission
-                                    } else if !transcript.trim().is_empty() && should_log_this_chunk
-                                    {
-                                        // PERFORMANCE: Only log low-confidence results occasionally
-                                        if let Some(c) = confidence_opt {
-                                            info!("Worker {} low-confidence transcription (confidence: {:.2}), skipping", worker_id, c);
-                                        }
                                     }
                                 }
                                 Err(e) => {
@@ -593,4 +584,21 @@ fn format_recording_time(seconds: f64) -> String {
     let secs = total_seconds % 60;
 
     format!("[{:02}:{:02}]", minutes, secs)
-}
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn keeps_short_acknowledgements() {
+            assert!(should_emit_transcript("Yes"));
+            assert!(should_emit_transcript("ok"));
+        }
+
+        #[test]
+        fn drops_empty_and_whitespace_only() {
+            assert!(!should_emit_transcript(""));
+            assert!(!should_emit_transcript("   "));
+        }
+    }


### PR DESCRIPTION
Removes the confidence-threshold gate that silently discarded non-empty transcripts (e.g. short acknowledgements like "Yes"/"ok") when confidence was below 0.3. Emission now only depends on the transcript text being non-empty, via a new should_emit_transcript helper. Adds unit tests for the helper.

## Description
Previously, transcripts with a confidence score below 0.3 were silently dropped, even when they contained valid short responses such as "Yes" or "ok". This change removes the confidence-based gate entirely and introduces a should_emit_transcript helper that decides emission based solely on whether the transcript text is non-empty (after trimming). Unit tests were added to cover both the "keep short acknowledgements" and "drop empty/whitespace-only" cases.

## Related Issue
Fixes #675

## Type of Change
- [x] Bug fix