### PR TITLE
Add global hotkeys (F13 and Cmd+Shift+M) to toggle recording

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,6 +2394,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,6 +2525,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c386b0a4a70cb2d39fffd74480f985b6f0bfbcb934b6a6b6b7e630e448f242e"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -3663,6 +3691,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-process",
@@ -6788,6 +6817,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9f4c5136c09cd962da0c86dc4accd4666db2ea591cf16e6597435843bd2b"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-log"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8931,6 +8975,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8939,6 +9000,12 @@ dependencies = [
  "libc",
  "rustix 1.1.4",
 ]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xz2"

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -154,6 +154,7 @@ tauri-plugin-store = "2.4.0"
 tauri-plugin-notification = "2.3.1"
 tauri-plugin-updater = "2.3.0"
 tauri-plugin-process = "2.3.0"
+tauri-plugin-global-shortcut = "2"
 
 # Desktop-only single instance guard
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -405,12 +405,53 @@ pub fn run() {
         }));
     }
 
+    // Global hotkeys to toggle recording without focusing the app.
+    // Uses the same toggle_recording_handler the tray menu already fires.
+    //
+    // Two shortcuts registered:
+    //   - F13            → for external keyboards (Wispr-Flow style single key)
+    //   - Cmd+Shift+M    → laptop-friendly fallback (M for Meeting, right-hand only)
+    //
+    // Requires macOS Accessibility permission (System Settings > Privacy > Accessibility)
+    // for global hotkeys to actually fire. Plugin register() succeeds silently
+    // without it, but events won't be delivered.
+    #[cfg(desktop)]
+    let global_shortcut_plugin = {
+        use tauri_plugin_global_shortcut::{Code, Modifiers, Shortcut, ShortcutState};
+
+        let f13_shortcut = Shortcut::new(None, Code::F13);
+        let combo_shortcut = Shortcut::new(
+            Some(Modifiers::META | Modifiers::SHIFT),
+            Code::KeyM,
+        );
+
+        log::info!("Global hotkeys: registering F13 and Cmd+Shift+M → toggle recording");
+
+        tauri_plugin_global_shortcut::Builder::new()
+            .with_shortcuts([f13_shortcut, combo_shortcut])
+            .expect("failed to register global toggle-recording shortcuts")
+            .with_handler(move |app, shortcut, event| {
+                log::debug!(
+                    "Global shortcut event: shortcut={:?} state={:?}",
+                    shortcut,
+                    event.state()
+                );
+                let matched = shortcut == &f13_shortcut || shortcut == &combo_shortcut;
+                if matched && event.state() == ShortcutState::Pressed {
+                    log::info!("Global hotkey pressed ({:?}): toggling recording", shortcut);
+                    tray::toggle_recording_handler(app);
+                }
+            })
+            .build()
+    };
+
     builder
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        .plugin(global_shortcut_plugin)
         .manage(whisper_engine::parallel_commands::ParallelProcessorState::new())
         .manage(Arc::new(RwLock::new(
             None::<notifications::manager::NotificationManager<tauri::Wry>>,

--- a/frontend/src-tauri/src/tray.rs
+++ b/frontend/src-tauri/src/tray.rs
@@ -52,7 +52,7 @@ fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, item_id: &str) {
         _ => {}
     }
 }
-fn toggle_recording_handler<R: Runtime>(app: &AppHandle<R>) {
+pub fn toggle_recording_handler<R: Runtime>(app: &AppHandle<R>) {
     focus_main_window(app);
     let app_clone = app.clone();
     tauri::async_runtime::spawn(async move {

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -65,6 +65,9 @@
                         "notification:allow-is-permission-granted",
                         "updater:default",
                         "process:default",
+                        "global-shortcut:default",
+                        "global-shortcut:allow-register",
+                        "global-shortcut:allow-unregister",
                         {
                             "identifier": "fs:scope",
                             "allow": [


### PR DESCRIPTION
## Summary

Registers a Tauri global-shortcut plugin so the tray's existing `toggle_recording` action can be fired from anywhere without focusing the app or opening the tray menu.

Two hotkeys are bound, both firing the same handler:
- **F13** — external keyboards (single key, zero conflicts)
- **Cmd+Shift+M** — laptop-friendly fallback (`M` for Meeting, one-hand hit)

## Why

The tray menu currently requires clicking the menubar icon to reach "Start Recording"/"Stop Recording". This is friction for two use cases:
1. **Manual quick-toggle** while working in another app — you don't lose focus.
2. **External automation** (Hammerspoon, Keyboard Maestro, etc.) — the tray icon on a Tauri app isn't reachable via macOS AX (`menu bar 2` reports `missing value`), so scripts can't click it directly. A global hotkey exposes a clean automation surface.

The same `toggle_recording_handler` the tray already uses is reused verbatim — no new state or logic paths.

## Changes

- `Cargo.toml` — add `tauri-plugin-global-shortcut`
- `tauri.conf.json` — add `global-shortcut:default`, `global-shortcut:allow-register`, `global-shortcut:allow-unregister` capabilities
- `src/tray.rs` — make `toggle_recording_handler` `pub` so `lib.rs` can call it from the plugin handler
- `src/lib.rs` — register the plugin, bind both shortcuts, wire the handler

## Test plan

- [x] Build with `pnpm run tauri:build` on macOS 26 (Apple Silicon)
- [x] Verify plugin registers at startup: log line `Global hotkeys: registering F13 and Cmd+Shift+M → toggle recording`
- [x] Press F13 (external keyboard) → recording toggles, no window focus
- [x] Press Cmd+Shift+M → recording toggles, no window focus
- [x] Confirm requires macOS Accessibility permission (plugin registers silently otherwise)

## Notes

- Hotkeys are hardcoded here for the initial cut. Happy to follow up with a settings UI (preferences.json entry + a `recording_preferences` command) if the maintainers would like them user-configurable — happy to make either default vs. configurable per your preference.
- On Linux/Windows this compiles unchanged; only the actual key delivery differs by platform (F13 works if the keyboard has it; Cmd on macOS = Super/Win elsewhere via `Modifiers::META`).
- Prerequisite for a follow-up PR on meeting auto-detection (#TBD) which uses this handler as its trigger surface.