### PR TITLE
fix(summary): handle Claude thinking blocks in Anthropic response parsing

### DIFF
--- a/frontend/src-tauri/src/summary/llm_client.rs
+++ b/frontend/src-tauri/src/summary/llm_client.rs
@@ -60,7 +60,17 @@ pub struct ClaudeChatResponse {
 
 #[derive(Deserialize, Debug)]
 pub struct ClaudeChatContent {
-    pub text: String,
+    // Only `text` blocks carry this field. Models that enable thinking by
+    // default (Sonnet 5, Opus 5) also return `thinking` blocks, which don't.
+    pub text: Option<String>,
+}
+
+impl ClaudeChatResponse {
+    /// First block that carries text. With thinking enabled the leading block
+    /// is a `thinking` block, so `content[0]` is not necessarily the answer.
+    fn first_text(&self) -> Option<&str> {
+        self.content.iter().find_map(|block| block.text.as_deref())
+    }
 }
 
 /// LLM Provider enumeration for multi-provider support
@@ -245,7 +255,9 @@ pub async fn generate_summary(
         serde_json::json!(ClaudeRequest {
             system: system_prompt.to_string(),
             model: model_name.to_string(),
-            max_tokens: 2048,
+            // Shared budget: on models with thinking enabled by default this
+            // covers thinking tokens as well as the answer.
+            max_tokens: 8192,
             messages: vec![ChatMessage {
                 role: "user".to_string(),
                 content: user_prompt.to_string(),
@@ -307,10 +319,8 @@ pub async fn generate_summary(
         info!("🐞 LLM Response received from Claude");
 
         let content = chat_response
-            .content
-            .get(0)
-            .ok_or("No content in LLM response")?
-            .text
+            .first_text()
+            .ok_or("No text content in LLM response")?
             .trim();
         Ok(content.to_string())
     } else {
@@ -342,5 +352,46 @@ fn provider_name(provider: &LLMProvider) -> &str {
         LLMProvider::BuiltInAI => "Built-in AI",
         LLMProvider::OpenRouter => "OpenRouter",
         LLMProvider::CustomOpenAI => "Custom OpenAI",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn claude_response_skips_leading_thinking_block() {
+        // Shape returned by models with thinking enabled by default,
+        // e.g. claude-sonnet-5 / claude-opus-5.
+        let response: ClaudeChatResponse = serde_json::from_value(json!({
+            "content": [
+                {"type": "thinking", "thinking": "", "signature": "abc"},
+                {"type": "text", "text": "Meeting summary."}
+            ]
+        }))
+        .expect("thinking blocks must not fail deserialization");
+
+        assert_eq!(response.first_text(), Some("Meeting summary."));
+    }
+
+    #[test]
+    fn claude_response_reads_plain_text_block() {
+        let response: ClaudeChatResponse = serde_json::from_value(json!({
+            "content": [{"type": "text", "text": "Meeting summary."}]
+        }))
+        .unwrap();
+
+        assert_eq!(response.first_text(), Some("Meeting summary."));
+    }
+
+    #[test]
+    fn claude_response_without_text_block_returns_none() {
+        let response: ClaudeChatResponse = serde_json::from_value(json!({
+            "content": [{"type": "thinking", "thinking": "", "signature": "abc"}]
+        }))
+        .unwrap();
+
+        assert_eq!(response.first_text(), None);
     }
 }


### PR DESCRIPTION
### Problem

Selecting `claude-sonnet-5` (or `claude-opus-5`) as the Claude model makes summary generation fail with:

```
Failed to parse LLM response: missing field `text`
```

The models are offered in the picker — it is populated live from `/v1/models` (`src/anthropic/anthropic.rs:74`) and `is_chat_model` accepts anything starting with `claude-` — so they are selectable but unusable.

### Root cause

These models enable adaptive thinking by default when the request omits a `thinking` parameter, so the response `content` array leads with a `thinking` block that carries no `text` field. `ClaudeChatContent` declared `text` as a required `String`, which fails deserialization of the entire response. Even with lenient parsing, `content.get(0)` would have returned the thinking block rather than the summary.

Older models (`claude-sonnet-4-5` and earlier) do not think unless asked, so `content[0]` was always a text block and the original assumption held.

### Fix

- `text` becomes `Option<String>` so non-text blocks deserialize.
- Select the first block that actually carries text, instead of block 0.
- `max_tokens` 2048 → 8192. It is a shared budget covering thinking *and* the answer, so 2048 truncated summaries mid-sentence on these models.

Backwards compatible: models without thinking return a single leading text block, which is still what gets selected.

### Testing

Three unit tests added in `llm_client.rs` covering the thinking-first, text-only, and no-text-block response shapes.

**Transparency:** I could not run `cargo test` or an end-to-end summary — I had no Rust toolchain available while preparing this. The change is small and hand-reviewed, but please let CI and a reviewer confirm rather than taking my word for it. Happy to push fixups.

### Related, not fixed here

The Python backend (`backend/app/transcript_processor.py`) hits the same wall from a different angle: `pydantic-ai==0.2.15` asserts that every non-text block is a `ToolUseBlock` (`pydantic_ai/models/anthropic.py:257`), so a thinking block raises `AssertionError`. That needs a dependency bump and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
