### PR TITLE
fix(build): locate CUDA static libs on distro-packaged toolkits

### DIFF
--- a/frontend/build-gpu.sh
+++ b/frontend/build-gpu.sh
@@ -88,6 +88,41 @@ else
     echo -e "${YELLOW}⚠️ No specific GPU feature detected or forced${NC}"
 fi
 
+# Locate CUDA static libraries.
+# llama-cpp-sys-2 links cudart_static/cublas_static/culibos and relies on
+# find_cuda_helper, which only probes $CUDA_LIBRARY_PATH/lib64, /opt/cuda/lib64
+# and /usr/local/cuda*/lib64. Distro packages (e.g. Ubuntu's nvidia-cuda-toolkit)
+# install into /usr/lib/<triple> instead, so rustc gets no -L path and fails with
+# "could not find native static library `cudart_static`".
+if [ "$TAURI_GPU_FEATURE" = "cuda" ] && [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    CUDA_LIB_DIR=""
+    NVCC_LIB_DIR=""
+    if command_exists nvcc; then
+        NVCC_LIB_DIR="$(dirname "$(command -v nvcc)")/../lib64"
+    fi
+    for candidate in \
+        "${CUDA_PATH:+$CUDA_PATH/lib64}" \
+        "${CUDA_HOME:+$CUDA_HOME/lib64}" \
+        "$NVCC_LIB_DIR" \
+        /usr/local/cuda/lib64 \
+        /opt/cuda/lib64 \
+        "/usr/lib/$(uname -m)-linux-gnu" \
+        /usr/lib64; do
+        if [ -n "$candidate" ] && [ -f "$candidate/libcudart_static.a" ]; then
+            CUDA_LIB_DIR="$(cd "$candidate" && pwd)"
+            break
+        fi
+    done
+
+    if [ -n "$CUDA_LIB_DIR" ]; then
+        echo -e "${GREEN}✅ Found CUDA libraries in $CUDA_LIB_DIR${NC}"
+        export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-L native=$CUDA_LIB_DIR"
+    else
+        echo -e "${YELLOW}⚠️ Could not locate libcudart_static.a${NC}"
+        echo -e "${YELLOW}   Install the CUDA toolkit or set CUDA_PATH; the link step may fail.${NC}"
+    fi
+fi
+
 # Build llama-helper
 echo ""
 echo -e "${BLUE}🦙 Building llama-helper sidecar (release)...${NC}"

--- a/frontend/dev-gpu.sh
+++ b/frontend/dev-gpu.sh
@@ -80,6 +80,41 @@ else
     echo -e "${YELLOW}⚠️ No specific GPU feature detected or forced${NC}"
 fi
 
+# Locate CUDA static libraries.
+# llama-cpp-sys-2 links cudart_static/cublas_static/culibos and relies on
+# find_cuda_helper, which only probes $CUDA_LIBRARY_PATH/lib64, /opt/cuda/lib64
+# and /usr/local/cuda*/lib64. Distro packages (e.g. Ubuntu's nvidia-cuda-toolkit)
+# install into /usr/lib/<triple> instead, so rustc gets no -L path and fails with
+# "could not find native static library `cudart_static`".
+if [ "$TAURI_GPU_FEATURE" = "cuda" ] && [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    CUDA_LIB_DIR=""
+    NVCC_LIB_DIR=""
+    if command_exists nvcc; then
+        NVCC_LIB_DIR="$(dirname "$(command -v nvcc)")/../lib64"
+    fi
+    for candidate in \
+        "${CUDA_PATH:+$CUDA_PATH/lib64}" \
+        "${CUDA_HOME:+$CUDA_HOME/lib64}" \
+        "$NVCC_LIB_DIR" \
+        /usr/local/cuda/lib64 \
+        /opt/cuda/lib64 \
+        "/usr/lib/$(uname -m)-linux-gnu" \
+        /usr/lib64; do
+        if [ -n "$candidate" ] && [ -f "$candidate/libcudart_static.a" ]; then
+            CUDA_LIB_DIR="$(cd "$candidate" && pwd)"
+            break
+        fi
+    done
+
+    if [ -n "$CUDA_LIB_DIR" ]; then
+        echo -e "${GREEN}✅ Found CUDA libraries in $CUDA_LIB_DIR${NC}"
+        export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-L native=$CUDA_LIB_DIR"
+    else
+        echo -e "${YELLOW}⚠️ Could not locate libcudart_static.a${NC}"
+        echo -e "${YELLOW}   Install the CUDA toolkit or set CUDA_PATH; the link step may fail.${NC}"
+    fi
+fi
+
 # Build llama-helper
 echo ""
 echo -e "${BLUE}🦙 Building llama-helper sidecar (debug)...${NC}"


### PR DESCRIPTION
## Problem

`./build-gpu.sh` fails on Linux machines that use a distro-packaged CUDA toolkit:

```
error: could not find native static library `cudart_static`, perhaps an -L flag is missing?
```

The build gets as far as `Detected GPU feature: cuda` and then dies while compiling `llama-cpp-sys-2`.

## Root cause

`llama-cpp-sys-2/build.rs` emits `cargo:rustc-link-lib=static=cudart_static` (plus `cublas_static`, `culibos`) and delegates `-L` path discovery to `find_cuda_helper`. That crate's `find_cuda_lib_dirs()` only probes:

- `$CUDA_LIBRARY_PATH`
- `/opt/cuda/lib64`
- `/usr/local/cuda*/lib64`

Distro packages such as Ubuntu's `nvidia-cuda-toolkit` install into `/usr`, putting `nvcc` at `/usr/bin/nvcc` and the libraries in `/usr/lib/x86_64-linux-gnu`. None of the probed paths exist, so rustc receives the `-l static=` flags with **zero** `-L` paths and the link fails.

This reproduces in isolation — a two-line crate with `#[link(name = "cudart_static", kind = "static")]` fails identically without `-L`, and succeeds with `-L native=/usr/lib/x86_64-linux-gnu`.

## Fix

Both `frontend/build-gpu.sh` and `frontend/dev-gpu.sh` now locate the CUDA static libraries before building and export a matching `-L native=` into `RUSTFLAGS`.

The block only runs when `TAURI_GPU_FEATURE = cuda` on `linux-gnu`, and probes in this order:

1. `$CUDA_PATH/lib64`
2. `$CUDA_HOME/lib64`
3. nvcc-relative `../lib64`
4. `/usr/local/cuda/lib64`
5. `/opt/cuda/lib64`
6. `/usr/lib/$(uname -m)-linux-gnu`
7. `/usr/lib64`

The first directory containing `libcudart_static.a` wins. Conventional locations are checked before the multiarch path, so existing `/usr/local/cuda` and `/opt/cuda` installs keep their current behaviour and see no change. `RUSTFLAGS` is appended to rather than overwritten.

If no candidate matches, the script prints a warning pointing at `CUDA_PATH` and continues rather than aborting — the link step may still succeed on setups this heuristic doesn't cover.

## Testing

On Ubuntu with `nvidia-cuda-toolkit` (nvcc 12.0 at `/usr/bin/nvcc`, no `/usr/local/cuda*`):

- Before: build fails at `llama-cpp-sys-2` with the error above.
- After: full build succeeds and produces both `.deb` and `.AppImage` bundles.
- `ldd` on the resulting binary confirms CUDA is genuinely linked: `libcudart.so.12`, `libcublas.so.12`, `libcublasLt.so.12`, `libcuda.so.1`.

No effect on macOS or Windows, or on Linux builds that aren't using the `cuda` feature.
