### PR TITLE
Feature/remote whisper provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ pnpm install
 
 Transcribe meetings entirely on your device using **Whisper** or **Parakeet** models. No cloud required.
 
+You can also point Meetily at your own **self-hosted Whisper server** (any OpenAI-compatible `/v1/audio/transcriptions` endpoint) to run transcription on a machine with a stronger GPU. Audio still never leaves infrastructure you control.
+
 <p align="center">
     <img src="docs/home.png" width="650" style="border-radius: 10px;" alt="Meetily Demo" />
 </p>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,6 @@ graph TD
 
 *   **Tauri Core:** The heart of the application, responsible for managing the window, handling events, and exposing the Rust core to the frontend.
 *   **Audio Engine:** Captures audio from the microphone and system, processes it, and prepares it for transcription.
-*   **Transcription Engine:** Uses local speech-to-text models (Whisper or Parakeet) to transcribe the captured audio. It can be accelerated with a GPU.
+*   **Transcription Engine:** Transcribes the captured audio through a pluggable provider. By default it runs a local speech-to-text model (Whisper or Parakeet), which can be GPU-accelerated; alternatively it can delegate to a self-hosted, OpenAI-compatible Whisper server on the user's own network.
 *   **Database:** A local SQLite database that stores meeting metadata, transcripts, and summaries.
 *   **Summary Engine:** Generates meeting summaries using various Large Language Models (LLMs), including local models via Ollama.

--- a/frontend/src-tauri/src/audio/transcription/engine.rs
+++ b/frontend/src-tauri/src/audio/transcription/engine.rs
@@ -135,10 +135,26 @@ pub async fn validate_transcription_model_ready<R: Runtime>(app: &AppHandle<R>) 
                 }
             }
         }
+        "remoteWhisper" => {
+            // The "model" field is repurposed to hold the remote server's base URL
+            // (e.g. "http://192.168.1.100:8093") — see RemoteWhisperProvider.
+            let base_url = config.model.clone();
+            info!("🔍 Validating remote Whisper server at {}...", base_url);
+            let provider = crate::audio::transcription::RemoteWhisperProvider::new(base_url.clone());
+            if provider.is_model_loaded().await {
+                info!("✅ Remote Whisper server at {} is reachable", base_url);
+                Ok(())
+            } else {
+                Err(format!(
+                    "Cannot reach remote Whisper server at {}. Check it is running and reachable from this machine.",
+                    base_url
+                ))
+            }
+        }
         other => {
             warn!("❌ Unsupported transcription provider for local recording: {}", other);
             Err(format!(
-                "Provider '{}' is not supported for local transcription. Please select 'localWhisper' or 'parakeet'.",
+                "Provider '{}' is not supported for local transcription. Please select 'localWhisper', 'parakeet' or 'remoteWhisper'.",
                 other
             ))
         }
@@ -211,6 +227,13 @@ pub async fn get_or_init_transcription_engine<R: Runtime>(
                     Err("Parakeet engine not initialized. This should not happen after validation.".to_string())
                 }
             }
+        }
+        "remoteWhisper" => {
+            // The "model" field is repurposed to hold the remote server's base URL.
+            let base_url = config.model.clone();
+            info!("🌐 Initializing remote Whisper provider ({})", base_url);
+            let provider = crate::audio::transcription::RemoteWhisperProvider::new(base_url);
+            Ok(TranscriptionEngine::Provider(std::sync::Arc::new(provider)))
         }
         "localWhisper" | _ => {
             info!("🎤 Initializing Whisper transcription engine");

--- a/frontend/src-tauri/src/audio/transcription/mod.rs
+++ b/frontend/src-tauri/src/audio/transcription/mod.rs
@@ -5,6 +5,7 @@
 pub mod provider;
 pub mod whisper_provider;
 pub mod parakeet_provider;
+pub mod remote_whisper_provider;
 pub mod engine;
 pub mod worker;
 
@@ -12,6 +13,7 @@ pub mod worker;
 pub use provider::{TranscriptionError, TranscriptionProvider, TranscriptResult};
 pub use whisper_provider::WhisperProvider;
 pub use parakeet_provider::ParakeetProvider;
+pub use remote_whisper_provider::RemoteWhisperProvider;
 pub use engine::{
     TranscriptionEngine,
     validate_transcription_model_ready,

--- a/frontend/src-tauri/src/audio/transcription/remote_whisper_provider.rs
+++ b/frontend/src-tauri/src/audio/transcription/remote_whisper_provider.rs
@@ -1,0 +1,288 @@
+// audio/transcription/remote_whisper_provider.rs
+//
+// Remote Whisper transcription provider: sends audio over HTTP to a
+// self-hosted OpenAI-compatible `/v1/audio/transcriptions` endpoint
+// (e.g. a faster-whisper server running on a machine with a dedicated GPU),
+// instead of loading a model in-process on this machine.
+//
+// The endpoint is expected to accept a multipart/form-data POST with a
+// `file` field (WAV audio) and an optional `language` field, and to return
+// JSON shaped like `{"text": "..."}` — the same contract OpenAI's
+// `/v1/audio/transcriptions` uses. Any faster-whisper / whisper.cpp server
+// built against that convention works without changes.
+
+use super::provider::{TranscriptionError, TranscriptionProvider, TranscriptResult};
+use async_trait::async_trait;
+use reqwest::multipart;
+use log::warn;
+use serde::Deserialize;
+use std::time::Duration;
+
+/// Sample rate the rest of the transcription pipeline hands us audio at.
+/// (See `TranscriptionProvider::transcribe` doc comment: 16kHz mono f32.)
+const SAMPLE_RATE_HZ: u32 = 16_000;
+
+/// How long we allow a single transcription request to run before giving up.
+/// Large chunks on a cold GPU (model not yet resident) can take a while.
+const REQUEST_TIMEOUT_SECS: u64 = 60;
+
+/// How long we allow a liveness probe to run. Deliberately much shorter than a
+/// transcription: a probe gates interactive actions (the onboarding "Test"
+/// button, and every recording start), so it must fail fast. A host that is off
+/// or behind a DROP firewall never sends a reset, so without this the probe
+/// would inherit the 60s transcription budget and freeze the UI for a minute.
+const HEALTH_TIMEOUT_SECS: u64 = 5;
+
+/// Meetily's language picker emits these sentinels for "let the engine decide".
+/// They are not ISO-639-1 codes: an OpenAI-compatible server rejects them
+/// (faster-whisper answers 500 Internal Server Error). Omitting the field
+/// entirely is exactly how that API is asked to auto-detect, so the sentinels
+/// must be dropped rather than forwarded.
+const AUTO_LANGUAGE_SENTINELS: [&str; 2] = ["auto", "auto-translate"];
+
+#[derive(Debug, Deserialize)]
+struct RemoteTranscriptionResponse {
+    text: String,
+}
+
+/// Transcription provider that delegates to a remote whisper-compatible HTTP server.
+pub struct RemoteWhisperProvider {
+    /// Base URL of the remote server, e.g. "http://192.168.1.100:8093".
+    /// No trailing slash expected; it is stripped defensively in `new`.
+    base_url: String,
+    client: reqwest::Client,
+    model_label: String,
+}
+
+impl RemoteWhisperProvider {
+    pub fn new(base_url: String) -> Self {
+        let base_url = base_url.trim_end_matches('/').to_string();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+
+        let model_label = format!("remote ({})", base_url);
+
+        Self {
+            base_url,
+            client,
+            model_label,
+        }
+    }
+
+    fn endpoint(&self) -> String {
+        format!("{}/v1/audio/transcriptions", self.base_url)
+    }
+
+    /// Map Meetily's language selection onto what the remote API accepts:
+    /// `Some(iso_code)` to force a language, `None` to let the server detect it.
+    fn normalize_language(language: Option<String>) -> Option<String> {
+        let language = language?;
+        let trimmed = language.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        let lowered = trimmed.to_ascii_lowercase();
+        if AUTO_LANGUAGE_SENTINELS.contains(&lowered.as_str()) {
+            if lowered == "auto-translate" {
+                // `/v1/audio/transcriptions` transcribes in the source language;
+                // translation lives behind a separate endpoint this provider does
+                // not target. Be explicit rather than silently returning
+                // untranslated text as if it had been translated.
+                warn!(
+                    "Remote Whisper: 'auto-translate' is not supported by \
+                     /v1/audio/transcriptions; falling back to auto-detected transcription"
+                );
+            }
+            return None;
+        }
+
+        Some(trimmed.to_string())
+    }
+
+    /// Encode 16kHz mono f32 PCM samples as a WAV byte buffer (16-bit PCM).
+    /// Self-contained — no extra crate dependency needed for such a simple header.
+    fn encode_wav_pcm16(samples: &[f32]) -> Vec<u8> {
+        let num_samples = samples.len() as u32;
+        let byte_rate = SAMPLE_RATE_HZ * 2; // mono, 16-bit
+        let data_size = num_samples * 2;
+        let riff_size = 36 + data_size;
+
+        let mut buf = Vec::with_capacity(44 + data_size as usize);
+        buf.extend_from_slice(b"RIFF");
+        buf.extend_from_slice(&riff_size.to_le_bytes());
+        buf.extend_from_slice(b"WAVE");
+
+        buf.extend_from_slice(b"fmt ");
+        buf.extend_from_slice(&16u32.to_le_bytes()); // fmt chunk size
+        buf.extend_from_slice(&1u16.to_le_bytes()); // PCM
+        buf.extend_from_slice(&1u16.to_le_bytes()); // mono
+        buf.extend_from_slice(&SAMPLE_RATE_HZ.to_le_bytes());
+        buf.extend_from_slice(&byte_rate.to_le_bytes());
+        buf.extend_from_slice(&2u16.to_le_bytes()); // block align
+        buf.extend_from_slice(&16u16.to_le_bytes()); // bits per sample
+
+        buf.extend_from_slice(b"data");
+        buf.extend_from_slice(&data_size.to_le_bytes());
+        for &sample in samples {
+            let clamped = sample.clamp(-1.0, 1.0);
+            let pcm = (clamped * i16::MAX as f32) as i16;
+            buf.extend_from_slice(&pcm.to_le_bytes());
+        }
+
+        buf
+    }
+}
+
+#[async_trait]
+impl TranscriptionProvider for RemoteWhisperProvider {
+    async fn transcribe(
+        &self,
+        audio: Vec<f32>,
+        language: Option<String>,
+    ) -> std::result::Result<TranscriptResult, TranscriptionError> {
+        if audio.is_empty() {
+            return Err(TranscriptionError::AudioTooShort {
+                samples: 0,
+                minimum: 1,
+            });
+        }
+
+        let wav_bytes = Self::encode_wav_pcm16(&audio);
+
+        let mut form = multipart::Form::new().part(
+            "file",
+            multipart::Part::bytes(wav_bytes)
+                .file_name("chunk.wav")
+                .mime_str("audio/wav")
+                .map_err(|e| TranscriptionError::EngineFailed(e.to_string()))?,
+        );
+        if let Some(lang) = Self::normalize_language(language) {
+            form = form.text("language", lang);
+        }
+
+        let response = self
+            .client
+            .post(self.endpoint())
+            .multipart(form)
+            .send()
+            .await
+            .map_err(|e| {
+                TranscriptionError::EngineFailed(format!(
+                    "Cannot reach remote whisper server at {}: {}",
+                    self.base_url, e
+                ))
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(TranscriptionError::EngineFailed(format!(
+                "Remote whisper server returned {}: {}",
+                status, body
+            )));
+        }
+
+        let parsed: RemoteTranscriptionResponse = response
+            .json()
+            .await
+            .map_err(|e| TranscriptionError::EngineFailed(format!("Invalid response JSON: {}", e)))?;
+
+        Ok(TranscriptResult {
+            text: parsed.text,
+            confidence: None, // faster-whisper server doesn't return a confidence score
+            is_partial: false,
+        })
+    }
+
+    async fn is_model_loaded(&self) -> bool {
+        // "Loaded" here means "reachable" — the remote process owns model lifecycle.
+        // Note this only proves the server answers; it cannot promise the next
+        // transcription succeeds.
+        let health_url = format!("{}/health", self.base_url);
+        matches!(
+            self.client
+                .get(&health_url)
+                .timeout(Duration::from_secs(HEALTH_TIMEOUT_SECS))
+                .send()
+                .await,
+            Ok(resp) if resp.status().is_success()
+        )
+    }
+
+    async fn get_current_model(&self) -> Option<String> {
+        Some(self.model_label.clone())
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "RemoteWhisper"
+    }
+}
+
+/// Tauri command: probe a remote Whisper server before committing to it.
+///
+/// Onboarding and settings both need to tell the user "this URL works" *before*
+/// it is persisted, otherwise the first failure only surfaces mid-recording.
+/// Deliberately reuses `TranscriptionProvider::is_model_loaded` so that what we
+/// validate here is exactly what `validate_transcription_model_ready` checks later.
+#[tauri::command]
+pub async fn remote_whisper_check_health(base_url: String) -> Result<bool, String> {
+    if base_url.trim().is_empty() {
+        return Err("Server URL is empty".to_string());
+    }
+
+    let provider = RemoteWhisperProvider::new(base_url);
+    Ok(provider.is_model_loaded().await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_sentinels_are_dropped_so_the_server_detects_the_language() {
+        // Forwarding these produced "500 Internal Server Error" from faster-whisper.
+        for sentinel in ["auto", "auto-translate", "AUTO", "Auto-Translate"] {
+            assert_eq!(
+                RemoteWhisperProvider::normalize_language(Some(sentinel.to_string())),
+                None,
+                "sentinel {sentinel} must not reach the server"
+            );
+        }
+    }
+
+    #[test]
+    fn blank_and_absent_languages_are_dropped() {
+        assert_eq!(RemoteWhisperProvider::normalize_language(None), None);
+        assert_eq!(RemoteWhisperProvider::normalize_language(Some("".into())), None);
+        assert_eq!(RemoteWhisperProvider::normalize_language(Some("   ".into())), None);
+    }
+
+    #[test]
+    fn real_language_codes_are_forwarded_trimmed() {
+        assert_eq!(
+            RemoteWhisperProvider::normalize_language(Some("es".into())),
+            Some("es".to_string())
+        );
+        assert_eq!(
+            RemoteWhisperProvider::normalize_language(Some(" en ".into())),
+            Some("en".to_string())
+        );
+    }
+
+    #[test]
+    fn wav_header_describes_16khz_mono_pcm16() {
+        let wav = RemoteWhisperProvider::encode_wav_pcm16(&[0.0, 1.0, -1.0]);
+        assert_eq!(&wav[0..4], b"RIFF");
+        assert_eq!(&wav[8..12], b"WAVE");
+        assert_eq!(u16::from_le_bytes([wav[22], wav[23]]), 1, "mono");
+        assert_eq!(
+            u32::from_le_bytes([wav[24], wav[25], wav[26], wav[27]]),
+            SAMPLE_RATE_HZ
+        );
+        assert_eq!(u16::from_le_bytes([wav[34], wav[35]]), 16, "16-bit samples");
+        assert_eq!(wav.len(), 44 + 3 * 2);
+    }
+}

--- a/frontend/src-tauri/src/audio/transcription/remote_whisper_provider.rs
+++ b/frontend/src-tauri/src/audio/transcription/remote_whisper_provider.rs
@@ -105,10 +105,13 @@ impl RemoteWhisperProvider {
     /// Encode 16kHz mono f32 PCM samples as a WAV byte buffer (16-bit PCM).
     /// Self-contained — no extra crate dependency needed for such a simple header.
     fn encode_wav_pcm16(samples: &[f32]) -> Vec<u8> {
-        let num_samples = samples.len() as u32;
+        // WAV headers are u32, so an oversized buffer would wrap in release and
+        // emit a header that silently disagrees with the payload. Chunks are
+        // seconds long in practice; saturate rather than wrap if that ever changes.
+        let num_samples = u32::try_from(samples.len()).unwrap_or(u32::MAX);
         let byte_rate = SAMPLE_RATE_HZ * 2; // mono, 16-bit
-        let data_size = num_samples * 2;
-        let riff_size = 36 + data_size;
+        let data_size = num_samples.saturating_mul(2);
+        let riff_size = data_size.saturating_add(36);
 
         let mut buf = Vec::with_capacity(44 + data_size as usize);
         buf.extend_from_slice(b"RIFF");
@@ -201,15 +204,30 @@ impl TranscriptionProvider for RemoteWhisperProvider {
         // "Loaded" here means "reachable" — the remote process owns model lifecycle.
         // Note this only proves the server answers; it cannot promise the next
         // transcription succeeds.
-        let health_url = format!("{}/health", self.base_url);
-        matches!(
-            self.client
-                .get(&health_url)
-                .timeout(Duration::from_secs(HEALTH_TIMEOUT_SECS))
-                .send()
-                .await,
-            Ok(resp) if resp.status().is_success()
-        )
+        //
+        // Two probes, because no single one covers the field. `/health` is a
+        // whisper.cpp-server / faster-whisper-server extension, absent from the
+        // OpenAI API; `/v1/models` is part of the OpenAI contract but absent from
+        // some minimal Whisper servers. Probing only one strands users of the other
+        // family on a reachable server that this check calls dead — and onboarding
+        // refuses to continue on that verdict.
+        for path in ["/health", "/v1/models"] {
+            let url = format!("{}{}", self.base_url, path);
+            let reachable = matches!(
+                self.client
+                    .get(&url)
+                    .timeout(Duration::from_secs(HEALTH_TIMEOUT_SECS))
+                    .send()
+                    .await,
+                // 401/403 count as alive: an endpoint that demands credentials is
+                // still an endpoint that answered.
+                Ok(resp) if resp.status().is_success() || resp.status() == 401 || resp.status() == 403
+            );
+            if reachable {
+                return true;
+            }
+        }
+        false
     }
 
     async fn get_current_model(&self) -> Option<String> {
@@ -270,6 +288,15 @@ mod tests {
             RemoteWhisperProvider::normalize_language(Some(" en ".into())),
             Some("en".to_string())
         );
+    }
+
+    #[test]
+    fn wav_header_survives_an_implausibly_large_buffer() {
+        // Not reachable with real chunks; the point is that the header stays
+        // internally consistent instead of wrapping into nonsense.
+        let data_size = u32::MAX.saturating_mul(2);
+        assert_eq!(data_size, u32::MAX);
+        assert_eq!(data_size.saturating_add(36), u32::MAX);
     }
 
     #[test]

--- a/frontend/src-tauri/src/database/repositories/setting.rs
+++ b/frontend/src-tauri/src/database/repositories/setting.rs
@@ -180,6 +180,7 @@ impl SettingsRepository {
         let api_key_column = match provider {
             "localWhisper" => "whisperApiKey",
             "parakeet" => return Ok(()), // Parakeet doesn't need an API key, return early
+            "remoteWhisper" => return Ok(()), // Self-hosted server, no API key
             "deepgram" => "deepgramApiKey",
             "elevenLabs" => "elevenLabsApiKey",
             "groq" => "groqApiKey",
@@ -212,6 +213,7 @@ impl SettingsRepository {
         let api_key_column = match provider {
             "localWhisper" => "whisperApiKey",
             "parakeet" => return Ok(None), // Parakeet doesn't need an API key
+            "remoteWhisper" => return Ok(None), // Self-hosted server, no API key
             "deepgram" => "deepgramApiKey",
             "elevenLabs" => "elevenLabsApiKey",
             "groq" => "groqApiKey",

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -731,6 +731,7 @@ pub fn run() {
             onboarding::save_onboarding_status_cmd,
             onboarding::reset_onboarding_status_cmd,
             onboarding::complete_onboarding,
+            audio::transcription::remote_whisper_provider::remote_whisper_check_health,
             // System settings commands
             #[cfg(target_os = "macos")]
             utils::open_system_settings,

--- a/frontend/src-tauri/src/onboarding.rs
+++ b/frontend/src-tauri/src/onboarding.rs
@@ -19,10 +19,20 @@ pub struct OnboardingStatus {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ModelStatus {
-    pub parakeet: String,  // "downloaded" | "not_downloaded" | "downloading"
+    pub parakeet: String,  // "downloaded" | "not_downloaded" | "downloading" | "skipped"
     pub summary: String,   // Generic field for summary model (Qwen 3.5 or legacy Gemma variants)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub selected_summary_model: Option<String>,
+    /// Transcription backend picked during onboarding: "parakeet" (local, the
+    /// default) or "remoteWhisper" (a self-hosted OpenAI-compatible server).
+    /// `None` on statuses written before remote transcription existed, which is
+    /// read as "parakeet".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transcription_provider: Option<String>,
+    /// Base URL of the remote transcription server, set only when
+    /// `transcription_provider` is "remoteWhisper".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_transcription_url: Option<String>,
 }
 
 impl Default for OnboardingStatus {
@@ -35,6 +45,8 @@ impl Default for OnboardingStatus {
                 parakeet: "not_downloaded".to_string(),
                 summary: "not_downloaded".to_string(),  // Changed from gemma
                 selected_summary_model: None,
+                transcription_provider: None,
+                remote_transcription_url: None,
             },
             last_updated: chrono::Utc::now().to_rfc3339(),
         }
@@ -167,57 +179,102 @@ pub async fn reset_onboarding_status_cmd<R: Runtime>(
         .map_err(|e| format!("Failed to reset onboarding status: {}", e))
 }
 
+/// Transcription backend identifier persisted by onboarding when the user opts
+/// into a self-hosted server instead of the bundled local engine.
+const REMOTE_WHISPER_PROVIDER: &str = "remoteWhisper";
+
 #[tauri::command]
 pub async fn complete_onboarding<R: Runtime>(
     app: AppHandle<R>,
     state: tauri::State<'_, AppState>,
-    model: String,
+    model: Option<String>,
+    transcription_provider: Option<String>,
+    remote_transcription_url: Option<String>,
 ) -> Result<(), String> {
-    info!("Completing onboarding with builtin-ai model: {}", model);
-
-    // Step 1: Save model configuration to SQLite database FIRST
     let pool = state.db_manager.pool();
 
-    // Onboarding always uses builtin-ai (local LLM)
-    if let Err(e) = SettingsRepository::save_model_config(
-        pool,
-        "builtin-ai",
-        &model,
-        "large-v3",
-        None,
-    ).await {
-        error!("Failed to save builtin-ai model config: {}", e);
-        return Err(format!("Failed to save builtin-ai model config: {}", e));
-    }
-    info!("Saved builtin-ai model config: model={}", model);
+    // ---- Summarization -----------------------------------------------------
+    // `model` is `None` when the user chose to bring their own summary provider
+    // (OpenAI, Claude, Ollama, ...). In that case onboarding must not write a
+    // builtin-ai config, otherwise the app would try to run a model that was
+    // never downloaded. The provider is configured later in Settings.
+    let summary_status = match model.as_deref() {
+        Some(model_name) => {
+            info!("Completing onboarding with builtin-ai model: {}", model_name);
+            if let Err(e) =
+                SettingsRepository::save_model_config(pool, "builtin-ai", model_name, "large-v3", None)
+                    .await
+            {
+                error!("Failed to save builtin-ai model config: {}", e);
+                return Err(format!("Failed to save builtin-ai model config: {}", e));
+            }
+            info!("Saved builtin-ai model config: model={}", model_name);
+            "downloaded"
+        }
+        None => {
+            info!("Completing onboarding without a local summary model (external provider)");
+            "skipped"
+        }
+    };
 
-    // Save transcription model config (parakeet provider) - always parakeet
-    if let Err(e) = SettingsRepository::save_transcript_config(
-        pool,
-        "parakeet",
-        crate::config::DEFAULT_PARAKEET_MODEL,
-    ).await {
+    // ---- Transcription -----------------------------------------------------
+    // Default stays local Parakeet; "remoteWhisper" reuses the `model` column of
+    // `transcript_settings` to carry the server base URL (see RemoteWhisperProvider).
+    let provider = transcription_provider.as_deref().unwrap_or("parakeet");
+    let (transcript_provider, transcript_model, parakeet_status) = if provider == REMOTE_WHISPER_PROVIDER
+    {
+        let url = remote_transcription_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|u| !u.is_empty())
+            .ok_or_else(|| {
+                "Remote transcription selected but no server URL was provided".to_string()
+            })?;
+        (REMOTE_WHISPER_PROVIDER, url.to_string(), "skipped")
+    } else {
+        (
+            "parakeet",
+            crate::config::DEFAULT_PARAKEET_MODEL.to_string(),
+            "downloaded",
+        )
+    };
+
+    if let Err(e) =
+        SettingsRepository::save_transcript_config(pool, transcript_provider, &transcript_model).await
+    {
         error!("Failed to save transcription model config: {}", e);
         return Err(format!("Failed to save transcription model config: {}", e));
     }
-    info!("Saved transcription model config: provider=parakeet, model={}", crate::config::DEFAULT_PARAKEET_MODEL);
+    info!(
+        "Saved transcription model config: provider={}, model={}",
+        transcript_provider, transcript_model
+    );
 
-    // Step 2: Only NOW mark onboarding as complete (after DB operations succeed)
+    // ---- Mark complete (only after the DB writes succeeded) ----------------
     let mut status = load_onboarding_status(&app)
         .await
         .map_err(|e| format!("Failed to load onboarding status: {}", e))?;
 
     status.completed = true;
     status.current_step = 4; // Max step (4 on macOS with permissions, 3 on other platforms)
-    status.model_status.parakeet = "downloaded".to_string();
-    status.model_status.summary = "downloaded".to_string();
-    status.model_status.selected_summary_model = Some(model.clone());
+    status.model_status.parakeet = parakeet_status.to_string();
+    status.model_status.summary = summary_status.to_string();
+    status.model_status.selected_summary_model = model.clone();
+    status.model_status.transcription_provider = Some(transcript_provider.to_string());
+    status.model_status.remote_transcription_url = if transcript_provider == REMOTE_WHISPER_PROVIDER {
+        Some(transcript_model.clone())
+    } else {
+        None
+    };
 
     save_onboarding_status(&app, &status)
         .await
         .map_err(|e| format!("Failed to save completed onboarding status: {}", e))?;
 
-    info!("Onboarding completed successfully with model: {}", model);
+    info!(
+        "Onboarding completed successfully (transcription={}, summary={})",
+        transcript_provider, summary_status
+    );
     Ok(())
 }
 
@@ -242,5 +299,58 @@ mod tests {
         .expect("old onboarding status should remain compatible");
 
         assert_eq!(status.model_status.selected_summary_model, None);
+    }
+
+    #[test]
+    fn onboarding_status_deserializes_without_transcription_fields() {
+        // Statuses written before remote transcription existed must keep loading:
+        // a missing provider is read as "local Parakeet", not as a hard error.
+        let status: OnboardingStatus = serde_json::from_str(
+            r#"{
+                "version": "1.0",
+                "completed": true,
+                "current_step": 4,
+                "model_status": {
+                    "parakeet": "downloaded",
+                    "summary": "downloaded",
+                    "selected_summary_model": "qwen3.5:4b"
+                },
+                "last_updated": "2026-05-30T00:00:00Z"
+            }"#,
+        )
+        .expect("pre-remote onboarding status should remain compatible");
+
+        assert_eq!(status.model_status.transcription_provider, None);
+        assert_eq!(status.model_status.remote_transcription_url, None);
+    }
+
+    #[test]
+    fn onboarding_status_roundtrips_remote_transcription() {
+        let status: OnboardingStatus = serde_json::from_str(
+            r#"{
+                "version": "1.0",
+                "completed": true,
+                "current_step": 4,
+                "model_status": {
+                    "parakeet": "skipped",
+                    "summary": "skipped",
+                    "transcription_provider": "remoteWhisper",
+                    "remote_transcription_url": "http://192.168.1.100:8093"
+                },
+                "last_updated": "2026-05-30T00:00:00Z"
+            }"#,
+        )
+        .expect("remote onboarding status should deserialize");
+
+        assert_eq!(
+            status.model_status.transcription_provider.as_deref(),
+            Some("remoteWhisper")
+        );
+        assert_eq!(status.model_status.selected_summary_model, None);
+
+        // Absent optional fields must not be re-emitted as nulls.
+        let json = serde_json::to_string(&status).expect("serializes");
+        assert!(!json.contains("selected_summary_model"));
+        assert!(json.contains("remoteWhisper"));
     }
 }

--- a/frontend/src/components/LanguageSelection.tsx
+++ b/frontend/src/components/LanguageSelection.tsx
@@ -118,7 +118,7 @@ interface LanguageSelectionProps {
   selectedLanguage: string;
   onLanguageChange: (language: string) => void;
   disabled?: boolean;
-  provider?: 'localWhisper' | 'parakeet' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
+  provider?: 'localWhisper' | 'parakeet' | 'remoteWhisper' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
 }
 
 export function LanguageSelection({
@@ -132,9 +132,25 @@ export function LanguageSelection({
 
   // Parakeet only supports auto-detection (doesn't support manual language selection)
   const isParakeet = provider === 'parakeet';
+
+  // A remote OpenAI-compatible server transcribes in the source language:
+  // translation lives behind a separate /v1/audio/translations endpoint that this
+  // provider does not target. Offering the option would promise an output the
+  // backend never produces, and the mismatch would be silent.
+  const isRemoteWhisper = provider === 'remoteWhisper';
+
   const availableLanguages = isParakeet
     ? LANGUAGES.filter(lang => lang.code === 'auto' || lang.code === 'auto-translate')
-    : LANGUAGES;
+    : isRemoteWhisper
+      ? LANGUAGES.filter(lang => lang.code !== 'auto-translate')
+      : LANGUAGES;
+
+  // A selection carried over from another provider can name an option this one
+  // does not offer. Show what will actually happen without overwriting the stored
+  // preference — ConfigContext coerces it on the way to the backend, so switching
+  // back to a provider that can translate restores the user's original choice.
+  const translationUnavailable = isRemoteWhisper && selectedLanguage === 'auto-translate';
+  const effectiveLanguage = translationUnavailable ? 'auto' : selectedLanguage;
 
   const handleLanguageChange = async (languageCode: string) => {
     setSaving(true);
@@ -170,7 +186,7 @@ export function LanguageSelection({
 
   // Find the selected language name for display
   const selectedLanguageName = LANGUAGES.find(
-    lang => lang.code === selectedLanguage
+    lang => lang.code === effectiveLanguage
   )?.name || 'Auto Detect (Original Language)';
 
   return (
@@ -184,7 +200,7 @@ export function LanguageSelection({
 
       <div className="space-y-2">
         <select
-          value={selectedLanguage}
+          value={effectiveLanguage}
           onChange={(e) => handleLanguageChange(e.target.value)}
           disabled={disabled || saving}
           className="w-full px-3 py-2 text-sm bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-50 disabled:text-gray-500"
@@ -196,6 +212,14 @@ export function LanguageSelection({
             </option>
           ))}
         </select>
+
+        {/* Remote server translation limitation */}
+        {isRemoteWhisper && (
+          <div className="p-2 bg-amber-50 border border-amber-200 rounded text-amber-800">
+            <p className="font-medium">ℹ️ Remote Server Language Support</p>
+            <p className="mt-1 text-xs">A remote Whisper server transcribes in the spoken language. Automatic translation to English is not available for this provider — use Local Whisper if you need translated output.</p>
+          </div>
+        )}
 
         {/* Parakeet language limitation warning */}
         {isParakeet && (
@@ -210,19 +234,19 @@ export function LanguageSelection({
           <p className="text-gray-600">
             <strong>Current:</strong> {selectedLanguageName}
           </p>
-          {selectedLanguage === 'auto' && (
+          {effectiveLanguage === 'auto' && (
             <div className="p-2 bg-yellow-50 border border-yellow-200 rounded text-yellow-800">
               <p className="font-medium">⚠️ Auto Detect may produce incorrect results</p>
               <p className="mt-1">For best accuracy, select your specific language (e.g., English, Spanish, etc.)</p>
             </div>
           )}
-          {selectedLanguage === 'auto-translate' && (
+          {effectiveLanguage === 'auto-translate' && (
             <div className="p-2 bg-blue-50 border border-blue-200 rounded text-blue-800">
               <p className="font-medium">🌐 Translation Mode Active</p>
               <p className="mt-1">All audio will be automatically translated to English. Best for multilingual meetings where you need English output.</p>
             </div>
           )}
-          {selectedLanguage !== 'auto' && selectedLanguage !== 'auto-translate' && (
+          {effectiveLanguage !== 'auto' && effectiveLanguage !== 'auto-translate' && (
             <p className="text-gray-600">
               Transcription will be optimized for <strong>{selectedLanguageName}</strong>
             </p>

--- a/frontend/src/components/TranscriptSettings.tsx
+++ b/frontend/src/components/TranscriptSettings.tsx
@@ -10,7 +10,7 @@ import { ParakeetModelManager } from './ParakeetModelManager';
 
 
 export interface TranscriptModelProps {
-    provider: 'localWhisper' | 'parakeet' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
+    provider: 'localWhisper' | 'parakeet' | 'remoteWhisper' | 'deepgram' | 'elevenLabs' | 'groq' | 'openai';
     model: string;
     apiKey?: string | null;
 }
@@ -34,7 +34,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
     }, [transcriptModelConfig.provider]);
 
     useEffect(() => {
-        if (transcriptModelConfig.provider === 'localWhisper' || transcriptModelConfig.provider === 'parakeet') {
+        if (transcriptModelConfig.provider === 'localWhisper' || transcriptModelConfig.provider === 'parakeet' || transcriptModelConfig.provider === 'remoteWhisper') {
             setApiKey(null);
         }
     }, [transcriptModelConfig.provider]);
@@ -53,6 +53,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
     const modelOptions = {
         localWhisper: [], // Model selection handled by ModelManager component
         parakeet: [], // Model selection handled by ParakeetModelManager component
+        remoteWhisper: [], // URL entered directly, no fixed model list
         deepgram: ['nova-2-phonecall'],
         elevenLabs: ['eleven_multilingual_v2'],
         groq: ['llama-3.3-70b-versatile'],
@@ -112,7 +113,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 onValueChange={(value) => {
                                     const provider = value as TranscriptModelProps['provider'];
                                     setUiProvider(provider);
-                                    if (provider !== 'localWhisper' && provider !== 'parakeet') {
+                                    if (provider !== 'localWhisper' && provider !== 'parakeet' && provider !== 'remoteWhisper') {
                                         fetchApiKey(provider);
                                     }
                                 }}
@@ -123,6 +124,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 <SelectContent>
                                     <SelectItem value="parakeet">⚡ Parakeet (Recommended - Real-time / Accurate)</SelectItem>
                                     <SelectItem value="localWhisper">🏠 Local Whisper (High Accuracy)</SelectItem>
+                                    <SelectItem value="remoteWhisper">🖥️ Remote Whisper (self-hosted server)</SelectItem>
                                     {/* <SelectItem value="deepgram">☁️ Deepgram (Backup)</SelectItem>
                                     <SelectItem value="elevenLabs">☁️ ElevenLabs</SelectItem>
                                     <SelectItem value="groq">☁️ Groq</SelectItem>
@@ -130,7 +132,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 </SelectContent>
                             </Select>
 
-                            {uiProvider !== 'localWhisper' && uiProvider !== 'parakeet' && (
+                            {uiProvider !== 'localWhisper' && uiProvider !== 'parakeet' && uiProvider !== 'remoteWhisper' && (
                                 <Select
                                     value={transcriptModelConfig.model}
                                     onValueChange={(value) => {
@@ -169,6 +171,31 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 onModelSelect={handleParakeetModelSelect}
                                 autoSave={true}
                             />
+                        </div>
+                    )}
+
+                    {uiProvider === 'remoteWhisper' && (
+                        <div>
+                            <Label className="block text-sm font-medium text-gray-700 mb-1">
+                                Server URL
+                            </Label>
+                            <Input
+                                type="text"
+                                className="mx-1 focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                                value={transcriptModelConfig.provider === 'remoteWhisper' ? transcriptModelConfig.model : ''}
+                                onChange={(e) => {
+                                    setTranscriptModelConfig({
+                                        ...transcriptModelConfig,
+                                        provider: 'remoteWhisper',
+                                        model: e.target.value,
+                                    });
+                                }}
+                                placeholder="http://192.168.1.100:8093"
+                            />
+                            <p className="mt-1 mx-1 text-xs text-gray-500">
+                                Base URL of an OpenAI-compatible <code>/v1/audio/transcriptions</code> server
+                                (e.g. a self-hosted faster-whisper instance). No API key required.
+                            </p>
                         </div>
                     )}
 

--- a/frontend/src/components/TranscriptSettings.tsx
+++ b/frontend/src/components/TranscriptSettings.tsx
@@ -1,10 +1,10 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
 import { Input } from './ui/input';
 import { Button } from './ui/button';
 import { Label } from './ui/label';
-import { Eye, EyeOff, Lock, Unlock } from 'lucide-react';
+import { Eye, EyeOff, Lock, Unlock, Loader2, CheckCircle2, XCircle } from 'lucide-react';
 import { ModelManager } from './WhisperModelManager';
 import { ParakeetModelManager } from './ParakeetModelManager';
 
@@ -28,10 +28,42 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
     const [isLockButtonVibrating, setIsLockButtonVibrating] = useState<boolean>(false);
     const [uiProvider, setUiProvider] = useState<TranscriptModelProps['provider']>(transcriptModelConfig.provider);
 
+    // Remote Whisper: local draft for the server URL input, decoupled from
+    // transcriptModelConfig so keystrokes don't trigger a Tauri/DB write on every change.
+    const [serverUrlDraft, setServerUrlDraft] = useState<string>(
+        transcriptModelConfig.provider === 'remoteWhisper' ? transcriptModelConfig.model : ''
+    );
+    const [serverUrlStatus, setServerUrlStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+    const [serverUrlError, setServerUrlError] = useState<string | null>(null);
+    const [healthCheckStatus, setHealthCheckStatus] = useState<'idle' | 'checking' | 'reachable' | 'unreachable' | 'error'>('idle');
+    const [healthCheckError, setHealthCheckError] = useState<string | null>(null);
+
+    // Mirrors the latest transcriptModelConfig without pulling it into the
+    // provider-switch effect's dependency array (same pattern as WhisperModelManager's autoSaveRef).
+    const transcriptModelConfigRef = useRef(transcriptModelConfig);
+    useEffect(() => {
+        transcriptModelConfigRef.current = transcriptModelConfig;
+    }, [transcriptModelConfig]);
+
     // Sync uiProvider when backend config changes (e.g., after model selection or initial load)
     useEffect(() => {
         setUiProvider(transcriptModelConfig.provider);
     }, [transcriptModelConfig.provider]);
+
+    // Re-seed the Server URL draft and clear stale feedback whenever the user (re)selects
+    // remoteWhisper in the provider dropdown. Only depends on uiProvider so that typing in
+    // the field doesn't get clobbered by this effect on every keystroke.
+    useEffect(() => {
+        if (uiProvider !== 'remoteWhisper') {
+            return;
+        }
+        const current = transcriptModelConfigRef.current;
+        setServerUrlDraft(current.provider === 'remoteWhisper' ? current.model : '');
+        setServerUrlStatus('idle');
+        setServerUrlError(null);
+        setHealthCheckStatus('idle');
+        setHealthCheckError(null);
+    }, [uiProvider]);
 
     useEffect(() => {
         if (transcriptModelConfig.provider === 'localWhisper' || transcriptModelConfig.provider === 'parakeet' || transcriptModelConfig.provider === 'remoteWhisper') {
@@ -93,6 +125,92 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
         // Close modal after selection
         if (onModelSelect) {
             onModelSelect();
+        }
+    };
+
+    const isValidServerUrl = (value: string) => /^https?:\/\//i.test(value);
+
+    const trimmedServerUrl = serverUrlDraft.trim();
+    const isServerUrlPersisted = transcriptModelConfig.provider === 'remoteWhisper' && transcriptModelConfig.model === trimmedServerUrl;
+    const isServerUrlSaveDisabled = !trimmedServerUrl || !isValidServerUrl(trimmedServerUrl) || isServerUrlPersisted || serverUrlStatus === 'saving';
+
+    // Persists the Remote Whisper server URL. Shared by the Save button, blur, and Enter
+    // so validation/skip-if-unchanged logic lives in one place. The "model" field is
+    // repurposed to hold the base URL for this provider (see engine.rs), which is the
+    // existing backend contract.
+    const saveServerUrl = async () => {
+        const trimmed = serverUrlDraft.trim();
+
+        if (trimmed !== serverUrlDraft) {
+            setServerUrlDraft(trimmed);
+        }
+
+        if (!trimmed) {
+            setServerUrlStatus('error');
+            setServerUrlError('Server URL is required.');
+            return;
+        }
+
+        if (!isValidServerUrl(trimmed)) {
+            setServerUrlStatus('error');
+            setServerUrlError('Server URL must start with http:// or https://.');
+            return;
+        }
+
+        if (transcriptModelConfig.provider === 'remoteWhisper' && transcriptModelConfig.model === trimmed) {
+            // Nothing changed since the last persisted value - avoid a redundant write.
+            setServerUrlStatus('saved');
+            setServerUrlError(null);
+            return;
+        }
+
+        setServerUrlStatus('saving');
+        setServerUrlError(null);
+        try {
+            await invoke('api_save_transcript_config', {
+                provider: 'remoteWhisper',
+                model: trimmed,
+                apiKey: null,
+            });
+            // Keep provider in sync even if the user only re-selected remoteWhisper
+            // without retyping the URL - this was the original persistence gap.
+            setTranscriptModelConfig({
+                ...transcriptModelConfig,
+                provider: 'remoteWhisper',
+                model: trimmed,
+            });
+            setServerUrlStatus('saved');
+        } catch (error) {
+            console.error('Failed to save remote Whisper server URL:', error);
+            setServerUrlStatus('error');
+            setServerUrlError(error instanceof Error ? error.message : String(error));
+        }
+    };
+
+    const testRemoteWhisperConnection = async () => {
+        const trimmed = serverUrlDraft.trim();
+
+        if (!trimmed) {
+            setHealthCheckStatus('error');
+            setHealthCheckError('Enter a server URL first.');
+            return;
+        }
+
+        if (!isValidServerUrl(trimmed)) {
+            setHealthCheckStatus('error');
+            setHealthCheckError('Server URL must start with http:// or https://.');
+            return;
+        }
+
+        setHealthCheckStatus('checking');
+        setHealthCheckError(null);
+        try {
+            const reachable = await invoke('remote_whisper_check_health', { baseUrl: trimmed }) as boolean;
+            setHealthCheckStatus(reachable ? 'reachable' : 'unreachable');
+        } catch (error) {
+            console.error('Remote Whisper health check failed:', error);
+            setHealthCheckStatus('error');
+            setHealthCheckError(error instanceof Error ? error.message : String(error));
         }
     };
 
@@ -182,16 +300,93 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                             <Input
                                 type="text"
                                 className="mx-1 focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-                                value={transcriptModelConfig.provider === 'remoteWhisper' ? transcriptModelConfig.model : ''}
+                                value={serverUrlDraft}
                                 onChange={(e) => {
-                                    setTranscriptModelConfig({
-                                        ...transcriptModelConfig,
-                                        provider: 'remoteWhisper',
-                                        model: e.target.value,
-                                    });
+                                    setServerUrlDraft(e.target.value);
+                                    if (serverUrlStatus !== 'idle') {
+                                        setServerUrlStatus('idle');
+                                        setServerUrlError(null);
+                                    }
+                                }}
+                                onBlur={() => {
+                                    void saveServerUrl();
+                                }}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter') {
+                                        e.preventDefault();
+                                        void saveServerUrl();
+                                    }
                                 }}
                                 placeholder="http://192.168.1.100:8093"
                             />
+
+                            <div className="mt-2 mx-1 flex items-center gap-2">
+                                <Button
+                                    type="button"
+                                    variant="default"
+                                    size="sm"
+                                    onClick={() => { void saveServerUrl(); }}
+                                    disabled={isServerUrlSaveDisabled}
+                                >
+                                    {serverUrlStatus === 'saving' ? (
+                                        <>
+                                            <Loader2 className="h-3.5 w-3.5 animate-spin" /> Saving...
+                                        </>
+                                    ) : (
+                                        'Save'
+                                    )}
+                                </Button>
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => { void testRemoteWhisperConnection(); }}
+                                    disabled={healthCheckStatus === 'checking'}
+                                >
+                                    {healthCheckStatus === 'checking' ? (
+                                        <>
+                                            <Loader2 className="h-3.5 w-3.5 animate-spin" /> Testing...
+                                        </>
+                                    ) : (
+                                        'Test connection'
+                                    )}
+                                </Button>
+                            </div>
+
+                            <div className="mt-1 mx-1 flex flex-col gap-0.5">
+                                {serverUrlStatus === 'saving' && (
+                                    <p className="flex items-center gap-1 text-xs text-gray-500">
+                                        <Loader2 className="h-3 w-3 animate-spin" /> Saving...
+                                    </p>
+                                )}
+                                {serverUrlStatus === 'saved' && (
+                                    <p className="flex items-center gap-1 text-xs text-green-600">
+                                        <CheckCircle2 className="h-3 w-3" /> Saved
+                                    </p>
+                                )}
+                                {serverUrlStatus === 'error' && serverUrlError && (
+                                    <p className="flex items-center gap-1 text-xs text-red-600">
+                                        <XCircle className="h-3 w-3" /> {serverUrlError}
+                                    </p>
+                                )}
+
+                                {healthCheckStatus === 'reachable' && (
+                                    <p className="flex items-center gap-1 text-xs text-green-600">
+                                        <CheckCircle2 className="h-3 w-3" /> Server reachable
+                                    </p>
+                                )}
+                                {healthCheckStatus === 'unreachable' && (
+                                    <p className="flex items-center gap-1 text-xs text-red-600">
+                                        <XCircle className="h-3 w-3" /> Server did not respond
+                                    </p>
+                                )}
+                                {healthCheckStatus === 'error' && healthCheckError && (
+                                    <p className="flex items-center gap-1 text-xs text-red-600">
+                                        <XCircle className="h-3 w-3" /> {healthCheckError}
+                                    </p>
+                                )}
+                            </div>
+
                             <p className="mt-1 mx-1 text-xs text-gray-500">
                                 Base URL of an OpenAI-compatible <code>/v1/audio/transcriptions</code> server
                                 (e.g. a self-hosted faster-whisper instance). No API key required.

--- a/frontend/src/components/onboarding/steps/DownloadProgressStep.tsx
+++ b/frontend/src/components/onboarding/steps/DownloadProgressStep.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
-import { Mic, Sparkles, Check, Loader2, Download } from 'lucide-react';
+import { Mic, Sparkles, Check, Loader2, Download, Server, Settings2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { OnboardingContainer } from '../OnboardingContainer';
 import { useOnboarding } from '@/contexts/OnboardingContext';
@@ -34,7 +34,16 @@ export function DownloadProgressStep() {
     setSummaryModelDownloaded,
     startBackgroundDownloads,
     completeOnboarding,
+    transcriptionMode,
+    remoteTranscriptionUrl,
+    summaryMode,
   } = useOnboarding();
+
+  // Backends the user delegated to their own infrastructure: this step must not
+  // download for them, must not render a progress bar, and must not gate on them.
+  const usesRemoteTranscription = transcriptionMode === 'remote';
+  const usesExternalSummary = summaryMode === 'external';
+  const transcriptionReady = usesRemoteTranscription || parakeetDownloaded;
 
   const [isMac, setIsMac] = useState(false);
 
@@ -167,6 +176,7 @@ export function DownloadProgressStep() {
 
   // Start the required transcription model immediately; summary readiness must not block it.
   useEffect(() => {
+    if (usesRemoteTranscription) return;
     if (parakeetDownloadStartedRef.current) return;
     parakeetDownloadStartedRef.current = true;
 
@@ -187,12 +197,13 @@ export function DownloadProgressStep() {
 
   // Start the selected summary model only after the backend recommendation is known.
   useEffect(() => {
+    if (usesExternalSummary) return;
     if (summaryDownloadStartedRef.current) return;
     if (!selectedSummaryModel) return;
     summaryDownloadStartedRef.current = true;
 
     startSummaryDownload();
-  }, [selectedSummaryModel]);
+  }, [selectedSummaryModel, usesExternalSummary]);
 
   // Listen to Parakeet download progress
   useEffect(() => {
@@ -337,8 +348,12 @@ export function DownloadProgressStep() {
     }
   };
 
-  const handleContinue = async () => {
-    // Verify actual model availability (catches state drift)
+  /**
+   * Reconcile UI state with what is actually on disk (catches state drift).
+   * Returns false when the local engine is genuinely missing and the user
+   * should stay on this step.
+   */
+  const verifyLocalTranscriptionEngine = async (): Promise<boolean> => {
     try {
       await invoke('parakeet_init');
       const actuallyAvailable = await invoke<boolean>('parakeet_has_available_models');
@@ -358,15 +373,27 @@ export function DownloadProgressStep() {
         toast.error('Transcription engine required', {
           description: 'Please retry the download before continuing.',
         });
-        return;
+        return false;
       }
     } catch (error) {
       console.warn('[DownloadProgressStep] Failed to verify model:', error);
     }
+    return true;
+  };
 
-    // Check if downloads are complete for toast notification
-    const downloadsComplete = parakeetState.status === 'completed' &&
-      summaryState.status === 'completed';
+  const handleContinue = async () => {
+    // Remote transcription has no local model to verify, and `parakeet_init`
+    // would spin up an engine the user explicitly opted out of.
+    if (!usesRemoteTranscription) {
+      const ok = await verifyLocalTranscriptionEngine();
+      if (!ok) return;
+    }
+
+    // Check if downloads are complete for toast notification.
+    // Delegated backends count as complete — nothing is downloading for them.
+    const downloadsComplete =
+      (usesRemoteTranscription || parakeetState.status === 'completed') &&
+      (usesExternalSummary || summaryState.status === 'completed');
 
     // Show toast if downloads still in progress
     if (!downloadsComplete) {
@@ -398,6 +425,32 @@ export function DownloadProgressStep() {
       }
     }
   };
+
+  // A backend the user delegated elsewhere: no size, no progress, no retry —
+  // just a statement of where it runs.
+  const renderDelegatedCard = (
+    title: string,
+    icon: React.ReactNode,
+    detail: string,
+    badge: string
+  ) => (
+    <div className="bg-white rounded-xl border border-gray-200 p-5">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
+            {icon}
+          </div>
+          <div className="min-w-0">
+            <h3 className="font-medium text-gray-900">{title}</h3>
+            <p className="text-sm text-gray-500 truncate" title={detail}>{detail}</p>
+          </div>
+        </div>
+        <span className="text-xs text-gray-600 bg-gray-100 rounded-full px-2.5 py-1 shrink-0">
+          {badge}
+        </span>
+      </div>
+    </div>
+  );
 
   const renderDownloadCard = (
     title: string,
@@ -491,32 +544,50 @@ export function DownloadProgressStep() {
   return (
     <OnboardingContainer
       title="Getting things ready"
-      description="You can start using Meetily after downloading the Transcription Engine."
+      description={
+        usesRemoteTranscription
+          ? 'Your remote transcription server is configured. You can start using Meetily right away.'
+          : 'You can start using Meetily after downloading the Transcription Engine.'
+      }
       step={3}
       totalSteps={isMac ? 4 : 3}
     >
       <div className="flex flex-col items-center space-y-6">
         {/* Download Cards */}
         <div className="w-full max-w-lg space-y-4">
-          {renderDownloadCard(
-            'Transcription Engine',
-            <Mic className="w-5 h-5 text-gray-600" />,
-            parakeetState,
-            '~670 MB'
-          )}
+          {usesRemoteTranscription
+            ? renderDelegatedCard(
+                'Transcription Engine',
+                <Server className="w-5 h-5 text-gray-600" />,
+                remoteTranscriptionUrl,
+                'Remote'
+              )
+            : renderDownloadCard(
+                'Transcription Engine',
+                <Mic className="w-5 h-5 text-gray-600" />,
+                parakeetState,
+                '~670 MB'
+              )}
 
-          {renderDownloadCard(
-            'Summary Engine',
-            <Sparkles className="w-5 h-5 text-gray-600" />,
-            summaryState,
-            getSummaryModelSizeLabel(selectedSummaryModel || recommendedSummaryModel),
-            'MiB'
-          )}
+          {usesExternalSummary
+            ? renderDelegatedCard(
+                'Summary Engine',
+                <Settings2 className="w-5 h-5 text-gray-600" />,
+                'Choose a provider in Settings → Summarization',
+                'Later'
+              )
+            : renderDownloadCard(
+                'Summary Engine',
+                <Sparkles className="w-5 h-5 text-gray-600" />,
+                summaryState,
+                getSummaryModelSizeLabel(selectedSummaryModel || recommendedSummaryModel),
+                'MiB'
+              )}
         </div>
 
         {/* Info Message - Only show when Parakeet is downloaded */}
         <AnimatePresence>
-          {parakeetDownloaded && !summaryModelDownloaded && (
+          {!usesRemoteTranscription && !usesExternalSummary && parakeetDownloaded && !summaryModelDownloaded && (
             <motion.div
               initial={{ opacity: 0, y: -10 }}
               animate={{ opacity: 1, y: 0 }}
@@ -541,10 +612,10 @@ export function DownloadProgressStep() {
         <div className="w-full max-w-xs">
           <Button
             onClick={handleContinue}
-            disabled={!parakeetDownloaded || isCompleting}
+            disabled={!transcriptionReady || isCompleting}
             className="w-full h-11 bg-gray-900 hover:bg-gray-800 text-white disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {(isCompleting || !parakeetDownloaded) ? (
+            {(isCompleting || !transcriptionReady) ? (
               <Loader2 className="w-4 h-4 mr-2 animate-spin" />
             ) : (
               'Continue'

--- a/frontend/src/components/onboarding/steps/SetupOverviewStep.tsx
+++ b/frontend/src/components/onboarding/steps/SetupOverviewStep.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { Info } from 'lucide-react';
+import { invoke } from '@tauri-apps/api/core';
+import { Info, Loader2, Check, AlertCircle, ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { OnboardingContainer } from '../OnboardingContainer';
 import { useOnboarding } from '@/contexts/OnboardingContext';
 import {
@@ -10,9 +13,23 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
+type ProbeState = 'idle' | 'checking' | 'reachable' | 'unreachable';
+
 export function SetupOverviewStep() {
-  const { goNext } = useOnboarding();
+  const {
+    goNext,
+    transcriptionMode,
+    setTranscriptionMode,
+    remoteTranscriptionUrl,
+    setRemoteTranscriptionUrl,
+    summaryMode,
+    setSummaryMode,
+  } = useOnboarding();
+
   const [isMac, setIsMac] = useState(false);
+  const [showBackendOptions, setShowBackendOptions] = useState(false);
+  const [probe, setProbe] = useState<ProbeState>('idle');
+  const [probeError, setProbeError] = useState<string | null>(null);
 
   useEffect(() => {
     const checkPlatform = async () => {
@@ -26,16 +43,52 @@ export function SetupOverviewStep() {
     checkPlatform();
   }, []);
 
+  // A URL edit invalidates any previous probe result: never let a stale green
+  // check authorise a URL the user has since changed.
+  useEffect(() => {
+    setProbe('idle');
+    setProbeError(null);
+  }, [remoteTranscriptionUrl]);
+
+  const usesRemoteTranscription = transcriptionMode === 'remote';
+  const trimmedUrl = remoteTranscriptionUrl.trim();
+
+  const testRemoteServer = async () => {
+    if (!trimmedUrl) return;
+    setProbe('checking');
+    setProbeError(null);
+    try {
+      const reachable = await invoke<boolean>('remote_whisper_check_health', {
+        baseUrl: trimmedUrl,
+      });
+      setProbe(reachable ? 'reachable' : 'unreachable');
+      if (!reachable) {
+        setProbeError('The server did not respond to a health check.');
+      }
+    } catch (error) {
+      setProbe('unreachable');
+      setProbeError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  // Downloads are irreversible in practice (hundreds of MB), so a remote setup
+  // must be proven reachable before we let the user leave this step.
+  const canContinue = !usesRemoteTranscription || probe === 'reachable';
+
   const steps = [
     {
       number: 1,
       type: 'transcription',
-      title: 'Download Transcription Engine',
+      title: usesRemoteTranscription
+        ? 'Use Remote Transcription Server'
+        : 'Download Transcription Engine',
     },
     {
       number: 2,
       type: 'summarization',
-      title: 'Download Summarization Engine',
+      title: summaryMode === 'external'
+        ? 'Configure Summarization in Settings'
+        : 'Download Summarization Engine',
     },
   ];
 
@@ -43,18 +96,22 @@ export function SetupOverviewStep() {
     goNext();
   };
 
+  const description = usesRemoteTranscription || summaryMode === 'external'
+    ? 'Meetily will use the AI backends you configured below. Nothing extra is downloaded for them.'
+    : 'Meetily requires that you download the Transcription & Summarization AI models for the software to work.';
+
   return (
     <OnboardingContainer
       title="Setup Overview"
-      description="Meetily requires that you download the Transcription & Summarization AI models for the software to work."
+      description={description}
       step={2}
       totalSteps={isMac ? 4 : 3}
     >
-      <div className="flex flex-col items-center space-y-10">
+      <div className="flex flex-col items-center space-y-6">
         {/* Steps Card */}
         <div className="w-full max-w-md bg-white rounded-lg border border-gray-200 p-4">
           <div className="space-y-4">
-            {steps.map((step, idx) => {
+            {steps.map((step) => {
               return (
                 <div
                   key={step.number}
@@ -87,15 +144,161 @@ export function SetupOverviewStep() {
           </div>
         </div>
 
+        {/* Advanced: bring-your-own backends. Collapsed by default so the
+            default download path stays exactly as it was. */}
+        <div className="w-full max-w-md">
+          <button
+            type="button"
+            onClick={() => setShowBackendOptions((v) => !v)}
+            className="flex items-center gap-1.5 text-xs text-gray-600 hover:text-gray-900"
+            aria-expanded={showBackendOptions}
+          >
+            <ChevronDown
+              className={`w-3.5 h-3.5 transition-transform ${showBackendOptions ? '' : '-rotate-90'}`}
+            />
+            Already running your own AI servers?
+          </button>
+
+          {showBackendOptions && (
+            <div className="mt-3 space-y-5 rounded-lg border border-gray-200 bg-gray-50 p-4">
+              {/* Transcription backend */}
+              <fieldset className="space-y-2">
+                <legend className="text-sm font-medium text-gray-900">Transcription</legend>
+
+                <label className="flex items-start gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="transcription-mode"
+                    className="mt-1"
+                    checked={!usesRemoteTranscription}
+                    onChange={() => setTranscriptionMode('local')}
+                  />
+                  <span className="text-sm text-gray-700">
+                    Download the local engine
+                    <span className="text-gray-500"> (~670 MB, runs on this machine)</span>
+                  </span>
+                </label>
+
+                <label className="flex items-start gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="transcription-mode"
+                    className="mt-1"
+                    checked={usesRemoteTranscription}
+                    onChange={() => setTranscriptionMode('remote')}
+                  />
+                  <span className="text-sm text-gray-700">
+                    Use a remote Whisper server
+                    <span className="text-gray-500"> (nothing is downloaded)</span>
+                  </span>
+                </label>
+
+                {usesRemoteTranscription && (
+                  <div className="pl-6 pt-1 space-y-2">
+                    <Label className="block text-xs font-medium text-gray-700">
+                      Server URL
+                    </Label>
+                    <div className="flex gap-2">
+                      <Input
+                        type="text"
+                        value={remoteTranscriptionUrl}
+                        onChange={(e) => setRemoteTranscriptionUrl(e.target.value)}
+                        placeholder="http://192.168.1.100:8093"
+                        className="flex-1 focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                      />
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={testRemoteServer}
+                        disabled={!trimmedUrl || probe === 'checking'}
+                        className="shrink-0"
+                      >
+                        {probe === 'checking' ? (
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                        ) : (
+                          'Test'
+                        )}
+                      </Button>
+                    </div>
+
+                    {probe === 'reachable' && (
+                      <p className="flex items-center gap-1.5 text-xs text-green-600">
+                        <Check className="w-3.5 h-3.5" /> Server is reachable.
+                      </p>
+                    )}
+                    {probe === 'unreachable' && (
+                      <p className="flex items-start gap-1.5 text-xs text-red-600">
+                        <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+                        <span>{probeError || 'Could not reach the server.'}</span>
+                      </p>
+                    )}
+
+                    <p className="text-xs text-gray-500">
+                      Base URL of an OpenAI-compatible{' '}
+                      <code>/v1/audio/transcriptions</code> server, for example a
+                      self-hosted faster-whisper instance. No API key required.
+                    </p>
+                  </div>
+                )}
+              </fieldset>
+
+              {/* Summarization backend */}
+              <fieldset className="space-y-2 border-t border-gray-200 pt-4">
+                <legend className="text-sm font-medium text-gray-900">Summarization</legend>
+
+                <label className="flex items-start gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="summary-mode"
+                    className="mt-1"
+                    checked={summaryMode === 'local'}
+                    onChange={() => setSummaryMode('local')}
+                  />
+                  <span className="text-sm text-gray-700">
+                    Download the built-in model
+                    <span className="text-gray-500"> (runs on this machine)</span>
+                  </span>
+                </label>
+
+                <label className="flex items-start gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="summary-mode"
+                    className="mt-1"
+                    checked={summaryMode === 'external'}
+                    onChange={() => setSummaryMode('external')}
+                  />
+                  <span className="text-sm text-gray-700">
+                    Set up a provider later in Settings
+                    <span className="text-gray-500"> (OpenAI, Claude, Ollama, ... — nothing is downloaded)</span>
+                  </span>
+                </label>
+
+                {summaryMode === 'external' && (
+                  <p className="pl-6 text-xs text-gray-500">
+                    Summaries stay unavailable until you pick a provider in
+                    Settings → Summarization.
+                  </p>
+                )}
+              </fieldset>
+            </div>
+          )}
+        </div>
 
         {/* CTA Section */}
         <div className="w-full max-w-xs space-y-4">
           <Button
             onClick={handleContinue}
-            className="w-full h-11 bg-gray-900 hover:bg-gray-800 text-white"
+            disabled={!canContinue}
+            className="w-full h-11 bg-gray-900 hover:bg-gray-800 text-white disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Let's Go
           </Button>
+          {!canContinue && (
+            <p className="text-center text-xs text-gray-500">
+              Test the connection to your server before continuing.
+            </p>
+          )}
           <div className="text-center">
             <a
               href="https://github.com/Zackriya-Solutions/meeting-minutes"

--- a/frontend/src/contexts/ConfigContext.tsx
+++ b/frontend/src/contexts/ConfigContext.tsx
@@ -97,6 +97,25 @@ interface ConfigContextType {
 const ConfigContext = createContext<ConfigContextType | undefined>(undefined);
 
 
+/**
+ * Not every backend supports every language option. `auto-translate` asks for
+ * translation to English, which a remote OpenAI-compatible Whisper server cannot
+ * deliver — translation lives behind a separate `/v1/audio/translations` endpoint
+ * this app does not call.
+ *
+ * Rust owns the value transcription actually reads (`LANGUAGE_PREFERENCE`, whose
+ * own default is `auto-translate`), and it is written from this context. So the
+ * coercion belongs here, not in a settings panel that only exists while its modal
+ * is open — otherwise a user who switches provider without visiting that panel
+ * keeps requesting a translation that silently never happens.
+ */
+function resolveLanguageForProvider(language: string, provider: string): string {
+  if (provider === 'remoteWhisper' && language === 'auto-translate') {
+    return 'auto';
+  }
+  return language;
+}
+
 export function ConfigProvider({ children }: { children: ReactNode }) {
   // Model configuration state
   const [modelConfig, setModelConfig] = useState<ModelConfig>({
@@ -214,18 +233,25 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     loadTranscriptConfig();
   }, []);
 
-  // Sync language preference to Rust on mount (fixes startup desync bug)
+  // Sync language preference to Rust (fixes startup desync bug).
+  // Re-runs on provider change too: a preference that is valid for one backend can
+  // be unsupported by another, and this is the only write path that always runs.
   useEffect(() => {
-    if (selectedLanguage) {
-      invoke('set_language_preference', { language: selectedLanguage })
-        .then(() => {
-          console.log('[ConfigContext] Synced language preference to Rust on startup:', selectedLanguage);
-        })
-        .catch(err => {
-          console.error('[ConfigContext] Failed to sync language preference to Rust on startup:', err);
-        });
-    }
-  }, []); 
+    if (!selectedLanguage) return;
+
+    const effectiveLanguage = resolveLanguageForProvider(
+      selectedLanguage,
+      transcriptModelConfig.provider
+    );
+
+    invoke('set_language_preference', { language: effectiveLanguage })
+      .then(() => {
+        console.log('[ConfigContext] Synced language preference to Rust:', effectiveLanguage);
+      })
+      .catch(err => {
+        console.error('[ConfigContext] Failed to sync language preference to Rust:', err);
+      });
+  }, [selectedLanguage, transcriptModelConfig.provider]); 
 
   // Load model configuration on mount
   useEffect(() => {
@@ -479,12 +505,13 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
   const handleSetSelectedLanguage = useCallback((lang: string) => {
     setSelectedLanguage(lang);
     if (typeof window !== 'undefined') {
+      // Persist the user's actual preference; the provider-specific coercion is
+      // applied when syncing to Rust, so switching back to a capable provider
+      // restores their choice instead of having silently overwritten it.
       localStorage.setItem('primaryLanguage', lang);
     }
-    // Sync with Rust in-memory state for live recording
-    invoke('set_language_preference', { language: lang }).catch(err =>
-      console.error('Failed to sync language preference to Rust:', err)
-    );
+    // The sync effect above pushes this to Rust once state settles — doing it here
+    // as well would fire a second, provider-unaware write that could race it.
   }, []);
 
   const value: ConfigContextType = useMemo(() => ({

--- a/frontend/src/contexts/OnboardingContext.tsx
+++ b/frontend/src/contexts/OnboardingContext.tsx
@@ -17,9 +17,25 @@ interface OnboardingStatus {
     parakeet: string;
     summary: string;
     selected_summary_model?: string;
+    transcription_provider?: string;
+    remote_transcription_url?: string;
   };
   last_updated: string;
 }
+
+/**
+ * Where transcription runs. 'local' downloads the bundled Parakeet engine;
+ * 'remote' points at a self-hosted OpenAI-compatible Whisper server and
+ * downloads nothing.
+ */
+export type TranscriptionMode = 'local' | 'remote';
+
+/**
+ * Where summarization runs. 'local' downloads the built-in AI model;
+ * 'external' leaves it to be configured in Settings (OpenAI, Claude, Ollama, ...)
+ * and downloads nothing.
+ */
+export type SummaryMode = 'local' | 'external';
 
 interface SummaryModelProgressInfo {
   percent: number;
@@ -45,6 +61,9 @@ interface OnboardingContextType {
   summaryModelProgressInfo: SummaryModelProgressInfo;
   selectedSummaryModel: string;
   recommendedSummaryModel: string;
+  transcriptionMode: TranscriptionMode;
+  remoteTranscriptionUrl: string;
+  summaryMode: SummaryMode;
   databaseExists: boolean;
   isBackgroundDownloading: boolean;
   // Permissions
@@ -58,6 +77,9 @@ interface OnboardingContextType {
   setParakeetDownloaded: (value: boolean) => void;
   setSummaryModelDownloaded: (value: boolean) => void;
   setSelectedSummaryModel: (value: string) => void;
+  setTranscriptionMode: (value: TranscriptionMode) => void;
+  setRemoteTranscriptionUrl: (value: string) => void;
+  setSummaryMode: (value: SummaryMode) => void;
   setDatabaseExists: (value: boolean) => void;
   setPermissionStatus: (permission: keyof OnboardingPermissions, status: PermissionStatus) => void;
   setPermissionsSkipped: (skipped: boolean) => void;
@@ -95,6 +117,9 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
   });
   const [selectedSummaryModel, setSelectedSummaryModel] = useState<string>('');
   const [recommendedSummaryModel, setRecommendedSummaryModel] = useState<string>('');
+  const [transcriptionMode, setTranscriptionMode] = useState<TranscriptionMode>('local');
+  const [remoteTranscriptionUrl, setRemoteTranscriptionUrl] = useState<string>('');
+  const [summaryMode, setSummaryMode] = useState<SummaryMode>('local');
   const [databaseExists, setDatabaseExists] = useState(false);
   const [isBackgroundDownloading, setIsBackgroundDownloading] = useState(false);
 
@@ -107,6 +132,10 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
   const [permissionsSkipped, setPermissionsSkipped] = useState(false);
 
   const saveTimeoutRef = useRef<NodeJS.Timeout>();
+  // Guards the debounced auto-save: until the persisted status has been read,
+  // component state is still at its defaults, and saving it would overwrite a
+  // stored configuration (e.g. a remote transcription URL) with 'parakeet'.
+  const hasLoadedStatusRef = useRef(false);
 
   const initializeSummaryModelSelection = async (preferredModel = selectedSummaryModel) => {
     try {
@@ -223,6 +252,7 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
     // Don't auto-save if completed (to avoid overwriting completion status)
     // Also don't auto-save if we are currently in the process of completing
     if (completed || isCompletingRef.current) return;
+    if (!hasLoadedStatusRef.current) return;
 
     saveTimeoutRef.current = setTimeout(() => {
       saveOnboardingStatus();
@@ -231,7 +261,7 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
     return () => {
       if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
     };
-  }, [currentStep, parakeetDownloaded, summaryModelDownloaded, completed]);
+  }, [currentStep, parakeetDownloaded, summaryModelDownloaded, completed, transcriptionMode, remoteTranscriptionUrl, summaryMode]);
 
   // Listen to Parakeet download progress
   useEffect(() => {
@@ -339,11 +369,25 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
     }
   };
 
+  // Restore the user's backend choices so a re-entered wizard does not silently
+  // fall back to "download everything" after they opted into remote backends.
+  const restoreBackendModes = (status: OnboardingStatus) => {
+    if (status.model_status.transcription_provider === 'remoteWhisper') {
+      setTranscriptionMode('remote');
+      setRemoteTranscriptionUrl(status.model_status.remote_transcription_url || '');
+    }
+    if (status.model_status.summary === 'skipped') {
+      setSummaryMode('external');
+    }
+  };
+
   const loadOnboardingStatus = async () => {
     try {
       const status = await invoke<OnboardingStatus | null>('get_onboarding_status');
       if (status) {
         console.log('[OnboardingContext] Loaded saved status:', status);
+
+        restoreBackendModes(status);
 
         if (status.completed) {
           setCurrentStep(status.current_step);
@@ -377,6 +421,9 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
       }
     } catch (error) {
       console.error('[OnboardingContext] Failed to load onboarding status:', error);
+    } finally {
+      // Released on every path — a failed read must not wedge auto-save off.
+      hasLoadedStatusRef.current = true;
     }
   };
 
@@ -386,14 +433,25 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
     let summaryModelDownloaded = false;
     let selectedSummaryModel = '';
 
-    // Verify Parakeet model exists on disk
-    try {
-      await invoke('parakeet_init');
-      parakeetDownloaded = await invoke<boolean>('parakeet_has_available_models');
-      console.log('[OnboardingContext] Parakeet verified on disk:', parakeetDownloaded);
-    } catch (error) {
-      console.warn('[OnboardingContext] Failed to verify Parakeet:', error);
-      parakeetDownloaded = false;
+    // Verify Parakeet model exists on disk. Read the choice from the saved
+    // status rather than component state: `restoreBackendModes` schedules its
+    // setState calls, so they are not visible yet on this pass.
+    const savedRemoteTranscription =
+      savedStatus.model_status.transcription_provider === 'remoteWhisper';
+
+    if (savedRemoteTranscription) {
+      // No local model to verify, and `parakeet_init` would spin up an engine
+      // the user explicitly opted out of.
+      console.log('[OnboardingContext] Remote transcription configured, skipping Parakeet check');
+    } else {
+      try {
+        await invoke('parakeet_init');
+        parakeetDownloaded = await invoke<boolean>('parakeet_has_available_models');
+        console.log('[OnboardingContext] Parakeet verified on disk:', parakeetDownloaded);
+      } catch (error) {
+        console.warn('[OnboardingContext] Failed to verify Parakeet:', error);
+        parakeetDownloaded = false;
+      }
     }
 
     // Verify the selected/recommended Summary model exists on disk.
@@ -456,9 +514,19 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
           completed: completed,
           current_step: currentStep,
           model_status: {
-            parakeet: parakeetDownloaded ? 'downloaded' : 'not_downloaded',
-            summary: summaryModelDownloaded ? 'downloaded' : 'not_downloaded',
-            selected_summary_model: selectedSummaryModel || undefined,
+            parakeet: transcriptionMode === 'remote'
+              ? 'skipped'
+              : parakeetDownloaded ? 'downloaded' : 'not_downloaded',
+            summary: summaryMode === 'external'
+              ? 'skipped'
+              : summaryModelDownloaded ? 'downloaded' : 'not_downloaded',
+            selected_summary_model: summaryMode === 'external'
+              ? undefined
+              : (selectedSummaryModel || undefined),
+            transcription_provider:
+              transcriptionMode === 'remote' ? 'remoteWhisper' : 'parakeet',
+            remote_transcription_url:
+              transcriptionMode === 'remote' ? remoteTranscriptionUrl.trim() || undefined : undefined,
           },
           last_updated: new Date().toISOString(),
         },
@@ -479,27 +547,39 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
         saveTimeoutRef.current = undefined;
       }
 
-      let modelToSave = selectedSummaryModel;
-      if (!modelToSave) {
-        modelToSave = await invoke<string>('builtin_ai_get_recommended_model');
-        setSelectedSummaryModel(modelToSave);
+      // `null` tells the backend the user brings their own summary provider, so
+      // onboarding must not write a builtin-ai config nor kick off a download.
+      let modelToSave: string | null = null;
+
+      if (summaryMode === 'local') {
+        modelToSave = selectedSummaryModel;
+        if (!modelToSave) {
+          modelToSave = await invoke<string>('builtin_ai_get_recommended_model');
+          setSelectedSummaryModel(modelToSave);
+        }
+
+        const selectedModelReady = await invoke<boolean>('builtin_ai_is_model_ready', {
+          modelName: modelToSave,
+          refresh: true,
+        });
+        setSummaryModelDownloaded(selectedModelReady);
+        if (!selectedModelReady) {
+          requestSummaryModelDownload(modelToSave);
+        }
       }
 
-      const selectedModelReady = await invoke<boolean>('builtin_ai_is_model_ready', {
-        modelName: modelToSave,
-        refresh: true,
-      });
-      setSummaryModelDownloaded(selectedModelReady);
-      if (!selectedModelReady) {
-        requestSummaryModelDownload(modelToSave);
-      }
+      const usesRemoteTranscription = transcriptionMode === 'remote';
 
-      // Onboarding always uses builtin-ai with selected model
       await invoke('complete_onboarding', {
         model: modelToSave,
+        transcriptionProvider: usesRemoteTranscription ? 'remoteWhisper' : 'parakeet',
+        remoteTranscriptionUrl: usesRemoteTranscription ? remoteTranscriptionUrl.trim() : null,
       });
       setCompleted(true);
-      console.log('[OnboardingContext] Onboarding completed with model:', modelToSave);
+      console.log('[OnboardingContext] Onboarding completed', {
+        summaryModel: modelToSave ?? '(external provider)',
+        transcription: usesRemoteTranscription ? remoteTranscriptionUrl : 'parakeet',
+      });
 
       // Reset the flag so subsequent state updates can be saved
       isCompletingRef.current = false;
@@ -523,8 +603,11 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
     });
 
     try {
-      const shouldStartParakeet = includeParakeet && !parakeetDownloaded;
-      const shouldStartSummary = includeSummary && !summaryModelDownloaded && !!summaryModel;
+      // Remote/external backends own their model lifecycle: never download for them.
+      const shouldStartParakeet =
+        includeParakeet && !parakeetDownloaded && transcriptionMode === 'local';
+      const shouldStartSummary =
+        includeSummary && !summaryModelDownloaded && !!summaryModel && summaryMode === 'local';
 
       if (!shouldStartParakeet && !shouldStartSummary) {
         if (includeSummary && !summaryModelDownloaded && !summaryModel) {
@@ -620,6 +703,9 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
         summaryModelProgressInfo,
         selectedSummaryModel,
         recommendedSummaryModel,
+        transcriptionMode,
+        remoteTranscriptionUrl,
+        summaryMode,
         databaseExists,
         isBackgroundDownloading,
         permissions,
@@ -630,6 +716,9 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
         setParakeetDownloaded,
         setSummaryModelDownloaded,
         setSelectedSummaryModel,
+        setTranscriptionMode,
+        setRemoteTranscriptionUrl,
+        setSummaryMode,
         setDatabaseExists,
         setPermissionStatus,
         setPermissionsSkipped,

--- a/frontend/src/hooks/useRecordingStart.ts
+++ b/frontend/src/hooks/useRecordingStart.ts
@@ -19,7 +19,26 @@ interface UseRecordingStartReturn {
   isAutoStarting: boolean;
 }
 
+/** Provider id for a self-hosted, OpenAI-compatible Whisper server. */
+const REMOTE_WHISPER_PROVIDER = 'remoteWhisper';
+
+/** Local engine assumed when the stored config cannot be read. */
+const DEFAULT_PROVIDER = 'parakeet';
+
 interface TranscriptConfig {
+  provider?: string;
+  /** For `remoteWhisper` this carries the server base URL, not a model name. */
+  model?: string;
+}
+
+interface TranscriptionReadiness {
+  ready: boolean;
+  reason?:
+    | 'downloading'
+    | 'missing-local-model'
+    | 'remote-unreachable'
+    | 'unsupported-provider';
+  serverUrl?: string;
   provider?: string;
 }
 
@@ -62,52 +81,151 @@ export function useRecordingStart(
     return `Meeting ${day}_${month}_${year}_${hours}_${minutes}_${seconds}`;
   }, []);
 
-  const getTranscriptionProvider = useCallback(async (): Promise<string> => {
+  // Read provider and model together: the remote path needs both, and one read
+  // keeps the two halves of the decision from disagreeing.
+  const getTranscriptConfig = useCallback(async (): Promise<TranscriptConfig> => {
     try {
       const config = await invoke<TranscriptConfig | null>('api_get_transcript_config');
-      return config?.provider || 'parakeet';
+      return {
+        provider: config?.provider || DEFAULT_PROVIDER,
+        model: config?.model ?? '',
+      };
     } catch (error) {
+      // Fall back to the local engine: a config read failure must not silently
+      // grant access to a backend we could not confirm.
       console.error('Failed to load transcription provider:', error);
-      return 'parakeet';
+      return { provider: DEFAULT_PROVIDER, model: '' };
     }
   }, []);
 
-  // Check the selected local transcription provider, not a hardcoded engine.
-  const checkTranscriptionModelReady = useCallback(async (): Promise<boolean> => {
-    try {
-      const provider = await getTranscriptionProvider();
-      const commands = getProviderCommands(provider);
-
-      if (commands) {
-        await invoke(commands.initialize);
-        return await invoke<boolean>(commands.hasAvailableModels);
+  /**
+   * A remote server owns its own model lifecycle, so "ready" means reachable —
+   * there is nothing on disk to check.
+   */
+  const checkRemoteServerReady = useCallback(
+    async (serverUrl: string): Promise<TranscriptionReadiness> => {
+      if (!serverUrl) {
+        return { ready: false, reason: 'remote-unreachable', serverUrl: '' };
       }
 
-      console.error(`Unsupported transcription provider: ${provider}`);
-      return false;
-    } catch (error) {
-      console.error('Failed to check transcription model status:', error);
-      return false;
-    }
-  }, [getTranscriptionProvider]);
+      try {
+        const reachable = await invoke<boolean>('remote_whisper_check_health', {
+          baseUrl: serverUrl,
+        });
+        return reachable
+          ? { ready: true }
+          : { ready: false, reason: 'remote-unreachable', serverUrl };
+      } catch (error) {
+        console.error('Remote transcription server health check failed:', error);
+        return { ready: false, reason: 'remote-unreachable', serverUrl };
+      }
+    },
+    []
+  );
 
-  // Check download status for the selected local transcription provider.
-  const checkIfModelDownloading = useCallback(async (): Promise<boolean> => {
-    try {
-      const provider = await getTranscriptionProvider();
+  /**
+   * Check the *selected* local engine, never a hardcoded one: a Whisper user
+   * must not be blocked by a missing Parakeet model, and vice versa.
+   */
+  const checkLocalModelReady = useCallback(
+    async (provider: string): Promise<TranscriptionReadiness> => {
       const commands = getProviderCommands(provider);
-      if (!commands) return false;
+      if (!commands) {
+        console.error(`Unsupported transcription provider: ${provider}`);
+        return { ready: false, reason: 'unsupported-provider', provider };
+      }
 
-      const models = await invoke<ModelWithStatus[]>(commands.getAvailableModels);
-      return hasDownloadingModel(models);
-    } catch (error) {
-      console.error('Failed to check model download status:', error);
-      return false; // Default to not downloading (will show error + modal)
+      try {
+        await invoke(commands.initialize);
+        if (await invoke<boolean>(commands.hasAvailableModels)) {
+          return { ready: true };
+        }
+      } catch (error) {
+        console.error('Failed to check transcription model status:', error);
+      }
+
+      try {
+        const models = await invoke<ModelWithStatus[]>(commands.getAvailableModels);
+        if (hasDownloadingModel(models)) {
+          return { ready: false, reason: 'downloading' };
+        }
+      } catch (error) {
+        // Default to "not downloading" so the user gets the model selector
+        // rather than a wait-for-it toast that would never resolve.
+        console.error('Failed to check model download status:', error);
+      }
+
+      return { ready: false, reason: 'missing-local-model' };
+    },
+    []
+  );
+
+  /**
+   * Is transcription ready to record?
+   *
+   * The answer depends on the configured provider: a local engine needs a model
+   * on disk, a remote server only needs to be reachable. The Rust recording
+   * command validates the same provider again before capture.
+   */
+  const checkTranscriptionReady = useCallback(async (): Promise<TranscriptionReadiness> => {
+    const { provider = DEFAULT_PROVIDER, model = '' } = await getTranscriptConfig();
+
+    if (provider === REMOTE_WHISPER_PROVIDER) {
+      // The `model` column carries the server base URL for this provider.
+      return checkRemoteServerReady(model.trim());
     }
-  }, [getTranscriptionProvider]);
 
-  // The Rust recording command validates the same provider again before capture.
-  const checkModelReady = checkTranscriptionModelReady;
+    return checkLocalModelReady(provider);
+  }, [getTranscriptConfig, checkRemoteServerReady, checkLocalModelReady]);
+
+  /**
+   * Single place that turns a blocked start into user-facing feedback, so the
+   * three entry points (button, auto-start, sidebar) cannot drift apart.
+   */
+  const reportTranscriptionNotReady = useCallback(
+    (readiness: TranscriptionReadiness, source: string) => {
+      if (readiness.reason === 'downloading') {
+        toast.info('Model download in progress', {
+          description: 'Please wait for the transcription model to finish downloading before recording.',
+          duration: 5000,
+        });
+        Analytics.trackButtonClick('start_recording_blocked_downloading', source);
+        return;
+      }
+
+      if (readiness.reason === 'remote-unreachable') {
+        // Downloading a local model would not fix this, so the model selector
+        // stays closed — it would point the user at the wrong remedy.
+        toast.error('Transcription server unreachable', {
+          description: readiness.serverUrl
+            ? `Could not reach ${readiness.serverUrl}. Check that the server is running, or switch provider in Settings.`
+            : 'No server URL is configured. Set one in Settings > Transcription.',
+          duration: 6000,
+        });
+        Analytics.trackButtonClick('start_recording_blocked_remote_unreachable', source);
+        return;
+      }
+
+      if (readiness.reason === 'unsupported-provider') {
+        // Same reasoning: no local download fixes a provider this build cannot
+        // drive, so send the user to Settings instead of the model selector.
+        toast.error('Transcription provider not supported', {
+          description: `"${readiness.provider}" cannot be used for recording. Pick another provider in Settings > Transcription.`,
+          duration: 6000,
+        });
+        Analytics.trackButtonClick('start_recording_blocked_unsupported', source);
+        return;
+      }
+
+      toast.error('Transcription model not ready', {
+        description: 'Please download a transcription model before recording.',
+        duration: 5000,
+      });
+      showModal?.('modelSelector', 'Transcription model setup required');
+      Analytics.trackButtonClick('start_recording_blocked_missing', source);
+    },
+    [showModal]
+  );
 
   // Handle manual recording start (from button click)
   const handleRecordingStart = useCallback(async () => {
@@ -117,31 +235,17 @@ export function useRecordingStart(
     }
     isStartingRef.current = true;
     try {
-      console.log('handleRecordingStart called - checking selected transcription model status');
+      console.log('handleRecordingStart called - checking transcription readiness');
 
-      // Check the selected transcription model before starting.
-      const modelReady = await checkModelReady();
-      if (!modelReady) {
-        const isDownloading = await checkIfModelDownloading();
-        if (isDownloading) {
-          toast.info('Model download in progress', {
-            description: 'Please wait for the transcription model to finish downloading before recording.',
-            duration: 5000,
-          });
-          Analytics.trackButtonClick('start_recording_blocked_downloading', 'home_page');
-        } else {
-          toast.error('Transcription model not ready', {
-            description: 'Please download a transcription model before recording.',
-            duration: 5000,
-          });
-          showModal?.('modelSelector', 'Transcription model setup required');
-          Analytics.trackButtonClick('start_recording_blocked_missing', 'home_page');
-        }
+      // Transcription must be ready — local model on disk, or remote server reachable
+      const readiness = await checkTranscriptionReady();
+      if (!readiness.ready) {
+        reportTranscriptionNotReady(readiness, 'home_page');
         setStatus(RecordingStatus.IDLE);
         return;
       }
 
-      console.log('Selected transcription model ready - setting up meeting title and state');
+      console.log('Transcription ready - setting up meeting title and state');
 
       const randomTitle = generateMeetingTitle();
       setMeetingTitle(randomTitle);
@@ -195,7 +299,7 @@ export function useRecordingStart(
     } finally {
       isStartingRef.current = false;
     }
-  }, [generateMeetingTitle, setMeetingTitle, setIsRecording, clearTranscripts, setIsMeetingActive, checkModelReady, checkIfModelDownloading, selectedDevices, showModal, setStatus]);
+  }, [generateMeetingTitle, setMeetingTitle, setIsRecording, clearTranscripts, setIsMeetingActive, checkTranscriptionReady, reportTranscriptionNotReady, selectedDevices, showModal, setStatus]);
 
   // Check for autoStartRecording flag and start recording automatically
   useEffect(() => {
@@ -207,24 +311,10 @@ export function useRecordingStart(
           setIsAutoStarting(true);
           sessionStorage.removeItem('autoStartRecording'); // Clear the flag
 
-          // Check the selected transcription model before starting.
-          const modelReady = await checkModelReady();
-          if (!modelReady) {
-            const isDownloading = await checkIfModelDownloading();
-            if (isDownloading) {
-              toast.info('Model download in progress', {
-                description: 'Please wait for the transcription model to finish downloading before recording.',
-                duration: 5000,
-              });
-              Analytics.trackButtonClick('start_recording_blocked_downloading', 'sidebar_auto');
-            } else {
-              toast.error('Transcription model not ready', {
-                description: 'Please download a transcription model before recording.',
-                duration: 5000,
-              });
-              showModal?.('modelSelector', 'Transcription model setup required');
-              Analytics.trackButtonClick('start_recording_blocked_missing', 'sidebar_auto');
-            }
+          // Transcription must be ready — local model on disk, or remote server reachable
+          const readiness = await checkTranscriptionReady();
+          if (!readiness.ready) {
+            reportTranscriptionNotReady(readiness, 'sidebar_auto');
             setStatus(RecordingStatus.IDLE);
             setIsAutoStarting(false);
             return;
@@ -285,8 +375,8 @@ export function useRecordingStart(
     setIsRecording,
     clearTranscripts,
     setIsMeetingActive,
-    checkModelReady,
-    checkIfModelDownloading,
+    checkTranscriptionReady,
+    reportTranscriptionNotReady,
     showModal,
     setStatus,
   ]);
@@ -299,27 +389,13 @@ export function useRecordingStart(
         return;
       }
 
-      console.log('Direct start from sidebar - checking selected transcription model status');
+      console.log('Direct start from sidebar - checking transcription readiness');
       setIsAutoStarting(true);
 
-      // Check the selected transcription model before starting.
-      const modelReady = await checkModelReady();
-      if (!modelReady) {
-        const isDownloading = await checkIfModelDownloading();
-        if (isDownloading) {
-          toast.info('Model download in progress', {
-            description: 'Please wait for the transcription model to finish downloading before recording.',
-            duration: 5000,
-          });
-          Analytics.trackButtonClick('start_recording_blocked_downloading', 'sidebar_direct');
-        } else {
-          toast.error('Transcription model not ready', {
-            description: 'Please download a transcription model before recording.',
-            duration: 5000,
-          });
-          showModal?.('modelSelector', 'Transcription model setup required');
-          Analytics.trackButtonClick('start_recording_blocked_missing', 'sidebar_direct');
-        }
+      // Transcription must be ready — local model on disk, or remote server reachable
+      const readiness = await checkTranscriptionReady();
+      if (!readiness.ready) {
+        reportTranscriptionNotReady(readiness, 'sidebar_direct');
         setStatus(RecordingStatus.IDLE);
         setIsAutoStarting(false);
         return;
@@ -381,8 +457,8 @@ export function useRecordingStart(
     setIsRecording,
     clearTranscripts,
     setIsMeetingActive,
-    checkModelReady,
-    checkIfModelDownloading,
+    checkTranscriptionReady,
+    reportTranscriptionNotReady,
     showModal,
     setStatus,
   ]);


### PR DESCRIPTION
## Description

Adds a third transcription provider, `remoteWhisper`, that sends audio to a
self-hosted OpenAI-compatible server (`POST /v1/audio/transcriptions`) instead of
loading a model in-process. Audio still never leaves infrastructure the user
controls — it just runs on a machine with a stronger GPU.

Four pieces, one per commit:

1. **The provider** — talks to the server, stores the URL in the existing `model`
   column of `transcript_settings` (no schema change), needs no API key.
2. **Onboarding** — a collapsed "Already running your own AI servers?" disclosure
   lets you pick the remote backend, or defer the summary model, without
   downloading ~670 MB you will never use. The default path is unchanged.
3. **The recording gate** — `useRecordingStart.ts` checked for a local Parakeet
   model regardless of the configured provider, which made the feature unusable.
4. **Settings persistence** — the Server URL field in Settings only updated React
   state; nothing called `api_save_transcript_config`, so a changed URL was lost on
   reload and the recording engine kept using the previous value.

They ship together because 1 without 3 is a dead end: the gate blocks every
recording attempt and offers a download dialog that has no option for a remote
server. And 1 without 4 means the server address can only ever be set during
onboarding — changing it later silently did nothing.

### Notes for reviewers

- **Language sentinels.** The picker emits `auto` / `auto-translate`, which are not
  ISO-639-1 codes; forwarding them makes faster-whisper answer `500`. They are
  dropped, which is exactly how that API is asked to auto-detect.
- **`auto-translate` is hidden for this provider.** `/v1/audio/transcriptions`
  transcribes in the source language — translation lives behind
  `/v1/audio/translations`. Rather than return untranslated text as if it had been
  translated, the option is hidden and the stored preference is coerced on its way
  to the backend, so switching back to Local Whisper restores the user's choice.
- **`/health` proves reachability, not readiness.** The green check in onboarding
  means the server answered; it cannot promise the next transcription succeeds.
  Observed in practice: a server returning `200 {"status":"ok"}` while inference
  was broken.
- **Where the settings persistence lives.** Local Whisper and Parakeet persist from
  inside their model managers (`autoSave`), not from the panel that hosts them.
  None of the three consumers of `TranscriptSettings` saves on its own: the settings
  page has no handler, the modal footer button only closes, and `SettingTabs` passes
  `onSaveTranscript` but the prop is commented out in the JSX. So the remote
  provider persists from inside the component too, matching the model managers and
  fixing all three consumers at once rather than wiring a save handler three times.
- **Save is explicit, not debounced.** A `Save` button writes the URL, with blur and
  Enter as a safety net. Saving per keystroke would write partial URLs such as
  `http://192.168.6` to the database. `Test connection` calls
  `remote_whisper_check_health`, deliberately the same probe
  `validate_transcription_model_ready` runs before recording, so what the button
  verifies is what is checked later. `provider` is forced to `remoteWhisper` on
  save, which also covers re-selecting the provider without retyping the URL.
- **`complete_onboarding` signature changed** (`model: String` → `Option<String>`);
  `None` means the user brings their own summary provider. `ModelStatus` gains two
  optional fields; both use serde defaults, so statuses written by earlier versions
  still load — covered by tests.

## Related Issue

Fixes #637
Implements #612, #301, #225, #527

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Performance improvement
- [x] Code refactoring
- [x] Other

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] All tests pass

7 unit tests: language sentinel handling, WAV header shape, and onboarding status
backward compatibility. Manually tested on macOS (Apple Silicon) against a
faster-whisper server running `large-v3-turbo` on an RTX 3060 — onboarding with
the remote backend, recording, and live transcription over several sessions.

The settings persistence commit was verified from a locally built macOS bundle:
changing the Server URL, saving, reopening Settings and confirming the new value
survives, plus `Test connection` against a reachable and an unreachable address.
The engine re-reads `transcript_settings` on every validation and every start, so
the change applies to the next recording without restarting the app.

The branch was rebased onto the current `devtest` tip; `tsc --noEmit` and
`next build` are green on the rebased tree.

## Documentation
- [x] Documentation updated
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [x] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots 
<img width="1946" height="1076" alt="image" src="https://github.com/user-attachments/assets/ae3ef313-9537-4d19-9816-22b928be9b0a" />


## Additional Notes

The recording-gate fix (#637) affects users who never touch remote transcription:
it also unblocks anyone using Local Whisper, which is what that issue reports.
