### PR TITLE
fix(audio): reduce live transcription fragmentation

### DIFF
--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -351,7 +351,7 @@ impl AudioCapture {
                 Ok(resampler) => {
                     info!("✅ Persistent resampler initialized for '{}' ({}Hz → {}Hz, chunk_size={})",
                           device.name, sample_rate, TARGET_SAMPLE_RATE, RESAMPLER_CHUNK_SIZE);
-                    info!("   Buffering enabled for variable chunk sizes (e.g., 320, 512, 1024, etc.)");
+                    info!("   Buffering enabled for variable-size chunks (e.g., 320, 512, 1024, etc.)");
                     Some(resampler)
                 }
                 Err(e) => {

--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -351,7 +351,7 @@ impl AudioCapture {
                 Ok(resampler) => {
                     info!("✅ Persistent resampler initialized for '{}' ({}Hz → {}Hz, chunk_size={})",
                           device.name, sample_rate, TARGET_SAMPLE_RATE, RESAMPLER_CHUNK_SIZE);
-                    info!("   Buffering enabled for variable-size chunks (e.g., 320, 512, 1024, etc.)");
+                    info!("   Buffering enabled for variable chunk sizes (e.g., 320, 512, 1024, etc.)");
                     Some(resampler)
                 }
                 Err(e) => {
@@ -719,12 +719,9 @@ impl AudioPipeline {
         // For now, we log it for monitoring and potential optimization
         let _ = (mic_device_name, mic_device_kind, system_device_name, system_device_kind);
 
-        // Create VAD processor with balanced redemption time for speech accumulation
-        // The VAD processor now handles 48kHz->16kHz resampling internally
-        // This bridges natural pauses without excessive fragmentation
-        // For mac os core audio, 900ms, for windows 400ms seems good
-
-        let redemption_time = if cfg!(target_os = "macos") { 400 } else { 400 };
+        // Match the continuous-speech VAD tuning in vad.rs so natural pauses do not
+        // split one-shot transcription into short, context-poor segments.
+        let redemption_time = 2_000;
 
         let vad_processor = match ContinuousVadProcessor::new(sample_rate, redemption_time) {
             Ok(processor) => {


### PR DESCRIPTION
## Description

The live pipeline was still using a 400ms VAD redemption time:

`let redemption_time = if cfg!(target_os = "macos") { 400 } else { 400 };`

That can split speech at normal pauses and send Parakeet short chunks with very little context.

`vad.rs` already documents this problem and has a test comparing 400ms vs 2000ms. This PR changes the live pipeline to use 2000ms as well.

I found this after comparing Meetily's live Parakeet transcript with Parakeet run directly on Meetily's saved recording. The saved audio transcribed much better, while the live transcript was broken into short fragments.

## Related Issue

Related: #171, #604, #657, #578

I couldn't find an existing issue for this exact 400ms VAD setting.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass

There is already a `test_vad_400ms_vs_2000ms_segmentation()` test in `vad.rs`.

## Documentation

- [ ] Documentation updated
- [x] No documentation needed

## Checklist

- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)

N/A

## Additional Notes

This only changes the live VAD redemption time from 400ms to 2000ms.