### PR TITLE
fix(audio): resolve Linux System Audio device by stripping display suffix

### DIFF
--- a/frontend/src-tauri/src/audio/devices/configuration.rs
+++ b/frontend/src-tauri/src/audio/devices/configuration.rs
@@ -154,11 +154,19 @@ pub async fn get_device_and_config(
 
                 #[cfg(target_os = "linux")]
                 {
-                    // For Linux, we use PulseAudio monitor sources for system audio
+                    // For Linux, we use PulseAudio monitor sources for system audio.
+                    // Device enumeration (see devices/platform/linux.rs) decorates
+                    // monitor device names with a " (System Audio)" suffix for display;
+                    // strip it back off before matching against the raw cpal device name.
+                    let raw_name = audio_device
+                        .name
+                        .trim_end_matches(" (System Audio)")
+                        .to_string();
+
                     if let Ok(pulse_host) = cpal::host_from_id(cpal::HostId::Alsa) {
                         for device in pulse_host.input_devices()? {
                             if let Ok(name) = device.name() {
-                                if name == audio_device.name {
+                                if name == raw_name {
                                     let default_config = device
                                         .default_input_config()
                                         .map_err(|e| anyhow!("Failed to get default input config: {}", e))?;


### PR DESCRIPTION
Fixes #701

## Problem

On Linux, `get_device_and_config()` resolves the "System Audio" device by comparing the raw cpal device name against the full stored device name. That stored name still carries the `" (System Audio)"` display suffix added by `configure_linux_audio()` in `devices/platform/linux.rs` — only `"(input)"`/`"(output)"` suffixes are stripped elsewhere (`AudioDevice::from_name`).

The comparison (`name == audio_device.name`) therefore never matches, `get_device_and_config()` always returns `Err("Device not found: ...")`, and that error is only `warn!()`-logged in `AudioStreamManager::start_streams()` (`// Don't fail if only system audio fails`) — so recordings silently proceed with microphone-only audio, with no indication to the user that system audio capture failed.

This affects every Linux user trying to record system/meeting audio, regardless of which device is selected in Settings.

## Fix

Strip the `" (System Audio)"` suffix before comparing, mirroring the existing suffix-stripping already done for `(input)`/`(output)` in `AudioDevice::from_name`.

## Testing

- `cargo check` and a full release build (`pnpm run tauri:build`) succeed.
- Reproduced the bug on a real system: selected a PipeWire monitor source as System Audio, recorded a Google Meet call — before the fix, the recording had no system audio and no error; after the fix, the recorded file contains the call audio.

See #701 for full repro steps and root-cause detail.