### PR TITLE
feat(summary): add Catalan (ca) as a summary output language

### DIFF
--- a/frontend/src-tauri/src/summary/language_detection.rs
+++ b/frontend/src-tauri/src/summary/language_detection.rs
@@ -124,6 +124,7 @@ fn summary_code_from_whatlang(lang: Lang) -> Option<&'static str> {
         Lang::Cmn => Some("zh"),
         Lang::Deu => Some("de"),
         Lang::Spa => Some("es"),
+        Lang::Cat => Some("ca"),
         Lang::Rus => Some("ru"),
         Lang::Kor => Some("ko"),
         Lang::Fra => Some("fr"),

--- a/frontend/src-tauri/src/summary/processor.rs
+++ b/frontend/src-tauri/src/summary/processor.rs
@@ -92,6 +92,7 @@ pub(crate) fn language_name_from_code(code: &str) -> Option<&'static str> {
         "zh" => Some("Chinese"),
         "de" => Some("German"),
         "es" => Some("Spanish"),
+        "ca" => Some("Catalan"),
         "ru" => Some("Russian"),
         "ko" => Some("Korean"),
         "fr" => Some("French"),

--- a/frontend/src/lib/summary-languages.ts
+++ b/frontend/src/lib/summary-languages.ts
@@ -14,6 +14,7 @@ export const LANGUAGE_OPTIONS: LanguageOption[] = [
   { code: 'zh-tw', label: 'Traditional Chinese' },
   { code: 'de', label: 'German' },
   { code: 'es', label: 'Spanish' },
+  { code: 'ca', label: 'Catalan' },
   { code: 'ru', label: 'Russian' },
   { code: 'ko', label: 'Korean' },
   { code: 'fr', label: 'French' },


### PR DESCRIPTION
## Description

Catalan (`ca`) is already available as a **transcription** language, but it was missing from the **summary** language options. As a result, summaries of Catalan meetings fell back to English (confirmed in-app: with Summary Language set to `Auto` on a Catalan transcript, the summary is produced in English).

This PR adds Catalan as a first-class summary output language, following the exact same three-file pattern as #582 (Persian):

- `frontend/src/lib/summary-languages.ts` — add `{ code: 'ca', label: 'Catalan' }` to the picker.
- `frontend/src-tauri/src/summary/processor.rs` — map `"ca" => Some("Catalan")` in `language_name_from_code` so the translation pass targets Catalan.
- `frontend/src-tauri/src/summary/language_detection.rs` — map `Lang::Cat => Some("ca")` in `summary_code_from_whatlang` so `Auto` mode resolves a Catalan-dominant transcript to a Catalan summary.

`frontend/src/constants/languages.ts` already lists Catalan, so no change was needed there.

## Related Issue

N/A — small additive enhancement.

## Type of Change
- [x] New feature

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed (transcription side)
- [ ] All tests pass

Verified in the released build that Catalan transcription works and that `Auto` summary currently falls back to English. This change is data-only and additive (mirroring the reviewed #582 pattern); it has **not yet been compiled/tested locally** on my side, so CI validation is welcome.

## Documentation
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Branch based on `devtest`
