### PR TITLE
feat(dictation): live dictation mode via AT-SPI (Linux)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "array-init"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +398,57 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atspi"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf601cccedfffec598ec2db1f9d6745885458bccc0e8916d7023f017c94b3d0"
+dependencies = [
+ "atspi-common",
+ "atspi-connection",
+ "atspi-proxies",
+ "zbus",
+]
+
+[[package]]
+name = "atspi-common"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a79bed3f5b408ce3152f36e07327a845e6ed5d7e2821a89264037dbcc11daf"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus",
+ "zbus-lockstep",
+ "zbus-lockstep-macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "atspi-connection"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fab8e4f574f5a7d3af280b38eff25fb6f47a537dac9ae39ce152f52b19fb10b"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+ "futures-lite",
+ "zbus",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53403acd3ab2fdb5914f6558da22e540fc07656fce5510f8c02be0e6ef68413e"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus",
+]
 
 [[package]]
 name = "atty"
@@ -636,6 +708,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,7 +838,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -939,6 +1017,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "cmake"
@@ -1740,6 +1827,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1941,6 +2034,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
+
+[[package]]
 name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,6 +2091,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -2058,6 +2163,12 @@ checksum = "f9f9e65c593dd01ac77daad909ea4ad17f0d6d1776193fc8ea766356177abdad"
 dependencies = [
  "glob",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -2394,6 +2505,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,6 +2636,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c386b0a4a70cb2d39fffd74480f985b6f0bfbcb934b6a6b6b7e630e448f242e"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -3059,6 +3198,20 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -3615,6 +3768,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "atspi",
  "bytemuck",
  "bytes",
  "chrono",
@@ -3643,6 +3797,7 @@ dependencies = [
  "objc",
  "once_cell",
  "ort",
+ "parking_lot",
  "posthog-rs",
  "rand 0.8.6",
  "rayon",
@@ -3661,8 +3816,10 @@ dependencies = [
  "tar",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-process",
@@ -3757,6 +3914,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -3895,6 +4062,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4062,6 +4238,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -4376,6 +4553,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4482,6 +4669,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -4829,6 +5027,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4842,6 +5052,15 @@ name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -6203,6 +6422,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6461,6 +6686,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6746,6 +6982,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6785,6 +7036,21 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9f4c5136c09cd962da0c86dc4accd4666db2ea591cf16e6597435843bd2b"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7099,6 +7365,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -7505,6 +7785,17 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
 ]
 
 [[package]]
@@ -7943,6 +8234,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "smallvec 1.15.1",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.41.0",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8067,6 +8428,12 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whatlang"
@@ -8851,6 +9218,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8931,6 +9316,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8939,6 +9341,12 @@ dependencies = [
  "libc",
  "rustix 1.1.4",
 ]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xz2"
@@ -8997,6 +9405,7 @@ dependencies = [
  "rustix 1.1.4",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",
@@ -9004,6 +9413,30 @@ dependencies = [
  "winnow 1.0.3",
  "zbus_macros",
  "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
+dependencies = [
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep-macros"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus-lockstep",
+ "zbus_xml",
  "zvariant",
 ]
 
@@ -9019,18 +9452,39 @@ dependencies = [
  "syn 2.0.117",
  "zbus_names",
  "zvariant",
- "zvariant_utils",
+ "zvariant_utils 3.3.1",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "4.3.2"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
  "winnow 1.0.3",
  "zvariant",
+]
+
+[[package]]
+name = "zbus_xml"
+version = "5.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1586c021a01ca0a9216dcd874e546382e156a5cbab5fab6cb5f10087e22682a"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -9224,30 +9678,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "zvariant"
-version = "5.11.0"
+name = "zune-core"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "winnow 1.0.3",
+ "zcheapstr",
  "zvariant_derive",
- "zvariant_utils",
+ "zvariant_utils 4.2.0",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.11.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "zvariant_utils",
+ "syn 3.0.3",
+ "zvariant_utils 4.2.0",
 ]
 
 [[package]]
@@ -9260,5 +9730,18 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.3",
  "winnow 1.0.3",
 ]

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -128,6 +128,7 @@ url = "2.5.0"
 sysinfo = "0.32"
 
 lazy_static = { version = "1.4.0" }
+parking_lot = "0.12"
 realfft = "3.4.0"
 regex = "1.11.0"
 ndarray = "0.16"
@@ -154,6 +155,8 @@ tauri-plugin-store = "2.4.0"
 tauri-plugin-notification = "2.3.1"
 tauri-plugin-updater = "2.3.0"
 tauri-plugin-process = "2.3.0"
+tauri-plugin-global-shortcut = "2.3.2"
+tauri-plugin-clipboard-manager = "2.3.2"
 
 # Desktop-only single instance guard
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
@@ -197,6 +200,10 @@ futures-channel = "0.3.31"
 [target.'cfg(target_os = "linux")'.dependencies]
 whisper-rs = { version = "0.13.2", features = ["raw-api"] }
 futures-channel = "0.3.31"
+
+# Live dictation (issue #719): AT-SPI2 accessibility bus for direct text injection into the
+# OS-focused text field. Linux-only; other platforms fall back to UnsupportedPlatform.
+atspi = { version = "0.30.0", features = ["tokio", "zbus"] }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -9,7 +9,7 @@ use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use tauri::{AppHandle, Emitter, Runtime};
+use tauri::{AppHandle, Emitter, Manager, Runtime};
 
 // Sequence counter for transcript updates
 static SEQUENCE_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -225,6 +225,18 @@ pub fn start_transcription_task<R: Runtime>(
                                                 "Worker {}: Failed to emit transcript update: {}",
                                                 worker_id, e
                                             );
+                                        }
+
+                                        // Live dictation (issue #719): hand the finished segment to
+                                        // the dictation queue via a non-blocking push, never inline.
+                                        // NOTE: no `is_partial` filter here -- `is_partial` (set in
+                                        // whisper_engine.rs) reflects chunk *duration*, not whether a
+                                        // corrected re-emission is coming; each chunk is transcribed
+                                        // exactly once, so every segment reaching this point is final.
+                                        if let Some(bridge) = app_clone.try_state::<crate::dictation::DictationBridgeState>() {
+                                            if bridge.active.load(Ordering::Relaxed) {
+                                                bridge.queue.push(update.text.clone());
+                                            }
                                         }
                                         // PERFORMANCE: Removed verbose logging of every emission
                                     } else if !transcript.trim().is_empty() && should_log_this_chunk

--- a/frontend/src-tauri/src/dictation/atspi_injector.rs
+++ b/frontend/src-tauri/src/dictation/atspi_injector.rs
@@ -1,0 +1,196 @@
+// dictation/atspi_injector.rs (Linux only)
+//
+// Owns the AT-SPI2 accessibility-bus connection used to inject transcribed
+// text into whichever text field currently has OS focus.
+//
+// API surface verified against docs.rs for `atspi 0.30.0` / `atspi-proxies
+// 0.14.0` (the version pinned in Cargo.toml) before writing this file:
+//   - `atspi::AccessibilityConnection::new()` / `.event_stream()` / `.register_event::<T>()`
+//   - `atspi::events::object::StateChangedEvent { item: ObjectRefOwned, state: State, enabled: bool }`
+//   - `atspi::proxy::accessible::ObjectRefExt::as_accessible_proxy(&self, &zbus::Connection)`
+//   - `atspi::proxy::proxy_ext::ProxyExt::proxies(&AccessibleProxy) -> Proxies` and
+//     `Proxies::text()` / `Proxies::editable_text()` are all `async fn`s in the pinned
+//     version actually resolved by Cargo (confirmed by `cargo check`, not just docs.rs)
+//   - `EditableTextProxy::insert_text(position: i32, text: &str, length: i32) -> zbus::Result<bool>`
+//     where `position`/`length` are AT-SPI *character* offsets, not byte offsets.
+//
+// IMPORTANT CORRECTION vs the original plan: the plan asserted a
+// `State::PasswordText` variant exists on `atspi_common::State`. It does not
+// (verified against the published `atspi-common` source: the `State` bitflag
+// enum has 44 variants and none of them is password-related). AT-SPI2
+// represents password entries via the *role* `Role::PasswordText` (role 40,
+// "a text object used for passwords, or other places where the text content
+// is not shown visibly to the user") -- this is also how screen readers such
+// as Orca detect password fields. Fix 2 below checks `get_role() ==
+// Role::PasswordText`, not a nonexistent state.
+
+use atspi::proxy::accessible::{AccessibleProxy, ObjectRefExt};
+use atspi::proxy::proxy_ext::ProxyExt;
+use atspi::zbus;
+use atspi::{events::object::StateChangedEvent, AccessibilityConnection};
+use atspi::{Interface, ObjectRefOwned, Role, State};
+use futures_util::StreamExt;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Why a single segment could not be injected. Both variants that indicate
+/// "no safe place to type" (`NoFocusedEditableText`, `PasswordField`) are
+/// handled identically by the caller: skip injection, fall back to clipboard.
+#[derive(Debug, thiserror::Error)]
+pub enum InjectError {
+    #[error("no focused editable text field")]
+    NoFocusedEditableText,
+    #[error("focused field is a password field")]
+    PasswordField,
+    #[error("AT-SPI D-Bus call failed: {0}")]
+    Zbus(#[from] zbus::Error),
+}
+
+/// Open a new connection to the AT-SPI accessibility bus.
+pub async fn connect() -> Result<AccessibilityConnection, zbus::Error> {
+    AccessibilityConnection::new()
+        .await
+        .map_err(|e| zbus::Error::Failure(format!("AT-SPI connection failed: {e}")))
+}
+
+/// A liveness cache of "the last object that received AT-SPI focus", kept up
+/// to date by [`spawn_focus_tracker`]. Per Fix 3, this is a *liveness signal
+/// only* -- `inject_segment` always re-validates it with a fresh query
+/// immediately before inserting text, it never trusts the cache blindly.
+#[derive(Clone)]
+pub struct FocusCache {
+    inner: Arc<RwLock<Option<ObjectRefOwned>>>,
+}
+
+impl FocusCache {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    async fn set(&self, item: Option<ObjectRefOwned>) {
+        *self.inner.write().await = item;
+    }
+
+    /// Snapshot of the currently cached focus target. `pub` so callers
+    /// (tests, diagnostics) can observe liveness without going through a
+    /// full `inject_segment` call.
+    pub async fn get(&self) -> Option<ObjectRefOwned> {
+        self.inner.read().await.clone()
+    }
+}
+
+/// Spawn a background task that subscribes to `object:state-changed:focused`
+/// AT-SPI events and keeps `cache` pointed at the most recently focused
+/// object. This is the liveness signal consumed (and re-validated) by
+/// `inject_segment`.
+pub fn spawn_focus_tracker(
+    connection: AccessibilityConnection,
+    cache: FocusCache,
+) -> tauri::async_runtime::JoinHandle<()> {
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = connection.register_event::<StateChangedEvent>().await {
+            log::error!("Dictation: failed to register AT-SPI focus events: {}", e);
+            return;
+        }
+
+        let events = connection.event_stream();
+        let mut events = std::pin::pin!(events);
+
+        log::info!("Dictation: AT-SPI focus tracker started");
+
+        while let Some(result) = events.next().await {
+            let event = match result {
+                Ok(event) => event,
+                Err(e) => {
+                    log::debug!("Dictation: AT-SPI event stream error: {}", e);
+                    continue;
+                }
+            };
+
+            let Ok(state_changed) = StateChangedEvent::try_from(event) else {
+                continue;
+            };
+
+            if state_changed.state == State::Focused {
+                if state_changed.enabled {
+                    cache.set(Some(state_changed.item)).await;
+                } else if cache.get().await.as_ref() == Some(&state_changed.item) {
+                    // The cached object explicitly lost focus and nothing new
+                    // has taken it yet; clear so a stale target isn't reused.
+                    cache.set(None).await;
+                }
+            }
+        }
+
+        log::info!("Dictation: AT-SPI focus tracker stopped (event stream ended)");
+    })
+}
+
+/// Attempt to inject `text` at the end of whatever is currently focused.
+///
+/// Implements Fix 2 (password-field skip) and Fix 3 (fresh re-validation +
+/// append-at-current-end, both queried immediately before the D-Bus
+/// `InsertText` call, not read from any cache) on every call.
+pub async fn inject_segment(
+    connection: &AccessibilityConnection,
+    cache: &FocusCache,
+    text: &str,
+) -> Result<(), InjectError> {
+    let cached_item = cache.get().await.ok_or(InjectError::NoFocusedEditableText)?;
+
+    let accessible: AccessibleProxy<'_> = cached_item
+        .as_accessible_proxy(connection.connection())
+        .await
+        .map_err(|_| InjectError::NoFocusedEditableText)?;
+
+    // Fix 3(a): re-confirm the cached object is still focused with a fresh,
+    // minimal query immediately before acting on it. This narrows, but (as
+    // documented in the plan) cannot fully eliminate, the TOCTOU window
+    // inherent to an async D-Bus round-trip.
+    let state = accessible.get_state().await?;
+    if !state.contains(State::Focused) {
+        return Err(InjectError::NoFocusedEditableText);
+    }
+
+    // Fix 2: never inject into a password field. Checked on every call, not
+    // just once at focus-change time.
+    let role = accessible.get_role().await?;
+    if role == Role::PasswordText {
+        return Err(InjectError::PasswordField);
+    }
+
+    let interfaces = accessible.get_interfaces().await?;
+    if !interfaces.contains(Interface::EditableText) || !interfaces.contains(Interface::Text) {
+        return Err(InjectError::NoFocusedEditableText);
+    }
+
+    let proxies = accessible
+        .proxies()
+        .await
+        .map_err(|_| InjectError::NoFocusedEditableText)?;
+    let text_proxy = proxies
+        .text()
+        .await
+        .map_err(|_| InjectError::NoFocusedEditableText)?;
+    let editable_proxy = proxies
+        .editable_text()
+        .await
+        .map_err(|_| InjectError::NoFocusedEditableText)?;
+
+    // Fix 3(b): always insert at the current end of the text content, queried
+    // fresh immediately before `insert_text` -- never a remembered/predicted
+    // caret offset.
+    let end_position = text_proxy.character_count().await?;
+    let char_len = text.chars().count() as i32;
+
+    let inserted = editable_proxy
+        .insert_text(end_position, text, char_len)
+        .await?;
+    if !inserted {
+        return Err(InjectError::NoFocusedEditableText);
+    }
+
+    Ok(())
+}

--- a/frontend/src-tauri/src/dictation/commands.rs
+++ b/frontend/src-tauri/src/dictation/commands.rs
@@ -1,0 +1,95 @@
+// dictation/commands.rs
+//
+// Tauri commands exposed to the frontend for the live dictation feature.
+
+use log::{info, warn};
+use tauri::{AppHandle, Runtime, State};
+use tauri_plugin_global_shortcut::GlobalShortcutExt;
+
+use super::manager::DictationManagerState;
+use super::settings;
+use super::types::{DictationSettings, DictationState};
+
+/// (Re)apply the global hotkey registration to match `settings`. This app
+/// only ever registers a single global shortcut (dictation's own toggle), so
+/// it is always safe to clear every registered shortcut before registering
+/// the current one.
+pub async fn apply_hotkey<R: Runtime>(app: &AppHandle<R>, settings: &DictationSettings) {
+    let global_shortcut = app.global_shortcut();
+    if let Err(e) = global_shortcut.unregister_all() {
+        warn!("Dictation: failed to unregister existing hotkey(s): {}", e);
+    }
+
+    if !settings.enabled {
+        return;
+    }
+
+    let Some(hotkey_str) = settings.hotkey.as_deref() else {
+        return;
+    };
+
+    match tauri_plugin_global_shortcut::Shortcut::try_from(hotkey_str) {
+        Ok(shortcut) => match global_shortcut.register(shortcut) {
+            Ok(()) => info!("Dictation: registered global hotkey '{}'", hotkey_str),
+            Err(e) => warn!(
+                "Dictation: failed to register hotkey '{}' (the global-shortcut plugin may not be \
+                 supported on this desktop session): {}",
+                hotkey_str, e
+            ),
+        },
+        Err(e) => warn!("Dictation: invalid hotkey string '{}': {}", hotkey_str, e),
+    }
+}
+
+#[tauri::command]
+pub async fn start_dictation(
+    manager: State<'_, DictationManagerState<tauri::Wry>>,
+) -> Result<(), String> {
+    manager.start().await.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn stop_dictation(
+    manager: State<'_, DictationManagerState<tauri::Wry>>,
+) -> Result<(), String> {
+    manager.stop().await;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn get_dictation_state(
+    manager: State<'_, DictationManagerState<tauri::Wry>>,
+) -> Result<DictationState, String> {
+    Ok(manager.state().await)
+}
+
+#[tauri::command]
+pub async fn get_dictation_settings(app: AppHandle<tauri::Wry>) -> Result<DictationSettings, String> {
+    settings::load_dictation_settings(&app)
+        .await
+        .map_err(|e| format!("Failed to load dictation settings: {}", e))
+}
+
+#[tauri::command]
+pub async fn set_dictation_settings(
+    app: AppHandle<tauri::Wry>,
+    manager: State<'_, DictationManagerState<tauri::Wry>>,
+    settings: DictationSettings,
+) -> Result<(), String> {
+    settings::save_dictation_settings(&app, &settings)
+        .await
+        .map_err(|e| format!("Failed to save dictation settings: {}", e))?;
+
+    apply_hotkey(&app, &settings).await;
+
+    // Keep the manager's live state in sync with the saved `enabled` flag so
+    // the Settings toggle behaves like a real on/off switch, not just a
+    // preference for next launch.
+    if settings.enabled && !manager.is_active() {
+        manager.start().await.map_err(|e| e.to_string())?;
+    } else if !settings.enabled && manager.is_active() {
+        manager.stop().await;
+    }
+
+    Ok(())
+}

--- a/frontend/src-tauri/src/dictation/manager.rs
+++ b/frontend/src-tauri/src/dictation/manager.rs
@@ -1,0 +1,233 @@
+// dictation/manager.rs
+//
+// Orchestrates the live dictation feature: owns the queue that worker.rs
+// feeds (Fix 4: decoupled from the serial transcription critical path via a
+// channel + separate task, never called inline), starts/stops the AT-SPI
+// injector task on Linux, and implements the clipboard+notification fallback
+// (Fix 6: never silently destroys the user's existing clipboard contents).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use tauri::{AppHandle, Runtime};
+use tauri_plugin_clipboard_manager::ClipboardExt;
+use tauri_plugin_notification::NotificationExt;
+use tokio::sync::RwLock;
+
+use super::queue::DictationQueue;
+use super::types::DictationState;
+
+#[cfg(target_os = "linux")]
+use super::atspi_injector;
+
+/// Default queue capacity: how many not-yet-injected segments may be queued
+/// before the oldest is dropped (see `DictationQueue`). Segments are short
+/// (a few seconds of speech each), so a small capacity is enough headroom
+/// for a brief AT-SPI hiccup without ever meaningfully lagging real time.
+const QUEUE_CAPACITY: usize = 8;
+
+/// How long the fallback clipboard write is held before the user's prior
+/// clipboard contents are restored (Fix 6).
+const CLIPBOARD_RESTORE_DELAY: Duration = Duration::from_secs(10);
+
+#[derive(Debug, thiserror::Error)]
+pub enum DictationError {
+    #[error("live dictation is not supported on this platform")]
+    UnsupportedPlatform,
+    #[error("failed to connect to the AT-SPI accessibility bus: {0}")]
+    ConnectionFailed(String),
+}
+
+/// The queue + active flag shared between worker.rs's hot path and the
+/// manager. Always present in app-managed state (even when dictation is
+/// off), so worker.rs's check is a single atomic load in the common case.
+pub struct DictationBridge {
+    pub queue: DictationQueue,
+    pub active: AtomicBool,
+}
+
+impl DictationBridge {
+    pub fn new() -> Self {
+        Self {
+            queue: DictationQueue::new(QUEUE_CAPACITY),
+            active: AtomicBool::new(false),
+        }
+    }
+}
+
+pub type DictationBridgeState = Arc<DictationBridge>;
+
+/// Shared handle used by the injector task to route a failed segment to the
+/// clipboard fallback without needing to lock the whole manager.
+#[derive(Clone)]
+struct FallbackHandler<R: Runtime> {
+    app_handle: AppHandle<R>,
+    state: Arc<RwLock<DictationState>>,
+}
+
+impl<R: Runtime> FallbackHandler<R> {
+    async fn handle(&self, text: String, reason: &str) {
+        *self.state.write().await = DictationState::InjectFailedFallback;
+
+        let clipboard = self.app_handle.clipboard();
+
+        // Fix 6: read and hold the user's existing clipboard content before
+        // overwriting it, so it can be restored afterwards.
+        let prior_clipboard = match clipboard.read_text() {
+            Ok(prior) => Some(prior),
+            Err(e) => {
+                log::debug!("Dictation fallback: no readable prior clipboard content: {}", e);
+                None
+            }
+        };
+
+        match clipboard.write_text(text) {
+            Ok(()) => {
+                log::info!("Dictation fallback: copied segment to clipboard ({})", reason);
+            }
+            Err(e) => {
+                log::error!("Dictation fallback: failed to write clipboard: {}", e);
+                return;
+            }
+        }
+
+        let restore_secs = CLIPBOARD_RESTORE_DELAY.as_secs();
+        let body = format!(
+            "Couldn't type into the focused field ({reason}). The dictated text was copied to \
+             your clipboard instead -- paste it now. Your previous clipboard content will be \
+             restored in {restore_secs} seconds."
+        );
+        if let Err(e) = self
+            .app_handle
+            .notification()
+            .builder()
+            .title("Live Dictation")
+            .body(&body)
+            .show()
+        {
+            log::warn!("Dictation fallback: failed to show notification: {}", e);
+        }
+
+        let app_for_restore = self.app_handle.clone();
+        tauri::async_runtime::spawn(async move {
+            tokio::time::sleep(CLIPBOARD_RESTORE_DELAY).await;
+            let clipboard = app_for_restore.clipboard();
+            let restore_result = match prior_clipboard {
+                Some(prior_text) => clipboard.write_text(prior_text),
+                None => clipboard.clear(),
+            };
+            if let Err(e) = restore_result {
+                log::warn!("Dictation fallback: failed to restore prior clipboard: {}", e);
+            }
+        });
+    }
+}
+
+/// Orchestrates the dictation feature's lifecycle. Cheap to clone (all state
+/// is `Arc`-backed); the clone held by the injector task can call back into
+/// `state` without contending with `start()`/`stop()` on the original held
+/// in app-managed state.
+#[derive(Clone)]
+pub struct DictationManager<R: Runtime> {
+    app_handle: AppHandle<R>,
+    bridge: DictationBridgeState,
+    state: Arc<RwLock<DictationState>>,
+    #[cfg(target_os = "linux")]
+    tasks: Arc<parking_lot::Mutex<Vec<tauri::async_runtime::JoinHandle<()>>>>,
+}
+
+impl<R: Runtime> DictationManager<R> {
+    pub fn new(app_handle: AppHandle<R>, bridge: DictationBridgeState) -> Self {
+        Self {
+            app_handle,
+            bridge,
+            state: Arc::new(RwLock::new(DictationState::Idle)),
+            #[cfg(target_os = "linux")]
+            tasks: Arc::new(parking_lot::Mutex::new(Vec::new())),
+        }
+    }
+
+    pub async fn state(&self) -> DictationState {
+        *self.state.read().await
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.bridge.active.load(Ordering::SeqCst)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub async fn start(&self) -> Result<(), DictationError> {
+        Err(DictationError::UnsupportedPlatform)
+    }
+
+    #[cfg(target_os = "linux")]
+    pub async fn start(&self) -> Result<(), DictationError> {
+        if self.is_active() {
+            return Ok(());
+        }
+
+        let connection = atspi_injector::connect()
+            .await
+            .map_err(|e| DictationError::ConnectionFailed(e.to_string()))?;
+
+        let cache = atspi_injector::FocusCache::new();
+        let focus_task = atspi_injector::spawn_focus_tracker(connection.clone(), cache.clone());
+
+        self.bridge.queue.reopen();
+        self.bridge.queue.clear();
+
+        let bridge = self.bridge.clone();
+        let fallback = FallbackHandler {
+            app_handle: self.app_handle.clone(),
+            state: self.state.clone(),
+        };
+        let injector_connection = connection.clone();
+        let injector_cache = cache.clone();
+        let injector_task = tauri::async_runtime::spawn(async move {
+            loop {
+                let Some(text) = bridge.queue.pop().await else {
+                    break;
+                };
+                match atspi_injector::inject_segment(&injector_connection, &injector_cache, &text)
+                    .await
+                {
+                    Ok(()) => {}
+                    Err(e) => {
+                        log::warn!("Dictation: injection failed, using clipboard fallback: {}", e);
+                        fallback.handle(text, &e.to_string()).await;
+                    }
+                }
+            }
+        });
+
+        *self.tasks.lock() = vec![focus_task, injector_task];
+        self.bridge.active.store(true, Ordering::SeqCst);
+        *self.state.write().await = DictationState::Listening;
+
+        log::info!("Dictation: started");
+        Ok(())
+    }
+
+    pub async fn stop(&self) {
+        if !self.is_active() {
+            return;
+        }
+
+        self.bridge.active.store(false, Ordering::SeqCst);
+        self.bridge.queue.close();
+
+        #[cfg(target_os = "linux")]
+        {
+            let tasks: Vec<_> = self.tasks.lock().drain(..).collect();
+            for task in tasks {
+                task.abort();
+            }
+        }
+
+        *self.state.write().await = DictationState::Idle;
+        log::info!("Dictation: stopped");
+    }
+}
+
+pub type DictationManagerState<R> = Arc<DictationManager<R>>;

--- a/frontend/src-tauri/src/dictation/manager.rs
+++ b/frontend/src-tauri/src/dictation/manager.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use tauri::{AppHandle, Runtime};
 use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_notification::NotificationExt;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 use super::queue::DictationQueue;
 use super::types::DictationState;
@@ -82,6 +82,7 @@ impl<R: Runtime> FallbackHandler<R> {
             }
         };
 
+        let written_text = text.clone();
         match clipboard.write_text(text) {
             Ok(()) => {
                 log::info!("Dictation fallback: copied segment to clipboard ({})", reason);
@@ -96,7 +97,7 @@ impl<R: Runtime> FallbackHandler<R> {
         let body = format!(
             "Couldn't type into the focused field ({reason}). The dictated text was copied to \
              your clipboard instead -- paste it now. Your previous clipboard content will be \
-             restored in {restore_secs} seconds."
+             restored in {restore_secs} seconds, unless you copy something else first."
         );
         if let Err(e) = self
             .app_handle
@@ -113,6 +114,31 @@ impl<R: Runtime> FallbackHandler<R> {
         tauri::async_runtime::spawn(async move {
             tokio::time::sleep(CLIPBOARD_RESTORE_DELAY).await;
             let clipboard = app_for_restore.clipboard();
+
+            // Only restore if the clipboard still holds exactly the text we
+            // wrote. If the user copied something else in the meantime (the
+            // whole point of this fallback is "paste it now", so they may
+            // well have gone on to copy something unrelated before the
+            // delay elapses), restoring unconditionally would silently
+            // destroy that newer content instead of the stale pre-dictation
+            // snapshot -- so leave it alone in that case.
+            match clipboard.read_text() {
+                Ok(current) if current != written_text => {
+                    log::debug!(
+                        "Dictation fallback: clipboard changed since the fallback write, skipping restore"
+                    );
+                    return;
+                }
+                Err(e) => {
+                    log::debug!(
+                        "Dictation fallback: clipboard unreadable at restore time ({}), skipping restore",
+                        e
+                    );
+                    return;
+                }
+                Ok(_) => {}
+            }
+
             let restore_result = match prior_clipboard {
                 Some(prior_text) => clipboard.write_text(prior_text),
                 None => clipboard.clear(),
@@ -135,6 +161,17 @@ pub struct DictationManager<R: Runtime> {
     state: Arc<RwLock<DictationState>>,
     #[cfg(target_os = "linux")]
     tasks: Arc<parking_lot::Mutex<Vec<tauri::async_runtime::JoinHandle<()>>>>,
+    // Serializes start()/stop() end to end (held across every .await in
+    // both) so a concurrent toggle -- tray menu double-click before its
+    // label flips, the global hotkey firing while a Settings-page save is
+    // in flight, start() racing stop() -- can never interleave. Without
+    // this, two overlapping start() calls could both observe is_active()
+    // == false, each open its own AT-SPI connection and spawn its own
+    // focus/injector tasks, and the second one's unconditional
+    // `*self.tasks.lock() = ...` would silently orphan the first pair of
+    // tasks (and their live D-Bus subscription) with no way for a later
+    // stop() to ever reach and abort them.
+    lifecycle_lock: Arc<Mutex<()>>,
 }
 
 impl<R: Runtime> DictationManager<R> {
@@ -145,6 +182,7 @@ impl<R: Runtime> DictationManager<R> {
             state: Arc::new(RwLock::new(DictationState::Idle)),
             #[cfg(target_os = "linux")]
             tasks: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            lifecycle_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -163,6 +201,7 @@ impl<R: Runtime> DictationManager<R> {
 
     #[cfg(target_os = "linux")]
     pub async fn start(&self) -> Result<(), DictationError> {
+        let _guard = self.lifecycle_lock.lock().await;
         if self.is_active() {
             return Ok(());
         }
@@ -210,6 +249,7 @@ impl<R: Runtime> DictationManager<R> {
     }
 
     pub async fn stop(&self) {
+        let _guard = self.lifecycle_lock.lock().await;
         if !self.is_active() {
             return;
         }

--- a/frontend/src-tauri/src/dictation/mod.rs
+++ b/frontend/src-tauri/src/dictation/mod.rs
@@ -1,0 +1,18 @@
+// Live dictation module (issue #719): transcribe speech directly into
+// whichever text field currently has OS focus, via the AT-SPI2 accessibility
+// bus on Linux. See local://plan-live-dictation-v2.md for the design.
+
+pub mod commands;
+pub mod manager;
+pub mod queue;
+pub mod settings;
+pub mod types;
+
+// AT-SPI is Linux-only; gate the submodule declaration itself per repo
+// convention (see `tray.rs`'s cfg-gating precedent), not with internal
+// `#[cfg]` sprinkled through a shared file.
+#[cfg(target_os = "linux")]
+pub mod atspi_injector;
+
+pub use manager::{DictationBridge, DictationBridgeState, DictationManager, DictationManagerState};
+pub use types::{DictationSettings, DictationState};

--- a/frontend/src-tauri/src/dictation/queue.rs
+++ b/frontend/src-tauri/src/dictation/queue.rs
@@ -1,0 +1,177 @@
+// dictation/queue.rs
+//
+// A small bounded, drop-oldest-on-overflow queue used to hand transcribed
+// segments from the (synchronous, hot-path) transcription worker over to the
+// dedicated AT-SPI injector task, without ever blocking the worker.
+//
+// This exists instead of a plain `tokio::sync::mpsc` channel because Fix 4 of
+// the live-dictation plan requires that a full queue drop the OLDEST queued
+// segment (not reject the newest), which a bounded mpsc channel cannot do:
+// `Sender::try_send` on a full channel simply fails, it cannot evict the
+// receiver's queued head. `push` is synchronous and non-blocking so it is
+// safe to call directly from worker.rs's serial transcription loop.
+
+use parking_lot::Mutex;
+use std::collections::VecDeque;
+use tokio::sync::Notify;
+
+pub struct DictationQueue {
+    inner: Mutex<QueueState>,
+    capacity: usize,
+    notify: Notify,
+}
+
+struct QueueState {
+    items: VecDeque<String>,
+    closed: bool,
+}
+
+impl DictationQueue {
+    pub fn new(capacity: usize) -> Self {
+        assert!(capacity > 0, "DictationQueue capacity must be non-zero");
+        Self {
+            inner: Mutex::new(QueueState {
+                items: VecDeque::with_capacity(capacity),
+                closed: false,
+            }),
+            capacity,
+            notify: Notify::new(),
+        }
+    }
+
+    /// Push a segment onto the queue. Non-blocking. If the queue is at
+    /// capacity, the oldest queued segment is dropped (and logged) to make
+    /// room, rather than blocking or rejecting the new segment.
+    pub fn push(&self, text: String) {
+        let mut state = self.inner.lock();
+        if state.closed {
+            return;
+        }
+        if state.items.len() >= self.capacity {
+            if let Some(dropped) = state.items.pop_front() {
+                log::warn!(
+                    "Dictation queue full (capacity {}); dropping oldest queued segment: {:?}",
+                    self.capacity,
+                    dropped
+                );
+            }
+        }
+        state.items.push_back(text);
+        drop(state);
+        self.notify.notify_one();
+    }
+
+    /// Wait for and remove the oldest queued segment. Returns `None` once the
+    /// queue has been closed and drained.
+    pub async fn pop(&self) -> Option<String> {
+        loop {
+            {
+                let mut state = self.inner.lock();
+                if let Some(text) = state.items.pop_front() {
+                    return Some(text);
+                }
+                if state.closed {
+                    return None;
+                }
+            }
+            self.notify.notified().await;
+        }
+    }
+
+    /// Discard any queued segments without processing them (used when
+    /// (re)starting dictation so stale segments from a prior session are not
+    /// injected).
+    pub fn clear(&self) {
+        self.inner.lock().items.clear();
+    }
+
+    /// Mark the queue closed and wake any waiting consumer; `pop` will drain
+    /// remaining items then return `None`.
+    pub fn close(&self) {
+        self.inner.lock().closed = true;
+        self.notify.notify_waiters();
+    }
+
+    /// Reopen a previously closed queue for a new dictation session.
+    pub fn reopen(&self) {
+        self.inner.lock().closed = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_pop_preserves_fifo_order() {
+        let queue = DictationQueue::new(4);
+        queue.push("one".to_string());
+        queue.push("two".to_string());
+        queue.push("three".to_string());
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            assert_eq!(queue.pop().await.as_deref(), Some("one"));
+            assert_eq!(queue.pop().await.as_deref(), Some("two"));
+            assert_eq!(queue.pop().await.as_deref(), Some("three"));
+        });
+    }
+
+    #[test]
+    fn overflow_drops_oldest_not_newest() {
+        let queue = DictationQueue::new(2);
+        queue.push("a".to_string());
+        queue.push("b".to_string());
+        // Queue is now full at capacity 2 with ["a", "b"]; pushing "c" must
+        // evict "a" (the oldest), keeping "b" and "c".
+        queue.push("c".to_string());
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            assert_eq!(queue.pop().await.as_deref(), Some("b"));
+            assert_eq!(queue.pop().await.as_deref(), Some("c"));
+        });
+    }
+
+    #[test]
+    fn close_drains_then_returns_none() {
+        let queue = DictationQueue::new(4);
+        queue.push("only".to_string());
+        queue.close();
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            // Draining a segment queued before close() still succeeds.
+            assert_eq!(queue.pop().await.as_deref(), Some("only"));
+            // Once drained, a closed queue yields None instead of hanging.
+            assert_eq!(queue.pop().await, None);
+        });
+    }
+
+    #[test]
+    fn push_after_close_is_ignored() {
+        let queue = DictationQueue::new(4);
+        queue.close();
+        queue.push("dropped".to_string());
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            assert_eq!(queue.pop().await, None);
+        });
+    }
+
+    #[test]
+    fn reopen_allows_a_new_session() {
+        let queue = DictationQueue::new(4);
+        queue.push("first-session".to_string());
+        queue.close();
+        queue.clear();
+        queue.reopen();
+        queue.push("second-session".to_string());
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            assert_eq!(queue.pop().await.as_deref(), Some("second-session"));
+        });
+    }
+}

--- a/frontend/src-tauri/src/dictation/settings.rs
+++ b/frontend/src-tauri/src/dictation/settings.rs
@@ -1,0 +1,69 @@
+// dictation/settings.rs
+//
+// Persistence for `DictationSettings`, mirroring
+// `audio::recording_preferences`'s exact load/save shape via the shared
+// `tauri-plugin-store` dependency (Fix 5 of the live-dictation plan).
+
+use anyhow::Result;
+use log::{info, warn};
+use tauri::{AppHandle, Runtime};
+use tauri_plugin_store::StoreExt;
+
+use super::types::DictationSettings;
+
+const STORE_FILE: &str = "dictation_settings.json";
+const STORE_KEY: &str = "settings";
+
+/// Load dictation settings from the store, falling back to defaults if the
+/// store is unavailable, empty, or fails to deserialize.
+pub async fn load_dictation_settings<R: Runtime>(app: &AppHandle<R>) -> Result<DictationSettings> {
+    let store = match app.store(STORE_FILE) {
+        Ok(store) => store,
+        Err(e) => {
+            warn!("Dictation: failed to access store: {}, using defaults", e);
+            return Ok(DictationSettings::default());
+        }
+    };
+
+    let settings = if let Some(value) = store.get(STORE_KEY) {
+        match serde_json::from_value::<DictationSettings>(value.clone()) {
+            Ok(s) => {
+                info!("Dictation: loaded settings from store");
+                s
+            }
+            Err(e) => {
+                warn!("Dictation: failed to deserialize settings: {}, using defaults", e);
+                DictationSettings::default()
+            }
+        }
+    } else {
+        info!("Dictation: no stored settings found, using defaults");
+        DictationSettings::default()
+    };
+
+    Ok(settings)
+}
+
+/// Persist dictation settings to disk.
+pub async fn save_dictation_settings<R: Runtime>(
+    app: &AppHandle<R>,
+    settings: &DictationSettings,
+) -> Result<()> {
+    let store = app
+        .store(STORE_FILE)
+        .map_err(|e| anyhow::anyhow!("Failed to access store: {}", e))?;
+
+    let value = serde_json::to_value(settings)
+        .map_err(|e| anyhow::anyhow!("Failed to serialize dictation settings: {}", e))?;
+
+    store.set(STORE_KEY, value);
+    store
+        .save()
+        .map_err(|e| anyhow::anyhow!("Failed to save store to disk: {}", e))?;
+
+    info!(
+        "Dictation: persisted settings (enabled={}, hotkey={:?})",
+        settings.enabled, settings.hotkey
+    );
+    Ok(())
+}

--- a/frontend/src-tauri/src/dictation/types.rs
+++ b/frontend/src-tauri/src/dictation/types.rs
@@ -1,0 +1,47 @@
+// dictation/types.rs
+//
+// Shared state and settings types for the live dictation feature (issue #719).
+
+use serde::{Deserialize, Serialize};
+
+/// Current lifecycle state of the dictation feature, surfaced to the frontend
+/// (tray tooltip / settings UI) so the user always has a persistent indicator
+/// of whether dictation is listening.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DictationState {
+    /// Dictation is off; no AT-SPI connection is held.
+    Idle,
+    /// Dictation is on and actively injecting transcribed segments.
+    Listening,
+    /// Dictation is on, but the most recent segment could not be injected
+    /// (no focused editable field, a password field, or an AT-SPI error) and
+    /// was routed to the clipboard fallback instead.
+    InjectFailedFallback,
+}
+
+impl Default for DictationState {
+    fn default() -> Self {
+        DictationState::Idle
+    }
+}
+
+/// User-configurable dictation preferences, persisted via `tauri-plugin-store`
+/// (see `dictation::settings`, mirroring `audio::recording_preferences`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DictationSettings {
+    /// Whether live dictation is enabled at all.
+    pub enabled: bool,
+    /// Global hotkey string (e.g. "Alt+Shift+D") used to toggle dictation on/off.
+    /// `None` means no global hotkey is registered; the tray toggle still works.
+    pub hotkey: Option<String>,
+}
+
+impl Default for DictationSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            hotkey: Some("Alt+Shift+D".to_string()),
+        }
+    }
+}

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub mod audio;
 pub mod config;
 pub mod console_utils;
 pub mod database;
+pub mod dictation;
 pub mod notifications;
 pub mod ollama;
 pub mod onboarding;
@@ -411,19 +412,58 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(
+            tauri_plugin_global_shortcut::Builder::new()
+                .with_handler(|app, _shortcut, event| {
+                    if event.state() == tauri_plugin_global_shortcut::ShortcutState::Pressed {
+                        tray::toggle_dictation_handler(app);
+                    }
+                })
+                .build(),
+        )
         .manage(whisper_engine::parallel_commands::ParallelProcessorState::new())
         .manage(Arc::new(RwLock::new(
             None::<notifications::manager::NotificationManager<tauri::Wry>>,
         )) as NotificationManagerState<tauri::Wry>)
         .manage(audio::init_system_audio_state())
         .manage(summary::summary_engine::ModelManagerState(Arc::new(tokio::sync::Mutex::new(None))))
+        .manage(Arc::new(dictation::DictationBridge::new()) as dictation::manager::DictationBridgeState)
         .setup(|_app| {
             log::info!("Application setup complete");
+
+            // Initialize the live dictation manager (issue #719) before the tray is
+            // created, so the tray's initial menu/tooltip can already query it.
+            let dictation_bridge = _app.state::<dictation::manager::DictationBridgeState>().inner().clone();
+            let dictation_manager = std::sync::Arc::new(dictation::DictationManager::new(
+                _app.handle().clone(),
+                dictation_bridge,
+            ));
+            _app.manage(dictation_manager as dictation::manager::DictationManagerState<tauri::Wry>);
 
             // Initialize system tray
             if let Err(e) = tray::create_tray(_app.handle()) {
                 log::error!("Failed to create system tray: {}", e);
             }
+
+            // Load persisted dictation settings, register the global hotkey (if any),
+            // and auto-start dictation if it was left enabled last session.
+            let app_for_dictation = _app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                let settings = dictation::settings::load_dictation_settings(&app_for_dictation)
+                    .await
+                    .unwrap_or_default();
+                dictation::commands::apply_hotkey(&app_for_dictation, &settings).await;
+                if settings.enabled {
+                    let manager = app_for_dictation
+                        .state::<dictation::manager::DictationManagerState<tauri::Wry>>();
+                    if let Err(e) = manager.start().await {
+                        log::warn!("Dictation: failed to auto-start on launch: {}", e);
+                    }
+                }
+                tray::update_tray_menu_async(&app_for_dictation).await;
+            });
+
 
             // Initialize notification system with proper defaults
             log::info!("Initializing notification system...");
@@ -748,6 +788,12 @@ pub fn run() {
             audio::import::start_import_audio_command,
             audio::import::cancel_import_command,
             audio::import::is_import_in_progress_command,
+            // Live dictation commands (issue #719)
+            dictation::commands::start_dictation,
+            dictation::commands::stop_dictation,
+            dictation::commands::get_dictation_state,
+            dictation::commands::get_dictation_settings,
+            dictation::commands::set_dictation_settings,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/frontend/src-tauri/src/tray.rs
+++ b/frontend/src-tauri/src/tray.rs
@@ -40,6 +40,7 @@ fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, item_id: &str) {
         "pause_recording" => pause_recording_handler(app),
         "resume_recording" => resume_recording_handler(app),
         "stop_recording" => stop_recording_handler(app),
+        "toggle_dictation" => toggle_dictation_handler(app),
         "open_window" => focus_main_window(app),
         "settings" => {
             focus_main_window(app);
@@ -51,6 +52,72 @@ fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, item_id: &str) {
         "quit" => app.exit(0),
         _ => {}
     }
+}
+
+/// Whether live dictation is currently listening. Cheap, synchronous (a
+/// single atomic load), safe to call from menu-building code.
+fn current_dictation_active<R: Runtime>(app: &AppHandle<R>) -> bool {
+    app.try_state::<crate::dictation::DictationManagerState<R>>()
+        .map(|state| state.is_active())
+        .unwrap_or(false)
+}
+
+fn dictation_tooltip(active: bool) -> &'static str {
+    if active {
+        "Meetily — Live Dictation Listening"
+    } else {
+        "Meetily"
+    }
+}
+
+/// Toggle live dictation on/off from the tray menu item or the global
+/// hotkey. Persists the resulting `enabled` state so it is remembered across
+/// restarts, and refreshes the tray to keep the persistent indicator (Fix's
+/// persistent-indicator requirement) accurate.
+pub(crate) fn toggle_dictation_handler<R: Runtime>(app: &AppHandle<R>) {
+    let app_clone = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let Some(manager) = app_clone.try_state::<crate::dictation::DictationManagerState<R>>()
+        else {
+            log::warn!("Dictation: manager not initialized, ignoring toggle");
+            return;
+        };
+        let manager = manager.inner().clone();
+
+        let now_active = if manager.is_active() {
+            manager.stop().await;
+            false
+        } else {
+            match manager.start().await {
+                Ok(()) => true,
+                Err(e) => {
+                    log::warn!("Dictation: failed to start ({})", e);
+                    if let Some(window) = app_clone.get_webview_window("main") {
+                        let _ = window.eval(&format!(
+                            "window.dispatchEvent(new CustomEvent('dictation-error', {{ detail: {:?} }}))",
+                            e.to_string()
+                        ));
+                    }
+                    false
+                }
+            }
+        };
+
+        let mut settings = crate::dictation::settings::load_dictation_settings(&app_clone)
+            .await
+            .unwrap_or_default();
+        settings.enabled = now_active;
+        if let Err(e) =
+            crate::dictation::settings::save_dictation_settings(&app_clone, &settings).await
+        {
+            log::warn!("Dictation: failed to persist toggled state: {}", e);
+        }
+
+        if let Some(tray) = app_clone.tray_by_id("main-tray") {
+            let _ = tray.set_tooltip(Some(dictation_tooltip(now_active)));
+        }
+        update_tray_menu_async(&app_clone).await;
+    });
 }
 fn toggle_recording_handler<R: Runtime>(app: &AppHandle<R>) {
     focus_main_window(app);
@@ -305,6 +372,7 @@ pub async fn update_tray_menu_async<R: Runtime>(app: &AppHandle<R>) {
         if let Some(tray) = app.tray_by_id("main-tray") {
             let result = tray.set_menu(Some(menu));
             log::info!("Tray: Menu update result: {:?}", result);
+            let _ = tray.set_tooltip(Some(dictation_tooltip(current_dictation_active(app))));
         } else {
             log::warn!("Tray: Could not find tray with id 'main-tray'");
         }
@@ -381,7 +449,16 @@ fn build_menu<R: Runtime>(
         }
     }
 
+    let dictation_active = current_dictation_active(app);
+    let dictation_label = if dictation_active {
+        "🎙 Stop Live Dictation"
+    } else {
+        "🎙 Start Live Dictation"
+    };
+
     builder
+        .item(&PredefinedMenuItem::separator(app)?)
+        .item(&MenuItemBuilder::with_id("toggle_dictation", dictation_label).build(app)?)
         .item(&PredefinedMenuItem::separator(app)?)
         .item(&MenuItemBuilder::with_id("open_window", "Open Main Window").build(app)?)
         .item(&MenuItemBuilder::with_id("settings", "Settings").build(app)?)

--- a/frontend/src-tauri/tests/dictation_atspi_live.rs
+++ b/frontend/src-tauri/tests/dictation_atspi_live.rs
@@ -1,0 +1,206 @@
+// Live end-to-end test for the dictation AT-SPI injector (issue #719).
+//
+// This is a genuine, non-mocked test: it opens a real `gnome-text-editor`
+// window on whatever desktop session is available, waits for AT-SPI to
+// report its text buffer as focused, injects a marker string through the
+// exact `atspi_injector::inject_segment` code path used in production, and
+// then reads the text back from the *live* application over a fresh AT-SPI
+// D-Bus round trip to confirm it actually landed.
+//
+// It requires a running AT-SPI accessibility bus and a launchable GUI editor
+// (i.e. an actual desktop session, not a bare headless CI container). Both
+// are auto-detected and the test is skipped (not failed) when unavailable,
+// so this file is safe to leave in the normal `cargo test` run on machines
+// without a desktop session, while still doing real work wherever one exists.
+
+#![cfg(target_os = "linux")]
+
+use app_lib::dictation::atspi_injector::{connect, inject_segment, spawn_focus_tracker, FocusCache, InjectError};
+use atspi::proxy::accessible::ObjectRefExt;
+use atspi::proxy::proxy_ext::ProxyExt;
+use std::process::{Child, Command};
+use std::time::Duration;
+
+struct KillOnDrop(Child);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Both tests in this file spawn a real GUI window and rely on it becoming
+/// the AT-SPI-focused object. Rust's test harness runs `#[tokio::test]`
+/// functions within one binary concurrently by default, which would let the
+/// two spawned windows race for OS focus on the same desktop session; this
+/// lock serializes them regardless of the harness's thread-pool settings.
+static GUI_TEST_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+#[tokio::test]
+async fn live_injects_into_a_real_gnome_text_editor_window() {
+    let _serialize = GUI_TEST_LOCK.lock().await;
+
+    let Ok(connection) = connect().await else {
+        eprintln!("SKIP live_injects_into_a_real_gnome_text_editor_window: no AT-SPI accessibility bus available in this environment");
+        return;
+    };
+
+    let cache = FocusCache::new();
+    let _focus_task = spawn_focus_tracker(connection.clone(), cache.clone());
+    // Let the registry event subscription land before anything could focus.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let Ok(child) = Command::new("gnome-text-editor")
+        .arg("--standalone")
+        .spawn()
+    else {
+        eprintln!(
+            "SKIP live_injects_into_a_real_gnome_text_editor_window: gnome-text-editor is not launchable in this environment"
+        );
+        return;
+    };
+    let _child_guard = KillOnDrop(child);
+
+    let marker = format!("dictation-live-test-{}", std::process::id());
+
+    // Poll: wait for the editor's text field to become focused AND for a
+    // real injection attempt to succeed. This exercises the identical retry
+    // pattern the production injector task uses when it drains the queue.
+    let mut last_err = None;
+    let mut injected = false;
+    for _ in 0..60 {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        match inject_segment(&connection, &cache, &marker).await {
+            Ok(()) => {
+                injected = true;
+                break;
+            }
+            Err(e) => last_err = Some(e.to_string()),
+        }
+    }
+
+    assert!(
+        injected,
+        "gnome-text-editor's text field never became AT-SPI-focused and injectable within 30s \
+         (last error: {:?}); this indicates either no accessibility bridge is active in this \
+         session, or the AT-SPI focus-tracking / injection code path is broken",
+        last_err
+    );
+
+    // Read the text back from the live application via a completely fresh
+    // AT-SPI query (not reusing any injector-side state) to prove the text
+    // really landed in the other process's real widget.
+    let item = cache
+        .get()
+        .await
+        .expect("focus cache should still hold the just-injected object");
+    let accessible = item
+        .as_accessible_proxy(connection.connection())
+        .await
+        .expect("should resolve AccessibleProxy for the focused object");
+    let proxies = accessible
+        .proxies()
+        .await
+        .expect("should resolve interface proxies");
+    let text_proxy = proxies.text().await.expect("object should implement Text");
+    let full_text = text_proxy
+        .get_text(0, -1)
+        .await
+        .expect("should be able to read back the buffer contents");
+
+    assert!(
+        full_text.contains(&marker),
+        "injected marker text {:?} was not found in the live GNOME Text Editor buffer \
+         (actual contents: {:?})",
+        marker,
+        full_text
+    );
+
+    eprintln!(
+        "PASS: live AT-SPI injection into gnome-text-editor verified end-to-end (buffer now contains {:?})",
+        full_text
+    );
+}
+
+#[tokio::test]
+async fn live_skips_a_real_password_field_and_never_types_into_it() {
+    let _serialize = GUI_TEST_LOCK.lock().await;
+
+    let Ok(connection) = connect().await else {
+        eprintln!("SKIP live_skips_a_real_password_field_and_never_types_into_it: no AT-SPI accessibility bus available");
+        return;
+    };
+
+    let cache = FocusCache::new();
+    let _focus_task = spawn_focus_tracker(connection.clone(), cache.clone());
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // `zenity --password` opens a real GTK password entry dialog (AT-SPI
+    // role `PasswordText`), auto-focused on open.
+    let Ok(child) = Command::new("zenity")
+        .args(["--password", "--title=dictation-live-password-test"])
+        .spawn()
+    else {
+        eprintln!(
+            "SKIP live_skips_a_real_password_field_and_never_types_into_it: zenity is not launchable in this environment"
+        );
+        return;
+    };
+    let _child_guard = KillOnDrop(child);
+
+    // Poll until the password field is focused AND we get back the specific
+    // `PasswordField` rejection -- not just "no focused field yet".
+    let mut saw_password_rejection = false;
+    let mut last_err = None;
+    for _ in 0..60 {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        match inject_segment(&connection, &cache, "should-never-appear").await {
+            Ok(()) => panic!(
+                "inject_segment must never succeed against a real password field -- Fix 2 (the \
+                 password-field skip) did not fire"
+            ),
+            Err(InjectError::PasswordField) => {
+                saw_password_rejection = true;
+                break;
+            }
+            Err(e) => last_err = Some(e.to_string()),
+        }
+    }
+
+    assert!(
+        saw_password_rejection,
+        "never observed the zenity password entry being AT-SPI-focused and rejected as a \
+         password field within 30s (last error: {:?})",
+        last_err
+    );
+
+    // Confirm the field is genuinely empty -- the skip must be an actual
+    // observed no-op, not merely an error being ignored downstream.
+    let item = cache
+        .get()
+        .await
+        .expect("focus cache should still hold the password field");
+    let accessible = item
+        .as_accessible_proxy(connection.connection())
+        .await
+        .expect("should resolve AccessibleProxy for the password field");
+    let proxies = accessible
+        .proxies()
+        .await
+        .expect("should resolve interface proxies");
+    let text_proxy = proxies.text().await.expect("password entry should implement Text");
+    let full_text = text_proxy
+        .get_text(0, -1)
+        .await
+        .expect("should be able to read back the (empty) password buffer");
+
+    assert!(
+        full_text.is_empty(),
+        "password field should remain untouched, but contains {:?}",
+        full_text
+    );
+
+    eprintln!("PASS: live AT-SPI password-field skip verified end-to-end (field left empty: {:?})", full_text);
+}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -10,6 +10,7 @@ import { RecordingSettings } from '@/components/RecordingSettings';
 import { PreferenceSettings } from '@/components/PreferenceSettings';
 import { SummaryModelSettings } from '@/components/SummaryModelSettings';
 import { BetaSettings } from '@/components/BetaSettings';
+import { DictationSettings } from '@/components/DictationSettings';
 import { useConfig } from '@/contexts/ConfigContext';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 
@@ -125,7 +126,10 @@ export default function SettingsPage() {
               <SummaryModelSettings />
             </TabsContent>
             <TabsContent value="beta" className="mt-6">
-              <BetaSettings />
+              <div className="space-y-6">
+                <BetaSettings />
+                <DictationSettings />
+              </div>
             </TabsContent>
           </Tabs>
         </div>

--- a/frontend/src/components/DictationSettings.tsx
+++ b/frontend/src/components/DictationSettings.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { invoke } from "@tauri-apps/api/core"
+import { Switch } from "./ui/switch"
+import { Mic, AlertCircle } from "lucide-react"
+
+interface DictationSettingsValue {
+  enabled: boolean;
+  hotkey: string | null;
+}
+
+const DEFAULT_HOTKEY = "Alt+Shift+D";
+
+export function DictationSettings() {
+  const [settings, setSettings] = useState<DictationSettingsValue | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const loaded = await invoke<DictationSettingsValue>("get_dictation_settings");
+        if (!cancelled) {
+          setSettings(loaded);
+        }
+      } catch (err) {
+        console.error("[DictationSettings] Failed to load settings:", err);
+        if (!cancelled) {
+          setError("Failed to load live dictation settings.");
+          setSettings({ enabled: false, hotkey: DEFAULT_HOTKEY });
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const persist = async (next: DictationSettingsValue) => {
+    setIsSaving(true);
+    setError(null);
+    const previous = settings;
+    setSettings(next);
+    try {
+      await invoke("set_dictation_settings", { settings: next });
+    } catch (err) {
+      console.error("[DictationSettings] Failed to save settings:", err);
+      setError(
+        typeof err === "string"
+          ? err
+          : "Failed to update live dictation. This feature currently requires Linux with AT-SPI accessibility support."
+      );
+      setSettings(previous);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isLoading || !settings) {
+    return <div className="max-w-2xl mx-auto p-6">Loading dictation settings...</div>;
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex-1">
+          <div className="flex items-center gap-2 mb-2">
+            <Mic className="h-5 w-5 text-gray-600" />
+            <h3 className="text-lg font-semibold text-gray-900">Live Dictation</h3>
+            <span className="px-2 py-0.5 text-xs font-medium bg-yellow-100 text-yellow-800 rounded-full">
+              BETA · LINUX
+            </span>
+          </div>
+          <p className="text-sm text-gray-600">
+            Transcribe your speech directly into whatever text field currently has focus in any
+            application, via the AT-SPI accessibility bus. Password fields are always skipped. If
+            a field can&apos;t be typed into, the segment is copied to your clipboard instead.
+          </p>
+        </div>
+
+        <div className="ml-6">
+          <Switch
+            checked={settings.enabled}
+            disabled={isSaving}
+            onCheckedChange={(checked) => persist({ ...settings, enabled: checked })}
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between border-t border-gray-100 pt-4">
+        <div>
+          <p className="text-sm font-medium text-gray-900">Global toggle hotkey</p>
+          <p className="text-xs text-gray-500">
+            Press this key combination anywhere, or use the tray icon menu, to start or stop
+            dictation.
+          </p>
+        </div>
+        <kbd className="px-2 py-1 text-xs font-mono bg-gray-100 border border-gray-300 rounded">
+          {settings.hotkey ?? DEFAULT_HOTKEY}
+        </kbd>
+      </div>
+
+      {error && (
+        <div className="flex items-start gap-3 p-3 bg-red-50 border border-red-200 rounded-lg">
+          <AlertCircle className="h-4 w-4 text-red-600 flex-shrink-0 mt-0.5" />
+          <p className="text-sm text-red-800">{error}</p>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Adds an optional "Live Dictation" mode: continuously transcribes speech and inserts the recognized text directly at the current text cursor in whatever application currently has OS focus (email client, chat app, editor, etc.), via AT-SPI2 on Linux -- reusing the app's existing local transcription pipeline rather than a separate dictation engine.

## Related Issue

Fixes #719

## Feasibility investigation (Linux-first, matches the issue's scope)

This machine is GNOME on Wayland (Mutter). `xdotool`/`wtype` can't reliably inject into native Wayland windows or don't support Mutter; `ydotool` works everywhere but needs one-time root/udev setup this app should never silently perform. AT-SPI (`org.a11y.Bus`) is already running with zero extra permissions and is the same mechanism real Linux dictation tools (Talon, nerd-dictation) use -- chosen as the only path that works today with no admin setup. `ydotool` is documented as an optional advanced path, not auto-configured.

## Design notes

An independent plan review before implementation required several safety fixes, and an independent code review after implementation required one more -- all implemented:

- **No `is_partial` filtering.** The plan initially assumed `is_partial` meant "wait for a final revision" -- it's actually a chunk-duration flag (`whisper_engine.rs`), and filtering on it would have silently dropped nearly all real dictation output. Every finalized `transcript-update` segment is injected.
- **Password-field protection.** Checks `Role::PasswordText` on the focused object before every injection (the atspi crate has no `State::PasswordText` as originally assumed -- verified against the actual published crate source; AT-SPI2 represents password fields via role, the same mechanism screen readers use). Skips injection and falls back to clipboard+notification if the focused field is a password field.
- **Fresh re-validation, append-only.** Immediately before every `insert_text` call, focus is re-confirmed and the insertion offset is the text's current end, queried fresh -- never a remembered/predicted caret position, to avoid corrupting either the dictated text or concurrent user typing.
- **Decoupled from transcription.** Injection never runs inline in the sole serial transcription worker (`worker.rs`, `NUM_WORKERS=1`, deliberately serial for zero chunk loss) -- a bounded, drop-oldest queue + separate task owns the AT-SPI connection.
- **Clipboard fallback preserves prior content**, restored after 10s -- but only if the clipboard still holds exactly the fallback text at restore time (a code-review fix: the initial version would have clobbered anything the user copied in between).
- **`start()`/`stop()` are now serialized** end-to-end via a lifecycle lock (a code-review fix: concurrent toggles -- tray double-click, hotkey racing a Settings save -- could otherwise both pass a stale `is_active()` check and each spawn an independent AT-SPI connection, orphaning the first one's D-Bus subscription with no way for a later `stop()` to reach it).

A lower-severity finding (queue-overflow drops are logged but not surfaced to the user, unlike the injection-failure path) is left as a known residual gap, noted here rather than silently dropped -- unlikely to trigger under normal dictation pacing given the small number of D-Bus round trips per segment.

## Type of Change
- [x] New feature

## Testing
- [x] Unit tests added/updated (`dictation::queue`: FIFO order, drop-oldest overflow, close/reopen semantics -- 5 tests)
- [x] Manual testing performed
- [x] All tests pass

Verified live end-to-end against real other applications on this machine, not mocked:
- `cargo check`/`cargo test --lib` clean (191 passing; the one pre-existing unrelated failure, a floating-point precision assertion in Bluetooth buffer-timeout code, predates and is untouched by this change).
- Wrote and ran real, non-mocked integration tests (`tests/dictation_atspi_live.rs`) against this machine's actual live GNOME Wayland session: spawned a real `gnome-text-editor`, drove the exact production `connect()`/focus-tracker/`inject_segment()` path to type a marker string, and confirmed it landed by reading the buffer back over an independent AT-SPI call -- **passed**. Spawned a real `zenity --password` dialog, confirmed injection is skipped every time it's focused, and confirmed the field was never typed into -- **passed**. Re-ran 3 consecutive times after the code-review fixes above, 2/2 passing each run (one earlier isolated run had a single flaky failure that didn't reproduce on retry, consistent with transient desktop-focus interference on a long-lived shared session, not a regression).
- `npx tsc --noEmit` clean for the new/touched frontend files.
- Not independently verified: the full `DictationManager` orchestration wired inside a fully running packaged app with its Whisper/Parakeet models and window (tray toggle, global-hotkey registration on this Wayland session specifically, settings save/load round-trip through the packaged app) -- verified via `cargo check`/`cargo test` and code review against the same live-verified `atspi_injector` primitives, not via a full running app session. Recommend a human/GUI smoke check: toggle dictation from the tray, dictate into a real app, confirm the fallback notification/clipboard-restore timing, and confirm whether `tauri-plugin-global-shortcut` actually registers on the target Wayland/GNOME session (support varies by compositor; the tray toggle is the documented, always-working fallback).

## Documentation
- [x] Documentation updated (Settings page notes the Linux/AT-SPI requirement; `ydotool` documented as an optional broader-coverage path, never auto-configured)

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [x] Updated README if needed (n/a)
- [x] Branch is up to date with devtest
- [x] No merge conflicts
