### PR TITLE
fix(audio): capture system audio on Linux via the sound server monitor source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3613,6 +3613,7 @@ dependencies = [
 name = "meetily"
 version = "0.4.0"
 dependencies = [
+ "alsa",
  "anyhow",
  "async-trait",
  "bytemuck",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -197,6 +197,10 @@ futures-channel = "0.3.31"
 [target.'cfg(target_os = "linux")'.dependencies]
 whisper-rs = { version = "0.13.2", features = ["raw-api"] }
 futures-channel = "0.3.31"
+# System audio capture from the PulseAudio/PipeWire monitor source.
+# cpal cannot enumerate or open monitor sources (see audio/capture/linux_monitor.rs),
+# so we open the ALSA `pulse:` PCM directly. Same crate cpal itself depends on.
+alsa = "0.9.1"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/frontend/src-tauri/src/audio/capture/linux_monitor.rs
+++ b/frontend/src-tauri/src/audio/capture/linux_monitor.rs
@@ -1,0 +1,367 @@
+// Linux system audio capture via the PulseAudio/PipeWire monitor source.
+//
+// WHY THIS EXISTS
+// ---------------
+// On Linux there is no "output device" that can be opened for capture. System
+// audio is captured from a *monitor source* exposed by the sound server
+// (PulseAudio or pipewire-pulse), e.g. `alsa_output.pci-0000_00_1f.3.analog-stereo.monitor`.
+//
+// cpal cannot reach those sources:
+//   * cpal's ALSA host enumerates devices via `snd_device_name_hint()`, which
+//     lists PCM plugins (`default`, `pulse`, `pipewire`, `hw:...`) but never
+//     individual PulseAudio sources, so no monitor ever appears.
+//   * cpal has no API to construct a `Device` from an arbitrary PCM name, and
+//     it eagerly opens PCM handles during enumeration, so the `PULSE_SOURCE`
+//     environment variable cannot be applied to just one stream.
+//
+// The ALSA `pulse` plugin accepts the source as an inline argument
+// (`pulse:<source>`, see /usr/share/alsa/alsa.conf.d/50-pulseaudio.conf), so we
+// open the PCM directly with the `alsa` crate — the same crate cpal itself uses.
+// `@DEFAULT_MONITOR@` resolves to the monitor of the current default sink, so it
+// follows the user's output device automatically.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+
+use alsa::pcm::{Access, Format, HwParams, State, PCM};
+use alsa::{Direction, ValueOr};
+use anyhow::{anyhow, Result};
+use log::{debug, error, info, warn};
+
+/// Friendly name surfaced to the UI and stored in recording metadata.
+pub const DEFAULT_MONITOR_DEVICE_NAME: &str = "Default System Audio (Monitor)";
+
+/// ALSA PCM that resolves to the monitor of the current default sink.
+const DEFAULT_MONITOR_PCM: &str = "pulse:@DEFAULT_MONITOR@";
+
+/// Sample rate requested from the monitor source. The sound server resamples
+/// for us if the sink runs at a different rate.
+const TARGET_SAMPLE_RATE: u32 = 48000;
+
+/// Channel count requested from the monitor source.
+const TARGET_CHANNELS: u32 = 2;
+
+/// Frames read per `readi` call. ~21 ms at 48 kHz.
+const FRAMES_PER_READ: usize = 1024;
+
+/// Map an `AudioDevice` name to the ALSA PCM string used to open it.
+///
+/// Accepts:
+/// * the friendly default name -> `pulse:@DEFAULT_MONITOR@`
+/// * an explicit `pulse:...` / `pipewire:...` PCM -> passed through
+/// * a raw PulseAudio source name ending in `.monitor` -> wrapped in `pulse:`
+/// * anything else -> falls back to the default monitor
+pub fn pcm_name_for(device_name: &str) -> String {
+    let trimmed = device_name.trim();
+
+    if trimmed.is_empty() || trimmed == DEFAULT_MONITOR_DEVICE_NAME || trimmed == "default" {
+        return DEFAULT_MONITOR_PCM.to_string();
+    }
+
+    if trimmed.starts_with("pulse:") || trimmed.starts_with("pipewire:") {
+        return trimmed.to_string();
+    }
+
+    if trimmed.ends_with(".monitor") || trimmed.starts_with('@') {
+        return format!("pulse:{}", trimmed);
+    }
+
+    warn!(
+        "🔊 [linux] Unrecognized system audio device '{}', falling back to the default monitor",
+        trimmed
+    );
+    DEFAULT_MONITOR_PCM.to_string()
+}
+
+/// Check whether a monitor source can actually be opened on this machine.
+///
+/// Used to decide if system audio should be offered at all (a machine with no
+/// running sound server, i.e. bare ALSA, has no monitor).
+pub fn is_monitor_available() -> bool {
+    match PCM::new(DEFAULT_MONITOR_PCM, Direction::Capture, false) {
+        Ok(_) => true,
+        Err(e) => {
+            debug!(
+                "🔊 [linux] Monitor source '{}' unavailable: {}",
+                DEFAULT_MONITOR_PCM, e
+            );
+            false
+        }
+    }
+}
+
+/// Negotiated stream format for an opened monitor PCM.
+#[derive(Debug, Clone, Copy)]
+pub struct MonitorFormat {
+    pub sample_rate: u32,
+    pub channels: u16,
+    /// True when the PCM delivers f32 samples, false when it delivers i16.
+    pub is_float: bool,
+}
+
+/// Open the monitor PCM and negotiate hardware parameters.
+fn open_monitor(pcm_name: &str) -> Result<(PCM, MonitorFormat)> {
+    let pcm = PCM::new(pcm_name, Direction::Capture, false)
+        .map_err(|e| anyhow!("Failed to open monitor PCM '{}': {}", pcm_name, e))?;
+
+    let format = {
+        let hwp = HwParams::any(&pcm)
+            .map_err(|e| anyhow!("Failed to query hw params for '{}': {}", pcm_name, e))?;
+
+        hwp.set_access(Access::RWInterleaved)
+            .map_err(|e| anyhow!("Monitor '{}' rejected interleaved access: {}", pcm_name, e))?;
+
+        // Prefer f32 (native pipeline format); fall back to S16 if unsupported.
+        let is_float = match hwp.set_format(Format::float()) {
+            Ok(()) => true,
+            Err(_) => {
+                hwp.set_format(Format::s16()).map_err(|e| {
+                    anyhow!("Monitor '{}' supports neither f32 nor s16: {}", pcm_name, e)
+                })?;
+                false
+            }
+        };
+
+        hwp.set_channels(TARGET_CHANNELS)
+            .or_else(|_| hwp.set_channels(1))
+            .map_err(|e| anyhow!("Monitor '{}' rejected channel count: {}", pcm_name, e))?;
+
+        hwp.set_rate(TARGET_SAMPLE_RATE, ValueOr::Nearest)
+            .map_err(|e| anyhow!("Monitor '{}' rejected sample rate: {}", pcm_name, e))?;
+
+        // Keep latency bounded; non-fatal if the plugin ignores these.
+        let _ = hwp.set_period_size_near(FRAMES_PER_READ as i64, ValueOr::Nearest);
+        let _ = hwp.set_buffer_size_near((FRAMES_PER_READ * 4) as i64);
+
+        let sample_rate = hwp
+            .get_rate()
+            .map_err(|e| anyhow!("Failed to read negotiated rate: {}", e))?;
+        let channels = hwp
+            .get_channels()
+            .map_err(|e| anyhow!("Failed to read negotiated channels: {}", e))?;
+
+        pcm.hw_params(&hwp)
+            .map_err(|e| anyhow!("Failed to apply hw params to '{}': {}", pcm_name, e))?;
+
+        MonitorFormat {
+            sample_rate,
+            channels: channels as u16,
+            is_float,
+        }
+    };
+
+    pcm.prepare()
+        .map_err(|e| anyhow!("Failed to prepare monitor PCM '{}': {}", pcm_name, e))?;
+
+    Ok((pcm, format))
+}
+
+/// A running monitor capture. Dropping (or calling [`stop`]) ends the thread.
+pub struct LinuxMonitorCapture {
+    pcm_name: String,
+    format: MonitorFormat,
+    stop_flag: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl LinuxMonitorCapture {
+    /// Open the monitor source for `device_name` and stream samples to a callback.
+    ///
+    /// The PCM is opened first, then `build_callback` is invoked with the
+    /// negotiated [`MonitorFormat`] so the caller can size its downstream
+    /// pipeline correctly (sample rate and channel count are decided by the
+    /// sound server, not by us).
+    ///
+    /// The returned callback receives **interleaved f32** frames with
+    /// [`MonitorFormat::channels`] channels at [`MonitorFormat::sample_rate`] Hz.
+    pub fn start<B, F>(device_name: &str, build_callback: B) -> Result<Self>
+    where
+        B: FnOnce(MonitorFormat) -> F,
+        F: FnMut(&[f32]) + Send + 'static,
+    {
+        let pcm_name = pcm_name_for(device_name);
+        info!(
+            "🔊 [linux] Opening system audio monitor: '{}' (from device '{}')",
+            pcm_name, device_name
+        );
+
+        let (pcm, format) = open_monitor(&pcm_name)?;
+
+        info!(
+            "✅ [linux] Monitor opened: {} Hz, {} ch, format: {}",
+            format.sample_rate,
+            format.channels,
+            if format.is_float { "f32" } else { "s16" }
+        );
+
+        let mut on_samples = build_callback(format);
+
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let thread_stop = stop_flag.clone();
+        let thread_pcm_name = pcm_name.clone();
+        let channels = format.channels as usize;
+
+        let thread = std::thread::Builder::new()
+            .name("meetily-sysaudio".into())
+            .spawn(move || {
+                // `alsa::PCM` is not Send-safe to share, but it is fine to move
+                // into this thread which exclusively owns it for its lifetime.
+                let pcm = pcm;
+
+                if let Err(e) = pcm.start() {
+                    // Some plugins auto-start on first read; only warn.
+                    debug!("🔊 [linux] PCM start returned {} (continuing)", e);
+                }
+
+                let mut float_buf = vec![0f32; FRAMES_PER_READ * channels];
+                let mut int_buf = vec![0i16; FRAMES_PER_READ * channels];
+                let mut converted = vec![0f32; FRAMES_PER_READ * channels];
+                let mut consecutive_errors = 0u32;
+
+                info!("✅ [linux] System audio capture thread started ({})", thread_pcm_name);
+
+                while !thread_stop.load(Ordering::Relaxed) {
+                    let read_result = if format.is_float {
+                        match pcm.io_f32() {
+                            Ok(io) => io.readi(&mut float_buf),
+                            Err(e) => Err(e),
+                        }
+                    } else {
+                        match pcm.io_i16() {
+                            Ok(io) => io.readi(&mut int_buf),
+                            Err(e) => Err(e),
+                        }
+                    };
+
+                    match read_result {
+                        Ok(frames) => {
+                            consecutive_errors = 0;
+                            let samples = frames * channels;
+                            if samples == 0 {
+                                continue;
+                            }
+
+                            if format.is_float {
+                                on_samples(&float_buf[..samples]);
+                            } else {
+                                for (dst, &src) in
+                                    converted[..samples].iter_mut().zip(int_buf[..samples].iter())
+                                {
+                                    *dst = src as f32 / i16::MAX as f32;
+                                }
+                                on_samples(&converted[..samples]);
+                            }
+                        }
+                        Err(e) => {
+                            if thread_stop.load(Ordering::Relaxed) {
+                                break;
+                            }
+
+                            consecutive_errors += 1;
+
+                            // Recover from xruns/suspends; this is expected when
+                            // the default sink changes or the server reconfigures.
+                            if pcm.try_recover(e, true).is_err() {
+                                error!(
+                                    "❌ [linux] Unrecoverable monitor read error on '{}': {}",
+                                    thread_pcm_name, e
+                                );
+                                break;
+                            }
+
+                            if consecutive_errors == 1 {
+                                warn!(
+                                    "⚠️ [linux] Monitor xrun on '{}', recovering",
+                                    thread_pcm_name
+                                );
+                            }
+
+                            if consecutive_errors > 50 {
+                                error!(
+                                    "❌ [linux] Too many consecutive monitor errors on '{}', stopping",
+                                    thread_pcm_name
+                                );
+                                break;
+                            }
+
+                            if pcm.state() != State::Running {
+                                let _ = pcm.prepare();
+                            }
+                        }
+                    }
+                }
+
+                let _ = pcm.drop();
+                info!("⚠️ [linux] System audio capture thread ended ({})", thread_pcm_name);
+            })
+            .map_err(|e| anyhow!("Failed to spawn system audio capture thread: {}", e))?;
+
+        Ok(Self {
+            pcm_name,
+            format,
+            stop_flag,
+            thread: Some(thread),
+        })
+    }
+
+    pub fn format(&self) -> MonitorFormat {
+        self.format
+    }
+
+    pub fn pcm_name(&self) -> &str {
+        &self.pcm_name
+    }
+
+    /// Signal the capture thread to stop and wait for it to exit.
+    pub fn stop(mut self) {
+        self.shutdown();
+    }
+
+    fn shutdown(&mut self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.thread.take() {
+            if handle.join().is_err() {
+                warn!("⚠️ [linux] System audio capture thread panicked during shutdown");
+            }
+        }
+    }
+}
+
+impl Drop for LinuxMonitorCapture {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_default_names_to_default_monitor() {
+        assert_eq!(pcm_name_for(DEFAULT_MONITOR_DEVICE_NAME), DEFAULT_MONITOR_PCM);
+        assert_eq!(pcm_name_for("default"), DEFAULT_MONITOR_PCM);
+        assert_eq!(pcm_name_for("   "), DEFAULT_MONITOR_PCM);
+    }
+
+    #[test]
+    fn passes_through_explicit_pcm_names() {
+        assert_eq!(pcm_name_for("pulse:my.source.monitor"), "pulse:my.source.monitor");
+        assert_eq!(pcm_name_for("pipewire:foo"), "pipewire:foo");
+    }
+
+    #[test]
+    fn wraps_raw_monitor_source_names() {
+        assert_eq!(
+            pcm_name_for("alsa_output.pci-0000_00_1f.3.analog-stereo.monitor"),
+            "pulse:alsa_output.pci-0000_00_1f.3.analog-stereo.monitor"
+        );
+        assert_eq!(pcm_name_for("@DEFAULT_MONITOR@"), "pulse:@DEFAULT_MONITOR@");
+    }
+
+    #[test]
+    fn unknown_names_fall_back_to_default_monitor() {
+        assert_eq!(pcm_name_for("Built-in Audio Analog Stereo"), DEFAULT_MONITOR_PCM);
+    }
+}

--- a/frontend/src-tauri/src/audio/capture/mod.rs
+++ b/frontend/src-tauri/src/audio/capture/mod.rs
@@ -7,6 +7,9 @@ pub mod backend_config;
 #[cfg(target_os = "macos")]
 pub mod core_audio;
 
+#[cfg(target_os = "linux")]
+pub mod linux_monitor;
+
 // Re-export capture functionality
 pub use system::{
     SystemAudioCapture, SystemAudioStream,
@@ -16,6 +19,11 @@ pub use system::{
 
 #[cfg(target_os = "macos")]
 pub use core_audio::{CoreAudioCapture, CoreAudioStream};
+
+#[cfg(target_os = "linux")]
+pub use linux_monitor::{
+    is_monitor_available, LinuxMonitorCapture, DEFAULT_MONITOR_DEVICE_NAME,
+};
 
 // Re-export backend configuration
 pub use backend_config::{

--- a/frontend/src-tauri/src/audio/devices/discovery.rs
+++ b/frontend/src-tauri/src/audio/devices/discovery.rs
@@ -2,7 +2,10 @@ use anyhow::Result;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use log::error;
 
-use super::configuration::{AudioDevice, DeviceType};
+use super::configuration::AudioDevice;
+// Only used by the non-Linux "additional devices" pass below.
+#[cfg(not(target_os = "linux"))]
+use super::configuration::DeviceType;
 use super::platform;
 
 /// List all available audio devices on the system
@@ -10,6 +13,8 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
     let host = cpal::default_host();
 
     // Platform-specific device enumeration
+    // (not mutated on Linux - the additional-devices pass below is skipped there)
+    #[cfg_attr(target_os = "linux", allow(unused_mut))]
     let mut devices = {
         #[cfg(target_os = "windows")]
         {
@@ -27,7 +32,14 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
         }
     };
 
-    // Add any additional devices from the default host
+    // Add any additional devices from the default host.
+    //
+    // NOTE: skipped on Linux. Every remaining ALSA PCM would be labelled as an
+    // Output device, but none of them can capture system audio - only the sound
+    // server's monitor source can (added by configure_linux_audio above).
+    // Listing them made the UI offer system audio devices that silently
+    // captured nothing or re-captured the microphone.
+    #[cfg(not(target_os = "linux"))]
     if let Ok(other_devices) = host.devices() {
         for device in other_devices {
             if let Ok(name) = device.name() {

--- a/frontend/src-tauri/src/audio/devices/platform/linux.rs
+++ b/frontend/src-tauri/src/audio/devices/platform/linux.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use cpal::traits::{DeviceTrait, HostTrait};
+use log::{info, warn};
 
+use crate::audio::capture::linux_monitor::{is_monitor_available, DEFAULT_MONITOR_DEVICE_NAME};
 use crate::audio::devices::configuration::{AudioDevice, DeviceType};
 
 /// Configure Linux audio devices using ALSA/PulseAudio
@@ -14,19 +16,26 @@ pub fn configure_linux_audio(host: &cpal::Host) -> Result<Vec<AudioDevice>> {
         }
     }
 
-    // Add PulseAudio monitor sources for system audio
-    if let Ok(pulse_host) = cpal::host_from_id(cpal::HostId::Alsa) {
-        for device in pulse_host.input_devices()? {
-            if let Ok(name) = device.name() {
-                // Check if it's a monitor source
-                if name.contains("monitor") {
-                    devices.push(AudioDevice::new(
-                        format!("{} (System Audio)", name),
-                        DeviceType::Output
-                    ));
-                }
-            }
-        }
+    // System audio.
+    //
+    // ALSA's device-name hints (which cpal enumerates) only expose PCM plugins
+    // like `default`, `pulse` and `hw:...` - never the PulseAudio/PipeWire
+    // monitor sources that actually carry system audio. Previously this scanned
+    // cpal's input devices for names containing "monitor", which never matched,
+    // so the UI listed no system audio devices at all.
+    //
+    // Instead we advertise a single logical device backed by
+    // `pulse:@DEFAULT_MONITOR@`, which always tracks the current default sink.
+    // See audio/capture/linux_monitor.rs.
+    if is_monitor_available() {
+        info!("🔊 [linux] System audio available via the default sink monitor");
+        devices.push(AudioDevice::new(
+            DEFAULT_MONITOR_DEVICE_NAME.to_string(),
+            DeviceType::Output,
+        ));
+    } else {
+        warn!("⚠️ [linux] No monitor source available - system audio cannot be captured");
+        warn!("   Requires a running PulseAudio or PipeWire (pipewire-pulse) sound server");
     }
 
     Ok(devices)

--- a/frontend/src-tauri/src/audio/devices/speakers.rs
+++ b/frontend/src-tauri/src/audio/devices/speakers.rs
@@ -35,7 +35,31 @@ pub fn default_output_device() -> Result<AudioDevice> {
         return Ok(AudioDevice::new(device.name()?, DeviceType::Output));
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    #[cfg(target_os = "linux")]
+    {
+        // On Linux there is no output device that can be opened for capture.
+        // System audio comes from the sound server's monitor source, so the
+        // "default system audio device" is the monitor of the default sink.
+        //
+        // Returning cpal's default output device here would name it "default",
+        // which get_device_and_config() then resolves against ALSA *capture*
+        // devices - silently opening the microphone a second time instead of
+        // capturing system audio.
+        use crate::audio::capture::linux_monitor::{is_monitor_available, DEFAULT_MONITOR_DEVICE_NAME};
+
+        if !is_monitor_available() {
+            return Err(anyhow!(
+                "No system audio monitor source available (requires a running PulseAudio or PipeWire server)"
+            ));
+        }
+
+        return Ok(AudioDevice::new(
+            DEFAULT_MONITOR_DEVICE_NAME.to_string(),
+            DeviceType::Output,
+        ));
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     {
         let host = cpal::default_host();
         let device = host

--- a/frontend/src-tauri/src/audio/recording_manager.rs
+++ b/frontend/src-tauri/src/audio/recording_manager.rs
@@ -68,6 +68,38 @@ impl RecordingManager {
     ) -> Result<mpsc::UnboundedReceiver<AudioChunk>> {
         info!("Starting recording manager (auto_save: {})", auto_save);
 
+        // Resolve unspecified devices to the system defaults.
+        //
+        // The UI sends `null` when the user leaves a selector on "Default".
+        // Without this, a "Default System Audio" selection meant *no* system
+        // audio stream was ever created, so system audio was silently missing
+        // from every recording.
+        let microphone_device = microphone_device.or_else(|| {
+            match super::devices::default_input_device() {
+                Ok(device) => {
+                    info!("🎤 Using default microphone: {}", device.name);
+                    Some(Arc::new(device))
+                }
+                Err(e) => {
+                    warn!("No default microphone available: {}", e);
+                    None
+                }
+            }
+        });
+
+        let system_device = system_device.or_else(|| {
+            match super::devices::default_output_device() {
+                Ok(device) => {
+                    info!("🔊 Using default system audio: {}", device.name);
+                    Some(Arc::new(device))
+                }
+                Err(e) => {
+                    warn!("No default system audio available: {}", e);
+                    None
+                }
+            }
+        });
+
         // Set up transcription channel
         let (transcription_sender, transcription_receiver) = mpsc::unbounded_channel::<AudioChunk>();
 

--- a/frontend/src-tauri/src/audio/stream.rs
+++ b/frontend/src-tauri/src/audio/stream.rs
@@ -13,6 +13,9 @@ use super::capture::{AudioCaptureBackend, get_current_backend};
 #[cfg(target_os = "macos")]
 use super::capture::CoreAudioCapture;
 
+#[cfg(target_os = "linux")]
+use super::capture::LinuxMonitorCapture;
+
 /// Stream backend implementation
 pub enum StreamBackend {
     /// CPAL-based stream (ScreenCaptureKit or default)
@@ -21,6 +24,11 @@ pub enum StreamBackend {
     #[cfg(target_os = "macos")]
     CoreAudio {
         task: Option<tokio::task::JoinHandle<()>>,
+    },
+    /// PulseAudio/PipeWire monitor source read directly via ALSA (Linux only)
+    #[cfg(target_os = "linux")]
+    LinuxMonitor {
+        capture: Option<LinuxMonitorCapture>,
     },
 }
 
@@ -87,6 +95,16 @@ impl AudioStream {
             return Self::create_core_audio_stream(device, state, device_type, recording_sender).await;
         }
 
+        // On Linux, system audio MUST come from the sound server's monitor source.
+        // CPAL cannot reach it (see capture/linux_monitor.rs) - routing system audio
+        // through CPAL silently opens the ALSA capture `default`, i.e. the microphone
+        // again, which is why system audio appeared to be "not detected".
+        #[cfg(target_os = "linux")]
+        if device_type == DeviceType::System {
+            info!("🎵 Stream: Using ALSA monitor backend for system audio");
+            return Self::create_linux_monitor_stream(device, state, device_type, recording_sender).await;
+        }
+
         // Default path: use CPAL
         #[cfg(target_os = "macos")]
         let backend_name = if backend_type == AudioCaptureBackend::ScreenCaptureKit {
@@ -137,6 +155,58 @@ impl AudioStream {
         Ok(Self {
             device,
             backend: StreamBackend::Cpal(stream),
+        })
+    }
+
+    /// Create a system audio stream from the PulseAudio/PipeWire monitor source (Linux only)
+    #[cfg(target_os = "linux")]
+    async fn create_linux_monitor_stream(
+        device: Arc<AudioDevice>,
+        state: Arc<RecordingState>,
+        device_type: DeviceType,
+        recording_sender: Option<mpsc::UnboundedSender<super::recording_state::AudioChunk>>,
+    ) -> Result<Self> {
+        info!("🔊 Stream: Creating Linux monitor stream for device: {}", device.name);
+
+        let capture_device = device.clone();
+
+        // The sound server decides the actual rate/channel count, so the pipeline
+        // processor is constructed only once the PCM has been negotiated.
+        let capture = LinuxMonitorCapture::start(&device.name, move |format| {
+            let processor = AudioCapture::new(
+                capture_device,
+                state,
+                format.sample_rate,
+                format.channels,
+                device_type,
+                recording_sender,
+            );
+
+            move |samples: &[f32]| {
+                processor.process_audio_data(samples);
+            }
+        })
+        .map_err(|e| {
+            error!("❌ Stream: Failed to start Linux monitor capture: {}", e);
+            anyhow::anyhow!(
+                "Failed to capture system audio from the monitor source: {}. \
+                 Make sure PulseAudio or PipeWire is running.",
+                e
+            )
+        })?;
+
+        info!(
+            "✅ Stream: Linux monitor stream started ({}, {} Hz, {} ch)",
+            capture.pcm_name(),
+            capture.format().sample_rate,
+            capture.format().channels
+        );
+
+        Ok(Self {
+            device,
+            backend: StreamBackend::LinuxMonitor {
+                capture: Some(capture),
+            },
         })
     }
 
@@ -341,6 +411,16 @@ impl AudioStream {
                     // This helps ensure Arc references in the closure are dropped
                     std::thread::sleep(std::time::Duration::from_millis(50));
                     info!("Core Audio task aborted");
+                }
+            }
+            #[cfg(target_os = "linux")]
+            StreamBackend::LinuxMonitor { capture } => {
+                if let Some(capture) = capture {
+                    info!("Stopping Linux monitor capture...");
+                    // Blocks until the capture thread exits, releasing the PCM
+                    // and dropping the Arc references held by its callback.
+                    capture.stop();
+                    info!("Linux monitor capture stopped");
                 }
             }
         }


### PR DESCRIPTION
## Description

On Linux, system audio is never captured. Selecting "Default System Audio" records nothing from it, and the device dropdown lists no usable system audio device.

### Root cause

Three compounding bugs, all rooted in one fact: **cpal cannot reach PulseAudio/PipeWire monitor sources.**

On Linux there is no output device that can be opened for capture — system audio comes from the sound server's *monitor source* (e.g. `alsa_output.pci-0000_00_1f.3.analog-stereo.monitor`). cpal cannot get to one:

- Its ALSA host enumerates via `snd_device_name_hint()`, which lists PCM plugins (`default`, `pulse`, `pipewire`, `hw:...`) but never individual PulseAudio sources.
- It has no API to construct a `Device` from an arbitrary PCM name.
- It eagerly opens PCM handles during enumeration, so `PULSE_SOURCE` cannot be scoped to a single stream.

Given that, the three failures were:

1. **No system audio device was ever listed.** `configure_linux_audio()` scanned cpal input devices for names containing `"monitor"` — a filter that can never match, for the reason above.
2. **"System audio" silently recorded the microphone a second time.** `default_output_device()` returned cpal's default output device, literally named `"default"`. `get_device_and_config()` then resolved that name against ALSA *capture* devices, matched `"default"`, and opened the mic again.
3. **Selecting the default created no system stream at all.** The UI sends `null` for a "Default" selection, and `RecordingManager::start_recording` never resolved `None` into an actual device.

### Fix

New file `frontend/src-tauri/src/audio/capture/linux_monitor.rs` opens the ALSA `pulse:` PCM directly using the `alsa` crate (the same one cpal itself depends on). The ALSA `pulse` plugin accepts the source as an inline argument, and `pulse:@DEFAULT_MONITOR@` resolves to the monitor of the current default sink, so it follows the user's output device automatically.

- The PCM is opened *before* the pipeline processor is built, and the negotiated format is handed to a callback — the sound server decides the rate and channel count, so the pipeline is sized from what was actually negotiated rather than from assumptions.
- A dedicated `meetily-sysaudio` thread reads interleaved f32 (falling back to s16 → f32 conversion), recovers from xruns via `try_recover`, bails out after 50 consecutive errors, and is joined on `stop()`/`Drop`.
- `pcm_name_for()` maps the friendly device name, `default`, an explicit `pulse:`/`pipewire:` PCM, or a raw `.monitor` source name onto the right PCM string.

Wiring:

- `audio/stream.rs` — new `StreamBackend::LinuxMonitor` variant plus `create_linux_monitor_stream()`; `create_with_backend()` short-circuits to it for `DeviceType::System` on Linux, and `stop()` joins the capture thread.
- `audio/devices/platform/linux.rs` — replaces the never-matching "monitor" scan with a single logical device, **"Default System Audio (Monitor)"**, advertised only when a monitor source is actually reachable; warns clearly when it isn't.
- `audio/devices/speakers.rs` — `default_output_device()` returns that monitor device on Linux instead of cpal's `"default"` output.
- `audio/recording_manager.rs` — resolves `None` mic/system devices to the platform defaults before starting streams.
- `audio/devices/discovery.rs` — skips the "additional devices from the default host" pass on Linux. It labelled every remaining ALSA PCM as an Output device, so the picker offered raw PCM names that captured nothing or re-captured the microphone.

New dependency: `alsa = "0.9.1"` under `[target.'cfg(target_os = "linux")'.dependencies]`. It is already in the tree transitively via cpal; this makes it a direct dependency on Linux only.

### Behaviour when no sound server is running

On bare ALSA (no PulseAudio/pipewire-pulse) there is no monitor source. `is_monitor_available()` returns false, no system audio device is advertised, and `default_output_device()` returns a clear error instead of silently opening the microphone. Recording continues microphone-only.

## Related Issue

Fixes #273
Fixes #383

Also removes the raw ALSA PCM entries described in #437 from the Linux device picker.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] All tests pass

Verified on Ubuntu 24.04 with PipeWire + pipewire-pulse:

- Monitor negotiated at **48000 Hz, 2 ch, f32**; the capture thread ran with zero xruns across multiple recordings.
- Browser playback was captured and transcribed end to end. Recording metadata showed `"system_audio": "Default System Audio (Monitor)"`, and the resulting transcript contained the spoken content of the video.
- A live capture harness measured peak amplitude 0.088 against a −91 dB silence baseline.
- 4 unit tests for `pcm_name_for` pass.
- `cargo build --release --features cuda` is clean, with no new warnings.

All new code is behind `cfg(target_os = "linux")`; macOS and Windows paths are untouched.

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)

N/A — no UI changes beyond the device name shown in the existing system audio dropdown.

## Additional Notes

Two things a reviewer may want to weigh in on:

1. `AudioStreamManager::start_streams` swallows system-stream failures with a `warn!` and continues microphone-only. That is pre-existing behaviour and unchanged here, but it means a broken system stream is invisible from the UI. Surfacing it might be worth a follow-up.
2. On Linux the same function logs `"System audio stream created with {backend} backend"` using the global backend enum rather than the backend actually used, so it prints `ScreenCaptureKit`. Cosmetic only; left alone here to keep the diff focused.
