### PR TITLE
feat(linux): native PipeWire/PulseAudio system-audio capture

### DIFF
--- a/BRIEF-linux-native-pipewire-system-audio.md
+++ b/BRIEF-linux-native-pipewire-system-audio.md
@@ -1,0 +1,129 @@
+# Brief: native PipeWire/PulseAudio system-audio capture on Linux
+
+## Status of this brief
+
+Drafted by Claude (Opus) during a debugging session with Loïc, to hand off to another
+agent for implementation. Not yet started. See "Reference material" at the bottom for
+everything already investigated this session.
+
+## Problem
+
+On Linux, Meetily's "System Audio" capture only works today because cpal (the audio
+library Meetily uses) has **no native PulseAudio/PipeWire backend** — only ALSA and
+JACK. To capture "what's playing" (e.g. a video call), a PipeWire/PulseAudio monitor
+source has to be manually exposed as a named ALSA pseudo-device (`~/.asoundrc`,
+`type pulse`, with a `hint { show on }` block, and the PCM name itself must contain
+the substring `"monitor"` since that's what `configure_linux_audio()` filters on).
+
+Without that manual setup — i.e. on any stock Linux install — the Settings → System
+Audio dropdown is simply empty, or (until this session's fixes landed) silently fails
+to record even when an entry is picked. Two bugs in that ALSA-hack path were already
+found and fixed this session (branch `fix/linux-system-audio-device-name-mismatch`,
+PR #702) — see "Reference material" below for full detail. Those fixes make the hack
+*work correctly*, but the underlying fragility remains: Linux users still need to
+hand-register (or run an external script/service, which is what Loïc is doing on his
+own machine, see below) an ALSA pseudo-device for every audio output they want to
+capture. That's a personal workaround, not something upstream can ship as "Linux
+support."
+
+macOS already avoids this whole class of problem: `capture/core_audio.rs` talks to
+Core Audio directly via the `cidre` crate, bypassing cpal entirely for system audio.
+This task is the Linux equivalent of that.
+
+## Goal
+
+Capture Linux system audio via PipeWire/PulseAudio's own client API directly, instead
+of through cpal's ALSA host, and instead of requiring any `~/.asoundrc` setup. Should
+work out of the box on any modern Linux desktop (PipeWire, which ships a
+PulseAudio-compatible server by default — the near-universal case today — as well as
+classic standalone PulseAudio), listing real sink names/descriptions with no manual
+configuration.
+
+## Suggested technical approach
+
+- **Crate choice**: `libpulse-binding` + `libpulse-simple-binding` are the pragmatic
+  choice — they speak the PulseAudio protocol, which PipeWire also implements
+  (pipewire-pulse), so the same code works on both PipeWire-via-pulse (the common
+  case) and classic PulseAudio, without needing PipeWire's own (heavier, more
+  PipeWire-specific) native API. Worth a quick spike to confirm before committing,
+  but this is the expected right call.
+- **New module**: `frontend/src-tauri/src/audio/capture/pulse_linux.rs` (or similar
+  name), `#[cfg(target_os = "linux")]`, structured as the Linux sibling of
+  `capture/core_audio.rs`.
+  - Enumerate sinks and their monitor sources with real names/descriptions (e.g. via
+    `pa_context_get_sink_info_list` or the `libpulse-binding` equivalent). This
+    replaces `configure_linux_audio()`'s ALSA-hint-based enumeration for the "System
+    Audio" section specifically — drop the `name.contains("monitor")` heuristic
+    entirely, since we'd be talking to Pulse directly and get real sink metadata.
+  - Open a record stream against the monitor source's real Pulse name (e.g.
+    `pa_stream_new` / the simple-binding record API), feeding samples into the
+    existing pipeline the same way `SystemAudioCapture` (macOS) does — see
+    `capture/system.rs` and `stream.rs::create_core_audio_stream` for the established
+    integration pattern (spawn a task, chunk samples, call
+    `AudioCapture::process_audio_data`).
+- **Wire-up**: in `frontend/src-tauri/src/audio/stream.rs::AudioStream::create_with_backend()`,
+  add a Linux-native-Pulse branch analogous to the existing `use_core_audio` branch
+  for macOS, selected instead of the CPAL/ALSA path when `device_type ==
+  DeviceType::System` on Linux.
+- `frontend/src-tauri/src/audio/devices/configuration.rs::get_device_and_config()`'s
+  Linux/Output branch would then resolve devices via the same Pulse API rather than
+  `cpal::host_from_id(cpal::HostId::Alsa)`.
+- The **Microphone** capture path is unaffected — it already works fine via cpal/ALSA
+  on Linux. Don't touch it.
+
+## Non-goals / out of scope
+
+- Don't change Microphone capture.
+- Don't remove the two bug fixes already on `fix/linux-system-audio-device-name-mismatch`
+  (the `" (System Audio)"` suffix-stripping fix in `configuration.rs`, and the
+  `snd_config_update_free_global()` ALSA-cache-reload fix in `discovery.rs`) as part
+  of this task. Once this native-Pulse path lands, that ALSA/cpal code for Linux
+  System Audio may become entirely dead — but treat that as a separate cleanup
+  decision to make with Loïc afterwards, not something to fold in here.
+- No Windows/macOS changes.
+
+## Acceptance criteria
+
+- On a Linux install with PipeWire and **zero** `~/.asoundrc` customization, Settings
+  → System Audio lists real sink names (e.g. "Built-in Speakers", "JBL Tune 770NC")
+  with no manual setup.
+- Selecting one and recording actually captures system audio — verify by playing
+  audio during a recording and checking the output file has a non-silent system
+  track, e.g.:
+  ```
+  ffmpeg -i recording.mp4 -af volumedetect -f null - 2>&1 | grep volume
+  ```
+- Switching outputs (plugging a new DAC, connecting a different Bluetooth device)
+  makes the new device appear without requiring a full app restart.
+- `cargo check` / `cargo build --release` succeed. This machine needs
+  `LIBCLANG_PATH=/usr/lib/llvm18/lib` for an unrelated `whisper-rs-sys` bindgen issue
+  — see `CLAUDE.md` → "Local build environment gotchas" at repo root for the full
+  story (system clang got upgraded past what whisper-rs-sys's bindgen tolerates).
+- AppImage bundling needs `NO_STRIP=1` on this machine too (unrelated linuxdeploy/RELR
+  issue, same section of `CLAUDE.md`).
+
+## Branch / PR
+
+- New branch off `main`: suggested name `feat/linux-native-pulse-system-audio`. This
+  is an architectural change, not a fix-on-top-of-a-fix — don't stack it on
+  `fix/linux-system-audio-device-name-mismatch`.
+- If PR #702 has merged upstream by the time this starts, rebase onto latest `main`
+  first.
+- Open as its own PR referencing issues/PR #701 / #702 for context once it's
+  implemented and verified end-to-end on Loïc's machine (real recording, real
+  playback check as above — not just `cargo check`).
+
+## Reference material already produced this session
+
+- Issue (full root-cause detail on the ALSA-hack fragility):
+  https://github.com/Zackriya-Solutions/meetily/issues/701
+- PR (the two already-fixed bugs): https://github.com/Zackriya-Solutions/meetily/pull/702
+- `CLAUDE.md` → "Session notes" section at repo root: full history of what was
+  investigated/fixed/tried this session, including the local build environment
+  gotchas (`LIBCLANG_PATH`, `NO_STRIP`) that will bite again on this task.
+- (Outside this repo, for context only — not to be touched by this task): Loïc has a
+  personal systemd `--user` service in his dotfiles
+  (`~/dotfiles/stow/audio-monitors/`) that auto-generates `~/.asoundrc` monitor
+  entries as a stopgap. Once this task lands, that service becomes unnecessary on
+  his machine — worth telling him when this is done, but it's his to remove, not part
+  of this task's scope.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,6 +3430,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libpulse-binding"
+version = "2.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909eb3049e16e373680fe65afe6e2a722ace06b671250cc4849557bc57d6a397"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "libpulse-sys",
+ "num-derive",
+ "num-traits",
+ "winapi",
+]
+
+[[package]]
+name = "libpulse-simple-binding"
+version = "2.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bebef0381c8e3e4b23cc24aaf36fab37472bece128de96f6a111efa464cfef"
+dependencies = [
+ "libpulse-binding",
+ "libpulse-simple-sys",
+ "libpulse-sys",
+]
+
+[[package]]
+name = "libpulse-simple-sys"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd96888fe37ad270d16abf5e82cccca1424871cf6afa2861824d2a52758eebc"
+dependencies = [
+ "libpulse-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libpulse-sys"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d74371848b22e989f829cc1621d2ebd74960711557d8b45cfe740f60d0a05e61"
+dependencies = [
+ "libc",
+ "num-derive",
+ "num-traits",
+ "pkg-config",
+ "winapi",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3636,6 +3684,8 @@ dependencies = [
  "futures-util",
  "infer 0.15.0",
  "lazy_static",
+ "libpulse-binding",
+ "libpulse-simple-binding",
  "log",
  "memory-stats",
  "ndarray",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -198,6 +198,11 @@ futures-channel = "0.3.31"
 whisper-rs = { version = "0.13.2", features = ["raw-api"] }
 futures-channel = "0.3.31"
 
+# Native PipeWire/PulseAudio client for system-audio capture (bypasses cpal's
+# ALSA-only host on Linux, no ~/.asoundrc setup required)
+libpulse-binding = "2.30.1"
+libpulse-simple-binding = "2.29.0"
+
 [dev-dependencies]
 tempfile = "3.3.0"
 infer = "0.15"

--- a/frontend/src-tauri/src/audio/capture/mod.rs
+++ b/frontend/src-tauri/src/audio/capture/mod.rs
@@ -7,6 +7,9 @@ pub mod backend_config;
 #[cfg(target_os = "macos")]
 pub mod core_audio;
 
+#[cfg(target_os = "linux")]
+pub mod pulse_linux;
+
 // Re-export capture functionality
 pub use system::{
     SystemAudioCapture, SystemAudioStream,
@@ -16,6 +19,9 @@ pub use system::{
 
 #[cfg(target_os = "macos")]
 pub use core_audio::{CoreAudioCapture, CoreAudioStream};
+
+#[cfg(target_os = "linux")]
+pub use pulse_linux::{PulseSink, PulseSystemCapture, list_sinks as list_pulse_sinks, find_monitor_source_by_description};
 
 // Re-export backend configuration
 pub use backend_config::{

--- a/frontend/src-tauri/src/audio/capture/pulse_linux.rs
+++ b/frontend/src-tauri/src/audio/capture/pulse_linux.rs
@@ -1,0 +1,299 @@
+// Native PipeWire/PulseAudio system-audio capture for Linux.
+//
+// Bypasses cpal's ALSA-only host entirely by talking to the PulseAudio client
+// protocol directly (which PipeWire also implements via pipewire-pulse). This
+// avoids the need to hand-register monitor sources as named ALSA pseudo-devices
+// in ~/.asoundrc: sink descriptions and monitor sources come straight from the
+// server's real metadata.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use libpulse_binding::callbacks::ListResult;
+use libpulse_binding::context::{Context, FlagSet as ContextFlagSet, State as ContextState};
+use libpulse_binding::mainloop::standard::{IterateResult, Mainloop};
+use libpulse_binding::operation::{Operation, State as OperationState};
+use libpulse_binding::proplist::Proplist;
+use libpulse_binding::sample::{Format, Spec};
+use libpulse_binding::stream::Direction;
+use libpulse_simple_binding::Simple;
+use log::{info, warn};
+
+/// A PulseAudio sink, with the metadata needed to offer it as a "System Audio"
+/// capture device: a real display description and its monitor source name.
+#[derive(Debug, Clone)]
+pub struct PulseSink {
+    pub description: String,
+    pub monitor_source_name: String,
+}
+
+/// Fixed capture format requested from the server. PulseAudio/PipeWire
+/// transparently resamples and remixes the monitor source to this spec
+/// server-side, so the rest of the pipeline (which expects 48kHz) never needs
+/// to know the sink's native sample rate or channel count.
+const CAPTURE_SAMPLE_RATE: u32 = 48000;
+const CAPTURE_CHANNELS: u16 = 2;
+
+/// Pump the mainloop until `operation` finishes, blocking between iterations.
+fn run_operation_to_completion<T: ?Sized>(
+    mainloop: &mut Mainloop,
+    operation: &Operation<T>,
+) -> Result<()> {
+    loop {
+        match mainloop.iterate(true) {
+            IterateResult::Quit(_) | IterateResult::Err(_) => {
+                return Err(anyhow!("PulseAudio mainloop iteration failed"));
+            }
+            IterateResult::Success(_) => {}
+        }
+
+        match operation.get_state() {
+            OperationState::Done => return Ok(()),
+            OperationState::Cancelled => {
+                return Err(anyhow!("PulseAudio operation was cancelled"));
+            }
+            OperationState::Running => continue,
+        }
+    }
+}
+
+/// Connect a fresh context to the default PulseAudio/PipeWire server, blocking
+/// until it's ready. Each call opens (and the caller later drops) its own
+/// connection — unlike ALSA's cached global config, there's no stale-state
+/// problem to work around here, so every call sees the server's current sinks.
+fn connect() -> Result<(Mainloop, Context)> {
+    info!("🔊 pulse_linux::connect: creating mainloop");
+    let mut mainloop =
+        Mainloop::new().ok_or_else(|| anyhow!("Failed to create PulseAudio mainloop"))?;
+
+    let proplist =
+        Proplist::new().ok_or_else(|| anyhow!("Failed to create PulseAudio proplist"))?;
+    let mut context = Context::new_with_proplist(&mainloop, "Meetily", &proplist)
+        .ok_or_else(|| anyhow!("Failed to create PulseAudio context"))?;
+
+    info!("🔊 pulse_linux::connect: calling context.connect()");
+    context
+        .connect(None, ContextFlagSet::NOFLAGS, None)
+        .map_err(|e| anyhow!("Failed to connect to PulseAudio/PipeWire server: {}", e))?;
+
+    info!("🔊 pulse_linux::connect: waiting for context to become Ready");
+    let mut iterations: u32 = 0;
+    loop {
+        iterations += 1;
+        if iterations % 50 == 0 {
+            info!("🔊 pulse_linux::connect: still waiting after {} iterations, state={:?}", iterations, context.get_state());
+        }
+
+        match mainloop.iterate(true) {
+            IterateResult::Quit(_) | IterateResult::Err(_) => {
+                return Err(anyhow!(
+                    "PulseAudio mainloop iteration failed while connecting"
+                ));
+            }
+            IterateResult::Success(_) => {}
+        }
+
+        match context.get_state() {
+            ContextState::Ready => break,
+            ContextState::Failed | ContextState::Terminated => {
+                return Err(anyhow!(
+                    "PulseAudio/PipeWire context connection failed or was terminated"
+                ));
+            }
+            _ => {}
+        }
+    }
+    info!("🔊 pulse_linux::connect: context Ready after {} iterations", iterations);
+
+    Ok((mainloop, context))
+}
+
+/// List all sinks (playback outputs) with their monitor source name, for use as
+/// "System Audio" capture devices. Descriptions come straight from the server —
+/// no manual ~/.asoundrc registration needed, and switching outputs (new DAC,
+/// different Bluetooth device) is picked up on the next call since nothing here
+/// is cached between calls.
+pub fn list_sinks() -> Result<Vec<PulseSink>> {
+    info!("🔊 pulse_linux::list_sinks: connecting");
+    let (mut mainloop, context) = connect()?;
+
+    info!("🔊 pulse_linux::list_sinks: connected, requesting sink list");
+    let sinks: Rc<RefCell<Vec<PulseSink>>> = Rc::new(RefCell::new(Vec::new()));
+    let sinks_cb = sinks.clone();
+
+    let operation = context.introspect().get_sink_info_list(move |result| {
+        if let ListResult::Item(info) = result {
+            let monitor_source_name = info.monitor_source_name.as_deref().unwrap_or_default();
+            if monitor_source_name.is_empty() {
+                return;
+            }
+
+            let description = info
+                .description
+                .as_deref()
+                .unwrap_or("Unknown output")
+                .to_string();
+
+            sinks_cb.borrow_mut().push(PulseSink {
+                description,
+                monitor_source_name: monitor_source_name.to_string(),
+            });
+        }
+    });
+
+    info!("🔊 pulse_linux::list_sinks: pumping mainloop until sink list operation completes");
+    run_operation_to_completion(&mut mainloop, &operation)?;
+    drop(operation);
+
+    let result = sinks.borrow().clone();
+    info!("🔊 pulse_linux::list_sinks: got {} sink(s)", result.len());
+    Ok(result)
+}
+
+/// Resolve a sink's real monitor source name from its display description (as
+/// shown in the "System Audio" picker, e.g. "JBL Tune 770NC").
+pub fn find_monitor_source_by_description(description: &str) -> Result<String> {
+    list_sinks()?
+        .into_iter()
+        .find(|sink| sink.description == description)
+        .map(|sink| sink.monitor_source_name)
+        .ok_or_else(|| anyhow!("No PulseAudio sink found matching '{}'", description))
+}
+
+/// Blocking system-audio capture stream, backed by libpulse-simple's record API
+/// against a sink's monitor source.
+pub struct PulseSystemCapture {
+    simple: Simple,
+    should_stop: Arc<AtomicBool>,
+}
+
+impl PulseSystemCapture {
+    pub fn new(monitor_source_name: &str) -> Result<Self> {
+        let spec = Spec {
+            format: Format::FLOAT32NE,
+            channels: CAPTURE_CHANNELS as u8,
+            rate: CAPTURE_SAMPLE_RATE,
+        };
+        if !spec.is_valid() {
+            return Err(anyhow!("Invalid PulseAudio sample spec"));
+        }
+
+        let simple = Simple::new(
+            None, // default server
+            "Meetily",
+            Direction::Record,
+            Some(monitor_source_name),
+            "System Audio",
+            &spec,
+            None, // default channel map
+            None, // default buffering attributes
+        )
+        .map_err(|e| {
+            anyhow!(
+                "Failed to open PulseAudio record stream on '{}': {}",
+                monitor_source_name,
+                e
+            )
+        })?;
+
+        Ok(Self {
+            simple,
+            should_stop: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
+    pub fn sample_rate(&self) -> u32 {
+        CAPTURE_SAMPLE_RATE
+    }
+
+    pub fn channels(&self) -> u16 {
+        CAPTURE_CHANNELS
+    }
+
+    /// Handle used to signal the capture loop (running on another thread) to stop.
+    pub fn stop_handle(&self) -> Arc<AtomicBool> {
+        self.should_stop.clone()
+    }
+
+    /// Runs a blocking read loop, invoking `on_samples` with interleaved f32
+    /// frames as they arrive. Meant to run on a `spawn_blocking` task, since
+    /// PulseAudio's simple API blocks on `read()`. Returns once `stop_handle()`
+    /// is signalled or the stream errors out.
+    pub fn run(&self, mut on_samples: impl FnMut(&[f32])) {
+        // ~21ms at 48kHz stereo: matches the 1024-frame chunking used by the
+        // macOS Core Audio path.
+        const FRAMES_PER_CHUNK: usize = 1024;
+        let mut byte_buf = vec![0u8; FRAMES_PER_CHUNK * CAPTURE_CHANNELS as usize * 4];
+        let mut sample_buf = Vec::with_capacity(FRAMES_PER_CHUNK * CAPTURE_CHANNELS as usize);
+
+        while !self.should_stop.load(Ordering::Acquire) {
+            if let Err(e) = self.simple.read(&mut byte_buf) {
+                warn!("PulseAudio record stream read error: {}", e);
+                break;
+            }
+
+            sample_buf.clear();
+            sample_buf.extend(
+                byte_buf
+                    .chunks_exact(4)
+                    .map(|b| f32::from_ne_bytes([b[0], b[1], b[2], b[3]])),
+            );
+
+            on_samples(&sample_buf);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore] // Requires a running PulseAudio/PipeWire server; run manually.
+    fn test_list_sinks() {
+        let sinks = list_sinks().expect("Failed to list sinks");
+        for sink in &sinks {
+            println!("sink: {} -> monitor {}", sink.description, sink.monitor_source_name);
+        }
+        assert!(!sinks.is_empty(), "Expected at least one sink on a machine with audio output");
+    }
+
+    #[test]
+    #[ignore] // Requires real audio playback during the test; run manually.
+    fn test_capture_reads_nonzero_samples() {
+        let sinks = list_sinks().expect("Failed to list sinks");
+        let sink = sinks
+            .into_iter()
+            .find(|s| s.monitor_source_name.to_lowercase().contains("bluez")
+                || s.monitor_source_name.to_lowercase().contains("running"))
+            .or_else(|| list_sinks().unwrap().into_iter().next())
+            .expect("No sink available");
+
+        println!("Capturing from: {} ({})", sink.description, sink.monitor_source_name);
+        let capture = PulseSystemCapture::new(&sink.monitor_source_name).expect("Failed to open capture");
+        let stop = capture.stop_handle();
+
+        let received = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let received_clone = received.clone();
+        let stop_clone = stop.clone();
+        let handle = std::thread::spawn(move || {
+            capture.run(|samples| {
+                received_clone.fetch_add(samples.len(), std::sync::atomic::Ordering::Relaxed);
+                if received_clone.load(std::sync::atomic::Ordering::Relaxed) > 48000 * 2 {
+                    stop_clone.store(true, std::sync::atomic::Ordering::Release);
+                }
+            });
+        });
+
+        std::thread::sleep(std::time::Duration::from_secs(3));
+        stop.store(true, std::sync::atomic::Ordering::Release);
+        handle.join().unwrap();
+
+        let total = received.load(std::sync::atomic::Ordering::Relaxed);
+        println!("Received {} samples", total);
+        assert!(total > 0, "Expected to receive some samples from the monitor source");
+    }
+}

--- a/frontend/src-tauri/src/audio/devices/discovery.rs
+++ b/frontend/src-tauri/src/audio/devices/discovery.rs
@@ -33,7 +33,15 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
     info!("🎙️ list_audio_devices: platform enumeration done, {} device(s) so far", devices.len());
 
     // Add any additional devices from the default host
-    if let Ok(other_devices) = host.devices() {
+    // On Linux this also enumerates via alsa-lib, so it must go through the
+    // same lock as configure_linux_audio (see ALSA_ENUM_LOCK's doc comment).
+    let other_devices_result = {
+        #[cfg(target_os = "linux")]
+        let _guard = platform::linux::ALSA_ENUM_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        host.devices()
+    };
+    if let Ok(other_devices) = other_devices_result {
         for device in other_devices {
             if let Ok(name) = device.name() {
                 if !devices.iter().any(|d| d.name == name) {

--- a/frontend/src-tauri/src/audio/devices/discovery.rs
+++ b/frontend/src-tauri/src/audio/devices/discovery.rs
@@ -1,12 +1,13 @@
 use anyhow::Result;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use log::error;
+use log::{error, info};
 
 use super::configuration::{AudioDevice, DeviceType};
 use super::platform;
 
 /// List all available audio devices on the system
 pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
+    info!("🎙️ list_audio_devices: start");
     let host = cpal::default_host();
 
     // Platform-specific device enumeration
@@ -18,7 +19,10 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
 
         #[cfg(target_os = "linux")]
         {
-            platform::configure_linux_audio(&host)?
+            info!("🎙️ list_audio_devices: calling configure_linux_audio");
+            let result = platform::configure_linux_audio(&host)?;
+            info!("🎙️ list_audio_devices: configure_linux_audio returned {} device(s)", result.len());
+            result
         }
 
         #[cfg(target_os = "macos")]
@@ -26,6 +30,7 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
             platform::configure_macos_audio(&host)?
         }
     };
+    info!("🎙️ list_audio_devices: platform enumeration done, {} device(s) so far", devices.len());
 
     // Add any additional devices from the default host
     if let Ok(other_devices) = host.devices() {

--- a/frontend/src-tauri/src/audio/devices/platform/linux.rs
+++ b/frontend/src-tauri/src/audio/devices/platform/linux.rs
@@ -1,9 +1,22 @@
 use anyhow::Result;
 use cpal::traits::{DeviceTrait, HostTrait};
 use log::{info, warn};
+use std::sync::Mutex;
 
 use crate::audio::capture::list_pulse_sinks;
 use crate::audio::devices::configuration::{AudioDevice, DeviceType};
+
+/// alsa-lib's device/config enumeration (`snd_device_name_hint`,
+/// `snd_config_update_r`) is not safe to call concurrently from multiple
+/// threads: it mutates a process-global config cache. `list_audio_devices()`
+/// is polled every few seconds by the device disconnect/reconnect monitor
+/// (device_monitor.rs) while a recording is active, and can also be invoked
+/// at any time from the UI (device list refresh) or when starting a new
+/// recording (recording_manager.rs). Without serialization, an overlapping
+/// call from a second Tokio worker thread corrupts alsa-lib's heap state,
+/// which glibc eventually detects and aborts the process on — this is what
+/// produced the SIGABRT crashes after ~30 minutes of recording.
+pub(crate) static ALSA_ENUM_LOCK: Mutex<()> = Mutex::new(());
 
 /// Configure Linux audio devices. Microphones still go through cpal/ALSA
 /// (unaffected by this). System Audio entries come from PulseAudio/PipeWire's
@@ -13,8 +26,12 @@ pub fn configure_linux_audio(host: &cpal::Host) -> Result<Vec<AudioDevice>> {
     let mut devices = Vec::new();
 
     info!("🎙️ configure_linux_audio: enumerating cpal/ALSA input devices");
-    // Add input devices
-    for device in host.input_devices()? {
+    // Serialize ALSA enumeration: see ALSA_ENUM_LOCK doc comment above.
+    let input_devices: Vec<_> = {
+        let _guard = ALSA_ENUM_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        host.input_devices()?.collect()
+    };
+    for device in input_devices {
         if let Ok(name) = device.name() {
             devices.push(AudioDevice::new(name, DeviceType::Input));
         }

--- a/frontend/src-tauri/src/audio/devices/platform/linux.rs
+++ b/frontend/src-tauri/src/audio/devices/platform/linux.rs
@@ -1,31 +1,39 @@
 use anyhow::Result;
 use cpal::traits::{DeviceTrait, HostTrait};
+use log::{info, warn};
 
+use crate::audio::capture::list_pulse_sinks;
 use crate::audio::devices::configuration::{AudioDevice, DeviceType};
 
-/// Configure Linux audio devices using ALSA/PulseAudio
+/// Configure Linux audio devices. Microphones still go through cpal/ALSA
+/// (unaffected by this). System Audio entries come from PulseAudio/PipeWire's
+/// own sink list (real descriptions, no ~/.asoundrc monitor-hint scanning) —
+/// see audio/capture/pulse_linux.rs for the actual capture implementation.
 pub fn configure_linux_audio(host: &cpal::Host) -> Result<Vec<AudioDevice>> {
     let mut devices = Vec::new();
 
+    info!("🎙️ configure_linux_audio: enumerating cpal/ALSA input devices");
     // Add input devices
     for device in host.input_devices()? {
         if let Ok(name) = device.name() {
             devices.push(AudioDevice::new(name, DeviceType::Input));
         }
     }
+    info!("🎙️ configure_linux_audio: cpal/ALSA gave {} input device(s), now listing Pulse sinks", devices.len());
 
-    // Add PulseAudio monitor sources for system audio
-    if let Ok(pulse_host) = cpal::host_from_id(cpal::HostId::Alsa) {
-        for device in pulse_host.input_devices()? {
-            if let Ok(name) = device.name() {
-                // Check if it's a monitor source
-                if name.contains("monitor") {
-                    devices.push(AudioDevice::new(
-                        format!("{} (System Audio)", name),
-                        DeviceType::Output
-                    ));
-                }
+    // Add PulseAudio/PipeWire sinks as "System Audio" devices
+    match list_pulse_sinks() {
+        Ok(sinks) => {
+            info!("🎙️ configure_linux_audio: list_pulse_sinks returned {} sink(s)", sinks.len());
+            for sink in sinks {
+                devices.push(AudioDevice::new(
+                    format!("{} (System Audio)", sink.description),
+                    DeviceType::Output,
+                ));
             }
+        }
+        Err(e) => {
+            warn!("Failed to list PulseAudio/PipeWire sinks for System Audio: {}", e);
         }
     }
 

--- a/frontend/src-tauri/src/audio/devices/speakers.rs
+++ b/frontend/src-tauri/src/audio/devices/speakers.rs
@@ -35,7 +35,25 @@ pub fn default_output_device() -> Result<AudioDevice> {
         return Ok(AudioDevice::new(device.name()?, DeviceType::Output));
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    #[cfg(target_os = "linux")]
+    {
+        // System audio on Linux is captured natively via PulseAudio/PipeWire
+        // (see audio/capture/pulse_linux.rs), not via cpal's ALSA host, so the
+        // "default" device must be one of the real Pulse sinks, decorated the
+        // same way configure_linux_audio() lists them.
+        let sinks = crate::audio::capture::list_pulse_sinks()
+            .map_err(|e| anyhow!("Failed to list PulseAudio/PipeWire sinks: {}", e))?;
+        let sink = sinks
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow!("No PulseAudio/PipeWire sink found"))?;
+        return Ok(AudioDevice::new(
+            format!("{} (System Audio)", sink.description),
+            DeviceType::Output,
+        ));
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     {
         let host = cpal::default_host();
         let device = host

--- a/frontend/src-tauri/src/audio/stream.rs
+++ b/frontend/src-tauri/src/audio/stream.rs
@@ -13,6 +13,11 @@ use super::capture::{AudioCaptureBackend, get_current_backend};
 #[cfg(target_os = "macos")]
 use super::capture::CoreAudioCapture;
 
+#[cfg(target_os = "linux")]
+use super::capture::{find_monitor_source_by_description, PulseSystemCapture};
+#[cfg(target_os = "linux")]
+use std::sync::atomic::AtomicBool;
+
 /// Stream backend implementation
 pub enum StreamBackend {
     /// CPAL-based stream (ScreenCaptureKit or default)
@@ -20,6 +25,12 @@ pub enum StreamBackend {
     /// Core Audio direct implementation (macOS only)
     #[cfg(target_os = "macos")]
     CoreAudio {
+        task: Option<tokio::task::JoinHandle<()>>,
+    },
+    /// Native PipeWire/PulseAudio implementation (Linux only)
+    #[cfg(target_os = "linux")]
+    Pulse {
+        should_stop: Arc<AtomicBool>,
         task: Option<tokio::task::JoinHandle<()>>,
     },
 }
@@ -85,6 +96,16 @@ impl AudioStream {
         if use_core_audio {
             info!("🎵 Stream: Using Core Audio backend (cidre) for system audio");
             return Self::create_core_audio_stream(device, state, device_type, recording_sender).await;
+        }
+
+        // Linux system audio always goes through the native PipeWire/PulseAudio
+        // path instead of cpal's ALSA host — no backend toggle needed, unlike
+        // macOS's ScreenCaptureKit/CoreAudio choice, since there's only one way
+        // to capture system audio natively on Linux.
+        #[cfg(target_os = "linux")]
+        if device_type == DeviceType::System {
+            info!("🎵 Stream: Using native PulseAudio/PipeWire backend for system audio");
+            return Self::create_pulse_stream(device, state, device_type, recording_sender).await;
         }
 
         // Default path: use CPAL
@@ -233,6 +254,62 @@ impl AudioStream {
         })
     }
 
+    /// Create a native PulseAudio/PipeWire stream (Linux only)
+    #[cfg(target_os = "linux")]
+    async fn create_pulse_stream(
+        device: Arc<AudioDevice>,
+        state: Arc<RecordingState>,
+        device_type: DeviceType,
+        recording_sender: Option<mpsc::UnboundedSender<super::recording_state::AudioChunk>>,
+    ) -> Result<Self> {
+        info!("🔊 Stream: Creating PulseAudio stream for device: {}", device.name);
+
+        // The picker shows "<sink description> (System Audio)" (see
+        // devices/platform/linux.rs); strip that suffix to recover the sink
+        // description and resolve it to its real monitor source name.
+        let description = device
+            .name
+            .strip_suffix(" (System Audio)")
+            .unwrap_or(&device.name);
+
+        let monitor_source_name = find_monitor_source_by_description(description)
+            .map_err(|e| anyhow::anyhow!("Failed to resolve PulseAudio sink '{}': {}", description, e))?;
+
+        let capture_impl = PulseSystemCapture::new(&monitor_source_name)
+            .map_err(|e| anyhow::anyhow!("Failed to open PulseAudio record stream: {}", e))?;
+
+        let sample_rate = capture_impl.sample_rate();
+        let channels = capture_impl.channels();
+        let should_stop = capture_impl.stop_handle();
+
+        // Create audio capture processor for pipeline integration
+        let capture = AudioCapture::new(
+            device.clone(),
+            state.clone(),
+            sample_rate,
+            channels,
+            device_type,
+            recording_sender,
+        );
+
+        let device_name = device.name.clone();
+        let task = tokio::task::spawn_blocking(move || {
+            info!("✅ Stream: PulseAudio capture thread started for {}", device_name);
+            capture_impl.run(|samples| capture.process_audio_data(samples));
+            info!("⚠️ Stream: PulseAudio capture thread ended for {}", device_name);
+        });
+
+        info!("✅ Stream: PulseAudio stream fully initialized for device: {}", device.name);
+
+        Ok(Self {
+            device: device.clone(),
+            backend: StreamBackend::Pulse {
+                should_stop,
+                task: Some(task),
+            },
+        })
+    }
+
     /// Build stream based on sample format
     fn build_stream(
         device: &Device,
@@ -342,6 +419,20 @@ impl AudioStream {
                     std::thread::sleep(std::time::Duration::from_millis(50));
                     info!("Core Audio task aborted");
                 }
+            }
+            #[cfg(target_os = "linux")]
+            StreamBackend::Pulse { should_stop, task } => {
+                // Signal the blocking capture thread to stop after its current
+                // read() call returns, then give it a moment to actually exit.
+                // Unlike CoreAudio's tokio task, abort() can't preempt a thread
+                // blocked in a foreign blocking call, so the flag is what matters.
+                info!("Stopping PulseAudio capture thread...");
+                should_stop.store(true, std::sync::atomic::Ordering::Release);
+                if let Some(task_handle) = task {
+                    task_handle.abort();
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                }
+                info!("PulseAudio capture thread stopped");
             }
         }
 


### PR DESCRIPTION
## Description

Replaces the ALSA monitor-hint hack for Linux "System Audio" capture with a native PipeWire/PulseAudio client, and fixes a heap-corruption crash in the ALSA device-enumeration path that this branch still shares with the rest of the app.

**Why the hack needed replacing**: cpal has no native PulseAudio/PipeWire backend on Linux — only ALSA/JACK. Capturing system audio therefore only worked if a monitor source was hand-registered as a named ALSA pseudo-device in `~/.asoundrc` (`type pulse`, a `hint { show on }` block, and a device name containing `"monitor"` since that's what `configure_linux_audio()` filtered on). On a stock install with no such setup, the System Audio list is simply empty. #701 covers this in detail, and #702 (still open) fixes a related bug in that same ALSA-hack path — this PR bypasses that path entirely for System Audio rather than patching it further.

**The crash**: `list_audio_devices()` is polled every 2-5s by the device disconnect/reconnect monitor for the whole duration of a recording, and can also be triggered from the UI or `recording_manager` at any time. alsa-lib's `snd_device_name_hint`/`snd_config_update_r` mutate a process-global config cache and are not safe to call concurrently — an overlapping call from a second Tokio worker thread was corrupting alsa-lib's heap state, which glibc eventually detected and aborted on. This produced SIGABRT crashes ~30-35 minutes into a recording (reproduced with two coredumps, both inside alsa-lib/malloc, both after that consistent delay).

## Related Issue

Fixes #701, #273, #383 — all three are the same underlying problem (Linux "System Audio" not capturing anything, via the ALSA monitor-hint hack), reported independently over the past few months:
- #273: `configure_linux_audio()` finds nothing because ALSA doesn't even have `pulse`/`jack` PCMs configured (`Unknown PCM pulse` in the logs) — this PR no longer depends on ALSA seeing those PCMs at all, since it talks to Pulse/PipeWire directly.
- #383: same root cause, reported against PipeWire specifically.

Also related:
- #702 (still open): interim fix on the same ALSA-hack path this PR bypasses — independently mergeable, this PR doesn't depend on it.
- #437: partially addressed. The System Audio picker now shows real Pulse sink descriptions instead of raw ALSA PCM names, but the Microphone picker (also affected by #437) still goes through cpal/ALSA unchanged — out of scope here, see "Fix" below.
- #32: the long-standing Linux-support tracking issue that lists system-audio capture as its main technical blocker. This PR closes that specific piece; Flatpak packaging and other items on #32 remain open.

## Type of Change
- [x] Bug fix
- [x] New feature

## Fix

- New module `audio/capture/pulse_linux.rs` (`#[cfg(target_os = "linux")]`), structured as the Linux sibling of the existing macOS `capture/core_audio.rs`: talks to the PulseAudio client protocol directly via `libpulse-binding`/`libpulse-simple-binding`, which PipeWire also implements (`pipewire-pulse`). Lists real sink names/descriptions and opens a record stream on a sink's monitor source — no `~/.asoundrc` needed on either PipeWire or classic PulseAudio.
- `audio/stream.rs`: Linux System Audio always routes through this native Pulse backend now, wired in the same way as macOS's Core Audio branch.
- `audio/devices/platform/linux.rs` and `audio/devices/speakers.rs`: System Audio device listing/default resolution now come from the real Pulse sink list instead of the ALSA `"monitor"` name heuristic.
- Microphone capture is untouched — still cpal/ALSA, out of scope here.
- `audio/devices/discovery.rs` and `audio/devices/platform/linux.rs`: added a process-wide `Mutex` (`ALSA_ENUM_LOCK`) serializing every remaining ALSA-touching enumeration call, to stop the concurrent-access heap corruption described above.

## Testing
- [x] Manual testing performed
- [x] All tests pass

- `cargo check` and `cargo build --release` succeed (Arch Linux, PipeWire 1.6.8, KDE Plasma / Wayland).
- Fresh state, zero `~/.asoundrc` customization: Settings → System Audio lists real sink names out of the box.
- Recorded while playing audio; confirmed the output file's system-audio track is non-silent (`ffmpeg -i recording.mp4 -af volumedetect -f null -`).
- Switched outputs (different sink) mid-session and saw the new device picked up without an app restart.
- Ran a recording past the ~30-35 minute mark that reliably triggered the pre-fix SIGABRT — no crash with the `ALSA_ENUM_LOCK` change.

No automated tests added for `pulse_linux.rs` beyond two `#[ignore]`d manual tests (`test_list_sinks`, `test_capture_reads_nonzero_samples`) — both require a live PipeWire/PulseAudio server and real audio playback, so they're not meant to run in CI.

## Documentation
- [x] No documentation needed

No user-facing docs affected. Module-level comments in `pulse_linux.rs` and on `ALSA_ENUM_LOCK` explain the approach and the concurrency hazard being fixed, respectively.

## Checklist
- [x] Code follows project style (mirrors the existing macOS Core Audio native-capture pattern)
- [x] Self-reviewed the code
- [x] Branch is up to date with main
- [x] No merge conflicts

## Additional Notes

Once this lands, the ALSA `"monitor"`-hint enumeration path for System Audio on Linux is effectively dead code (Microphone capture still needs the rest of `configure_linux_audio()`). Left it in place — removing it is a separate cleanup, not folded into this PR.
