### PR TITLE
fix(audio): resolve real PulseAudio/PipeWire monitor sources for Linux system audio capture

### DIFF
--- a/frontend/src-tauri/src/audio/capture/mod.rs
+++ b/frontend/src-tauri/src/audio/capture/mod.rs
@@ -7,6 +7,9 @@ pub mod backend_config;
 #[cfg(target_os = "macos")]
 pub mod core_audio;
 
+#[cfg(target_os = "linux")]
+pub mod pulse;
+
 // Re-export capture functionality
 pub use system::{
     SystemAudioCapture, SystemAudioStream,
@@ -16,6 +19,9 @@ pub use system::{
 
 #[cfg(target_os = "macos")]
 pub use core_audio::{CoreAudioCapture, CoreAudioStream};
+
+#[cfg(target_os = "linux")]
+pub use pulse::PulseMonitorSource;
 
 // Re-export backend configuration
 pub use backend_config::{

--- a/frontend/src-tauri/src/audio/capture/pulse.rs
+++ b/frontend/src-tauri/src/audio/capture/pulse.rs
@@ -1,0 +1,226 @@
+// PulseAudio/PipeWire system-audio (loopback) capture for Linux.
+//
+// cpal's ALSA backend cannot enumerate or open PulseAudio/PipeWire "monitor"
+// sources: ALSA's `snd_device_name_hint` only reports genuine ALSA PCM
+// devices, and PulseAudio/PipeWire never register per-sink monitors as ALSA
+// hardware devices (confirmed: `arecord -L` never lists them). WASAPI
+// (Windows) and Core Audio (macOS) both support native loopback capture
+// through cpal/cidre; ALSA has no equivalent, so system audio devices
+// selected via cpal on Linux (mistakenly labelled as monitors, or as the
+// raw default *playback* device) always fail to open as an input stream and
+// recording silently falls back to microphone-only.
+//
+// Monitor sources are only visible through PulseAudio's own client
+// protocol. Rather than linking libpulse directly (the `-devel`/`-dev`
+// headers are frequently missing on end-user systems), this module shells
+// out to `pactl`/`parec`, which ship in `pulseaudio-utils` and are also
+// provided by PipeWire's `pipewire-pulse` compatibility layer -- i.e.
+// present on essentially every modern Linux desktop.
+
+use anyhow::{anyhow, Result};
+use std::process::{Child, Command, Stdio};
+
+/// A PulseAudio/PipeWire source that monitors a sink's output, i.e. usable
+/// for system-audio/loopback capture.
+#[derive(Debug, Clone)]
+pub struct PulseMonitorSource {
+    /// Technical PulseAudio source name, e.g. "alsa_output.pci-....monitor"
+    pub name: String,
+    /// Human-readable description, e.g. "Monitor of Built-in Audio Speaker"
+    pub description: String,
+    /// Name of the sink this source monitors.
+    pub monitor_of_sink: String,
+}
+
+/// List every PulseAudio/PipeWire source that monitors a sink (i.e. every
+/// source usable for system-audio capture). Requires `pactl`.
+pub fn list_monitor_sources() -> Result<Vec<PulseMonitorSource>> {
+    let output = Command::new("pactl")
+        .args(["list", "sources"])
+        .output()
+        .map_err(|e| {
+            anyhow!(
+                "Failed to run `pactl` ({e}); install `pulseaudio-utils` (or `pipewire-pulse`) for system audio capture"
+            )
+        })?;
+
+    if !output.status.success() {
+        return Err(anyhow!(
+            "`pactl list sources` exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(parse_source_list(&String::from_utf8_lossy(&output.stdout)))
+}
+
+/// Parse the plain-text output of `pactl list sources` into monitor-only
+/// entries (sources whose `Monitor of Sink:` field is not `n/a`).
+fn parse_source_list(text: &str) -> Vec<PulseMonitorSource> {
+    let mut sources = Vec::new();
+
+    let mut name: Option<String> = None;
+    let mut description: Option<String> = None;
+    let mut monitor_of_sink: Option<String> = None;
+
+    fn take(
+        name: &mut Option<String>,
+        description: &mut Option<String>,
+        monitor_of_sink: &mut Option<String>,
+    ) -> Option<PulseMonitorSource> {
+        let name = name.take()?;
+        let description = description.take()?;
+        let monitor_of_sink = monitor_of_sink.take()?;
+        if monitor_of_sink == "n/a" {
+            return None;
+        }
+        Some(PulseMonitorSource { name, description, monitor_of_sink })
+    }
+
+    for line in text.lines() {
+        if line.starts_with("Source #") {
+            if let Some(source) = take(&mut name, &mut description, &mut monitor_of_sink) {
+                sources.push(source);
+            }
+            continue;
+        }
+
+        let trimmed = line.trim_start();
+        if let Some(v) = trimmed.strip_prefix("Name: ") {
+            name = Some(v.trim().to_string());
+        } else if let Some(v) = trimmed.strip_prefix("Description: ") {
+            description = Some(v.trim().to_string());
+        } else if let Some(v) = trimmed.strip_prefix("Monitor of Sink: ") {
+            monitor_of_sink = Some(v.trim().to_string());
+        }
+    }
+    if let Some(source) = take(&mut name, &mut description, &mut monitor_of_sink) {
+        sources.push(source);
+    }
+
+    sources
+}
+
+/// Resolve a display name (as produced by `list_monitor_sources` and shown
+/// in the device picker) back to the technical PulseAudio source name.
+pub fn resolve_monitor_source_name(display_name: &str) -> Result<String> {
+    let sources = list_monitor_sources()?;
+
+    sources
+        .iter()
+        .find(|s| s.description == display_name)
+        .or_else(|| sources.iter().find(|s| s.name == display_name))
+        .map(|s| s.name.clone())
+        .ok_or_else(|| {
+            anyhow!(
+                "No PulseAudio/PipeWire monitor source matching '{}' (available: {})",
+                display_name,
+                sources.iter().map(|s| s.description.as_str()).collect::<Vec<_>>().join(", ")
+            )
+        })
+}
+
+/// Get the monitor source for the current default playback sink, if any.
+pub fn default_monitor_source() -> Result<PulseMonitorSource> {
+    let sink = default_sink_name()?;
+    let sources = list_monitor_sources()?;
+    sources
+        .into_iter()
+        .find(|s| s.monitor_of_sink == sink)
+        .ok_or_else(|| anyhow!("No monitor source found for default sink '{}'", sink))
+}
+
+fn default_sink_name() -> Result<String> {
+    let output = Command::new("pactl")
+        .arg("get-default-sink")
+        .output()
+        .map_err(|e| anyhow!("Failed to run `pactl get-default-sink`: {e}"))?;
+
+    if !output.status.success() {
+        return Err(anyhow!(
+            "`pactl get-default-sink` exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if name.is_empty() {
+        return Err(anyhow!("`pactl get-default-sink` returned an empty sink name"));
+    }
+    Ok(name)
+}
+
+/// Spawn a `parec` process streaming raw interleaved little-endian f32 PCM
+/// captured from the given monitor source to stdout.
+pub fn spawn_monitor_capture(source_name: &str, sample_rate: u32, channels: u16) -> Result<Child> {
+    let mut child = Command::new("parec")
+        .arg("--raw")
+        .arg(format!("--device={}", source_name))
+        .arg(format!("--rate={}", sample_rate))
+        .arg(format!("--channels={}", channels))
+        .arg("--format=float32le")
+        .arg("--client-name=meetily-system-audio")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| {
+            anyhow!(
+                "Failed to spawn `parec` for system audio capture (is `pulseaudio-utils`/`pipewire-pulse` installed?): {e}"
+            )
+        })?;
+
+    // Drain and log stderr on a background thread: without this, parec can
+    // block writing to a full pipe once its stderr buffer fills, and real
+    // failures (e.g. an invalid source name) would otherwise vanish silently.
+    if let Some(stderr) = child.stderr.take() {
+        std::thread::spawn(move || {
+            use std::io::{BufRead, BufReader};
+            for line in BufReader::new(stderr).lines().flatten() {
+                log::warn!("parec: {}", line);
+            }
+        });
+    }
+
+    Ok(child)
+}
+
+/// Whether the PulseAudio/PipeWire CLI tools needed for system audio capture
+/// are available on this system.
+pub fn is_available() -> bool {
+    Command::new("pactl")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_monitor_and_skips_plain_sources() {
+        let sample = "\
+Source #53
+\tState: SUSPENDED
+\tName: alsa_input.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__Mic2__source
+\tDescription: Meteor Lake-P HD Audio Controller Stereo Microphone
+\tMonitor of Sink: n/a
+
+Source #2520
+\tState: RUNNING
+\tName: alsa_output.usb-Apple__Inc._EarPods_N9FYLVQL6F-00.analog-stereo.monitor
+\tDescription: Monitor of EarPods Analog Stereo
+\tMonitor of Sink: alsa_output.usb-Apple__Inc._EarPods_N9FYLVQL6F-00.analog-stereo
+";
+
+        let sources = parse_source_list(sample);
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].name, "alsa_output.usb-Apple__Inc._EarPods_N9FYLVQL6F-00.analog-stereo.monitor");
+        assert_eq!(sources[0].description, "Monitor of EarPods Analog Stereo");
+        assert_eq!(sources[0].monitor_of_sink, "alsa_output.usb-Apple__Inc._EarPods_N9FYLVQL6F-00.analog-stereo");
+    }
+}

--- a/frontend/src-tauri/src/audio/capture/pulse.rs
+++ b/frontend/src-tauri/src/audio/capture/pulse.rs
@@ -37,6 +37,13 @@ pub struct PulseMonitorSource {
 pub fn list_monitor_sources() -> Result<Vec<PulseMonitorSource>> {
     let output = Command::new("pactl")
         .args(["list", "sources"])
+        // pactl's field labels ("Name:", "Description:", "Monitor of Sink:")
+        // are gettext-translated based on the desktop locale. Force C so the
+        // labels parse_source_list() matches on stay in English regardless
+        // of the user's LANG/LC_ALL -- otherwise this silently returns an
+        // empty Vec on any non-English desktop, reproducing the exact
+        // silent mic-only fallback this module exists to fix.
+        .env("LC_ALL", "C")
         .output()
         .map_err(|e| {
             anyhow!(
@@ -134,6 +141,7 @@ pub fn default_monitor_source() -> Result<PulseMonitorSource> {
 fn default_sink_name() -> Result<String> {
     let output = Command::new("pactl")
         .arg("get-default-sink")
+        .env("LC_ALL", "C")
         .output()
         .map_err(|e| anyhow!("Failed to run `pactl get-default-sink`: {e}"))?;
 
@@ -192,6 +200,7 @@ pub fn spawn_monitor_capture(source_name: &str, sample_rate: u32, channels: u16)
 pub fn is_available() -> bool {
     Command::new("pactl")
         .arg("--version")
+        .env("LC_ALL", "C")
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
@@ -222,5 +231,32 @@ Source #2520
         assert_eq!(sources[0].name, "alsa_output.usb-Apple__Inc._EarPods_N9FYLVQL6F-00.analog-stereo.monitor");
         assert_eq!(sources[0].description, "Monitor of EarPods Analog Stereo");
         assert_eq!(sources[0].monitor_of_sink, "alsa_output.usb-Apple__Inc._EarPods_N9FYLVQL6F-00.analog-stereo");
+    }
+
+    /// Regression test for the locale bug found in Gate B review: pactl's
+    /// field labels are gettext-translated, so without forcing LC_ALL=C on
+    /// the spawned process, list_monitor_sources() would silently return an
+    /// empty Vec on any non-English desktop (reproducing issue #701's
+    /// silent mic-only fallback under a different trigger). This sets the
+    /// *test process's own* environment to German and confirms
+    /// list_monitor_sources() still finds sources -- i.e. that the `.env()`
+    /// override on the Command actually wins over an inherited LANG/LC_ALL,
+    /// not just that it's present in the source.
+    #[test]
+    fn list_monitor_sources_ignores_process_locale() {
+        if !is_available() {
+            eprintln!("pactl not available, skipping live locale test");
+            return;
+        }
+        std::env::set_var("LC_ALL", "de_DE.UTF-8");
+        std::env::set_var("LANG", "de_DE.UTF-8");
+        let result = list_monitor_sources();
+        std::env::remove_var("LC_ALL");
+        std::env::remove_var("LANG");
+        let sources = result.expect("list_monitor_sources should succeed under a non-English process locale");
+        assert!(
+            !sources.is_empty(),
+            "expected at least one monitor source even with the test process's own LANG/LC_ALL set to German"
+        );
     }
 }

--- a/frontend/src-tauri/src/audio/devices/configuration.rs
+++ b/frontend/src-tauri/src/audio/devices/configuration.rs
@@ -154,19 +154,15 @@ pub async fn get_device_and_config(
 
                 #[cfg(target_os = "linux")]
                 {
-                    // For Linux, we use PulseAudio monitor sources for system audio
-                    if let Ok(pulse_host) = cpal::host_from_id(cpal::HostId::Alsa) {
-                        for device in pulse_host.input_devices()? {
-                            if let Ok(name) = device.name() {
-                                if name == audio_device.name {
-                                    let default_config = device
-                                        .default_input_config()
-                                        .map_err(|e| anyhow!("Failed to get default input config: {}", e))?;
-                                    return Ok((device, default_config));
-                                }
-                            }
-                        }
-                    }
+                    // Linux has no cpal loopback backend: system audio is
+                    // captured via PulseAudio/PipeWire monitor sources
+                    // outside cpal entirely (see audio::stream::AudioStream
+                    // and audio::capture::pulse). This function must never
+                    // be reached for a Linux System device.
+                    return Err(anyhow!(
+                        "System audio device '{}' must be resolved via PulseAudio/PipeWire, not cpal",
+                        audio_device.name
+                    ));
                 }
             }
         }

--- a/frontend/src-tauri/src/audio/devices/discovery.rs
+++ b/frontend/src-tauri/src/audio/devices/discovery.rs
@@ -2,7 +2,9 @@ use anyhow::Result;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use log::error;
 
-use super::configuration::{AudioDevice, DeviceType};
+use super::configuration::AudioDevice;
+#[cfg(not(target_os = "linux"))]
+use super::configuration::DeviceType;
 use super::platform;
 
 /// List all available audio devices on the system
@@ -10,6 +12,7 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
     let host = cpal::default_host();
 
     // Platform-specific device enumeration
+    #[cfg_attr(target_os = "linux", allow(unused_mut))]
     let mut devices = {
         #[cfg(target_os = "windows")]
         {
@@ -27,7 +30,11 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
         }
     };
 
-    // Add any additional devices from the default host
+    // Add any additional devices from the default host. Skipped on Linux:
+    // raw ALSA/cpal output devices are playback sinks, not usable for
+    // system-audio capture (only real PulseAudio/PipeWire monitor sources,
+    // already added by configure_linux_audio, are usable there).
+    #[cfg(not(target_os = "linux"))]
     if let Ok(other_devices) = host.devices() {
         for device in other_devices {
             if let Ok(name) = device.name() {

--- a/frontend/src-tauri/src/audio/devices/platform/linux.rs
+++ b/frontend/src-tauri/src/audio/devices/platform/linux.rs
@@ -1,31 +1,36 @@
 use anyhow::Result;
 use cpal::traits::{DeviceTrait, HostTrait};
+use log::warn;
 
+use crate::audio::capture::pulse;
 use crate::audio::devices::configuration::{AudioDevice, DeviceType};
 
-/// Configure Linux audio devices using ALSA/PulseAudio
+/// Configure Linux audio devices.
+///
+/// Microphones are enumerated through cpal's ALSA backend (works
+/// correctly: real capture hardware is exposed as ALSA PCM devices).
+/// System audio has no ALSA equivalent -- PulseAudio/PipeWire monitor
+/// sources are only visible through the PulseAudio client protocol, so
+/// they're listed via `pactl` instead (see `audio::capture::pulse`).
 pub fn configure_linux_audio(host: &cpal::Host) -> Result<Vec<AudioDevice>> {
     let mut devices = Vec::new();
 
-    // Add input devices
+    // Add input devices (microphones)
     for device in host.input_devices()? {
         if let Ok(name) = device.name() {
             devices.push(AudioDevice::new(name, DeviceType::Input));
         }
     }
 
-    // Add PulseAudio monitor sources for system audio
-    if let Ok(pulse_host) = cpal::host_from_id(cpal::HostId::Alsa) {
-        for device in pulse_host.input_devices()? {
-            if let Ok(name) = device.name() {
-                // Check if it's a monitor source
-                if name.contains("monitor") {
-                    devices.push(AudioDevice::new(
-                        format!("{} (System Audio)", name),
-                        DeviceType::Output
-                    ));
-                }
+    // Add PulseAudio/PipeWire monitor sources for system audio capture
+    match pulse::list_monitor_sources() {
+        Ok(sources) => {
+            for source in sources {
+                devices.push(AudioDevice::new(source.description, DeviceType::Output));
             }
+        }
+        Err(e) => {
+            warn!("No system audio monitor sources available: {}", e);
         }
     }
 

--- a/frontend/src-tauri/src/audio/devices/speakers.rs
+++ b/frontend/src-tauri/src/audio/devices/speakers.rs
@@ -4,6 +4,9 @@ use log::{info, warn};
 
 use super::configuration::{AudioDevice, DeviceType};
 
+#[cfg(target_os = "linux")]
+use crate::audio::capture::pulse;
+
 /// Get the default output (speaker/system audio) device for the system
 pub fn default_output_device() -> Result<AudioDevice> {
     #[cfg(target_os = "macos")]
@@ -35,7 +38,17 @@ pub fn default_output_device() -> Result<AudioDevice> {
         return Ok(AudioDevice::new(device.name()?, DeviceType::Output));
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    #[cfg(target_os = "linux")]
+    {
+        // cpal has no ALSA loopback backend; the default system-audio
+        // device is the PulseAudio/PipeWire monitor source for whatever
+        // sink is currently the default playback device.
+        let monitor = pulse::default_monitor_source()
+            .map_err(|e| anyhow!("No system audio monitor source available: {}", e))?;
+        return Ok(AudioDevice::new(monitor.description, DeviceType::Output));
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     {
         let host = cpal::default_host();
         let device = host

--- a/frontend/src-tauri/src/audio/stream.rs
+++ b/frontend/src-tauri/src/audio/stream.rs
@@ -267,7 +267,16 @@ impl AudioStream {
         const CHANNELS: u16 = 2;
 
         info!("🔊 Stream: Resolving PulseAudio/PipeWire monitor source for: {}", device.name);
-        let source_name = pulse::resolve_monitor_source_name(&device.name).map_err(|e| {
+        // resolve_monitor_source_name() shells out to `pactl` synchronously;
+        // run it via spawn_blocking so it can't stall a tokio worker thread,
+        // matching the pattern already used below for the parec reader loop.
+        let device_name_for_resolve = device.name.clone();
+        let source_name = tokio::task::spawn_blocking(move || {
+            pulse::resolve_monitor_source_name(&device_name_for_resolve)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("Monitor source resolution task panicked: {}", e))?
+        .map_err(|e| {
             error!("❌ Stream: Failed to resolve monitor source '{}': {}", device.name, e);
             anyhow::anyhow!("Failed to resolve system audio monitor source '{}': {}", device.name, e)
         })?;

--- a/frontend/src-tauri/src/audio/stream.rs
+++ b/frontend/src-tauri/src/audio/stream.rs
@@ -13,6 +13,9 @@ use super::capture::{AudioCaptureBackend, get_current_backend};
 #[cfg(target_os = "macos")]
 use super::capture::CoreAudioCapture;
 
+#[cfg(target_os = "linux")]
+use super::capture::pulse;
+
 /// Stream backend implementation
 pub enum StreamBackend {
     /// CPAL-based stream (ScreenCaptureKit or default)
@@ -20,6 +23,12 @@ pub enum StreamBackend {
     /// Core Audio direct implementation (macOS only)
     #[cfg(target_os = "macos")]
     CoreAudio {
+        task: Option<tokio::task::JoinHandle<()>>,
+    },
+    /// PulseAudio/PipeWire `parec` subprocess implementation (Linux system audio only)
+    #[cfg(target_os = "linux")]
+    Pulse {
+        child: std::process::Child,
         task: Option<tokio::task::JoinHandle<()>>,
     },
 }
@@ -85,6 +94,15 @@ impl AudioStream {
         if use_core_audio {
             info!("🎵 Stream: Using Core Audio backend (cidre) for system audio");
             return Self::create_core_audio_stream(device, state, device_type, recording_sender).await;
+        }
+
+        // Linux has no cpal loopback backend: system audio must always go
+        // through PulseAudio/PipeWire monitor sources (see audio::capture::pulse),
+        // never CPAL/ALSA.
+        #[cfg(target_os = "linux")]
+        if device_type == DeviceType::System {
+            info!("🎵 Stream: Using PulseAudio/PipeWire monitor capture for system audio");
+            return Self::create_pulse_stream(device, state, device_type, recording_sender).await;
         }
 
         // Default path: use CPAL
@@ -233,6 +251,104 @@ impl AudioStream {
         })
     }
 
+    /// Create a PulseAudio/PipeWire monitor-source stream (Linux system audio only)
+    ///
+    /// cpal's ALSA backend has no loopback capability, so system audio is
+    /// captured by spawning `parec` against the resolved monitor source and
+    /// reading raw interleaved f32le PCM from its stdout.
+    #[cfg(target_os = "linux")]
+    async fn create_pulse_stream(
+        device: Arc<AudioDevice>,
+        state: Arc<RecordingState>,
+        device_type: DeviceType,
+        recording_sender: Option<mpsc::UnboundedSender<super::recording_state::AudioChunk>>,
+    ) -> Result<Self> {
+        const SAMPLE_RATE: u32 = 48000;
+        const CHANNELS: u16 = 2;
+
+        info!("🔊 Stream: Resolving PulseAudio/PipeWire monitor source for: {}", device.name);
+        let source_name = pulse::resolve_monitor_source_name(&device.name).map_err(|e| {
+            error!("❌ Stream: Failed to resolve monitor source '{}': {}", device.name, e);
+            anyhow::anyhow!("Failed to resolve system audio monitor source '{}': {}", device.name, e)
+        })?;
+
+        info!("🔊 Stream: Spawning parec capture for monitor source: {}", source_name);
+        let mut child = pulse::spawn_monitor_capture(&source_name, SAMPLE_RATE, CHANNELS).map_err(|e| {
+            error!("❌ Stream: Failed to spawn parec: {}", e);
+            anyhow::anyhow!("Failed to start system audio capture: {}", e)
+        })?;
+
+        let mut stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to capture stdout from parec process"))?;
+
+        let capture = AudioCapture::new(
+            device.clone(),
+            state.clone(),
+            SAMPLE_RATE,
+            CHANNELS,
+            device_type,
+            recording_sender,
+        );
+
+        let device_name = device.name.clone();
+        info!("🔊 Stream: Spawning blocking task to read parec output...");
+        let task = tokio::task::spawn_blocking(move || {
+            use std::io::Read;
+
+            const FRAMES_PER_CHUNK: usize = 1024;
+            let bytes_per_frame = CHANNELS as usize * 4;
+            let mut raw = vec![0u8; FRAMES_PER_CHUNK * bytes_per_frame];
+            let mut filled = 0usize;
+
+            info!("✅ Stream: PulseAudio capture task started for {}", device_name);
+
+            loop {
+                match stdout.read(&mut raw[filled..]) {
+                    Ok(0) => break, // EOF: parec exited (killed on stop, or crashed)
+                    Ok(n) => {
+                        filled += n;
+                        if filled == raw.len() {
+                            let samples: Vec<f32> = raw
+                                .chunks_exact(4)
+                                .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                                .collect();
+                            capture.process_audio_data(&samples);
+                            filled = 0;
+                        }
+                    }
+                    Err(e) => {
+                        warn!("PulseAudio capture read error for {}: {}", device_name, e);
+                        break;
+                    }
+                }
+            }
+
+            // Process any trailing partial chunk
+            let usable = filled - (filled % 4);
+            if usable > 0 {
+                let samples: Vec<f32> = raw[..usable]
+                    .chunks_exact(4)
+                    .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                    .collect();
+                capture.process_audio_data(&samples);
+            }
+
+            info!("⚠️ Stream: PulseAudio capture task ended for {}", device_name);
+        });
+
+        info!("✅ Stream: PulseAudio stream fully initialized for device: {}", device.name);
+
+        Ok(Self {
+            device,
+            backend: StreamBackend::Pulse {
+                child,
+                task: Some(task),
+            },
+        })
+    }
+
     /// Build stream based on sample format
     fn build_stream(
         device: &Device,
@@ -342,6 +458,23 @@ impl AudioStream {
                     std::thread::sleep(std::time::Duration::from_millis(50));
                     info!("Core Audio task aborted");
                 }
+            }
+            #[cfg(target_os = "linux")]
+            StreamBackend::Pulse { mut child, task } => {
+                // Kill parec first: this makes its stdout pipe hit EOF, which
+                // unblocks the reader thread's blocking read() and lets the
+                // task finish on its own (spawn_blocking tasks can't be
+                // preempted mid-syscall, so abort() alone would not help).
+                info!("Stopping PulseAudio capture (parec)...");
+                if let Err(e) = child.kill() {
+                    warn!("Failed to kill parec process: {}", e);
+                }
+                if let Err(e) = child.wait() {
+                    warn!("Failed to reap parec process: {}", e);
+                }
+                drop(task);
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                info!("PulseAudio capture stopped");
             }
         }
 


### PR DESCRIPTION
## Description

On Linux, cpal has no ALSA loopback backend, so system audio was never actually captured: recording silently fell back to microphone-only, with no error surfaced anywhere.

- `configure_linux_audio()` tried to find PulseAudio/PipeWire monitor sources via `cpal::host_from_id(HostId::Alsa)` -- the same host cpal already defaults to on Linux (there's no separate Pulse `HostId`). ALSA's `snd_device_name_hint` enumeration never exposes monitor sources (confirmed live: `arecord -L` lists none even when `pactl list sources` shows several), so no usable system-audio device was ever offered in the device picker.
- `default_output_device()` (the path used whenever no device is explicitly selected -- the common case) returned a playback sink, not a capture source. `get_device_and_config()` then tried to open it as a cpal input stream and failed. The failure was only logged as a `warn!`, so recording silently continued mic-only.
- The generic "any leftover cpal device -> Output" fallback in `discovery.rs` also made the Settings permission-check's `hasSystemAudio` flag a false positive on Linux, so users got no warning either.

## Related Issue

Fixes #701

## Fix

Adds a Linux-only `audio::capture::pulse` module that shells out to `pactl`/`parec` (from `pulseaudio-utils`, also provided by PipeWire's `pipewire-pulse` compatibility layer -- present on essentially every modern Linux desktop) to enumerate real monitor sources, resolve the default sink's monitor, and stream captured system audio into the existing `AudioCapture` pipeline. This mirrors the existing macOS Core Audio backend split already present in `stream.rs`. Also drops the generic Linux fallback in `discovery.rs` that was producing unusable pseudo-devices.

Two issues caught in an independent code review before merge and fixed:
- `pactl`'s field labels (`Name:`, `Description:`, `Monitor of Sink:`) are gettext-translated per desktop locale; without forcing `LC_ALL=C` the parser silently found nothing on any non-English desktop, reproducing this exact bug under a different trigger. Fixed, with a regression test that sets the test process's own `LANG`/`LC_ALL` to German and confirms sources are still found (verified it actually fails without the fix).
- The `pactl`-based monitor resolution ran synchronously on the tokio runtime instead of via `spawn_blocking`, inconsistent with the pattern already used for the `parec` reader loop in the same function. Fixed.

## Type of Change
- [x] Bug fix

## Testing
- [x] Unit tests added/updated (`frontend/src-tauri/src/audio/capture/pulse.rs`: pactl output parser test + locale-override regression test)
- [x] Manual testing performed
- [x] All tests pass

Verified live end-to-end on a GNOME/PipeWire Linux desktop, not just compiled:
- Enumerated real monitor sources via the new module; resolved the default sink's monitor; round-tripped display name -> technical source name.
- Played a test tone through `paplay` while capturing from the resolved monitor: captured samples showed clear non-silence (max amplitude 0.41, 87% non-zero samples), proving real loopback capture, not silence or mic bleed.
- Built and installed a full release `.deb`, launched the packaged app, started a real recording with no explicit device selection (the common path), and confirmed via `/proc/<pid>/io` on the app's own spawned `parec` child that it sustained ~384 KB/s -- the exact expected rate for 48kHz/2ch/f32 -- for the duration of the recording.
- Confirmed the same install correctly resolves and captures via the packaged binary's own logs (`Using PulseAudio/PipeWire monitor capture for system audio`, `Recording manager started successfully with 2 active streams`).

## Documentation
- [x] No documentation needed (internal implementation fix, no user-facing config/API change)

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [x] Updated README if needed (n/a)
- [x] Branch is up to date with devtest
- [x] No merge conflicts
