### PR TITLE
fix(linux): resolve system audio device by stripping ' (System Audio)' display suffix

### DIFF
--- a/frontend/src-tauri/src/audio/devices/configuration.rs
+++ b/frontend/src-tauri/src/audio/devices/configuration.rs
@@ -154,11 +154,20 @@ pub async fn get_device_and_config(
 
                 #[cfg(target_os = "linux")]
                 {
-                    // For Linux, we use PulseAudio monitor sources for system audio
+                    // For Linux, we use PulseAudio monitor sources for system audio.
+                    // Monitor sources are listed with a " (System Audio)" display suffix
+                    // (see configure_linux_audio); strip it before matching the raw
+                    // cpal device name, mirroring the "(input)"/"(output)" stripping
+                    // done in AudioDevice::from_name.
+                    let raw_name = audio_device
+                        .name
+                        .trim_end_matches(" (System Audio)")
+                        .to_string();
+
                     if let Ok(pulse_host) = cpal::host_from_id(cpal::HostId::Alsa) {
                         for device in pulse_host.input_devices()? {
                             if let Ok(name) = device.name() {
-                                if name == audio_device.name {
+                                if name == raw_name {
                                     let default_config = device
                                         .default_input_config()
                                         .map_err(|e| anyhow!("Failed to get default input config: {}", e))?;


### PR DESCRIPTION
Fixes #701

## Problem

On Linux, selecting any "System Audio" device in Settings and starting a recording never actually captures system audio, and no error is surfaced in the UI. The recording proceeds microphone-only.

## Root cause

- `configure_linux_audio()` (`frontend/src-tauri/src/audio/devices/platform/linux.rs`) enumerates PulseAudio/PipeWire monitor sources and decorates their names with a `" (System Audio)"` suffix for display:
  ```rust
  format!("{} (System Audio)", name)
  ```
  This decorated string is what gets persisted to `recording_preferences.json`.

- At recording start, `get_device_and_config()` (`frontend/src-tauri/src/audio/devices/configuration.rs`) resolves the actual cpal device by exact string comparison against the raw cpal device name. The stored name still carries the `" (System Audio)"` suffix — only `"(input)"`/`"(output)"` suffixes are stripped in `AudioDevice::from_name` — so `name == audio_device.name` never matches and the function returns `Err("Device not found: ...")`.

- That error is swallowed in `AudioStreamManager::start_streams()` (`frontend/src-tauri/src/audio/stream.rs`), which only logs a warning and continues with mic-only audio.

Net effect: no "System Audio" entry can ever be opened on Linux, regardless of which one is selected.

## Fix

Strip the `" (System Audio)"` display suffix before comparing against the raw cpal device name, mirroring the existing `"(input)"`/`"(output)"` stripping already done in `AudioDevice::from_name`. This is an 11-line change confined to the Linux branch of `get_device_and_config()`; no other platforms are affected (the change is inside `#[cfg(target_os = "linux")]`).

## Testing

- `cargo check --lib` passes on Linux with this change.
- Verified end-to-end on a PipeWire desktop: with the fix applied, starting a recording with a monitor source selected under "System Audio" now opens the capture stream successfully and the recorded file contains system audio; without the fix it fails silently as described in #701.