### PR TITLE
fix(transcription): complete post-merge follow-ups

### DIFF
--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -736,6 +736,7 @@ fn write_retranscription_metadata(
         let existing = std::fs::read_to_string(&metadata_path)?;
         let mut value: serde_json::Value = serde_json::from_str(&existing)?;
         if let Some(obj) = value.as_object_mut() {
+            obj.insert("duration_seconds".to_string(), serde_json::json!(duration_seconds));
             obj.insert("retranscribed_at".to_string(), serde_json::json!(now));
             obj.insert("status".to_string(), serde_json::json!("completed"));
             obj.insert("transcript_file".to_string(), serde_json::json!("transcripts.json"));
@@ -1012,5 +1013,41 @@ mod tests {
         // Non-audio formats
         assert!(!AUDIO_EXTENSIONS.contains(&"txt"));
         assert!(!AUDIO_EXTENSIONS.contains(&"pdf"));
+    }
+
+    #[test]
+    fn retranscription_metadata_replaces_stale_duration_without_losing_existing_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let metadata_path = dir.path().join("metadata.json");
+        std::fs::write(
+            &metadata_path,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "meeting_id": "existing-meeting",
+                "duration_seconds": 2523.2,
+                "audio_file": "recording.m4a",
+                "summary_language": "fr",
+                "detected_summary_language": "en",
+                "custom_field": "preserve me"
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        write_retranscription_metadata(
+            dir.path(),
+            "ignored-for-existing-metadata",
+            5046.4,
+            "recording.m4a",
+        )
+        .unwrap();
+
+        let metadata: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(metadata_path).unwrap()).unwrap();
+        assert_eq!(metadata["duration_seconds"], 5046.4);
+        assert_eq!(metadata["meeting_id"], "existing-meeting");
+        assert_eq!(metadata["audio_file"], "recording.m4a");
+        assert_eq!(metadata["summary_language"], "fr");
+        assert_eq!(metadata["custom_field"], "preserve me");
+        assert!(metadata.get("detected_summary_language").is_none());
     }
 }

--- a/frontend/src-tauri/src/whisper_engine/commands.rs
+++ b/frontend/src-tauri/src/whisper_engine/commands.rs
@@ -1,4 +1,4 @@
-use crate::whisper_engine::{is_download_cancelled, ModelInfo, WhisperEngine};
+use crate::whisper_engine::{is_download_cancelled, CancelDownloadOutcome, ModelInfo, WhisperEngine};
 use std::sync::{Arc, Mutex};
 use std::path::PathBuf;
 use tauri::{command, Emitter, Manager, AppHandle, Runtime};
@@ -492,7 +492,7 @@ pub async fn whisper_download_model(
 }
 
 #[command]
-pub async fn whisper_cancel_download(model_name: String) -> Result<(), String> {
+pub async fn whisper_cancel_download(model_name: String) -> Result<CancelDownloadOutcome, String> {
     let engine = {
         let guard = WHISPER_ENGINE.lock().unwrap();
         guard.as_ref().cloned()

--- a/frontend/src-tauri/src/whisper_engine/commands.rs
+++ b/frontend/src-tauri/src/whisper_engine/commands.rs
@@ -1,4 +1,4 @@
-use crate::whisper_engine::{ModelInfo, WhisperEngine};
+use crate::whisper_engine::{is_download_cancelled, ModelInfo, WhisperEngine};
 use std::sync::{Arc, Mutex};
 use std::path::PathBuf;
 use tauri::{command, Emitter, Manager, AppHandle, Runtime};
@@ -463,6 +463,13 @@ pub async fn whisper_download_model(
                 ) {
                     log::error!("Failed to emit download complete event: {}", e);
                 }
+                Ok(())
+            }
+            Err(e) if is_download_cancelled(&e) => {
+                // Cancellation is handled by the existing cancel command/UI path. Do not
+                // emit a terminal event or reject the original request, which would
+                // otherwise overwrite that path's Missing state with an error.
+                log::info!("Download cancelled for {}", model_name);
                 Ok(())
             }
             Err(e) => {

--- a/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
+++ b/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
@@ -935,6 +935,32 @@ impl WhisperEngine {
 
         if result.is_ok() && !active_download.cancellation.is_cancelled() {
             result = self.validate_model_file(file_path).await;
+
+            if result.is_ok() {
+                let expected_min_size = WHISPER_MODEL_CATALOG
+                    .iter()
+                    .find(|model| model.0 == model_name)
+                    .map(|model| ((model.2 as f64 * 0.9) as u64) * 1024 * 1024);
+
+                result = match expected_min_size {
+                    Some(expected_min_size) => match fs::metadata(file_path).await {
+                        Ok(metadata) if metadata.len() >= expected_min_size => Ok(()),
+                        Ok(metadata) => Err(anyhow!(
+                            "Downloaded model file is too small: {} bytes (expected at least {} bytes)",
+                            metadata.len(),
+                            expected_min_size
+                        )),
+                        Err(e) => Err(anyhow!(
+                            "Failed to read downloaded model file metadata: {}",
+                            e
+                        )),
+                    },
+                    None => Err(anyhow!(
+                        "Unsupported model for download validation: {}",
+                        model_name
+                    )),
+                };
+            }
         }
 
         if result.is_err() && !active_download.cancellation.is_cancelled() && file_path.exists() {
@@ -1472,21 +1498,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn downloaded_model_sends_user_agent_and_validates_header() {
+    async fn downloaded_model_sends_user_agent_and_rejects_undersized_valid_header() {
         let dir = tempfile::tempdir().unwrap();
         let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
         engine.discover_models().await.unwrap();
         let (url, request, server) = response_http_server(8, b"ggml\0\0\0\0").await;
 
-        engine.download_model_from_url("tiny", &url, None).await.unwrap();
+        let error = engine.download_model_from_url("tiny", &url, None).await.unwrap_err();
         let request = String::from_utf8(request.await.unwrap()).unwrap();
         server.await.unwrap();
 
+        assert!(error.to_string().contains("too small"));
         assert!(request.to_ascii_lowercase().contains(&format!(
             "user-agent: meetily/{}",
             env!("CARGO_PKG_VERSION")
         )));
         assert!(!engine.active_downloads.lock().await.contains_key("tiny"));
+        assert!(!dir.path().join("ggml-tiny.bin").exists());
         assert!(matches!(
             engine
                 .available_models
@@ -1495,7 +1523,7 @@ mod tests {
                 .get("tiny")
                 .expect("tiny should remain cached")
                 .status,
-            ModelStatus::Available
+            ModelStatus::Missing
         ));
     }
 

--- a/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
+++ b/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
@@ -3,7 +3,8 @@
 use std::path::{PathBuf};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{watch, Mutex, RwLock};
+use tokio_util::sync::CancellationToken;
 use whisper_rs::{WhisperContext, WhisperContextParameters, FullParams, SamplingStrategy};
 use serde::{Serialize, Deserialize};
 use anyhow::{Result, anyhow};
@@ -33,6 +34,19 @@ pub struct ModelInfo {
     pub description: String,
 }
 
+struct ActiveDownload {
+    cancellation: CancellationToken,
+    completion: watch::Sender<bool>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Download cancelled by user")]
+pub(crate) struct DownloadCancelled;
+
+pub(crate) fn is_download_cancelled(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<DownloadCancelled>().is_some()
+}
+
 pub struct WhisperEngine {
     models_dir: PathBuf,
     current_context: Arc<RwLock<Option<WhisperContext>>>,
@@ -43,10 +57,8 @@ pub struct WhisperEngine {
     short_audio_warning_logged: Arc<RwLock<bool>>,
     // Performance optimization: reduce logging frequency
     transcription_count: Arc<RwLock<u64>>,
-    // Download cancellation tracking
-    cancel_download_flag: Arc<RwLock<Option<String>>>, // Model name being cancelled
-    // Active downloads tracking to prevent concurrent downloads
-    active_downloads: Arc<RwLock<HashSet<String>>>, // Set of models currently being downloaded
+    // A model remains active until its owning worker has completed cleanup.
+    active_downloads: Arc<Mutex<HashMap<String, Arc<ActiveDownload>>>>,
 }
 
 impl WhisperEngine {
@@ -159,10 +171,7 @@ impl WhisperEngine {
             short_audio_warning_logged: Arc::new(RwLock::new(false)),
             // Performance optimization: reduce logging frequency
             transcription_count: Arc::new(RwLock::new(0)),
-            // Initialize cancellation tracking
-            cancel_download_flag: Arc::new(RwLock::new(None)),
-            // Initialize active downloads tracking
-            active_downloads: Arc::new(RwLock::new(HashSet::new())),
+            active_downloads: Arc::new(Mutex::new(HashMap::new())),
         };
         
         Ok(engine)
@@ -173,7 +182,13 @@ impl WhisperEngine {
         let mut models = Vec::new();
         // Use centralized model catalog from config.rs
         let model_configs = WHISPER_MODEL_CATALOG;
-        let active_downloads = self.active_downloads.read().await.clone();
+        let active_downloads: HashSet<String> = self
+            .active_downloads
+            .lock()
+            .await
+            .keys()
+            .cloned()
+            .collect();
         let cached_download_progress: HashMap<String, u8> = self
             .available_models
             .read()
@@ -888,119 +903,167 @@ impl WhisperEngine {
         }
     }
     
-    async fn clear_active_download(&self, model_name: &str) {
-        self.active_downloads.write().await.remove(model_name);
+    async fn reserve_active_download(&self, model_name: &str) -> Result<Arc<ActiveDownload>> {
+        let mut active_downloads = self.active_downloads.lock().await;
+        if active_downloads.contains_key(model_name) {
+            return Err(anyhow!("Download already in progress for model: {}", model_name));
+        }
+
+        let (completion, _) = watch::channel(false);
+        let active_download = Arc::new(ActiveDownload {
+            cancellation: CancellationToken::new(),
+            completion,
+        });
+
+        active_downloads.insert(model_name.to_string(), Arc::clone(&active_download));
+        Ok(active_download)
+    }
+
+    async fn finish_download(
+        &self,
+        model_name: &str,
+        active_download: &Arc<ActiveDownload>,
+        file_path: &PathBuf,
+        mut result: Result<()>,
+    ) -> Result<()> {
+        let cancellation_won = {
+            let mut active_downloads = self.active_downloads.lock().await;
+            match active_downloads.get(model_name) {
+                Some(current) if Arc::ptr_eq(current, active_download) => {
+                    if active_download.cancellation.is_cancelled() {
+                        true
+                    } else {
+                        active_downloads.remove(model_name);
+                        false
+                    }
+                }
+                _ => {
+                    log::warn!("Download owner for {} was no longer active during cleanup", model_name);
+                    active_download.cancellation.is_cancelled()
+                }
+            }
+        };
+
+        if cancellation_won {
+            result = Err(DownloadCancelled.into());
+            if file_path.exists() {
+                if let Err(e) = fs::remove_file(file_path).await {
+                    log::warn!("Failed to clean up cancelled download file: {}", e);
+                } else {
+                    log::info!("Cleaned up cancelled download file: {}", file_path.display());
+                }
+            }
+
+            let mut models = self.available_models.write().await;
+            if let Some(model_info) = models.get_mut(model_name) {
+                model_info.status = ModelStatus::Missing;
+            }
+
+            let removed = {
+                let mut active_downloads = self.active_downloads.lock().await;
+                match active_downloads.get(model_name) {
+                    Some(current) if Arc::ptr_eq(current, active_download) => {
+                        active_downloads.remove(model_name);
+                        true
+                    }
+                    _ => false,
+                }
+            };
+            if !removed {
+                log::warn!("Download owner for {} was no longer active during cancellation cleanup", model_name);
+            }
+        }
+
+        active_download.completion.send_replace(true);
+        result
     }
 
     pub async fn download_model(&self, model_name: &str, progress_callback: Option<Box<dyn Fn(u8) + Send>>) -> Result<()> {
         log::info!("Starting download for model: {}", model_name);
 
-        // Validate before registering an active transfer so invalid names cannot leave stale state.
         let model_url = match model_name {
-            // Standard f16 models
             "tiny" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin",
             "base" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin",
             "small" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin",
             "medium" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.bin",
             "large-v3-turbo" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin",
             "large-v3" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3.bin",
-
-            // Q5_1 quantized models
             "tiny-q5_1" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny-q5_1.bin",
             "base-q5_1" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base-q5_1.bin",
             "small-q5_1" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small-q5_1.bin",
-
-            // Q5_0 quantized models
             "medium-q5_0" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium-q5_0.bin",
             "large-v3-turbo-q5_0" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin",
             "large-v3-q5_0" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-q5_0.bin",
-
             _ => return Err(anyhow!("Unsupported model: {}", model_name)),
         };
 
-        // Check if download is already in progress for this model
-        {
-            let active = self.active_downloads.read().await;
-            if active.contains(model_name) {
-                log::warn!("Download already in progress for model: {}", model_name);
-                return Err(anyhow!("Download already in progress for model: {}", model_name));
-            }
+        self.download_model_from_url(model_name, model_url, progress_callback).await
+    }
+
+    async fn download_model_from_url(
+        &self,
+        model_name: &str,
+        model_url: &str,
+        progress_callback: Option<Box<dyn Fn(u8) + Send>>,
+    ) -> Result<()> {
+        let active_download = self.reserve_active_download(model_name).await?;
+        let file_path = self.models_dir.join(format!("ggml-{}.bin", model_name));
+
+        let result = self
+            .download_model_with_owner(
+                model_name,
+                model_url,
+                &file_path,
+                &active_download,
+                progress_callback,
+            )
+            .await;
+
+        self.finish_download(model_name, &active_download, &file_path, result)
+            .await
+    }
+
+    async fn download_model_with_owner(
+        &self,
+        model_name: &str,
+        model_url: &str,
+        file_path: &PathBuf,
+        active_download: &ActiveDownload,
+        progress_callback: Option<Box<dyn Fn(u8) + Send>>,
+    ) -> Result<()> {
+        if active_download.cancellation.is_cancelled() {
+            return Err(DownloadCancelled.into());
         }
 
-        // Add to active downloads
-        {
-            let mut active = self.active_downloads.write().await;
-            active.insert(model_name.to_string());
-        }
-
-        // Clear any previous cancellation flag for this model
-        {
-            let mut cancel_flag = self.cancel_download_flag.write().await;
-            *cancel_flag = None;
-        }
-
-        log::info!("Model URL for {}: {}", model_name, model_url);
-        
-        // Generate correct filename - all models follow ggml-{model_name}.bin pattern
-        let filename = format!("ggml-{}.bin", model_name);
-        let file_path = self.models_dir.join(&filename);
-        
-        log::info!("Downloading to file path: {}", file_path.display());
-        
-        // Create models directory if it doesn't exist
         if !self.models_dir.exists() {
-            if let Err(e) = fs::create_dir_all(&self.models_dir).await {
-                self.clear_active_download(model_name).await;
-                return Err(anyhow!("Failed to create models directory: {}", e));
-            }
+            fs::create_dir_all(&self.models_dir)
+                .await
+                .map_err(|e| anyhow!("Failed to create models directory: {}", e))?;
         }
-        
-        // Update model status to downloading
+
         {
             let mut models = self.available_models.write().await;
             if let Some(model_info) = models.get_mut(model_name) {
                 model_info.status = ModelStatus::Downloading { progress: 0 };
             }
         }
-        
-        log::info!("Creating HTTP client and starting request...");
+
         let client = Client::new();
-        
-        log::info!("Sending GET request to: {}", model_url);
-        let response = match client.get(model_url).send().await {
-            Ok(response) => response,
-            Err(e) => {
-                self.clear_active_download(model_name).await;
-                return Err(anyhow!("Failed to start download: {}", e));
-            }
+        let response = tokio::select! {
+            biased;
+            _ = active_download.cancellation.cancelled() => return Err(DownloadCancelled.into()),
+            response = client.get(model_url).send() => response
+                .map_err(|e| anyhow!("Failed to start download: {}", e))?,
         };
-        
-        log::info!("Received response with status: {}", response.status());
+
         if !response.status().is_success() {
-            self.clear_active_download(model_name).await;
             return Err(anyhow!("Download failed with status: {}", response.status()));
         }
-        
+
         let total_size = response.content_length().unwrap_or(0);
-        log::info!("Response successful, content length: {} bytes ({:.1} MB)", total_size, total_size as f64 / (1024.0 * 1024.0));
-        
-        if total_size == 0 {
-            log::warn!("Content length is 0 or unknown - download may not show accurate progress");
-        }
-        
-        let mut file = match fs::File::create(&file_path).await {
-            Ok(file) => file,
-            Err(e) => {
-                self.clear_active_download(model_name).await;
-                return Err(anyhow!("Failed to create file: {}", e));
-            }
-        };
-        
-        log::info!("File created successfully at: {}", file_path.display());
-        
-        // Stream download with real progress reporting
-        log::info!("Starting streaming download...");
-        log::info!("Expected size: {:.1} MB", total_size as f64 / (1024.0 * 1024.0));
+        let mut file = fs::File::create(file_path)
+            .await
+            .map_err(|e| anyhow!("Failed to create file: {}", e))?;
 
         use futures_util::StreamExt;
         let mut stream = response.bytes_stream();
@@ -1008,61 +1071,44 @@ impl WhisperEngine {
         let mut last_progress_report = 0u8;
         let mut last_report_time = std::time::Instant::now();
 
-        // Emit initial 0% progress immediately
         if let Some(ref callback) = progress_callback {
             callback(0);
         }
 
-        while let Some(chunk_result) = stream.next().await {
-            // Check for cancellation before processing chunk
-            {
-                let cancel_flag = self.cancel_download_flag.read().await;
-                if cancel_flag.as_ref() == Some(&model_name.to_string()) {
-                    log::info!("Download cancelled for {}", model_name);
-                    self.clear_active_download(model_name).await;
-                    return Err(anyhow!("Download cancelled by user"));
-                }
-            }
-
-            let chunk = match chunk_result {
-                Ok(chunk) => chunk,
-                Err(e) => {
-                    self.clear_active_download(model_name).await;
-                    return Err(anyhow!("Failed to read chunk: {}", e));
-                }
+        loop {
+            let chunk_result = tokio::select! {
+                biased;
+                _ = active_download.cancellation.cancelled() => return Err(DownloadCancelled.into()),
+                chunk_result = stream.next() => chunk_result,
             };
 
-            if let Err(e) = file.write_all(&chunk).await {
-                self.clear_active_download(model_name).await;
-                return Err(anyhow!("Failed to write chunk to file: {}", e));
+            let Some(chunk_result) = chunk_result else {
+                break;
+            };
+
+            if active_download.cancellation.is_cancelled() {
+                return Err(DownloadCancelled.into());
             }
 
-            downloaded += chunk.len() as u64;
+            let chunk = chunk_result.map_err(|e| anyhow!("Failed to read chunk: {}", e))?;
+            file.write_all(&chunk)
+                .await
+                .map_err(|e| anyhow!("Failed to write chunk to file: {}", e))?;
 
-            // Calculate progress
+            downloaded += chunk.len() as u64;
             let progress = if total_size > 0 {
                 ((downloaded as f64 / total_size as f64) * 100.0) as u8
             } else {
                 0
             };
 
-            // Report progress every 1% or every 2 seconds for better UI responsiveness
             let time_since_last_report = last_report_time.elapsed().as_secs();
             if progress >= last_progress_report + 1 || progress == 100 || time_since_last_report >= 2 {
-                log::info!("Download progress: {}% ({:.1} MB / {:.1} MB)",
-                         progress,
-                         downloaded as f64 / (1024.0 * 1024.0),
-                         total_size as f64 / (1024.0 * 1024.0));
-
-                // Update progress in model info
-                {
-                    let mut models = self.available_models.write().await;
-                    if let Some(model_info) = models.get_mut(model_name) {
-                        model_info.status = ModelStatus::Downloading { progress };
-                    }
+                let mut models = self.available_models.write().await;
+                if let Some(model_info) = models.get_mut(model_name) {
+                    model_info.status = ModelStatus::Downloading { progress };
                 }
 
-                // Call progress callback
                 if let Some(ref callback) = progress_callback {
                     callback(progress);
                 }
@@ -1072,75 +1118,49 @@ impl WhisperEngine {
             }
         }
 
-        log::info!("Streaming download completed: {} bytes", downloaded);
-        
-        // Ensure 100% progress is always reported
         {
             let mut models = self.available_models.write().await;
             if let Some(model_info) = models.get_mut(model_name) {
                 model_info.status = ModelStatus::Downloading { progress: 100 };
             }
         }
-        
+
         if let Some(ref callback) = progress_callback {
             callback(100);
         }
-        
-        if let Err(e) = file.flush().await {
-            self.clear_active_download(model_name).await;
-            return Err(anyhow!("Failed to flush file: {}", e));
-        }
-        
-        log::info!("Download completed for model: {}", model_name);
-        
-        // Update model status to available
-        {
-            let mut models = self.available_models.write().await;
-            if let Some(model_info) = models.get_mut(model_name) {
-                model_info.status = ModelStatus::Available;
-                model_info.path = file_path.clone();
-            }
+
+        file.flush()
+            .await
+            .map_err(|e| anyhow!("Failed to flush file: {}", e))?;
+
+        if active_download.cancellation.is_cancelled() {
+            return Err(DownloadCancelled.into());
         }
 
-        self.clear_active_download(model_name).await;
+        let mut models = self.available_models.write().await;
+        if let Some(model_info) = models.get_mut(model_name) {
+            model_info.status = ModelStatus::Available;
+            model_info.path = file_path.clone();
+        }
 
         Ok(())
     }
-    
+
     pub async fn cancel_download(&self, model_name: &str) -> Result<()> {
         log::info!("Cancelling download for model: {}", model_name);
 
-        // Set cancellation flag to interrupt the download loop
-        {
-            let mut cancel_flag = self.cancel_download_flag.write().await;
-            *cancel_flag = Some(model_name.to_string());
-        }
+        let Some(active_download) = self.active_downloads.lock().await.get(model_name).cloned() else {
+            return Ok(());
+        };
 
-        // Remove from active downloads
-        {
-            let mut active = self.active_downloads.write().await;
-            active.remove(model_name);
-        }
+        active_download.cancellation.cancel();
 
-        // Update model status to Missing (so it can be retried)
-        {
-            let mut models = self.available_models.write().await;
-            if let Some(model_info) = models.get_mut(model_name) {
-                model_info.status = ModelStatus::Missing;
-            }
-        }
-
-        // Clean up partially downloaded files
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await; // Brief delay to let download loop detect cancellation
-
-        let filename = format!("ggml-{}.bin", model_name);
-        let file_path = self.models_dir.join(&filename);
-        if file_path.exists() {
-            if let Err(e) = fs::remove_file(&file_path).await {
-                log::warn!("Failed to clean up cancelled download file: {}", e);
-            } else {
-                log::info!("Cleaned up cancelled download file: {}", file_path.display());
-            }
+        let mut completion = active_download.completion.subscribe();
+        if !*completion.borrow() {
+            completion
+                .changed()
+                .await
+                .map_err(|_| anyhow!("Download worker ended before completing cancellation cleanup"))?;
         }
 
         Ok(())
@@ -1150,6 +1170,10 @@ impl WhisperEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::sync::oneshot;
+    use tokio::time::{timeout, Duration};
 
     fn tiny_model(models: &[ModelInfo]) -> &ModelInfo {
         models
@@ -1163,11 +1187,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
 
-        engine
-            .active_downloads
-            .write()
-            .await
-            .insert("tiny".to_string());
+        let _active_download = engine.reserve_active_download("tiny").await.unwrap();
         engine.available_models.write().await.insert(
             "tiny".to_string(),
             ModelInfo {
@@ -1227,6 +1247,147 @@ mod tests {
         let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
 
         assert!(engine.download_model("not-a-model", None).await.is_err());
-        assert!(!engine.active_downloads.read().await.contains("not-a-model"));
+        assert!(!engine.active_downloads.lock().await.contains_key("not-a-model"));
+    }
+
+    #[tokio::test]
+    async fn duplicate_download_reservation_is_rejected_while_the_first_owner_is_active() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
+
+        let _first_owner = engine.reserve_active_download("tiny").await.unwrap();
+        assert!(engine.reserve_active_download("tiny").await.is_err());
+    }
+
+    async fn stalled_http_server(
+    ) -> (
+        String,
+        oneshot::Receiver<()>,
+        oneshot::Sender<()>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (headers_sent, headers_ready) = oneshot::channel();
+        let (release_body, body_released) = oneshot::channel();
+
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            socket.read(&mut request).await.unwrap();
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\nConnection: close\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            socket.flush().await.unwrap();
+            headers_sent.send(()).unwrap();
+            let _ = body_released.await;
+            let _ = socket.write_all(b"test").await;
+        });
+
+        (format!("http://{address}/model.bin"), headers_ready, release_body, server)
+    }
+
+    #[tokio::test]
+    async fn cancelling_a_stalled_download_waits_for_cleanup_before_retry_can_start() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = Arc::new(WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap());
+        let (url_a, headers_a, release_a, server_a) = stalled_http_server().await;
+
+        let download_a_engine = Arc::clone(&engine);
+        let download_a = tokio::spawn(async move {
+            download_a_engine
+                .download_model_from_url("tiny", &url_a, None)
+                .await
+        });
+
+        timeout(Duration::from_secs(1), headers_a)
+            .await
+            .expect("first request should receive response headers")
+            .unwrap();
+
+        assert!(engine.active_downloads.lock().await.contains_key("tiny"));
+        let status_while_active = engine.discover_models().await.unwrap();
+        assert!(matches!(
+            tiny_model(&status_while_active).status,
+            ModelStatus::Downloading { progress: 0 }
+        ));
+
+        timeout(Duration::from_secs(1), engine.cancel_download("tiny"))
+            .await
+            .expect("cancellation should not wait for a stalled response body")
+            .unwrap();
+
+        let download_a_result = timeout(Duration::from_secs(1), download_a)
+            .await
+            .expect("cancelled worker should finish promptly")
+            .unwrap();
+        assert!(is_download_cancelled(&download_a_result.unwrap_err()));
+        assert!(!engine.active_downloads.lock().await.contains_key("tiny"));
+        assert!(!dir.path().join("ggml-tiny.bin").exists());
+
+        let (url_b, headers_b, release_b, server_b) = stalled_http_server().await;
+        let download_b_engine = Arc::clone(&engine);
+        let download_b = tokio::spawn(async move {
+            download_b_engine
+                .download_model_from_url("tiny", &url_b, None)
+                .await
+        });
+        timeout(Duration::from_secs(1), headers_b)
+            .await
+            .expect("retry should reserve the released model slot")
+            .unwrap();
+        assert!(engine.active_downloads.lock().await.contains_key("tiny"));
+
+        timeout(Duration::from_secs(1), engine.cancel_download("tiny"))
+            .await
+            .expect("retry cancellation should also complete promptly")
+            .unwrap();
+        assert!(is_download_cancelled(
+            &timeout(Duration::from_secs(1), download_b)
+                .await
+                .expect("retry worker should finish promptly")
+                .unwrap()
+                .unwrap_err()
+        ));
+
+        let _ = release_a.send(());
+        let _ = release_b.send(());
+        let _ = server_a.await;
+        let _ = server_b.await;
+    }
+
+    #[tokio::test]
+    async fn terminal_download_error_releases_the_active_transfer() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
+        std::fs::write(dir.path().join("ggml-tiny.bin"), vec![0_u8; 2 * 1024 * 1024]).unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            socket.read(&mut request).await.unwrap();
+            socket
+                .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n")
+                .await
+                .unwrap();
+        });
+
+        assert!(engine
+            .download_model_from_url("tiny", &format!("http://{address}/model.bin"), None)
+            .await
+            .is_err());
+        server.await.unwrap();
+
+        assert!(!engine.active_downloads.lock().await.contains_key("tiny"));
+        let models = engine.discover_models().await.unwrap();
+        assert!(matches!(
+            tiny_model(&models).status,
+            ModelStatus::Corrupted { .. }
+        ));
     }
 }

--- a/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
+++ b/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
@@ -40,12 +40,27 @@ struct ActiveDownload {
     completion: watch::Sender<bool>,
 }
 
+#[cfg(test)]
+struct DownloadStateTestHook {
+    cancellation_first_lock_acquired: tokio::sync::Notify,
+    continue_cancellation: tokio::sync::Notify,
+    discovery_active_lock_acquired: tokio::sync::Notify,
+    continue_discovery: tokio::sync::Notify,
+}
+
 #[derive(Debug, thiserror::Error)]
 #[error("Download cancelled by user")]
 pub(crate) struct DownloadCancelled;
 
 pub(crate) fn is_download_cancelled(error: &anyhow::Error) -> bool {
     error.downcast_ref::<DownloadCancelled>().is_some()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CancelDownloadOutcome {
+    Cancelled,
+    Pending,
 }
 
 const CANCEL_DOWNLOAD_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -62,6 +77,8 @@ pub struct WhisperEngine {
     transcription_count: Arc<RwLock<u64>>,
     // A model remains active until its owning worker has completed cleanup.
     active_downloads: Arc<Mutex<HashMap<String, Arc<ActiveDownload>>>>,
+    #[cfg(test)]
+    download_state_test_hook: std::sync::Mutex<Option<Arc<DownloadStateTestHook>>>,
 }
 
 impl WhisperEngine {
@@ -175,9 +192,19 @@ impl WhisperEngine {
             // Performance optimization: reduce logging frequency
             transcription_count: Arc::new(RwLock::new(0)),
             active_downloads: Arc::new(Mutex::new(HashMap::new())),
+            #[cfg(test)]
+            download_state_test_hook: std::sync::Mutex::new(None),
         };
         
         Ok(engine)
+    }
+
+    #[cfg(test)]
+    fn test_hook(&self) -> Option<Arc<DownloadStateTestHook>> {
+        self.download_state_test_hook
+            .lock()
+            .expect("download state test hook mutex should not be poisoned")
+            .clone()
     }
     
     pub async fn discover_models(&self) -> Result<Vec<ModelInfo>> {
@@ -240,6 +267,11 @@ impl WhisperEngine {
         }
         
         let active_downloads = self.active_downloads.lock().await;
+        #[cfg(test)]
+        if let Some(hook) = self.test_hook() {
+            hook.discovery_active_lock_acquired.notify_one();
+            hook.continue_discovery.notified().await;
+        }
         let mut available_models = self.available_models.write().await;
         for model in &mut models {
             if active_downloads.contains_key(&model.name) {
@@ -999,15 +1031,20 @@ impl WhisperEngine {
                 }
             }
 
-            let mut models = self.available_models.write().await;
-            if let Some(model_info) = models.get_mut(model_name) {
-                model_info.status = ModelStatus::Missing;
-            }
-
             let removed = {
                 let mut active_downloads = self.active_downloads.lock().await;
+                #[cfg(test)]
+                if let Some(hook) = self.test_hook() {
+                    hook.cancellation_first_lock_acquired.notify_one();
+                    hook.continue_cancellation.notified().await;
+                }
+
+                let mut models = self.available_models.write().await;
                 match active_downloads.get(model_name) {
                     Some(current) if Arc::ptr_eq(current, active_download) => {
+                        if let Some(model_info) = models.get_mut(model_name) {
+                            model_info.status = ModelStatus::Missing;
+                        }
                         active_downloads.remove(model_name);
                         true
                     }
@@ -1199,7 +1236,7 @@ impl WhisperEngine {
         Ok(())
     }
 
-    pub async fn cancel_download(&self, model_name: &str) -> Result<()> {
+    pub async fn cancel_download(&self, model_name: &str) -> Result<CancelDownloadOutcome> {
         self.cancel_download_with_timeout(model_name, CANCEL_DOWNLOAD_CLEANUP_TIMEOUT)
             .await
     }
@@ -1208,11 +1245,11 @@ impl WhisperEngine {
         &self,
         model_name: &str,
         cleanup_timeout: Duration,
-    ) -> Result<()> {
+    ) -> Result<CancelDownloadOutcome> {
         log::info!("Cancelling download for model: {}", model_name);
 
         let Some(active_download) = self.active_downloads.lock().await.get(model_name).cloned() else {
-            return Ok(());
+            return Ok(CancelDownloadOutcome::Cancelled);
         };
 
         active_download.cancellation.cancel();
@@ -1225,12 +1262,12 @@ impl WhisperEngine {
                     return Err(anyhow!("Download worker ended before completing cancellation cleanup"));
                 }
                 Err(_) => {
-                    return Err(anyhow!("Timed out waiting for download cancellation cleanup"));
+                    return Ok(CancelDownloadOutcome::Pending);
                 }
             }
         }
 
-        Ok(())
+        Ok(CancelDownloadOutcome::Cancelled)
     }
 }
 
@@ -1404,26 +1441,133 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelled_finalization_holds_active_ownership_before_discovery() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = Arc::new(WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap());
+        engine.discover_models().await.unwrap();
+
+        let active_download = engine.reserve_active_download("tiny").await.unwrap();
+        active_download.cancellation.cancel();
+
+        let hook = Arc::new(DownloadStateTestHook {
+            cancellation_first_lock_acquired: tokio::sync::Notify::new(),
+            continue_cancellation: tokio::sync::Notify::new(),
+            discovery_active_lock_acquired: tokio::sync::Notify::new(),
+            continue_discovery: tokio::sync::Notify::new(),
+        });
+        *engine.download_state_test_hook.lock().unwrap() = Some(Arc::clone(&hook));
+
+        let finalization_engine = Arc::clone(&engine);
+        let finalization_owner = Arc::clone(&active_download);
+        let model_path = dir.path().join("ggml-tiny.bin");
+        let finalization = tokio::spawn(async move {
+            finalization_engine
+                .finish_download(
+                    "tiny",
+                    &finalization_owner,
+                    &model_path,
+                    Err(DownloadCancelled.into()),
+                )
+                .await
+        });
+
+        timeout(
+            Duration::from_secs(1),
+            hook.cancellation_first_lock_acquired.notified(),
+        )
+        .await
+        .expect("cancellation finalization should reach its first lock");
+
+        let discovery_engine = Arc::clone(&engine);
+        let discovery = tokio::spawn(async move { discovery_engine.discover_models().await });
+
+        assert!(
+            timeout(
+                Duration::from_millis(100),
+                hook.discovery_active_lock_acquired.notified(),
+            )
+            .await
+            .is_err(),
+            "discovery must wait for cancellation to release active ownership"
+        );
+
+        hook.continue_cancellation.notify_one();
+        let finalization_result = timeout(Duration::from_secs(1), finalization)
+            .await
+            .expect("cancelled finalization should complete")
+            .unwrap()
+            .unwrap_err();
+        assert!(is_download_cancelled(&finalization_result));
+
+        timeout(
+            Duration::from_secs(1),
+            hook.discovery_active_lock_acquired.notified(),
+        )
+        .await
+        .expect("discovery should acquire active ownership after cancellation finalizes");
+        hook.continue_discovery.notify_one();
+
+        let models = timeout(Duration::from_secs(1), discovery)
+            .await
+            .expect("discovery should complete")
+            .unwrap()
+            .unwrap();
+        assert!(matches!(tiny_model(&models).status, ModelStatus::Missing));
+        assert!(!engine.active_downloads.lock().await.contains_key("tiny"));
+    }
+
+    #[tokio::test]
     async fn cancelling_an_unresponsive_download_keeps_ownership_reserved() {
         let dir = tempfile::tempdir().unwrap();
         let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
         let active_download = engine.reserve_active_download("tiny").await.unwrap();
 
-        let error = engine
+        let outcome = engine
             .cancel_download_with_timeout("tiny", Duration::from_millis(1))
             .await
-            .unwrap_err();
+            .expect("an unresponsive download should report cancellation pending");
 
-        assert_eq!(
-            error.to_string(),
-            "Timed out waiting for download cancellation cleanup"
-        );
+        assert_eq!(outcome, CancelDownloadOutcome::Pending);
         assert!(active_download.cancellation.is_cancelled());
         assert!(matches!(
             engine.active_downloads.lock().await.get("tiny"),
             Some(current) if Arc::ptr_eq(current, &active_download)
         ));
         assert!(engine.reserve_active_download("tiny").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn late_cancellation_preserves_a_completed_model_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
+        let model_path = dir.path().join("ggml-tiny.bin");
+
+        std::fs::write(&model_path, b"ggml\0\0\0\0").unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&model_path)
+            .unwrap()
+            .set_len(68 * 1024 * 1024)
+            .unwrap();
+
+        engine.discover_models().await.unwrap();
+        let active_download = engine.reserve_active_download("tiny").await.unwrap();
+        engine
+            .finish_download("tiny", &active_download, &model_path, Ok(()))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            engine
+                .cancel_download_with_timeout("tiny", Duration::from_millis(1))
+                .await
+                .unwrap(),
+            CancelDownloadOutcome::Cancelled
+        );
+        assert!(matches!(
+            tiny_model(&engine.discover_models().await.unwrap()).status,
+            ModelStatus::Available
+        ));
     }
 
     async fn stalled_http_server(

--- a/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
+++ b/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
@@ -173,10 +173,25 @@ impl WhisperEngine {
         let mut models = Vec::new();
         // Use centralized model catalog from config.rs
         let model_configs = WHISPER_MODEL_CATALOG;
+        let active_downloads = self.active_downloads.read().await.clone();
+        let cached_download_progress: HashMap<String, u8> = self
+            .available_models
+            .read()
+            .await
+            .iter()
+            .filter_map(|(name, model)| match model.status {
+                ModelStatus::Downloading { progress } => Some((name.clone(), progress)),
+                _ => None,
+            })
+            .collect();
 
         for &(name, filename, size_mb, accuracy, speed, description) in model_configs {
             let model_path = models_dir.join(filename);
-            let status = if model_path.exists() {
+            let status = if active_downloads.contains(name) {
+                ModelStatus::Downloading {
+                    progress: cached_download_progress.get(name).copied().unwrap_or(0),
+                }
+            } else if model_path.exists() {
                 // Check if file size is reasonable (at least 1MB for a valid model)
                 match std::fs::metadata(&model_path) {
                     Ok(metadata) => {
@@ -198,32 +213,11 @@ impl WhisperEngine {
                                 }
                             }
                         } else if file_size_mb > 0 {
-                            // File exists but is smaller than expected
-                            // Check if this model is currently being downloaded
-                            let models_guard = self.available_models.read().await;
-                            if let Some(existing_model) = models_guard.get(name) {
-                                match &existing_model.status {
-                                    ModelStatus::Downloading { progress } => {
-                                        log::debug!("Model {} appears to be downloading ({} MB so far, {}% complete)",
-                                                  filename, file_size_mb, progress);
-                                        ModelStatus::Downloading { progress: *progress }
-                                    }
-                                    _ => {
-                                        log::warn!("Model file {} exists but is corrupted ({} MB, expected ~{} MB)",
-                                                 filename, file_size_mb, size_mb);
-                                        ModelStatus::Corrupted {
-                                            file_size: file_size_bytes,
-                                            expected_min_size: (expected_min_size_mb * 1024 * 1024) as u64
-                                        }
-                                    }
-                                }
-                            } else {
-                                log::warn!("Model file {} exists but is corrupted ({} MB, expected ~{} MB)",
-                                         filename, file_size_mb, size_mb);
-                                ModelStatus::Corrupted {
-                                    file_size: file_size_bytes,
-                                    expected_min_size: (expected_min_size_mb * 1024 * 1024) as u64
-                                }
+                            log::warn!("Model file {} exists but is corrupted ({} MB, expected ~{} MB)",
+                                     filename, file_size_mb, size_mb);
+                            ModelStatus::Corrupted {
+                                file_size: file_size_bytes,
+                                expected_min_size: (expected_min_size_mb * 1024 * 1024) as u64
                             }
                         } else {
                             ModelStatus::Missing
@@ -894,8 +888,35 @@ impl WhisperEngine {
         }
     }
     
+    async fn clear_active_download(&self, model_name: &str) {
+        self.active_downloads.write().await.remove(model_name);
+    }
+
     pub async fn download_model(&self, model_name: &str, progress_callback: Option<Box<dyn Fn(u8) + Send>>) -> Result<()> {
         log::info!("Starting download for model: {}", model_name);
+
+        // Validate before registering an active transfer so invalid names cannot leave stale state.
+        let model_url = match model_name {
+            // Standard f16 models
+            "tiny" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin",
+            "base" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin",
+            "small" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin",
+            "medium" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.bin",
+            "large-v3-turbo" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin",
+            "large-v3" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3.bin",
+
+            // Q5_1 quantized models
+            "tiny-q5_1" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny-q5_1.bin",
+            "base-q5_1" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base-q5_1.bin",
+            "small-q5_1" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small-q5_1.bin",
+
+            // Q5_0 quantized models
+            "medium-q5_0" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium-q5_0.bin",
+            "large-v3-turbo-q5_0" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin",
+            "large-v3-q5_0" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-q5_0.bin",
+
+            _ => return Err(anyhow!("Unsupported model: {}", model_name)),
+        };
 
         // Check if download is already in progress for this model
         {
@@ -918,29 +939,6 @@ impl WhisperEngine {
             *cancel_flag = None;
         }
 
-        // Official ggerganov/whisper.cpp model URLs from Hugging Face
-        let model_url = match model_name {
-            // Standard f16 models
-            "tiny" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin",
-            "base" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin",
-            "small" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin",
-            "medium" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.bin",
-            "large-v3-turbo" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin",
-            "large-v3" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3.bin",
-
-            // Q5_1 quantized models
-            "tiny-q5_1" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny-q5_1.bin",
-            "base-q5_1" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base-q5_1.bin",
-            "small-q5_1" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small-q5_1.bin",
-
-            // Q5_0 quantized models
-            "medium-q5_0" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium-q5_0.bin",
-            "large-v3-turbo-q5_0" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin",
-            "large-v3-q5_0" => "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-q5_0.bin",
-
-            _ => return Err(anyhow!("Unsupported model: {}", model_name))
-        };
-        
         log::info!("Model URL for {}: {}", model_name, model_url);
         
         // Generate correct filename - all models follow ggml-{model_name}.bin pattern
@@ -951,8 +949,10 @@ impl WhisperEngine {
         
         // Create models directory if it doesn't exist
         if !self.models_dir.exists() {
-            fs::create_dir_all(&self.models_dir).await
-                .map_err(|e| anyhow!("Failed to create models directory: {}", e))?;
+            if let Err(e) = fs::create_dir_all(&self.models_dir).await {
+                self.clear_active_download(model_name).await;
+                return Err(anyhow!("Failed to create models directory: {}", e));
+            }
         }
         
         // Update model status to downloading
@@ -967,14 +967,17 @@ impl WhisperEngine {
         let client = Client::new();
         
         log::info!("Sending GET request to: {}", model_url);
-        let response = client.get(model_url).send().await
-            .map_err(|e| anyhow!("Failed to start download: {}", e))?;
+        let response = match client.get(model_url).send().await {
+            Ok(response) => response,
+            Err(e) => {
+                self.clear_active_download(model_name).await;
+                return Err(anyhow!("Failed to start download: {}", e));
+            }
+        };
         
         log::info!("Received response with status: {}", response.status());
         if !response.status().is_success() {
-            // Remove from active downloads on error
-            let mut active = self.active_downloads.write().await;
-            active.remove(model_name);
+            self.clear_active_download(model_name).await;
             return Err(anyhow!("Download failed with status: {}", response.status()));
         }
         
@@ -985,8 +988,13 @@ impl WhisperEngine {
             log::warn!("Content length is 0 or unknown - download may not show accurate progress");
         }
         
-        let mut file = fs::File::create(&file_path).await
-            .map_err(|e| anyhow!("Failed to create file: {}", e))?;
+        let mut file = match fs::File::create(&file_path).await {
+            Ok(file) => file,
+            Err(e) => {
+                self.clear_active_download(model_name).await;
+                return Err(anyhow!("Failed to create file: {}", e));
+            }
+        };
         
         log::info!("File created successfully at: {}", file_path.display());
         
@@ -1011,18 +1019,23 @@ impl WhisperEngine {
                 let cancel_flag = self.cancel_download_flag.read().await;
                 if cancel_flag.as_ref() == Some(&model_name.to_string()) {
                     log::info!("Download cancelled for {}", model_name);
-                    // Remove from active downloads on cancellation
-                    let mut active = self.active_downloads.write().await;
-                    active.remove(model_name);
+                    self.clear_active_download(model_name).await;
                     return Err(anyhow!("Download cancelled by user"));
                 }
             }
 
-            let chunk = chunk_result
-                .map_err(|e| anyhow!("Failed to read chunk: {}", e))?;
+            let chunk = match chunk_result {
+                Ok(chunk) => chunk,
+                Err(e) => {
+                    self.clear_active_download(model_name).await;
+                    return Err(anyhow!("Failed to read chunk: {}", e));
+                }
+            };
 
-            file.write_all(&chunk).await
-                .map_err(|e| anyhow!("Failed to write chunk to file: {}", e))?;
+            if let Err(e) = file.write_all(&chunk).await {
+                self.clear_active_download(model_name).await;
+                return Err(anyhow!("Failed to write chunk to file: {}", e));
+            }
 
             downloaded += chunk.len() as u64;
 
@@ -1073,8 +1086,10 @@ impl WhisperEngine {
             callback(100);
         }
         
-        file.flush().await
-            .map_err(|e| anyhow!("Failed to flush file: {}", e))?;
+        if let Err(e) = file.flush().await {
+            self.clear_active_download(model_name).await;
+            return Err(anyhow!("Failed to flush file: {}", e));
+        }
         
         log::info!("Download completed for model: {}", model_name);
         
@@ -1087,11 +1102,7 @@ impl WhisperEngine {
             }
         }
 
-        // Remove from active downloads on completion
-        {
-            let mut active = self.active_downloads.write().await;
-            active.remove(model_name);
-        }
+        self.clear_active_download(model_name).await;
 
         Ok(())
     }
@@ -1133,5 +1144,89 @@ impl WhisperEngine {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tiny_model(models: &[ModelInfo]) -> &ModelInfo {
+        models
+            .iter()
+            .find(|model| model.name == "tiny")
+            .expect("tiny should be present in the Whisper model catalog")
+    }
+
+    #[tokio::test]
+    async fn discover_models_keeps_active_downloads_downloading_before_a_file_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
+
+        engine
+            .active_downloads
+            .write()
+            .await
+            .insert("tiny".to_string());
+        engine.available_models.write().await.insert(
+            "tiny".to_string(),
+            ModelInfo {
+                name: "tiny".to_string(),
+                path: dir.path().join("ggml-tiny.bin"),
+                size_mb: 75,
+                accuracy: "Basic".to_string(),
+                speed: "Fast".to_string(),
+                status: ModelStatus::Downloading { progress: 42 },
+                description: "test model".to_string(),
+            },
+        );
+
+        let absent = engine.discover_models().await.unwrap();
+        assert!(matches!(
+            tiny_model(&absent).status,
+            ModelStatus::Downloading { progress: 42 }
+        ));
+
+        std::fs::write(dir.path().join("ggml-tiny.bin"), b"").unwrap();
+        let zero_byte = engine.discover_models().await.unwrap();
+        assert!(matches!(
+            tiny_model(&zero_byte).status,
+            ModelStatus::Downloading { progress: 42 }
+        ));
+
+        std::fs::write(dir.path().join("ggml-tiny.bin"), [0_u8; 32]).unwrap();
+        let partial = engine.discover_models().await.unwrap();
+        assert!(matches!(
+            tiny_model(&partial).status,
+            ModelStatus::Downloading { progress: 42 }
+        ));
+    }
+
+    #[tokio::test]
+    async fn discover_models_uses_disk_state_after_a_download_is_no_longer_active() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
+
+        let model_path = dir.path().join("ggml-tiny.bin");
+        std::fs::write(&model_path, b"").unwrap();
+        let missing_models = engine.discover_models().await.unwrap();
+        assert!(matches!(tiny_model(&missing_models).status, ModelStatus::Missing));
+
+        std::fs::write(&model_path, vec![0_u8; 2 * 1024 * 1024]).unwrap();
+        let corrupted_models = engine.discover_models().await.unwrap();
+
+        assert!(matches!(
+            tiny_model(&corrupted_models).status,
+            ModelStatus::Corrupted { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn unsupported_download_does_not_leave_an_active_transfer() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
+
+        assert!(engine.download_model("not-a-model", None).await.is_err());
+        assert!(!engine.active_downloads.read().await.contains("not-a-model"));
     }
 }

--- a/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
+++ b/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
@@ -3,6 +3,7 @@
 use std::path::{PathBuf};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{watch, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
 use whisper_rs::{WhisperContext, WhisperContextParameters, FullParams, SamplingStrategy};
@@ -46,6 +47,8 @@ pub(crate) struct DownloadCancelled;
 pub(crate) fn is_download_cancelled(error: &anyhow::Error) -> bool {
     error.downcast_ref::<DownloadCancelled>().is_some()
 }
+
+const CANCEL_DOWNLOAD_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub struct WhisperEngine {
     models_dir: PathBuf,
@@ -917,6 +920,31 @@ impl WhisperEngine {
         file_path: &PathBuf,
         mut result: Result<()>,
     ) -> Result<()> {
+        let active_owner_matches = {
+            let active_downloads = self.active_downloads.lock().await;
+            matches!(
+                active_downloads.get(model_name),
+                Some(current) if Arc::ptr_eq(current, active_download)
+            )
+        };
+        if !active_owner_matches {
+            log::warn!("Download owner for {} was no longer active during finalization", model_name);
+            active_download.completion.send_replace(true);
+            return result;
+        }
+
+        if result.is_ok() && !active_download.cancellation.is_cancelled() {
+            result = self.validate_model_file(file_path).await;
+        }
+
+        if result.is_err() && !active_download.cancellation.is_cancelled() && file_path.exists() {
+            if let Err(e) = fs::remove_file(file_path).await {
+                log::warn!("Failed to clean up failed download file: {}", e);
+            } else {
+                log::info!("Cleaned up failed download file: {}", file_path.display());
+            }
+        }
+
         let (released_active_owner, cancellation_won) = {
             let mut active_downloads = self.active_downloads.lock().await;
             match active_downloads.get(model_name) {
@@ -929,7 +957,7 @@ impl WhisperEngine {
                     }
                 }
                 _ => {
-                    log::warn!("Download owner for {} was no longer active during cleanup", model_name);
+                    log::warn!("Download owner for {} was no longer active during finalization", model_name);
                     (false, active_download.cancellation.is_cancelled())
                 }
             }
@@ -963,13 +991,15 @@ impl WhisperEngine {
             if !removed {
                 log::warn!("Download owner for {} was no longer active during cancellation cleanup", model_name);
             }
-        }
-
-        if released_active_owner && result.is_ok() && !cancellation_won {
+        } else if released_active_owner {
             let mut models = self.available_models.write().await;
             if let Some(model_info) = models.get_mut(model_name) {
-                model_info.status = ModelStatus::Available;
-                model_info.path = file_path.clone();
+                if result.is_ok() {
+                    model_info.status = ModelStatus::Available;
+                    model_info.path = file_path.clone();
+                } else {
+                    model_info.status = ModelStatus::Missing;
+                }
             }
         }
 
@@ -1047,7 +1077,10 @@ impl WhisperEngine {
             }
         }
 
-        let client = Client::new();
+        let client = Client::builder()
+            .user_agent(concat!("Meetily/", env!("CARGO_PKG_VERSION")))
+            .build()
+            .map_err(|e| anyhow!("Failed to create download client: {}", e))?;
         let response = tokio::select! {
             biased;
             _ = active_download.cancellation.cancelled() => return Err(DownloadCancelled.into()),
@@ -1141,6 +1174,15 @@ impl WhisperEngine {
     }
 
     pub async fn cancel_download(&self, model_name: &str) -> Result<()> {
+        self.cancel_download_with_timeout(model_name, CANCEL_DOWNLOAD_CLEANUP_TIMEOUT)
+            .await
+    }
+
+    async fn cancel_download_with_timeout(
+        &self,
+        model_name: &str,
+        cleanup_timeout: Duration,
+    ) -> Result<()> {
         log::info!("Cancelling download for model: {}", model_name);
 
         let Some(active_download) = self.active_downloads.lock().await.get(model_name).cloned() else {
@@ -1151,10 +1193,15 @@ impl WhisperEngine {
 
         let mut completion = active_download.completion.subscribe();
         if !*completion.borrow() {
-            completion
-                .changed()
-                .await
-                .map_err(|_| anyhow!("Download worker ended before completing cancellation cleanup"))?;
+            match tokio::time::timeout(cleanup_timeout, completion.changed()).await {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) => {
+                    return Err(anyhow!("Download worker ended before completing cancellation cleanup"));
+                }
+                Err(_) => {
+                    return Err(anyhow!("Timed out waiting for download cancellation cleanup"));
+                }
+            }
         }
 
         Ok(())
@@ -1282,6 +1329,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn finish_download_rejects_invalid_header_and_cleans_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
+        let model_path = dir.path().join("ggml-tiny.bin");
+        std::fs::write(&model_path, b"not-a-model").unwrap();
+
+        engine.discover_models().await.unwrap();
+        let active_download = engine.reserve_active_download("tiny").await.unwrap();
+        let error = engine
+            .finish_download("tiny", &active_download, &model_path, Ok(()))
+            .await
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("Invalid model file: missing GGML/GGUF magic number"));
+        assert!(!engine.active_downloads.lock().await.contains_key("tiny"));
+        assert!(!model_path.exists());
+        assert!(matches!(
+            engine
+                .available_models
+                .read()
+                .await
+                .get("tiny")
+                .expect("tiny should remain cached")
+                .status,
+            ModelStatus::Missing
+        ));
+    }
+
+    #[tokio::test]
     async fn unsupported_download_does_not_leave_an_active_transfer() {
         let dir = tempfile::tempdir().unwrap();
         let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
@@ -1296,6 +1374,29 @@ mod tests {
         let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
 
         let _first_owner = engine.reserve_active_download("tiny").await.unwrap();
+        assert!(engine.reserve_active_download("tiny").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn cancelling_an_unresponsive_download_keeps_ownership_reserved() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
+        let active_download = engine.reserve_active_download("tiny").await.unwrap();
+
+        let error = engine
+            .cancel_download_with_timeout("tiny", Duration::from_millis(1))
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Timed out waiting for download cancellation cleanup"
+        );
+        assert!(active_download.cancellation.is_cancelled());
+        assert!(matches!(
+            engine.active_downloads.lock().await.get("tiny"),
+            Some(current) if Arc::ptr_eq(current, &active_download)
+        ));
         assert!(engine.reserve_active_download("tiny").await.is_err());
     }
 
@@ -1329,6 +1430,75 @@ mod tests {
 
         (format!("http://{address}/model.bin"), headers_ready, release_body, server)
     }
+
+    async fn response_http_server(
+        content_length: usize,
+        body: &'static [u8],
+    ) -> (
+        String,
+        oneshot::Receiver<Vec<u8>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_sent, request_received) = oneshot::channel();
+
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 1024];
+            loop {
+                let bytes_read = socket.read(&mut buffer).await.unwrap();
+                if bytes_read == 0 {
+                    break;
+                }
+
+                request.extend_from_slice(&buffer[..bytes_read]);
+                if request.ends_with(b"\r\n\r\n") {
+                    break;
+                }
+            }
+            request_sent.send(request).unwrap();
+
+            let headers = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {content_length}\r\nConnection: close\r\n\r\n"
+            );
+            socket.write_all(headers.as_bytes()).await.unwrap();
+            socket.write_all(body).await.unwrap();
+            socket.flush().await.unwrap();
+        });
+
+        (format!("http://{address}/model.bin"), request_received, server)
+    }
+
+    #[tokio::test]
+    async fn downloaded_model_sends_user_agent_and_validates_header() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
+        engine.discover_models().await.unwrap();
+        let (url, request, server) = response_http_server(8, b"ggml\0\0\0\0").await;
+
+        engine.download_model_from_url("tiny", &url, None).await.unwrap();
+        let request = String::from_utf8(request.await.unwrap()).unwrap();
+        server.await.unwrap();
+
+        assert!(request.to_ascii_lowercase().contains(&format!(
+            "user-agent: meetily/{}",
+            env!("CARGO_PKG_VERSION")
+        )));
+        assert!(!engine.active_downloads.lock().await.contains_key("tiny"));
+        assert!(matches!(
+            engine
+                .available_models
+                .read()
+                .await
+                .get("tiny")
+                .expect("tiny should remain cached")
+                .status,
+            ModelStatus::Available
+        ));
+    }
+
 
     #[tokio::test]
     async fn cancelling_a_stalled_download_waits_for_cleanup_before_retry_can_start() {
@@ -1400,10 +1570,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn incomplete_response_cleans_partial_file_and_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
+        let model_path = dir.path().join("ggml-tiny.bin");
+        engine.discover_models().await.unwrap();
+        let (url, _request, server) = response_http_server(8, b"ggml").await;
+
+        let error = engine
+            .download_model_from_url("tiny", &url, None)
+            .await
+            .unwrap_err();
+        server.await.unwrap();
+
+        assert!(error.to_string().contains("Failed to read chunk"));
+        assert!(!engine.active_downloads.lock().await.contains_key("tiny"));
+        assert!(!model_path.exists());
+        assert!(matches!(
+            engine
+                .available_models
+                .read()
+                .await
+                .get("tiny")
+                .expect("tiny should remain cached")
+                .status,
+            ModelStatus::Missing
+        ));
+
+        let models = engine.discover_models().await.unwrap();
+        assert!(matches!(tiny_model(&models).status, ModelStatus::Missing));
+    }
+
+    #[tokio::test]
     async fn terminal_download_error_releases_the_active_transfer() {
         let dir = tempfile::tempdir().unwrap();
         let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
-        std::fs::write(dir.path().join("ggml-tiny.bin"), vec![0_u8; 2 * 1024 * 1024]).unwrap();
+        let model_path = dir.path().join("ggml-tiny.bin");
+        std::fs::write(&model_path, vec![0_u8; 2 * 1024 * 1024]).unwrap();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
 
@@ -1424,10 +1627,8 @@ mod tests {
         server.await.unwrap();
 
         assert!(!engine.active_downloads.lock().await.contains_key("tiny"));
+        assert!(!model_path.exists());
         let models = engine.discover_models().await.unwrap();
-        assert!(matches!(
-            tiny_model(&models).status,
-            ModelStatus::Corrupted { .. }
-        ));
+        assert!(matches!(tiny_model(&models).status, ModelStatus::Missing));
     }
 }

--- a/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
+++ b/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
@@ -182,31 +182,10 @@ impl WhisperEngine {
         let mut models = Vec::new();
         // Use centralized model catalog from config.rs
         let model_configs = WHISPER_MODEL_CATALOG;
-        let active_downloads: HashSet<String> = self
-            .active_downloads
-            .lock()
-            .await
-            .keys()
-            .cloned()
-            .collect();
-        let cached_download_progress: HashMap<String, u8> = self
-            .available_models
-            .read()
-            .await
-            .iter()
-            .filter_map(|(name, model)| match model.status {
-                ModelStatus::Downloading { progress } => Some((name.clone(), progress)),
-                _ => None,
-            })
-            .collect();
 
         for &(name, filename, size_mb, accuracy, speed, description) in model_configs {
             let model_path = models_dir.join(filename);
-            let status = if active_downloads.contains(name) {
-                ModelStatus::Downloading {
-                    progress: cached_download_progress.get(name).copied().unwrap_or(0),
-                }
-            } else if model_path.exists() {
+            let status = if model_path.exists() {
                 // Check if file size is reasonable (at least 1MB for a valid model)
                 match std::fs::metadata(&model_path) {
                     Ok(metadata) => {
@@ -257,8 +236,20 @@ impl WhisperEngine {
             models.push(model_info);
         }
         
-        // Update internal cache
+        let active_downloads = self.active_downloads.lock().await;
         let mut available_models = self.available_models.write().await;
+        for model in &mut models {
+            if active_downloads.contains_key(&model.name) {
+                let progress = available_models
+                    .get(&model.name)
+                    .and_then(|cached| match cached.status {
+                        ModelStatus::Downloading { progress } => Some(progress),
+                        _ => None,
+                    })
+                    .unwrap_or(0);
+                model.status = ModelStatus::Downloading { progress };
+            }
+        }
         available_models.clear();
         for model in &models {
             available_models.insert(model.name.clone(), model.clone());
@@ -926,20 +917,20 @@ impl WhisperEngine {
         file_path: &PathBuf,
         mut result: Result<()>,
     ) -> Result<()> {
-        let cancellation_won = {
+        let (released_active_owner, cancellation_won) = {
             let mut active_downloads = self.active_downloads.lock().await;
             match active_downloads.get(model_name) {
                 Some(current) if Arc::ptr_eq(current, active_download) => {
                     if active_download.cancellation.is_cancelled() {
-                        true
+                        (false, true)
                     } else {
                         active_downloads.remove(model_name);
-                        false
+                        (true, false)
                     }
                 }
                 _ => {
                     log::warn!("Download owner for {} was no longer active during cleanup", model_name);
-                    active_download.cancellation.is_cancelled()
+                    (false, active_download.cancellation.is_cancelled())
                 }
             }
         };
@@ -971,6 +962,14 @@ impl WhisperEngine {
             };
             if !removed {
                 log::warn!("Download owner for {} was no longer active during cancellation cleanup", model_name);
+            }
+        }
+
+        if released_active_owner && result.is_ok() && !cancellation_won {
+            let mut models = self.available_models.write().await;
+            if let Some(model_info) = models.get_mut(model_name) {
+                model_info.status = ModelStatus::Available;
+                model_info.path = file_path.clone();
             }
         }
 
@@ -1137,11 +1136,6 @@ impl WhisperEngine {
             return Err(DownloadCancelled.into());
         }
 
-        let mut models = self.available_models.write().await;
-        if let Some(model_info) = models.get_mut(model_name) {
-            model_info.status = ModelStatus::Available;
-            model_info.path = file_path.clone();
-        }
 
         Ok(())
     }
@@ -1238,6 +1232,52 @@ mod tests {
         assert!(matches!(
             tiny_model(&corrupted_models).status,
             ModelStatus::Corrupted { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn finish_download_publishes_available_after_releasing_active_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = WhisperEngine::new_with_models_dir(Some(dir.path().to_path_buf())).unwrap();
+        let model_path = dir.path().join("ggml-tiny.bin");
+
+        std::fs::write(&model_path, b"ggml\0\0\0\0").unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&model_path)
+            .unwrap()
+            .set_len(68 * 1024 * 1024)
+            .unwrap();
+
+        engine.discover_models().await.unwrap();
+        let active_download = engine.reserve_active_download("tiny").await.unwrap();
+        let active_models = engine.discover_models().await.unwrap();
+        assert!(matches!(
+            tiny_model(&active_models).status,
+            ModelStatus::Downloading { progress: 0 }
+        ));
+
+        engine
+            .finish_download("tiny", &active_download, &model_path, Ok(()))
+            .await
+            .unwrap();
+
+        assert!(!engine.active_downloads.lock().await.contains_key("tiny"));
+        assert!(matches!(
+            engine
+                .available_models
+                .read()
+                .await
+                .get("tiny")
+                .expect("tiny should remain cached")
+                .status,
+            ModelStatus::Available
+        ));
+
+        let rediscovered_models = engine.discover_models().await.unwrap();
+        assert!(matches!(
+            tiny_model(&rediscovered_models).status,
+            ModelStatus::Available
         ));
     }
 

--- a/frontend/src/components/ModelDownloadProgress.tsx
+++ b/frontend/src/components/ModelDownloadProgress.tsx
@@ -13,7 +13,7 @@ export function ModelDownloadProgress({ status, modelName, onCancel }: ModelDown
     return null;
   }
 
-  const progress = status.Downloading;
+  const progress = status.Downloading.progress;
   const isCompleted = progress >= 100;
 
   return (

--- a/frontend/src/components/WhisperModelManager.tsx
+++ b/frontend/src/components/WhisperModelManager.tsx
@@ -33,6 +33,7 @@ export function ModelManager({
   const [error, setError] = useState<string | null>(null);
   const [initialized, setInitialized] = useState(false);
   const [downloadingModels, setDownloadingModels] = useState<Set<string>>(new Set());
+  const [cancellingModels, setCancellingModels] = useState<Set<string>>(new Set());
   const [hasUserSelection, setHasUserSelection] = useState(false);
 
   // Refs for stable callbacks
@@ -41,6 +42,8 @@ export function ModelManager({
 
   // Progress throttle map to prevent rapid updates
   const progressThrottleRef = useRef<Map<string, { progress: number; timestamp: number }>>(new Map());
+  const cancellationReconciliationModelsRef = useRef<Set<string>>(new Set());
+  const cancellationReconcileTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
   // Update refs when props change
   useEffect(() => {
@@ -65,6 +68,70 @@ export function ModelManager({
       localStorage.setItem('downloading-models', JSON.stringify(Array.from(newSet)));
       return newSet;
     });
+  };
+
+  const clearCancellationReconciliation = (modelName: string) => {
+    cancellationReconciliationModelsRef.current.delete(modelName);
+    const timer = cancellationReconcileTimersRef.current.get(modelName);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      cancellationReconcileTimersRef.current.delete(modelName);
+    }
+    setCancellingModels(prev => {
+      const next = new Set(prev);
+      next.delete(modelName);
+      return next;
+    });
+  };
+
+  const reconcileCancellation = (modelName: string) => {
+    if (cancellationReconciliationModelsRef.current.has(modelName)) return;
+
+    cancellationReconciliationModelsRef.current.add(modelName);
+    setCancellingModels(prev => new Set([...prev, modelName]));
+
+    const scheduleNextCheck = () => {
+      if (!cancellationReconciliationModelsRef.current.has(modelName)) return;
+      const timer = setTimeout(() => {
+        cancellationReconcileTimersRef.current.delete(modelName);
+        void reconcile();
+      }, 1000);
+      cancellationReconcileTimersRef.current.set(modelName, timer);
+    };
+
+    const reconcile = async () => {
+      try {
+        const modelList = await WhisperAPI.getAvailableModels();
+        if (!cancellationReconciliationModelsRef.current.has(modelName)) return;
+
+        const model = modelList.find(candidate => candidate.name === modelName);
+
+        const isStillDownloading = typeof model?.status === 'object' && 'Downloading' in model.status;
+        if (model && !isStillDownloading) {
+          clearCancellationReconciliation(modelName);
+          updateDownloadingModels(prev => {
+            const next = new Set(prev);
+            next.delete(modelName);
+            return next;
+          });
+          setModels(modelList);
+          progressThrottleRef.current.delete(modelName);
+          toast.info(
+            model.status === 'Available'
+              ? `${getDisplayName(modelName)} download completed before cancellation`
+              : `${getDisplayName(modelName)} download cancelled`,
+            { duration: 3000 }
+          );
+          return;
+        }
+      } catch (err) {
+        console.warn('Failed to reconcile pending download cancellation:', err);
+      }
+
+      scheduleNextCheck();
+    };
+
+    void reconcile();
   };
 
   // Initialize models
@@ -164,6 +231,8 @@ export function ModelManager({
           const model = models.find(m => m.name === modelName);
           const displayName = getDisplayName(modelName);
 
+          clearCancellationReconciliation(modelName);
+
           setModels(prevModels =>
             prevModels.map(model =>
               model.name === modelName
@@ -172,7 +241,7 @@ export function ModelManager({
             )
           );
 
-          setDownloadingModels(prev => {
+          updateDownloadingModels(prev => {
             const newSet = new Set(prev);
             newSet.delete(modelName);
             return newSet;
@@ -203,6 +272,8 @@ export function ModelManager({
           const { modelName, error } = event.payload;
           const displayName = getDisplayName(modelName);
 
+          clearCancellationReconciliation(modelName);
+
           setModels(prevModels =>
             prevModels.map(model =>
               model.name === modelName
@@ -211,7 +282,7 @@ export function ModelManager({
             )
           );
 
-          setDownloadingModels(prev => {
+          updateDownloadingModels(prev => {
             const newSet = new Set(prev);
             newSet.delete(modelName);
             return newSet;
@@ -239,6 +310,11 @@ export function ModelManager({
       if (unlistenProgress) unlistenProgress();
       if (unlistenComplete) unlistenComplete();
       if (unlistenError) unlistenError();
+      for (const timer of cancellationReconcileTimersRef.current.values()) {
+        clearTimeout(timer);
+      }
+      cancellationReconcileTimersRef.current.clear();
+      cancellationReconciliationModelsRef.current.clear();
     };
   }, []); // Empty dependency array - listeners use refs for stable callbacks
 
@@ -258,28 +334,19 @@ export function ModelManager({
     const displayName = getDisplayName(modelName);
 
     try {
-      await WhisperAPI.cancelDownload(modelName);
+      const outcome = await WhisperAPI.cancelDownload(modelName);
+      if (outcome === 'pending') {
+        reconcileCancellation(modelName);
+        toast.info(`Cancelling ${displayName}...`, {
+          description: 'The download is still shutting down. Retry will be available when cleanup completes.',
+          duration: 4000
+        });
+        return;
+      }
 
-      updateDownloadingModels(prev => {
-        const newSet = new Set(prev);
-        newSet.delete(modelName);
-        return newSet;
-      });
-
-      setModels(prevModels =>
-        prevModels.map(model =>
-          model.name === modelName
-            ? { ...model, status: 'Missing' as ModelStatus }
-            : model
-        )
-      );
-
-      // Clean up throttle data
-      progressThrottleRef.current.delete(modelName);
-
-      toast.info(`${displayName} download cancelled`, {
-        duration: 3000
-      });
+      // A worker can finish between the user's click and the cancellation command
+      // acquiring its owner. Reconcile instead of overwriting a valid Available state.
+      reconcileCancellation(modelName);
     } catch (err) {
       console.error('Failed to cancel download:', err);
       toast.error('Failed to cancel download', {
@@ -291,6 +358,8 @@ export function ModelManager({
 
   const downloadModel = async (modelName: string) => {
     if (downloadingModels.has(modelName)) return;
+
+    clearCancellationReconciliation(modelName);
 
     const displayName = getDisplayName(modelName);
 
@@ -436,6 +505,7 @@ export function ModelManager({
               onCancel={() => cancelDownload(model.name)}
               onDelete={() => deleteModel(model.name)}
               isDownloading={downloadingModels.has(model.name)}
+              isCancelling={cancellingModels.has(model.name)}
               displayName={getDisplayName(model.name)}
             />
           );
@@ -466,6 +536,7 @@ export function ModelManager({
                     onCancel={() => cancelDownload(model.name)}
                     onDelete={() => deleteModel(model.name)}
                     isDownloading={downloadingModels.has(model.name)}
+                    isCancelling={cancellingModels.has(model.name)}
                     displayName={getDisplayName(model.name)}
                   />
                 ))}
@@ -499,6 +570,7 @@ interface ModelCardProps {
   onCancel: () => void;
   onDelete: () => void;
   isDownloading: boolean;
+  isCancelling: boolean;
   displayName: string;
 }
 
@@ -511,6 +583,7 @@ function ModelCard({
   onCancel,
   onDelete,
   isDownloading,
+  isCancelling,
   displayName
 }: ModelCardProps) {
   const [isHovered, setIsHovered] = useState(false);
@@ -689,19 +762,29 @@ function ModelCard({
           >
             <div className="flex items-center justify-between mb-2">
               <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-blue-600">Downloading...</span>
-                <span className="text-sm font-semibold text-blue-600">{Math.round(downloadProgress)}%</span>
+                <span className="text-sm font-medium text-blue-600">
+                  {isCancelling ? 'Cancelling…' : 'Downloading...'}
+                </span>
+                {!isCancelling && (
+                  <span className="text-sm font-semibold text-blue-600">{Math.round(downloadProgress)}%</span>
+                )}
               </div>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onCancel();
-                }}
-                className="text-xs text-gray-600 hover:text-red-600 font-medium transition-colors px-2 py-1 rounded hover:bg-red-50"
-                title="Cancel download"
-              >
-                Cancel
-              </button>
+              {isCancelling ? (
+                <span className="text-xs text-gray-500 font-medium px-2 py-1">
+                  Cancellation requested
+                </span>
+              ) : (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onCancel();
+                  }}
+                  className="text-xs text-gray-600 hover:text-red-600 font-medium transition-colors px-2 py-1 rounded hover:bg-red-50"
+                  title="Cancel download"
+                >
+                  Cancel
+                </button>
+              )}
             </div>
             <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
               <motion.div

--- a/frontend/src/components/WhisperModelManager.tsx
+++ b/frontend/src/components/WhisperModelManager.tsx
@@ -96,7 +96,7 @@ export function ModelManager({
               });
               return model;
             } else {
-              return { ...model, status: { Downloading: 0 } as ModelStatus };
+              return { ...model, status: { Downloading: { progress: 0 } } as ModelStatus };
             }
           }
           return model;
@@ -148,7 +148,7 @@ export function ModelManager({
             setModels(prevModels =>
               prevModels.map(model =>
                 model.name === modelName
-                  ? { ...model, status: { Downloading: progress } as ModelStatus }
+                  ? { ...model, status: { Downloading: { progress } } as ModelStatus }
                   : model
               )
             );
@@ -300,7 +300,7 @@ export function ModelManager({
       setModels(prevModels =>
         prevModels.map(model =>
           model.name === modelName
-            ? { ...model, status: { Downloading: 0 } as ModelStatus }
+            ? { ...model, status: { Downloading: { progress: 0 } } as ModelStatus }
             : model
         )
       );
@@ -521,7 +521,7 @@ function ModelCard({
   const isCorrupted = typeof model.status === 'object' && 'Corrupted' in model.status;
   const downloadProgress =
     typeof model.status === 'object' && 'Downloading' in model.status
-      ? model.status.Downloading
+      ? model.status.Downloading.progress
       : null;
 
   return (

--- a/frontend/src/lib/whisper.ts
+++ b/frontend/src/lib/whisper.ts
@@ -15,7 +15,7 @@ export type ProcessingSpeed = 'Slow' | 'Medium' | 'Fast' | 'Very Fast';
 export type ModelStatus =
   | 'Available'
   | 'Missing'
-  | { Downloading: number }
+  | { Downloading: { progress: number } }
   | { Error: string }
   | { Corrupted: { file_size: number; expected_min_size: number } };
 

--- a/frontend/src/lib/whisper.ts
+++ b/frontend/src/lib/whisper.ts
@@ -19,6 +19,8 @@ export type ModelStatus =
   | { Error: string }
   | { Corrupted: { file_size: number; expected_min_size: number } };
 
+export type CancelDownloadOutcome = 'cancelled' | 'pending';
+
 export interface ModelDownloadProgress {
   modelName: string;
   progress: number;
@@ -312,8 +314,8 @@ export class WhisperAPI {
     await invoke('whisper_download_model', { modelName });
   }
 
-  static async cancelDownload(modelName: string): Promise<void> {
-    await invoke('whisper_cancel_download', { modelName });
+  static async cancelDownload(modelName: string): Promise<CancelDownloadOutcome> {
+    return await invoke<CancelDownloadOutcome>('whisper_cancel_download', { modelName });
   }
 
   static async deleteCorruptedModel(modelName: string): Promise<string> {

--- a/frontend/tests/lib/transcription-model-readiness.test.ts
+++ b/frontend/tests/lib/transcription-model-readiness.test.ts
@@ -29,6 +29,7 @@ describe('transcription model readiness', () => {
   test('recognizes only active downloads', () => {
     expect(hasDownloadingModel([{ status: 'Available' }])).toBeFalse();
     expect(hasDownloadingModel([{ status: 'Downloading' }])).toBeTrue();
+    expect(hasDownloadingModel([{ status: { Downloading: 0 } }])).toBeTrue();
     expect(hasDownloadingModel([{ status: { Downloading: 42 } }])).toBeTrue();
   });
 });

--- a/frontend/tests/lib/transcription-model-readiness.test.ts
+++ b/frontend/tests/lib/transcription-model-readiness.test.ts
@@ -29,7 +29,7 @@ describe('transcription model readiness', () => {
   test('recognizes only active downloads', () => {
     expect(hasDownloadingModel([{ status: 'Available' }])).toBeFalse();
     expect(hasDownloadingModel([{ status: 'Downloading' }])).toBeTrue();
-    expect(hasDownloadingModel([{ status: { Downloading: 0 } }])).toBeTrue();
-    expect(hasDownloadingModel([{ status: { Downloading: 42 } }])).toBeTrue();
+    expect(hasDownloadingModel([{ status: { Downloading: { progress: 0 } } }])).toBeTrue();
+    expect(hasDownloadingModel([{ status: { Downloading: { progress: 42 } } }])).toBeTrue();
   });
 });


### PR DESCRIPTION
## Description

Completes the post-merge follow-ups from PRs #608 and #639.

- Corrects historical `metadata.json.duration_seconds` during an explicit retranscription, while preserving unrelated metadata.
- Keeps active Local Whisper downloads in `Downloading` state before a usable file exists, including zero-byte and partial downloads.
- Clears native active-download state on cancellation, failure, unsupported models, and success so users are offered setup again after a terminal failure.
- Adds Rust regressions and frontend readiness coverage for initial Whisper download state.

## Related Issues

Refs #734 and #735.

Related: #607, #608, #637, and #639.

## Testing

- [x] Targeted Rust regression tests
- [x] Frontend readiness tests
- [x] Production frontend build
- [ ] Packaged desktop matrix

## Release notes

The user-facing historical HE-AAC recovery note is tracked in #734.