### PR TITLE
fix: handle CPU-only builds in build-gpu.sh

### DIFF
--- a/frontend/build-gpu.sh
+++ b/frontend/build-gpu.sh
@@ -81,7 +81,7 @@ if [ -z "$TAURI_GPU_FEATURE" ]; then
     fi
 fi
 
-if [ -n "$TAURI_GPU_FEATURE" ]; then
+if [ -n "$TAURI_GPU_FEATURE" ] && [ "$TAURI_GPU_FEATURE" != "none" ]; then
     echo -e "${GREEN}✅ Detected GPU feature: $TAURI_GPU_FEATURE${NC}"
     export TAURI_GPU_FEATURE
 else


### PR DESCRIPTION
Fixes #587. Prevents CPU-only builds using TAURI_GPU_FEATURE=none from passing the invalid Cargo feature --features none. Valid GPU features continue to work normally.