### PR TITLE
feat(gpu): enable CUDA for Parakeet and improve Windows CUDA builds

### DIFF
--- a/.github/workflows/ACCELERATION_GUIDE.md
+++ b/.github/workflows/ACCELERATION_GUIDE.md
@@ -272,6 +272,19 @@ openblas = ["whisper-rs/openblas"]  # Optimized CPU BLAS
 
 The built-in Qwen/GGUF summarizer runs in the separate `llama-helper` sidecar. Build that package with its own `cuda` feature to enable `llama.cpp` CUDA offload.
 
+### Windows CUDA vs Vulkan Build Scripts
+
+The existing `frontend/build-gpu.ps1` is a Vulkan-only wrapper for the Tauri application and does not build or stage `llama-helper`. The Windows Vulkan instructions in `docs/BUILDING.md` therefore build and stage a CPU helper explicitly. In that documented configuration, Vulkan accelerates Whisper, while Parakeet and `llama-helper` use the CPU.
+
+`frontend/build-cuda.ps1` is intentionally separate because a complete CUDA package must coordinate two independent builds:
+
+- the Tauri application enables CUDA for Whisper and Parakeet;
+- `llama-helper` enables CUDA separately for Qwen/GGUF summarization.
+
+The CUDA script also validates the CUDA Toolkit installation, Visual Studio integration, and LLVM/libclang prerequisites required by the Windows build, then stages the matching CUDA sidecar before packaging. Local builds are unsigned by default; maintainers with the repository signing environment can use `-Signed`.
+
+This difference is specific to the Windows PowerShell scripts. When run from the `frontend` directory, `./build-gpu.sh` already detects the backend for the Tauri application and builds and stages `llama-helper` with the corresponding supported backend on Linux and macOS. CUDA and Vulkan use the same feature in both targets; macOS CoreML is mapped to Metal for `llama-helper`, which does not support CoreML. The Cargo CUDA wiring is cross-platform, but the CUDA package described here has been runtime-tested only on Windows.
+
 ### Why Not CUDA on Hosted CI?
 
 **CUDA requires:**
@@ -350,10 +363,10 @@ error: could not find OpenBLAS library
 
 ### Potential Enhancements
 
-1. **Add CUDA support** for users with NVIDIA GPUs
-   - Detect if NVIDIA GPU available
-   - Optionally enable CUDA feature
-   - Fallback to Vulkan if CUDA fails
+1. **Complete CUDA validation and release support**
+   - Runtime-test the existing cross-platform CUDA feature on Linux NVIDIA systems
+   - Decide whether maintainers will publish an official signed Windows CUDA installer
+   - Add CUDA CI only if suitable GPU-backed runners become available
 
 2. **Add CoreML support** for macOS
    - Enable explicit CoreML acceleration

--- a/.github/workflows/ACCELERATION_GUIDE.md
+++ b/.github/workflows/ACCELERATION_GUIDE.md
@@ -257,31 +257,38 @@ pnpm run tauri build
 
 ## Technical Details
 
-### Whisper.cpp Features
+### Cargo Acceleration Features
 
-The `whisper-rs` crate (which wraps whisper.cpp) supports these features:
+The Tauri application maps its Cargo features to the native inference engines:
 
 ```toml
 [features]
 metal = ["whisper-rs/metal"]       # macOS Metal
-cuda = ["whisper-rs/cuda"]          # NVIDIA CUDA
+cuda = ["whisper-rs/cuda", "ort/cuda"] # NVIDIA CUDA for Whisper and Parakeet
 vulkan = ["whisper-rs/vulkan"]      # Cross-platform Vulkan
 hipblas = ["whisper-rs/hipblas"]    # AMD ROCm
 openblas = ["whisper-rs/openblas"]  # Optimized CPU BLAS
 ```
 
-### Why Not CUDA?
+The built-in Qwen/GGUF summarizer runs in the separate `llama-helper` sidecar. Build that package with its own `cuda` feature to enable `llama.cpp` CUDA offload.
+
+### Why Not CUDA on Hosted CI?
 
 **CUDA requires:**
 - NVIDIA GPU hardware
 - CUDA toolkit installation
 - NVIDIA drivers
 
-**GitHub Actions runners:**
-- Don't have NVIDIA GPUs
-- Can't use CUDA
+**Standard GitHub-hosted runners:**
+- Do not have NVIDIA GPUs for runtime validation
+- Do not include this repository's required CUDA Toolkit and Visual Studio integration
 
-**Vulkan is better for CI/CD because:**
+**The CI strategy is therefore:**
+- Run the repository's existing workflows manually when maintainers need CI validation
+- Keep the existing Vulkan packaging workflow for hosted Windows builds
+- Build and smoke-test CUDA locally with `frontend/build-cuda.ps1` on a prepared NVIDIA development machine
+
+**Vulkan remains useful for hosted packaging because:**
 - Software-based fallback available
 - Works without dedicated GPU hardware
 - Broader compatibility

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Built-in support for hardware acceleration across platforms:
 - **macOS**: Apple Silicon (Metal) + CoreML
 - **Windows/Linux**: NVIDIA (CUDA), AMD/Intel (Vulkan)
 
-Automatically enabled at build time - no configuration needed.
+The GPU-aware build scripts select a backend based on the available development toolkit. See the [GPU Acceleration Guide](docs/GPU_ACCELERATION.md) for supported configurations.
 
 ## System Architecture
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -316,4 +316,39 @@ pnpm tauri:build
 
 By default, the application will be built with CPU-only processing. To enable GPU acceleration, see the [GPU Acceleration Guide](GPU_ACCELERATION.md).
 
+### NVIDIA CUDA build
+
+CUDA builds additionally require:
+
+- NVIDIA CUDA Toolkit with `nvcc` on `PATH`
+- CUDA Visual Studio/MSBuild integration
+- LLVM with `libclang.dll`
+
+After installing these prerequisites, run the local unsigned-build script from the repository root:
+
+```powershell
+.\frontend\build-cuda.ps1
+```
+
+This enables CUDA for Whisper transcription, Parakeet transcription through ONNX Runtime, and Qwen/GGUF summarization through `llama-helper`.
+
+The script disables updater artifacts for this local build and produces unsigned MSI and NSIS installers under `target/release/bundle`.
+
+Repository maintainers who have configured the existing DigiCert and Tauri updater signing environment can instead run `.\frontend\build-cuda.ps1 -Signed`. The script validates the required signing inputs before starting the build.
+
+### AMD/Intel Vulkan build
+
+Install the Vulkan SDK. From the repository root, build and stage the CPU `llama-helper`, then build the Tauri application with Vulkan:
+
+```powershell
+cargo build --release -p llama-helper
+New-Item -ItemType Directory -Force frontend\src-tauri\binaries | Out-Null
+Copy-Item target\release\llama-helper.exe frontend\src-tauri\binaries\llama-helper-x86_64-pc-windows-msvc.exe -Force
+Set-Location frontend
+pnpm install --frozen-lockfile
+pnpm run tauri:build:vulkan
+```
+
+This enables Vulkan for Whisper transcription. Parakeet and `llama-helper` use the CPU in this configuration.
+
 </details>

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -332,6 +332,10 @@ After installing these prerequisites, run the local unsigned-build script from t
 
 This enables CUDA for Whisper transcription, Parakeet transcription through ONNX Runtime, and Qwen/GGUF summarization through `llama-helper`.
 
+Windows uses a dedicated CUDA script because a complete CUDA package has two independently compiled Rust targets: the Tauri application (Whisper and Parakeet) and the `llama-helper` sidecar (Qwen/GGUF). The script builds both with CUDA, stages the matching sidecar, and validates the additional CUDA, Visual Studio, and LLVM prerequisites. The existing `build-gpu.ps1` is a Vulkan-only wrapper for the Tauri application; the Vulkan instructions below build and stage the CPU `llama-helper` explicitly.
+
+This distinction is specific to the Windows PowerShell scripts. When run from the `frontend` directory, `./build-gpu.sh` already detects the backend for the Tauri application and builds and stages `llama-helper` with the corresponding supported backend on Linux and macOS. CUDA and Vulkan use the same feature in both targets; macOS CoreML is mapped to Metal for `llama-helper`, which does not support CoreML. The CUDA feature wiring is cross-platform, but this CUDA change has been runtime-tested only on Windows.
+
 The script disables updater artifacts for this local build and produces unsigned MSI and NSIS installers under `target/release/bundle`.
 
 Repository maintainers who have configured the existing DigiCert and Tauri updater signing environment can instead run `.\frontend\build-cuda.ps1 -Signed`. The script validates the required signing inputs before starting the build.

--- a/docs/GPU_ACCELERATION.md
+++ b/docs/GPU_ACCELERATION.md
@@ -1,16 +1,34 @@
 # GPU Acceleration Guide
 
-Meetily supports GPU acceleration for transcription, which can significantly improve performance. This guide provides detailed information on how to set up and configure GPU acceleration for your system.
+Meetily supports GPU acceleration for transcription and built-in local summarization. GPU acceleration backends are selected at build time, and CUDA and Vulkan are independent Cargo features.
 
 ## Supported Backends
 
-Meetily uses the `whisper-rs` library, which supports several GPU acceleration backends:
+Meetily has more than one local inference engine:
 
-*   **CUDA:** For NVIDIA GPUs.
-*   **Metal:** For Apple Silicon and modern Intel-based Macs.
-*   **Core ML:** An additional acceleration layer for Apple Silicon.
-*   **Vulkan:** A cross-platform solution for modern AMD and Intel GPUs.
-*   **OpenBLAS:** A CPU-based optimization that can provide a significant speed-up over standard CPU processing.
+* **Whisper transcription** uses `whisper-rs`, a Rust wrapper around `whisper.cpp`.
+* **Parakeet transcription** uses ONNX Runtime (`ort` is its Rust interface).
+* **Built-in Qwen/GGUF summarization** runs in the `llama-helper` sidecar through `llama.cpp`.
+
+The supported build backends are:
+
+* **CUDA:** NVIDIA GPU acceleration. It enables CUDA for Whisper and ONNX Runtime in the Tauri application; `llama-helper` must also be built with its CUDA feature to accelerate built-in summarization.
+* **Metal/Core ML:** Apple acceleration.
+* **Vulkan:** A separate Whisper backend for modern AMD and Intel GPUs on Windows/Linux.
+* **OpenBLAS:** CPU optimization rather than GPU acceleration.
+
+Parakeet currently supports CPU or CUDA in Meetily. Selecting Vulkan does not enable Vulkan for Parakeet.
+
+### Acceleration coverage
+
+| Build | Whisper transcription | Parakeet transcription | Built-in Qwen/GGUF summarization |
+| --- | --- | --- | --- |
+| CPU | CPU | CPU | CPU |
+| CUDA | CUDA through `whisper.cpp` | ONNX Runtime CUDA, with CPU fallback | CUDA through `llama.cpp`, with CPU fallback |
+| Vulkan | Vulkan through `whisper.cpp` | CPU | Requires a separately Vulkan-enabled `llama-helper` build |
+| Metal | Metal through `whisper.cpp` | CPU | Metal through `llama.cpp` |
+
+Installing or detecting the CUDA Toolkit does not change an application that was already built. Parakeet uses the NVIDIA GPU only when Meetily is compiled with the `cuda` Cargo feature—which enables `ort/cuda`—and ONNX Runtime successfully initializes its CUDA execution provider. Otherwise, Parakeet uses its CPU provider.
 
 ## Automatic GPU Detection
 
@@ -23,24 +41,21 @@ Here's the detection priority:
 3.  **Vulkan (AMD/Intel)**
 4.  **OpenBLAS (CPU)**
 
-If no GPU is detected, the application will fall back to CPU-only processing.
+If no supported GPU backend is available, the application falls back to CPU processing. CUDA Parakeet sessions prefer the CUDA execution provider and keep the CPU provider as fallback. Built-in summarization retries model loading once on CPU if CUDA loading fails.
 
 ## Manual Configuration
 
-If you want to manually configure the GPU acceleration backend, you can do so by enabling the corresponding feature flag in the `frontend/src-tauri/Cargo.toml` file.
+GPU backends are selected with Cargo features. Passing `--features cuda` does not enable unrelated features such as Vulkan.
 
-For example, to enable CUDA, you would modify the `[features]` section as follows:
+The existing Cargo feature mapping is:
 
 ```toml
 [features]
-default = ["cuda"]
-
-# ... other features
-
-cuda = ["whisper-rs/cuda"]
+cuda = ["whisper-rs/cuda", "ort/cuda"]
+vulkan = ["whisper-rs/vulkan"]
 ```
 
-Then, you would build the application using the standard `pnpm tauri:build` command.
+Do not edit `default` to select a backend. Pass the desired feature to the build command instead.
 
 ## Platform-Specific Instructions
 
@@ -54,4 +69,4 @@ On macOS, Metal GPU acceleration is enabled by default. No additional configurat
 
 ### Windows
 
-To enable GPU acceleration on Windows, you will need to install the appropriate toolkit for your GPU (e.g., the CUDA Toolkit for NVIDIA GPUs) and then build the application with the corresponding feature flag enabled.
+See the [Windows build instructions](BUILDING.md#-building-on-windows) for NVIDIA CUDA and AMD/Intel Vulkan prerequisites and commands.

--- a/frontend/build-cuda.ps1
+++ b/frontend/build-cuda.ps1
@@ -1,0 +1,202 @@
+<#
+Builds Windows installers with CUDA acceleration.
+
+By default, the installers are local development builds: Windows code signing
+and Tauri updater signatures are disabled. Maintainers can run
+`./build-cuda.ps1 -Signed` after configuring the repository's DigiCert and
+Tauri updater signing environment.
+
+Prerequisites:
+- Rust MSVC toolchain
+- Visual Studio C++ Build Tools
+- CMake
+- LLVM/libclang compatible with the repository's bindgen version
+- NVIDIA CUDA Toolkit with Visual Studio integration
+- Node.js with Corepack (preferred) or pnpm 9+
+
+The script builds both the CUDA-enabled llama-helper sidecar and the Tauri
+application.
+#>
+
+param([switch]$Signed)
+
+$ErrorActionPreference = "Stop"
+
+$frontendRoot = $PSScriptRoot
+$repoRoot = Split-Path -Parent $frontendRoot
+$targetRoot = Join-Path $repoRoot "target"
+$temporaryToolsDirectory = Join-Path $targetRoot "build-cuda-tools"
+$localTauriConfigPath = Join-Path $targetRoot "build-cuda-local.conf.json"
+$originalPath = $env:PATH
+$originalLibclangPath = $env:LIBCLANG_PATH
+
+function Assert-Command {
+    param([Parameter(Mandatory = $true)][string]$Name)
+
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command '$Name' was not found on PATH."
+    }
+}
+
+function Assert-SigningEnvironment {
+    Assert-Command "smctl"
+
+    if (-not $env:DIGICERT_KEYPAIR_ALIAS) {
+        throw "Signed builds require DIGICERT_KEYPAIR_ALIAS for Windows code signing."
+    }
+
+    if (-not $env:TAURI_SIGNING_PRIVATE_KEY) {
+        throw "Signed builds require TAURI_SIGNING_PRIVATE_KEY for Tauri updater signatures."
+    }
+}
+
+function Resolve-LibclangDirectory {
+    if ($env:LIBCLANG_PATH) {
+        $configuredLibrary = Join-Path $env:LIBCLANG_PATH "libclang.dll"
+        if (Test-Path -LiteralPath $configuredLibrary) {
+            return $env:LIBCLANG_PATH
+        }
+        throw "LIBCLANG_PATH is set to '$env:LIBCLANG_PATH', but libclang.dll was not found there."
+    }
+
+    $defaultDirectory = "C:\Program Files\LLVM\bin"
+    if (Test-Path -LiteralPath (Join-Path $defaultDirectory "libclang.dll")) {
+        return $defaultDirectory
+    }
+
+    throw "libclang.dll was not found. Install LLVM or set LIBCLANG_PATH to its bin directory."
+}
+
+function Assert-CudaVisualStudioIntegration {
+    if (-not $env:CUDA_PATH -or -not (Test-Path -LiteralPath $env:CUDA_PATH)) {
+        throw "CUDA_PATH is not set to an installed NVIDIA CUDA Toolkit."
+    }
+
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+    if (-not (Test-Path -LiteralPath $vswhere)) {
+        throw "vswhere.exe was not found. Install Visual Studio with the Desktop development with C++ workload."
+    }
+
+    $visualStudioPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+    if ($LASTEXITCODE -ne 0 -or -not $visualStudioPath) {
+        throw "Visual Studio C++ Build Tools were not found."
+    }
+
+    $buildCustomizationsRoot = Join-Path $visualStudioPath "MSBuild\Microsoft\VC"
+    $cudaVersion = (Split-Path -Leaf $env:CUDA_PATH) -replace '^v', ''
+    $cudaTargets = Get-ChildItem -LiteralPath $buildCustomizationsRoot -Recurse -Filter "CUDA $cudaVersion.targets" -ErrorAction SilentlyContinue |
+        Where-Object { $_.DirectoryName -like "*BuildCustomizations*" } |
+        Select-Object -First 1
+
+    if (-not $cudaTargets) {
+        $integrationSource = Join-Path $env:CUDA_PATH "extras\visual_studio_integration\MSBuildExtensions"
+        throw @"
+CUDA $cudaVersion Visual Studio integration was not found under '$buildCustomizationsRoot'.
+Repair the CUDA Toolkit installation after installing Visual Studio, or copy the
+files from '$integrationSource' into the active VC BuildCustomizations directory.
+"@
+    }
+
+    Write-Host "CUDA integration: $($cudaTargets.FullName)" -ForegroundColor DarkGray
+}
+
+function Initialize-PnpmCommand {
+    $corepack = Get-Command corepack -ErrorAction SilentlyContinue
+    if ($corepack) {
+        New-Item -ItemType Directory -Force -Path $temporaryToolsDirectory | Out-Null
+        $shimPath = Join-Path $temporaryToolsDirectory "pnpm.cmd"
+        Set-Content -LiteralPath $shimPath -Encoding Ascii -Value "@echo off`r`n@corepack pnpm@10 %*"
+        $env:PATH = "$temporaryToolsDirectory;$originalPath"
+        return
+    }
+
+    $pnpm = Get-Command pnpm -ErrorAction SilentlyContinue
+    if (-not $pnpm) {
+        throw "Neither Corepack nor pnpm was found. Install Node.js with Corepack support."
+    }
+
+    $pnpmVersion = (& pnpm --version).Trim()
+    if ($LASTEXITCODE -ne 0 -or [int]($pnpmVersion.Split('.')[0]) -lt 9) {
+        throw "pnpm 9 or newer is required for frontend/pnpm-lock.yaml; found '$pnpmVersion'."
+    }
+}
+
+function Invoke-Pnpm {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$PnpmArgs)
+
+    & pnpm @PnpmArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "pnpm failed with exit code $LASTEXITCODE."
+    }
+}
+
+New-Item -ItemType Directory -Force -Path $targetRoot | Out-Null
+
+try {
+    Assert-Command "cargo"
+    Assert-Command "cmake"
+    Assert-Command "node"
+    Assert-Command "nvcc"
+
+    $env:LIBCLANG_PATH = Resolve-LibclangDirectory
+    Assert-CudaVisualStudioIntegration
+    Initialize-PnpmCommand
+
+    if ($Signed) {
+        Assert-SigningEnvironment
+        Write-Host "Signed build enabled; using the repository signing configuration." -ForegroundColor Yellow
+    }
+    else {
+        Set-Content -LiteralPath $localTauriConfigPath -Encoding Ascii -Value '{"bundle":{"createUpdaterArtifacts":false}}'
+        Write-Host "Unsigned local build; code signing and updater signatures are disabled." -ForegroundColor Yellow
+    }
+
+    Push-Location $repoRoot
+    try {
+        Write-Host "Building CUDA-enabled llama-helper..." -ForegroundColor Cyan
+        cargo build --release -p llama-helper --features cuda
+        if ($LASTEXITCODE -ne 0) {
+            throw "CUDA llama-helper build failed with exit code $LASTEXITCODE."
+        }
+
+        $binaryDirectory = Join-Path $frontendRoot "src-tauri\binaries"
+        $helperSource = Join-Path $targetRoot "release\llama-helper.exe"
+        $helperDestination = Join-Path $binaryDirectory "llama-helper-x86_64-pc-windows-msvc.exe"
+        New-Item -ItemType Directory -Force -Path $binaryDirectory | Out-Null
+        Copy-Item -LiteralPath $helperSource -Destination $helperDestination -Force
+
+        Push-Location $frontendRoot
+        try {
+            Write-Host "Installing frontend dependencies..." -ForegroundColor Cyan
+            Invoke-Pnpm install --frozen-lockfile
+
+            Write-Host "Building Meetily with CUDA..." -ForegroundColor Cyan
+            $tauriCommand = Join-Path $frontendRoot "node_modules\.bin\tauri.CMD"
+            $tauriArguments = @("build")
+            if (-not $Signed) {
+                $tauriArguments += @("--no-sign", "--config", $localTauriConfigPath)
+            }
+            $tauriArguments += @("--", "--features", "cuda")
+
+            & $tauriCommand @tauriArguments
+            if ($LASTEXITCODE -ne 0) {
+                throw "Meetily CUDA build failed with exit code $LASTEXITCODE."
+            }
+        }
+        finally {
+            Pop-Location
+        }
+
+        Write-Host "CUDA build complete." -ForegroundColor Green
+        Write-Host "Installers: $(Join-Path $targetRoot 'release\bundle')" -ForegroundColor Green
+    }
+    finally {
+        Pop-Location
+    }
+}
+finally {
+    $env:PATH = $originalPath
+    $env:LIBCLANG_PATH = $originalLibclangPath
+    Remove-Item -LiteralPath $localTauriConfigPath -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $temporaryToolsDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  prosemirror-model: 1.25.3
+  prosemirror-state: 1.4.3
+  prosemirror-view: 1.41.3
+  prosemirror-transform: 1.10.4
+  prosemirror-tables: 1.8.1
+
 importers:
 
   .:
@@ -2930,10 +2937,10 @@ packages:
       '@types/hast': ^3.0.0
       highlight.js: ^11.9.0
       lowlight: ^3.1.0
-      prosemirror-model: ^1.19.3
-      prosemirror-state: ^1.4.3
-      prosemirror-transform: ^1.8.0
-      prosemirror-view: ^1.32.4
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.41.3
       refractor: ^5.0.0
       sugar-high: ^0.6.1 || ^0.7.0 || ^0.8.0 || ^0.9.0
     peerDependenciesMeta:
@@ -2979,9 +2986,9 @@ packages:
   prosemirror-paste-rules@3.0.0:
     resolution: {integrity: sha512-p2ayp2xtSTtDPZutoxZyK6UKJhJk0hEpIfdfVYfd3DSENE1Lyrcg96pju+ClgwXlTjPUykXx5DrsfRbHCY+gGQ==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-schema-basic@1.2.4:
     resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
@@ -2995,9 +3002,9 @@ packages:
   prosemirror-suggest@3.0.0:
     resolution: {integrity: sha512-cEYnJHOAnQ+ET7PKY1tY8SMSpyR2rQAuYfPEmVtet0V9exgHAeiaSEzyBcCSeLesxXJRIv8b9cofyqoqyMjlEw==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-tables@1.8.1:
     resolution: {integrity: sha512-DAgDoUYHCcc6tOGpLVPSU1k84kCUWTWnfWX3UDy2Delv4ryH0KqTD6RBI6k4yi9j9I8gl3j8MkPpRD/vWPZbug==}
@@ -3005,9 +3012,9 @@ packages:
   prosemirror-trailing-node@3.0.0:
     resolution: {integrity: sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==}
     peerDependencies:
-      prosemirror-model: ^1.22.1
-      prosemirror-state: ^1.4.2
-      prosemirror-view: ^1.33.8
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
 
   prosemirror-transform@1.10.4:
     resolution: {integrity: sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==}
@@ -3448,9 +3455,9 @@ packages:
     resolution: {integrity: sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==}
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     peerDependencies:
-      prosemirror-model: ^1.7.1
-      prosemirror-state: ^1.2.3
-      prosemirror-view: ^1.9.10
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.41.3
       y-protocols: ^1.0.1
       yjs: ^13.5.38
 

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -44,7 +44,7 @@ platform-default = []
 # Manual GPU acceleration options (for power users to override defaults)
 metal = ["whisper-rs/metal"]       # macOS: Apple Metal GPU (Auto-enabled on macOS)
 coreml = ["whisper-rs/coreml"]     # macOS: Apple CoreML acceleration
-cuda = ["whisper-rs/cuda"]         # Windows/Linux: NVIDIA CUDA GPU
+cuda = ["whisper-rs/cuda", "ort/cuda"] # Windows/Linux: NVIDIA CUDA GPU
 vulkan = ["whisper-rs/vulkan"]     # Windows/Linux: AMD/Intel Vulkan GPU
 hipblas = ["whisper-rs/hipblas"]   # Linux: AMD ROCm HIP
 

--- a/frontend/src-tauri/src/parakeet_engine/model.rs
+++ b/frontend/src-tauri/src/parakeet_engine/model.rs
@@ -1,6 +1,8 @@
 use ndarray::{Array, Array1, Array2, Array3, ArrayD, ArrayViewD, IxDyn};
 use once_cell::sync::Lazy;
-use ort::execution_providers::CPUExecutionProvider;
+#[cfg(feature = "cuda")]
+use ort::execution_providers::CUDAExecutionProvider;
+use ort::execution_providers::{CPUExecutionProvider, ExecutionProviderDispatch};
 use ort::inputs;
 use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;
@@ -20,11 +22,61 @@ const TDT_DURATIONS: [usize; 5] = [0, 1, 2, 3, 4];
 static DECODE_SPACE_RE: Lazy<Result<Regex, regex::Error>> =
     Lazy::new(|| Regex::new(r"\A\s|\s\B|(\s)\b"));
 
+fn execution_provider_names() -> Vec<&'static str> {
+    #[cfg(feature = "cuda")]
+    {
+        vec!["CUDA", "CPU"]
+    }
+
+    #[cfg(not(feature = "cuda"))]
+    {
+        vec!["CPU"]
+    }
+}
+
+fn execution_providers() -> Vec<ExecutionProviderDispatch> {
+    #[cfg(feature = "cuda")]
+    {
+        vec![
+            CUDAExecutionProvider::default().build(),
+            CPUExecutionProvider::default().build(),
+        ]
+    }
+
+    #[cfg(not(feature = "cuda"))]
+    {
+        vec![CPUExecutionProvider::default().build()]
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct TimestampedResult {
     pub text: String,
     pub timestamps: Vec<f32>,
     pub tokens: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn execution_provider_policy_always_keeps_cpu_fallback_last() {
+        let names = execution_provider_names();
+        assert_eq!(names.last(), Some(&"CPU"));
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn cuda_build_prefers_cuda_before_cpu() {
+        assert_eq!(execution_provider_names(), vec!["CUDA", "CPU"]);
+    }
+
+    #[cfg(not(feature = "cuda"))]
+    #[test]
+    fn ordinary_build_uses_cpu_only() {
+        assert_eq!(execution_provider_names(), vec!["CPU"]);
+    }
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -54,7 +106,10 @@ pub struct ParakeetModel {
 
 impl Drop for ParakeetModel {
     fn drop(&mut self) {
-        log::debug!("Dropping ParakeetModel with {} vocab tokens", self.vocab.len());
+        log::debug!(
+            "Dropping ParakeetModel with {} vocab tokens",
+            self.vocab.len()
+        );
     }
 }
 
@@ -89,14 +144,22 @@ impl ParakeetModel {
         intra_threads: Option<usize>,
         try_quantized: bool,
     ) -> Result<Session, ParakeetError> {
-        let providers = vec![CPUExecutionProvider::default().build()];
+        let provider_names = execution_provider_names();
+        log::info!(
+            "Parakeet execution provider preference: {}",
+            provider_names.join(" -> ")
+        );
+        let providers = execution_providers();
 
         // Try quantized version first if requested, fallback to regular version
         let model_filename = if try_quantized {
             let quantized_name = format!("{}.int8.onnx", model_name);
             let quantized_path = model_dir.as_ref().join(&quantized_name);
             if quantized_path.exists() {
-                log::info!("Loading quantized Parakeet model from {}...", quantized_name);
+                log::info!(
+                    "Loading quantized Parakeet model from {}...",
+                    quantized_name
+                );
                 quantized_name
             } else {
                 let regular_name = format!("{}.onnx", model_name);

--- a/llama-helper/src/main.rs
+++ b/llama-helper/src/main.rs
@@ -128,13 +128,13 @@ impl SamplingConfig {
 // ============================================================================
 
 /// Detect available VRAM in GB
-fn detect_vram_gb() -> f32 {
+fn detect_vram_gb() -> Option<f32> {
     #[cfg(feature = "metal")]
     {
         // macOS Metal: Query recommended max working set size
         if let Some(vram) = detect_metal_vram() {
             eprintln!("Metal VRAM detected: {:.2} GB", vram);
-            return vram;
+            return Some(vram);
         }
     }
 
@@ -143,14 +143,13 @@ fn detect_vram_gb() -> f32 {
         // NVIDIA CUDA: Query device memory
         if let Some(vram) = detect_cuda_vram() {
             eprintln!("CUDA VRAM detected: {:.2} GB", vram);
-            return vram;
+            return Some(vram);
         }
     }
 
-    /// TODO: Vulkan VRAM detection
-
-    eprintln!("VRAM detection not available, using conservative estimate");
-    4.0 // Conservative fallback
+    // TODO: Vulkan VRAM detection
+    eprintln!("VRAM detection not available; using CPU fallback");
+    None
 }
 
 #[cfg(feature = "metal")]
@@ -199,7 +198,16 @@ fn calculate_gpu_layers(
         .map(|m| m.len() as f32 / 1024.0 / 1024.0 / 1024.0)
         .unwrap_or(0.0);
 
-    if file_size_gb == 0.0 {
+    calculate_gpu_layers_for_size(file_size_gb, model_layers, vram_gb, context_size)
+}
+
+fn calculate_gpu_layers_for_size(
+    file_size_gb: f32,
+    model_layers: u32,
+    vram_gb: f32,
+    context_size: u32,
+) -> u32 {
+    if file_size_gb <= 0.0 || model_layers == 0 || vram_gb <= 0.0 {
         eprintln!("⚠️ Could not determine model file size, using conservative default");
         return 0;
     }
@@ -258,9 +266,7 @@ fn calculate_gpu_layers(
     layers
 }
 
-/// Get default GPU layer count with smart detection
-fn get_default_gpu_layers(model_path: &PathBuf, context_size: u32) -> u32 {
-    let vram = detect_vram_gb();
+fn estimate_model_layers(model_path: &PathBuf) -> u32 {
     // TODO: Use actual model metadata instead of heuristics
     // Heuristic: Estimate total layers based on file size
     // 7B models (Q4) are ~4.1GB and have ~32-35 layers
@@ -269,9 +275,50 @@ fn get_default_gpu_layers(model_path: &PathBuf, context_size: u32) -> u32 {
         .map(|m| m.len() as f32 / 1024.0 / 1024.0 / 1024.0)
         .unwrap_or(0.0);
 
-    let estimated_layers = if file_size_gb > 2.5 { 33 } else { 28 };
+    if file_size_gb > 2.5 {
+        33
+    } else {
+        28
+    }
+}
 
-    calculate_gpu_layers(model_path, estimated_layers, vram, context_size)
+/// Get default GPU layer count and estimated total layer count with smart detection
+fn get_default_gpu_layers(model_path: &PathBuf, context_size: u32) -> (u32, u32) {
+    let estimated_layers = estimate_model_layers(model_path);
+    let Some(vram) = detect_vram_gb() else {
+        return (0, estimated_layers);
+    };
+
+    (
+        calculate_gpu_layers(model_path, estimated_layers, vram, context_size),
+        estimated_layers,
+    )
+}
+
+fn gpu_backend_label(used_gpu_layers: u32, total_model_layers: u32) -> &'static str {
+    if used_gpu_layers == 0 {
+        "CPU fallback"
+    } else if used_gpu_layers == total_model_layers {
+        "CUDA full offload"
+    } else {
+        "CUDA partial offload"
+    }
+}
+
+fn load_with_cpu_fallback<T, F>(gpu_layers: u32, mut load: F) -> Result<(T, u32)>
+where
+    F: FnMut(u32) -> Result<T>,
+{
+    match load(gpu_layers) {
+        Ok(model) => Ok((model, gpu_layers)),
+        Err(gpu_error) if gpu_layers > 0 => {
+            eprintln!("⚠️ CUDA model load failed ({gpu_error:#}); retrying with CPU fallback");
+            load(0)
+                .context("CPU fallback model load failed")
+                .map(|model| (model, 0))
+        }
+        Err(error) => Err(error),
+    }
 }
 
 // ============================================================================
@@ -327,14 +374,20 @@ impl ModelState {
         eprintln!("📥 Loading model: {}", model_path.display());
 
         // Detect GPU layers
-        let gpu_layers = get_default_gpu_layers(&model_path, context_size);
+        let (gpu_layers, total_model_layers) = get_default_gpu_layers(&model_path, context_size);
 
-        // Configure model parameters with GPU offload
-        let model_params = LlamaModelParams::default().with_n_gpu_layers(gpu_layers);
-        let model_params = pin!(model_params);
+        let (model, used_gpu_layers) = load_with_cpu_fallback(gpu_layers, |layers| {
+            let model_params = LlamaModelParams::default().with_n_gpu_layers(layers);
+            let model_params = pin!(model_params);
+            LlamaModel::load_from_file(&self.backend, model_path.clone(), &model_params)
+                .with_context(|| format!("unable to load model at {:?}", model_path))
+        })?;
 
-        let model = LlamaModel::load_from_file(&self.backend, model_path.clone(), &model_params)
-            .with_context(|| format!("unable to load model at {:?}", model_path))?;
+        let backend_label = gpu_backend_label(used_gpu_layers, total_model_layers);
+        eprintln!(
+            "Built-in AI backend: {} ({} GPU layers)",
+            backend_label, used_gpu_layers
+        );
 
         self.model = Some(model);
         self.model_path = Some(model_path);
@@ -628,12 +681,7 @@ fn main() -> Result<()> {
                         }
 
                         // Generate response with sampling parameters
-                        match state.generate(
-                            prompt,
-                            max_tokens,
-                            sampling,
-                            stop_tokens,
-                        ) {
+                        match state.generate(prompt, max_tokens, sampling, stop_tokens) {
                             Ok(text) => {
                                 send_response(&Response::Response { text, error: None })?;
                             }
@@ -678,8 +726,64 @@ mod tests {
     use super::*;
 
     #[test]
+    fn gpu_layer_policy_uses_cpu_when_no_vram_is_detected() {
+        assert_eq!(calculate_gpu_layers_for_size(2.6, 33, 0.0, 4096), 0);
+    }
+
+    #[test]
+    fn gpu_layer_policy_partially_offloads_when_vram_is_constrained() {
+        let layers = calculate_gpu_layers_for_size(2.6, 33, 2.0, 4096);
+        assert!(layers > 0);
+        assert!(layers < 33);
+    }
+
+    #[test]
+    fn gpu_layer_policy_fully_offloads_when_vram_is_sufficient() {
+        assert_eq!(calculate_gpu_layers_for_size(2.6, 33, 8.0, 4096), 33);
+    }
+
+    #[test]
+    fn backend_label_uses_total_model_layers_instead_of_arbitrary_threshold() {
+        assert_eq!(gpu_backend_label(0, 24), "CPU fallback");
+        assert_eq!(gpu_backend_label(20, 24), "CUDA partial offload");
+        assert_eq!(gpu_backend_label(24, 24), "CUDA full offload");
+        assert_eq!(gpu_backend_label(28, 33), "CUDA partial offload");
+        assert_eq!(gpu_backend_label(33, 33), "CUDA full offload");
+    }
+
+    #[test]
+    fn model_load_retries_once_on_cpu_after_gpu_failure() {
+        let mut attempted_layers = Vec::new();
+        let (model, used_layers) = load_with_cpu_fallback(20, |layers| {
+            attempted_layers.push(layers);
+            if layers > 0 {
+                anyhow::bail!("simulated CUDA load failure");
+            }
+            Ok("cpu model")
+        })
+        .unwrap();
+
+        assert_eq!(model, "cpu model");
+        assert_eq!(used_layers, 0);
+        assert_eq!(attempted_layers, vec![20, 0]);
+    }
+
+    #[test]
+    fn cpu_model_load_is_not_retried() {
+        let mut attempts = 0;
+        let result: Result<(&str, u32)> = load_with_cpu_fallback(0, |_| {
+            attempts += 1;
+            anyhow::bail!("CPU load failure")
+        });
+
+        assert!(result.is_err());
+        assert_eq!(attempts, 1);
+    }
+
+    #[test]
     fn generate_request_defaults_penalties_when_omitted() {
-        let json = r#"{"type":"generate","prompt":"summarize","temperature":0.5,"top_k":20,"top_p":0.8}"#;
+        let json =
+            r#"{"type":"generate","prompt":"summarize","temperature":0.5,"top_k":20,"top_p":0.8}"#;
         let request: Request = serde_json::from_str(json).unwrap();
         let Request::Generate {
             temperature,
@@ -690,7 +794,8 @@ mod tests {
             repeat_penalty,
             penalty_last_n,
             ..
-        } = request else {
+        } = request
+        else {
             panic!("expected generate request");
         };
 
@@ -724,7 +829,8 @@ mod tests {
             repeat_penalty,
             penalty_last_n,
             ..
-        } = request else {
+        } = request
+        else {
             panic!("expected generate request");
         };
 


### PR DESCRIPTION
  ## Description

  Extends Meetily's existing CUDA support to Parakeet and provides a reproducible
  local Windows CUDA build.

  Before this change, the Tauri application's `cuda` feature enabled CUDA for
  Whisper through `whisper-rs`. Parakeet explicitly registered only ONNX
  Runtime's CPU execution provider. The separate `llama-helper` package already
  had a CUDA feature, but it had to be built and staged independently.

  This PR:

  - maps the application `cuda` feature to both `whisper-rs/cuda` and `ort/cuda`;
  - configures Parakeet to prefer ONNX Runtime's CUDA execution provider while
    retaining CPU fallback;
  - adds tests for Parakeet execution-provider selection;
  - adds `frontend/build-cuda.ps1` to build and package the CUDA-enabled Tauri
    application and `llama-helper` together;
  - calculates full or partial `llama-helper` GPU offload from available VRAM;
  - falls back to CPU when NVIDIA VRAM cannot be detected;
  - retries Qwen/GGUF model loading once on CPU if CUDA loading fails;
  - reports CPU, partial CUDA, and full CUDA offload without relying on a
    model-specific layer constant;
  - skips Windows code signing and updater signatures for ordinary local builds;
  - supports `-Signed` for maintainers using the repository's existing DigiCert
    and Tauri updater-signing configuration;
  - documents which engines are accelerated by CUDA and Vulkan.

  The existing Vulkan build path remains unchanged. On Windows, it accelerates
  Whisper, while Parakeet and the CPU-built `llama-helper` remain on CPU.

  No CUDA GitHub Actions workflow is added. GitHub-hosted Windows runners do not
  provide NVIDIA GPU hardware and do not contain this build's required CUDA and
  Visual Studio integration, so they cannot meaningfully validate CUDA execution.

  ## Related Issue

  Addresses #456.

  This PR provides a reproducible CUDA-enabled source build and improves CUDA
  coverage. It does not add a runtime GPU toggle or publish an official prebuilt
  CUDA installer, so additional work may remain before closing the issue.

  ## Type of Change

  - [x] Bug fix
  - [x] New feature
  - [x] Documentation update
  - [x] Performance improvement
  - [ ] Code refactoring
  - [ ] Other

  ## Testing

  - [x] Unit tests added/updated
  - [x] Manual testing performed
  - [x] All tests pass

  Test results:

  - Meetily unit tests: 189 passed, 2 ignored
  - Meetily documentation tests: 1 passed
  - Test failures: 0
  - `llama-helper` tests: 8 passed
  - Parakeet CUDA execution-provider configuration test passed
  - PowerShell script syntax and signing-mode checks passed
  - CUDA-enabled Windows release build completed successfully
  - MSI and NSIS installers were generated under `target/release/bundle`

  The installer build was tested without repository signing credentials. Local
  builds now pass Tauri's `--no-sign` option and disable updater artifacts.

  ## Documentation

  - [x] Documentation updated
  - [ ] No documentation needed

  Updated documentation covers:

  - Windows CUDA prerequisites and local build command;
  - CUDA versus Vulkan engine support;
  - Parakeet's CUDA and CPU fallback behavior;
  - unsigned contributor builds and maintainer signed builds;
  - why CUDA validation remains local instead of using hosted CI.

  ## Checklist

  - [x] Code follows the existing project style
  - [x] Self-reviewed the code
  - [x] Added comments for non-obvious behavior
  - [x] Updated README and build documentation
  - [x] Existing Vulkan support remains available
  - [x] No dedicated CUDA GitHub Actions runner is introduced