### PR TITLE
Level quiet remote speakers before VAD sees them

### DIFF
--- a/frontend/src-tauri/src/audio/mod.rs
+++ b/frontend/src-tauri/src/audio/mod.rs
@@ -4,6 +4,7 @@ pub mod decoder;
 pub mod encode;
 pub mod ffmpeg;
 pub mod vad;
+pub mod speech_normalizer;  // Levels quiet remote speakers before VAD sees them
 
 // Modularized device management
 pub mod devices;

--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -12,6 +12,7 @@ use super::devices::AudioDevice;
 use super::recording_state::{AudioChunk, AudioError, RecordingState, DeviceType};
 use super::audio_processing::{audio_to_mono, LoudnessNormalizer, NoiseSuppressionProcessor, HighPassFilter};
 use super::vad::{ContinuousVadProcessor};
+use super::speech_normalizer::SpeechNormalizer;
 
 /// Ring buffer for synchronized audio mixing
 /// Accumulates samples from mic and system streams until we have aligned windows
@@ -692,6 +693,9 @@ pub struct AudioPipeline {
     // PROFESSIONAL AUDIO MIXING: Ring buffer + RMS-based mixer
     ring_buffer: AudioMixerRingBuffer,
     mixer: ProfessionalAudioMixer,
+    // Lifts quiet remote speakers on the way to VAD/Whisper. Transcription path only -
+    // the recording written to disk stays untouched.
+    normalizer: SpeechNormalizer,
     // Recording sender for pre-mixed audio
     recording_sender_for_mixed: Option<mpsc::UnboundedSender<AudioChunk>>,
 }
@@ -759,6 +763,7 @@ impl AudioPipeline {
             // Initialize professional audio mixing
             ring_buffer,
             mixer,
+            normalizer: SpeechNormalizer::new(),
             recording_sender_for_mixed: None,  // Will be set by manager
         }
     }
@@ -825,14 +830,16 @@ impl AudioPipeline {
                             // Simple mixing without aggressive ducking
                             let mixed_clean = self.mixer.mix_window(&mic_window, &sys_window);
 
-                            // NO POST-GAIN NEEDED: Microphone already normalized by EBU R128 to -23 LUFS
-                            // This is broadcast-standard loudness (Netflix/YouTube/Spotify level)
-                            // System audio at natural levels
-                            // Previous 2x gain was causing excessive limiting/distortion
-                            let mixed_with_gain = mixed_clean;
+                            // The mic is normalized to -23 LUFS at capture, but the far side of a
+                            // call is not: a phone on speaker or someone across the room lands
+                            // 15-20 dB lower in the mixed stream, quiet enough for the VAD to drop
+                            // it as background. Level that up before VAD sees it, otherwise those
+                            // words never reach Whisper and one side of the conversation is simply
+                            // missing from the transcript.
+                            let for_transcription = self.normalizer.process(&mixed_clean);
 
                             // STEP 3: Send mixed audio for transcription (VAD + Whisper)
-                            match self.vad_processor.process_audio(&mixed_with_gain) {
+                            match self.vad_processor.process_audio(&for_transcription) {
                                 Ok(speech_segments) => {
                                     for segment in speech_segments {
                                         let duration_ms = segment.end_timestamp_ms - segment.start_timestamp_ms;
@@ -866,9 +873,11 @@ impl AudioPipeline {
                             }
 
                             // STEP 4: Send mixed audio for recording (WAV file)
+                            // Deliberately the un-levelled mix: the saved file should stay a
+                            // faithful copy of what the microphones picked up.
                             if let Some(ref sender) = self.recording_sender_for_mixed {
                                 let recording_chunk = AudioChunk {
-                                    data: mixed_with_gain.clone(),
+                                    data: mixed_clean.clone(),
                                     sample_rate: self.sample_rate,
                                     timestamp: chunk.timestamp,
                                     chunk_id: self.chunk_id_counter,

--- a/frontend/src-tauri/src/audio/speech_normalizer.rs
+++ b/frontend/src-tauri/src/audio/speech_normalizer.rs
@@ -1,0 +1,197 @@
+//! Levels out loud and quiet talkers before the audio reaches VAD and Whisper.
+//!
+//! Mic and system audio are summed into one mono stream. When both sides are close to their
+//! microphones that works fine. It breaks down when one side is far away - a phone on speaker
+//! next to the laptop, someone at the other end of a meeting room, a headset held in hand.
+//! That side can end up 15-20 dB below the local speaker in the mixed signal, which is quiet
+//! enough for the VAD to treat it as background and drop it. The words never reach Whisper,
+//! and the transcript silently loses one side of the conversation.
+//!
+//! Measured on a real recording where the remote side came in over a phone speaker: the local
+//! speaker sat around -21 dBFS at the 90th percentile while quiet passages ran near -40 dBFS,
+//! an 18 dB spread inside a single mono file. Re-running the same audio through the same model
+//! after levelling recovered 18 % more words, including whole sentences from the remote side
+//! that the live transcript had dropped entirely.
+//!
+//! This is a slow automatic gain control, not a compressor. It tracks the speech level over a
+//! window of about a second and a half and applies one smoothed gain to the whole window, so
+//! quiet speech is lifted without the pumping that fast per-sample compression causes. Three
+//! properties keep it from making things worse:
+//!
+//! - It only ever amplifies. Loud speech is left exactly as it is.
+//! - Below `NOISE_FLOOR` nothing happens, so room tone and fan noise are not lifted into the
+//!   range where Whisper starts inventing words.
+//! - Gain changes are smoothed and capped, and the output passes through a soft limiter.
+//!
+//! Only the transcription path uses this. The recording written to disk stays untouched, so the
+//! saved audio remains a faithful copy of what the microphones picked up.
+
+/// Target speech level. Slightly below the -18 dBFS that whisper.cpp's own examples assume,
+/// leaving headroom for the peaks that sit above the RMS of natural speech.
+const TARGET_RMS: f32 = 0.1; // -20 dBFS
+
+/// Below this level the input is treated as silence or room tone and left alone. -55 dBFS sits
+/// under any speech that is still intelligible but above a typical noise floor.
+const NOISE_FLOOR: f32 = 0.0018;
+
+/// Never amplify by more than this. 18 dB covers the measured 18 dB spread; going further mostly
+/// raises noise in the gaps.
+const MAX_GAIN: f32 = 8.0;
+
+/// How much of the new gain estimate is taken per window when the signal gets louder. Small value
+/// means slow reaction, which is what avoids audible pumping.
+const ATTACK: f32 = 0.15;
+
+/// Same when the signal gets quieter. Slower than attack so short pauses inside a sentence do not
+/// ramp the gain up.
+const RELEASE: f32 = 0.05;
+
+/// Level at which the soft limiter starts bending the curve.
+const LIMIT_THRESHOLD: f32 = 0.95;
+
+/// Slow automatic gain control for the mixed signal on its way to VAD and Whisper.
+pub struct SpeechNormalizer {
+    /// Smoothed gain carried across windows so the level does not jump at window boundaries.
+    gain: f32,
+}
+
+impl SpeechNormalizer {
+    pub fn new() -> Self {
+        Self { gain: 1.0 }
+    }
+
+    /// Returns the window with quiet speech lifted towards `TARGET_RMS`.
+    ///
+    /// Windows that are empty, or quieter than `NOISE_FLOOR`, come back unchanged apart from the
+    /// gain already in flight from previous windows.
+    pub fn process(&mut self, samples: &[f32]) -> Vec<f32> {
+        if samples.is_empty() {
+            return Vec::new();
+        }
+
+        let rms = rms_of(samples);
+
+        // Only chase a new target when there is something that could be speech. In the gaps the
+        // gain is held rather than reset, so a short pause does not cause a jump on the next word.
+        if rms > NOISE_FLOOR {
+            let wanted = (TARGET_RMS / rms).clamp(1.0, MAX_GAIN);
+            let rate = if wanted > self.gain { ATTACK } else { RELEASE };
+            self.gain += (wanted - self.gain) * rate;
+        }
+
+        if (self.gain - 1.0).abs() < f32::EPSILON {
+            return samples.to_vec();
+        }
+
+        samples.iter().map(|&s| soft_limit(s * self.gain)).collect()
+    }
+}
+
+impl Default for SpeechNormalizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn rms_of(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let sum: f32 = samples.iter().map(|&s| s * s).sum();
+    (sum / samples.len() as f32).sqrt()
+}
+
+/// Keeps peaks inside ±1.0 without the hard edge that clipping puts into the spectrum.
+/// Everything below the threshold passes through untouched.
+fn soft_limit(sample: f32) -> f32 {
+    let magnitude = sample.abs();
+    if magnitude <= LIMIT_THRESHOLD {
+        return sample;
+    }
+    let excess = magnitude - LIMIT_THRESHOLD;
+    let headroom = 1.0 - LIMIT_THRESHOLD;
+    let limited = LIMIT_THRESHOLD + headroom * (excess / (excess + headroom));
+    limited * sample.signum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A sine wave at the given amplitude, long enough to look like one mixing window.
+    fn tone(amplitude: f32, samples: usize) -> Vec<f32> {
+        (0..samples)
+            .map(|i| amplitude * (i as f32 * 0.1).sin())
+            .collect()
+    }
+
+    #[test]
+    fn quiet_speech_is_lifted_towards_the_target() {
+        let mut n = SpeechNormalizer::new();
+        let quiet = tone(0.02, 2400); // roughly -37 dBFS, the level that gets dropped today
+
+        // Feed several windows so the smoothed gain has time to settle, as it would in a call.
+        let mut out = Vec::new();
+        for _ in 0..60 {
+            out = n.process(&quiet);
+        }
+
+        assert!(
+            rms_of(&out) > rms_of(&quiet) * 3.0,
+            "quiet speech should end up clearly louder, got {} from {}",
+            rms_of(&out),
+            rms_of(&quiet)
+        );
+    }
+
+    #[test]
+    fn loud_speech_is_left_alone() {
+        let mut n = SpeechNormalizer::new();
+        let loud = tone(0.5, 2400);
+        let out = n.process(&loud);
+        assert_eq!(out, loud, "speech already above the target must not be touched");
+    }
+
+    #[test]
+    fn room_tone_is_not_amplified() {
+        let mut n = SpeechNormalizer::new();
+        let noise = tone(0.0005, 2400); // below NOISE_FLOOR
+
+        for _ in 0..60 {
+            n.process(&noise);
+        }
+
+        assert_eq!(n.gain, 1.0, "silence must not raise the gain and lift the noise floor");
+    }
+
+    #[test]
+    fn output_stays_inside_range() {
+        let mut n = SpeechNormalizer::new();
+        // Quiet enough to ask for full gain, with peaks that would overshoot once applied.
+        let spiky: Vec<f32> = (0..2400)
+            .map(|i| if i % 100 == 0 { 0.4 } else { 0.01 })
+            .collect();
+
+        for _ in 0..60 {
+            for &s in n.process(&spiky).iter() {
+                assert!(s.abs() <= 1.0, "sample {} escaped the limiter", s);
+            }
+        }
+    }
+
+    #[test]
+    fn gain_never_drops_below_unity() {
+        let mut n = SpeechNormalizer::new();
+        // Far above the target: the normalizer must not turn into a downward compressor.
+        for _ in 0..60 {
+            n.process(&tone(0.9, 2400));
+        }
+        assert!(n.gain >= 1.0, "gain fell to {}, this stage only amplifies", n.gain);
+    }
+
+    #[test]
+    fn empty_input_is_handled() {
+        let mut n = SpeechNormalizer::new();
+        assert!(n.process(&[]).is_empty());
+    }
+}


### PR DESCRIPTION
## What this fixes

When one side of a call is far from its microphone, that side goes missing from the transcript.

I record a lot of calls where the other person is on a phone sitting on speaker next to my Mac. In the mixed mono stream my own voice (close-talking USB mic, normalized to -23 LUFS at capture) ends up roughly 18 dB above them. That is quiet enough for the VAD to treat their speech as background and drop it, so those words never reach Whisper. The recording sounds fine when you play it back. The transcript just quietly has one side of the conversation missing.

## Numbers from my own recordings

I measured this on 46 recordings I made with Meetily since June. Average per-segment confidence is 0.70, with 30 to 50 % of segments below 0.6.

On one call (3:47, remote side on a phone speaker) I measured the mixed file directly:

- no clipping, 18 of 3.6M samples at full scale, so the mic is fine
- integrated loudness -23.6 LUFS, which is also fine
- but speech RMS runs from -39.9 dBFS (p10) to -21.6 dBFS (p90), an **18.3 dB spread inside one mono file**

Re-running that same file through the same model after levelling the audio recovered **18 % more words** (321 to 379). The extra text is not padding. It is whole sentences from the remote side that the live transcript had dropped, including a stretch where they explain something at length and the live version kept only my own short replies. Individual words also stop being mangled: one place where the live transcript invented a non-word, the levelled run has the ordinary term that was actually said.

As a control I did the same on a 41 minute Zoom call, where the far side arrives digitally through the system audio tap and is already at a sane level: 781 words live vs 758 after levelling, so no meaningful difference. This only helps the case it is meant to help.

## The change

`AudioPipeline` gains a slow AGC that runs on the mixed signal **on its way to VAD and Whisper only**. The recording written to disk is untouched, so the saved file stays a faithful copy of what the microphones picked up.

It is deliberately conservative:

- only amplifies, never attenuates, so speech already at a good level is passed through byte for byte
- does nothing below -55 dBFS, so room tone and fan noise are not lifted into the range where Whisper starts inventing words
- gain is capped at +18 dB and smoothed across windows (slow attack, slower release) so it does not pump
- output goes through a soft limiter instead of hard clipping

New file `audio/speech_normalizer.rs` with 6 unit tests covering quiet speech getting lifted, loud speech being left alone, noise not being amplified, output staying in range, gain never dropping below unity, and empty input.

## While reading the code

Two spots where the comment and the code disagree. I have not touched either, happy to open separate PRs if you want them fixed:

- `pipeline.rs:165-169` says "pre-scale system audio to 70 % to leave headroom" but the code is `let sys_scaled = sys * 1.0;`, and `let _mic_scaled = mic * 0.8;` on the next line is never used. The scaling the comment describes is effectively off.
- `vad.rs:309-312` says "New values (0.03/0.08) are more balanced, catch quiet speech" but the code checks `if rms < 0.2 || peak < 0.20`. That is 2.5x to 6x stricter than documented. It only applies to sub-100ms segments, but quiet speech is exactly the case it catches.

## Testing

`cargo test --lib speech_normalizer` passes on macOS 26.2 (Apple M4) with the default metal and coreml features.

The recording path is unchanged by construction rather than by measurement: `mixed_with_gain` was a plain rebinding of `mixed_clean`, so STEP 4 now passes the same values it always did. Only STEP 3 sees the levelled copy.

The word counts above come from re-running saved recordings offline through whisper.cpp with the same model, not from the patched app, since that isolates the audio change from everything else in the pipeline. Happy to run whatever else you want checked before this goes in.
