### PR TITLE
Add meeting auto-detection (call apps + browser tabs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,6 +2394,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,6 +2525,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c386b0a4a70cb2d39fffd74480f985b6f0bfbcb934b6a6b6b7e630e448f242e"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -3663,6 +3691,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-process",
@@ -6788,6 +6817,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9f4c5136c09cd962da0c86dc4accd4666db2ea591cf16e6597435843bd2b"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-log"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8931,6 +8975,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8939,6 +9000,12 @@ dependencies = [
  "libc",
  "rustix 1.1.4",
 ]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xz2"

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -154,6 +154,7 @@ tauri-plugin-store = "2.4.0"
 tauri-plugin-notification = "2.3.1"
 tauri-plugin-updater = "2.3.0"
 tauri-plugin-process = "2.3.0"
+tauri-plugin-global-shortcut = "2"
 
 # Desktop-only single instance guard
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -52,6 +52,7 @@ pub mod parakeet_engine;
 pub mod state;
 pub mod summary;
 pub mod tray;
+pub mod meeting_detector;
 pub mod utils;
 pub mod whisper_engine;
 
@@ -465,6 +466,11 @@ pub fn run() {
             if let Err(e) = tray::create_tray(_app.handle()) {
                 log::error!("Failed to create system tray: {}", e);
             }
+
+            // Auto-detect meetings (Zoom/Teams/Slack/Discord/Webex processes +
+            // Meet/Zoom-web/Teams-web/Whereby browser tabs) and toggle recording
+            // without user input. Poll interval 10s.
+            meeting_detector::spawn(_app.handle().clone());
 
             // Initialize notification system with proper defaults
             log::info!("Initializing notification system...");

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -405,12 +405,53 @@ pub fn run() {
         }));
     }
 
+    // Global hotkeys to toggle recording without focusing the app.
+    // Uses the same toggle_recording_handler the tray menu already fires.
+    //
+    // Two shortcuts registered:
+    //   - F13            → for external keyboards (Wispr-Flow style single key)
+    //   - Cmd+Shift+M    → laptop-friendly fallback (M for Meeting, right-hand only)
+    //
+    // Requires macOS Accessibility permission (System Settings > Privacy > Accessibility)
+    // for global hotkeys to actually fire. Plugin register() succeeds silently
+    // without it, but events won't be delivered.
+    #[cfg(desktop)]
+    let global_shortcut_plugin = {
+        use tauri_plugin_global_shortcut::{Code, Modifiers, Shortcut, ShortcutState};
+
+        let f13_shortcut = Shortcut::new(None, Code::F13);
+        let combo_shortcut = Shortcut::new(
+            Some(Modifiers::META | Modifiers::SHIFT),
+            Code::KeyM,
+        );
+
+        log::info!("Global hotkeys: registering F13 and Cmd+Shift+M → toggle recording");
+
+        tauri_plugin_global_shortcut::Builder::new()
+            .with_shortcuts([f13_shortcut, combo_shortcut])
+            .expect("failed to register global toggle-recording shortcuts")
+            .with_handler(move |app, shortcut, event| {
+                log::debug!(
+                    "Global shortcut event: shortcut={:?} state={:?}",
+                    shortcut,
+                    event.state()
+                );
+                let matched = shortcut == &f13_shortcut || shortcut == &combo_shortcut;
+                if matched && event.state() == ShortcutState::Pressed {
+                    log::info!("Global hotkey pressed ({:?}): toggling recording", shortcut);
+                    tray::toggle_recording_handler(app);
+                }
+            })
+            .build()
+    };
+
     builder
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        .plugin(global_shortcut_plugin)
         .manage(whisper_engine::parallel_commands::ParallelProcessorState::new())
         .manage(Arc::new(RwLock::new(
             None::<notifications::manager::NotificationManager<tauri::Wry>>,

--- a/frontend/src-tauri/src/meeting_detector.rs
+++ b/frontend/src-tauri/src/meeting_detector.rs
@@ -1,0 +1,240 @@
+// Auto-detect meetings and toggle recording without user input.
+//
+// Signals watched:
+//   1. Process launches — Zoom, Teams, Slack, Discord, Webex, GoToMeeting desktop apps
+//   2. Browser tab URLs — Google Meet, Zoom-web, Teams-web, Whereby (Chrome/Safari/Arc/Edge)
+//
+// State machine:
+//   - "auto-started" flag tracks whether WE fired the record. If the user
+//     manually stops recording, the flag clears so we don't try to stop again.
+//   - We only auto-stop if we auto-started; a manually-started recording is
+//     never touched by the detector.
+//
+// Polling interval: 10s (light on CPU, catches meeting starts within 10s).
+
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use tauri::{AppHandle, Runtime};
+
+use crate::tray;
+
+static AUTO_STARTED: AtomicBool = AtomicBool::new(false);
+
+/// Apps whose presence in the process list is a "call-only" signal — these
+/// apps are launched to make/join a call, not left idling. Zoom is EXCLUDED
+/// from this list even though it's the most common — Zoom often idles with
+/// its home screen open, so we check its window title instead (see below).
+const CALL_ONLY_PROCESSES: &[&str] = &[
+    "Webex",             // Webex
+    "GoToMeeting",       // GoTo Meeting
+    "BlueJeans",         // BlueJeans
+    "GoogleMeet",        // Google Meet standalone app (if installed)
+];
+
+/// Substring in Zoom's window title that means we're actually in a meeting
+/// (as opposed to sitting on the home screen). Zoom uses "Zoom Meeting" for
+/// active meetings, and "Zoom" / "Zoom - Free Account" etc. when idle.
+const ZOOM_IN_MEETING_TITLE_SUBSTRING: &str = "Meeting";
+
+/// Substrings that mark a browser tab URL as a meeting-in-progress.
+const MEETING_URL_PATTERNS: &[&str] = &[
+    "meet.google.com/",             // Google Meet (path segment after the / is the meeting id)
+    "zoom.us/j/",                   // Zoom join links
+    "zoom.us/wc/",                  // Zoom web-client meeting
+    "app.zoom.us/wc/",              // Zoom web-client alt host
+    "teams.microsoft.com/l/meetup-join", // Teams meetup-join
+    "teams.live.com/meet",          // Teams personal
+    "teams.microsoft.com/v2/",      // Teams v2 web client
+    "whereby.com/",                 // Whereby room URLs
+    "app.gather.town/app/",         // Gather Town
+    "around.co/r/",                 // Around
+];
+
+/// Browsers we can query for open tabs via AppleScript.
+const BROWSERS: &[&str] = &[
+    "Google Chrome",
+    "Google Chrome Canary",
+    "Brave Browser",
+    "Microsoft Edge",
+    "Safari",
+    "Arc",
+    "Wavebox",
+    "Vivaldi",
+    "Orion",
+    "SigmaOS",
+];
+
+fn matching_meeting_process() -> Option<String> {
+    use sysinfo::System;
+    let mut sys = System::new();
+    sys.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+
+    // 1) Call-only apps: presence = meeting.
+    let processes = sys.processes();
+    for proc in processes.values() {
+        let name = proc.name().to_string_lossy();
+        for target in CALL_ONLY_PROCESSES {
+            if name == *target {
+                return Some(name.to_string());
+            }
+        }
+    }
+
+    // 2) Zoom: only fires if its main window title contains "Meeting" (idle
+    // Zoom shows "Zoom" or "Zoom - Free Account", active meeting shows
+    // "Zoom Meeting"). Skips the false-positive of idle Zoom.
+    let zoom_running = processes.values().any(|p| p.name().to_string_lossy() == "zoom.us");
+    if zoom_running && zoom_window_indicates_meeting() {
+        return Some("Zoom (in meeting)".into());
+    }
+
+    None
+}
+
+/// Ask System Events for Zoom's window title and check if it contains "Meeting".
+fn zoom_window_indicates_meeting() -> bool {
+    let script = r#"
+    tell application "System Events"
+        try
+            tell process "zoom.us"
+                set winTitles to name of every window
+                repeat with t in winTitles
+                    if t contains "Meeting" then return "yes"
+                end repeat
+            end tell
+        end try
+        return "no"
+    end tell
+    "#;
+    match Command::new("osascript").arg("-e").arg(script).output() {
+        Ok(o) if o.status.success() => {
+            String::from_utf8_lossy(&o.stdout).trim() == "yes"
+        }
+        _ => false,
+    }
+}
+
+fn get_tab_urls(browser: &str) -> Vec<String> {
+    // Only run the AppleScript if the browser is actually running (fast path).
+    let is_running = Command::new("osascript")
+        .arg("-e")
+        .arg(format!(
+            "tell application \"System Events\" to (name of processes) contains \"{}\"",
+            browser
+        ))
+        .output()
+        .ok()
+        .and_then(|o| Some(String::from_utf8_lossy(&o.stdout).trim() == "true"))
+        .unwrap_or(false);
+
+    if !is_running {
+        return Vec::new();
+    }
+
+    let script = if browser == "Safari" {
+        // Safari's tab addressability is slightly different from Chromium-based browsers
+        format!(
+            r#"tell application "{}"
+                set urlList to {{}}
+                try
+                    repeat with w in windows
+                        repeat with t in tabs of w
+                            try
+                                set end of urlList to URL of t
+                            end try
+                        end repeat
+                    end repeat
+                end try
+                return urlList
+            end tell"#,
+            browser
+        )
+    } else {
+        format!(
+            r#"tell application "{}"
+                set urlList to {{}}
+                try
+                    repeat with w in windows
+                        repeat with t in tabs of w
+                            try
+                                set end of urlList to URL of t
+                            end try
+                        end repeat
+                    end repeat
+                end try
+                return urlList
+            end tell"#,
+            browser
+        )
+    };
+
+    match Command::new("osascript").arg("-e").arg(&script).output() {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
+            .split(", ")
+            .map(|s| s.trim().trim_matches('"').to_string())
+            .filter(|s| !s.is_empty())
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn matching_meeting_url() -> Option<String> {
+    for browser in BROWSERS {
+        let urls = get_tab_urls(browser);
+        for url in urls {
+            for pat in MEETING_URL_PATTERNS {
+                if url.contains(pat) {
+                    return Some(url.clone());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Spawn the background watcher. Runs for the lifetime of the app.
+pub fn spawn<R: Runtime>(app: AppHandle<R>) {
+    tauri::async_runtime::spawn(async move {
+        log::info!("[auto-detect] meeting watcher started (interval=10s)");
+
+        loop {
+            tokio::time::sleep(Duration::from_secs(10)).await;
+
+            let proc_hit = matching_meeting_process();
+            let url_hit = matching_meeting_url();
+            let meeting_active = proc_hit.is_some() || url_hit.is_some();
+            let currently_recording = crate::is_recording().await;
+            let we_started = AUTO_STARTED.load(Ordering::Relaxed);
+
+            match (meeting_active, currently_recording, we_started) {
+                // Meeting detected, not recording → auto-start
+                (true, false, _) => {
+                    let reason = match (&proc_hit, &url_hit) {
+                        (Some(p), _) => format!("process={}", p),
+                        (_, Some(u)) => format!("url={}", u.chars().take(80).collect::<String>()),
+                        _ => "(unknown)".into(),
+                    };
+                    log::info!("[auto-detect] meeting detected ({}) → auto-starting recording", reason);
+                    tray::toggle_recording_handler(&app);
+                    AUTO_STARTED.store(true, Ordering::Relaxed);
+                }
+
+                // No meeting active, we started this recording → auto-stop
+                (false, true, true) => {
+                    log::info!("[auto-detect] no meeting active → stopping our auto-recording");
+                    tray::toggle_recording_handler(&app);
+                    AUTO_STARTED.store(false, Ordering::Relaxed);
+                }
+
+                // Recording stopped (probably by user) → clear our flag
+                (_, false, true) => {
+                    AUTO_STARTED.store(false, Ordering::Relaxed);
+                }
+
+                _ => {}
+            }
+        }
+    });
+}

--- a/frontend/src-tauri/src/tray.rs
+++ b/frontend/src-tauri/src/tray.rs
@@ -52,7 +52,7 @@ fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, item_id: &str) {
         _ => {}
     }
 }
-fn toggle_recording_handler<R: Runtime>(app: &AppHandle<R>) {
+pub fn toggle_recording_handler<R: Runtime>(app: &AppHandle<R>) {
     focus_main_window(app);
     let app_clone = app.clone();
     tauri::async_runtime::spawn(async move {

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -65,6 +65,9 @@
                         "notification:allow-is-permission-granted",
                         "updater:default",
                         "process:default",
+                        "global-shortcut:default",
+                        "global-shortcut:allow-register",
+                        "global-shortcut:allow-unregister",
                         {
                             "identifier": "fs:scope",
                             "allow": [


### PR DESCRIPTION
## Summary

Adds a background watcher that polls every 10 seconds and auto-fires the tray's existing `toggle_recording_handler` when a meeting starts, and auto-stops when it ends. Conservative signals only — no false-positives when apps are just open in the background.

**Depends on #732** (uses the `pub toggle_recording_handler` exposed there).

## Signals

Detects **only** the following as "in a meeting":

1. **Call-only apps running**: `Webex`, `GoToMeeting`, `BlueJeans`, `GoogleMeet` — apps people don't leave idling
2. **Zoom AND window title contains "Meeting"** — skips idle Zoom home screen (`Zoom` / `Zoom - Free Account`), fires only on `Zoom Meeting`
3. **Meeting URL in a browser tab**, across:
   - Google Meet: `meet.google.com/…`
   - Zoom web: `zoom.us/j/…`, `zoom.us/wc/…`
   - Teams web: `teams.microsoft.com/l/meetup-join`, `teams.live.com/meet`
   - Whereby, Gather, Around
   - Browsers scanned: Chrome, Chrome Canary, Brave, Edge, Safari, Arc, Wavebox, Vivaldi, Orion, SigmaOS
   
   Browser tabs enumerated via AppleScript. Firefox is not supported — no AppleScript surface for its tabs (documented in the source).

## Explicitly EXCLUDED from process detection

Discord, Slack, Teams desktop, and FaceTime are **not** watched via process presence — they're commonly left idling in the background and would false-positive. Their web variants are still caught via the URL patterns (unambiguous), and manual toggle via the global hotkey (#732) covers the rest.

## State machine

- Tracks whether **we** started the current recording (`AUTO_STARTED` atomic)
- Only auto-stops what we auto-started — never touches a user-initiated recording
- If the user manually stops mid-auto-recording, the flag clears so we don't try to stop it again

## Why 10 seconds

- Light on CPU (sysinfo refresh + a handful of `osascript` calls per tick)
- Catches meeting starts within one polling interval — imperceptible in practice
- Could be made configurable via a preference key if desired

## Test plan

- [x] Open Zoom to home screen → nothing happens (title = "Zoom")
- [x] Start a Zoom call (title = "Zoom Meeting") → auto-records within 10s
- [x] End Zoom call → auto-stops within 10s
- [x] Open Discord (idle) → nothing happens (not in the process list)
- [x] Open `meet.google.com/xxx-xxxx-xxx` in Wavebox → auto-records within 10s
- [x] Close the Meet tab → auto-stops within 10s
- [x] Manually stop recording via the tray or global hotkey while auto-recording → auto-stopper doesn't fire again
- [x] Manually start recording without any meeting active → auto-stopper doesn't touch it

## Changes

- `src/lib.rs` — `pub mod meeting_detector;` + `meeting_detector::spawn(app.handle().clone())` in setup
- `src/meeting_detector.rs` — new module, ~240 lines with docs

## Follow-ups (happy to do in follow-up PRs)

- Settings toggle to disable auto-detect entirely
- User-configurable app/URL lists
- Firefox support via a WebExtension talking to Meetily
- Mic-in-use as an AND-condition to also cover Slack huddles / Discord voice chat safely (needs CoreAudio FFI)