### PR TITLE
fix(build): remove redundant cd in build-gpu.sh GPU detection step

### DIFF
--- a/frontend/build-gpu.sh
+++ b/frontend/build-gpu.sh
@@ -68,17 +68,9 @@ fi
 # Detect GPU feature if not already set
 if [ -z "$TAURI_GPU_FEATURE" ]; then
     echo -e "${BLUE}🔍 Detecting GPU features...${NC}"
-    # Run the detection script and capture output
-    # We need to run it from frontend dir
-    if [ "$FRONTEND_DIR" != "." ]; then
-        cd "$FRONTEND_DIR"
-    fi
-    
+    # We are already inside FRONTEND_DIR at this point (see cd above), so
+    # run the detection script relative to the current directory.
     TAURI_GPU_FEATURE=$(node scripts/auto-detect-gpu.js)
-    
-    if [ "$FRONTEND_DIR" != "." ]; then
-        cd ..
-    fi
 fi
 
 if [ -n "$TAURI_GPU_FEATURE" ]; then


### PR DESCRIPTION
## Summary
- `frontend/build-gpu.sh` fails with `cd: frontend: No existe el fichero o el directorio` when invoked from the repo root as `./frontend/build-gpu.sh` (instead of `cd frontend && ./build-gpu.sh`).
- Root cause: the script already `cd`s into `frontend/` earlier (setting `FRONTEND_DIR="frontend"`), but the GPU-detection block later does `cd "$FRONTEND_DIR"` again, which resolves to the non-existent `frontend/frontend`.
- Fix removes the redundant `cd "$FRONTEND_DIR"` / `cd ..` pair in the GPU detection step, since the script is already inside `FRONTEND_DIR` by that point.

## Test plan
- [x] `bash -n frontend/build-gpu.sh` (syntax check)
- [x] Manually reproduced the original failure by running `./frontend/build-gpu.sh` from the repo root before the fix
- [x] Confirmed after the fix that `node scripts/auto-detect-gpu.js` is invoked with the correct working directory and the script proceeds past GPU detection
- [x] Ran a full build on Linux (CachyOS) with `TAURI_GPU_FEATURE=vulkan ./build-gpu.sh` invoked both from `frontend/` and via `./frontend/build-gpu.sh` from repo root — both succeed and produce the `.deb`/`.AppImage` bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)