### PR TITLE
feat: add Deepgram transcription provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,6 +1508,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,6 +3679,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -7240,6 +7247,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7512,6 +7533,26 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "typeid"

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -100,6 +100,7 @@ nnnoiseless = "0.5"
 # NOTE: whisper-rs is declared in platform-specific sections below (macOS/Windows/Linux)
 # to ensure correct GPU features are enabled per platform
 futures-util = "0.3"
+tokio-tungstenite = { version = "0.21", features = ["native-tls"] }
 silero_rs = { git = "https://github.com/emotechlab/silero-rs", rev = "26a6460", package = "silero" }
 
 # Parakeet (ONNX-based fast transcription) dependencies

--- a/frontend/src-tauri/src/audio/deepgram.rs
+++ b/frontend/src-tauri/src/audio/deepgram.rs
@@ -901,7 +901,7 @@ impl<R: Runtime> RealtimeSegmentBuffer<R> {
             let gap = self
                 .tokens
                 .last()
-                .map(|last| token.start_ms - last.end_ms > 1200.0)
+                .map(|last| token.start_ms - last.end_ms > 1500.0)
                 .unwrap_or(false);
             let speaker_changed = self
                 .tokens
@@ -915,11 +915,16 @@ impl<R: Runtime> RealtimeSegmentBuffer<R> {
 
             self.tokens.push(token);
 
-            if self
-                .tokens
-                .last()
-                .map(|last| ends_sentence(&last.text))
-                .unwrap_or(false)
+            // Avoid micro-chunking: only flush on sentence boundary if we have at least 4 tokens
+            // or if the accumulated segment duration is >= 4.0 seconds.
+            let duration_ms = self.tokens.last().map(|l| l.end_ms).unwrap_or(0.0)
+                - self.tokens.first().map(|f| f.start_ms).unwrap_or(0.0);
+            if (self.tokens.len() >= 4 || duration_ms >= 4000.0)
+                && self
+                    .tokens
+                    .last()
+                    .map(|last| ends_sentence(&last.text))
+                    .unwrap_or(false)
             {
                 self.flush();
             }

--- a/frontend/src-tauri/src/audio/deepgram.rs
+++ b/frontend/src-tauri/src/audio/deepgram.rs
@@ -100,6 +100,10 @@ pub struct DeepgramLiveResponse {
     #[serde(default)]
     pub words: Vec<DeepgramWord>,
     #[serde(default)]
+    pub code: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
     pub error: Option<String>,
     #[serde(default)]
     pub err_code: Option<String>,
@@ -479,6 +483,7 @@ pub async fn run_realtime_transcription<R: Runtime>(
             _ => crate::config::DEFAULT_DEEPGRAM_REALTIME_MODEL.to_string(),
         };
 
+    let is_flux = model.to_lowercase().contains("flux");
     let ws_url = build_realtime_ws_url(&model, language.as_deref());
     info!(
         "Connecting to Deepgram realtime transcription at {}",
@@ -505,6 +510,7 @@ pub async fn run_realtime_transcription<R: Runtime>(
     let writer_time_map = time_map.clone();
     let writer_cursor = stream_cursor_ms.clone();
     let writer_shutdown = shutdown.clone();
+    let writer_is_flux = is_flux;
     let writer_handle = tokio::spawn(async move {
         let mut receiver = transcription_receiver;
         let mut ping_interval = tokio::time::interval(Duration::from_secs(10));
@@ -518,9 +524,15 @@ pub async fn run_realtime_transcription<R: Runtime>(
                     }
                 }
                 _ = ping_interval.tick() => {
-                    let keepalive = serde_json::json!({ "type": "KeepAlive" });
-                    if let Err(e) = write.send(Message::Text(keepalive.to_string())).await {
-                        return Err(anyhow!("Failed to send KeepAlive to Deepgram realtime API: {}", e));
+                    if writer_is_flux {
+                        if let Err(e) = write.send(Message::Ping(Vec::new())).await {
+                            return Err(anyhow!("Failed to send WebSocket ping to Deepgram realtime API: {}", e));
+                        }
+                    } else {
+                        let keepalive = serde_json::json!({ "type": "KeepAlive" });
+                        if let Err(e) = write.send(Message::Text(keepalive.to_string())).await {
+                            return Err(anyhow!("Failed to send KeepAlive to Deepgram realtime API: {}", e));
+                        }
                     }
                 }
                 maybe_chunk = receiver.recv() => {
@@ -570,9 +582,14 @@ pub async fn run_realtime_transcription<R: Runtime>(
             }
         }
 
-        let close_stream = serde_json::json!({ "type": "CloseStream" });
-        let _ = write.send(Message::Text(close_stream.to_string())).await;
-        let _ = write.send(Message::Binary(Vec::new())).await;
+        if writer_is_flux {
+            let close_stream = serde_json::json!({ "type": "CloseStream" });
+            let _ = write.send(Message::Text(close_stream.to_string())).await;
+        } else {
+            let close_stream = serde_json::json!({ "type": "CloseStream" });
+            let _ = write.send(Message::Text(close_stream.to_string())).await;
+            let _ = write.send(Message::Binary(Vec::new())).await;
+        }
         Ok::<(), anyhow::Error>(())
     });
 
@@ -606,8 +623,18 @@ pub async fn run_realtime_transcription<R: Runtime>(
                         }
                     };
 
-                    if let Some(message) = response.err_msg.or(response.error).or(response.err_code)
-                    {
+                    let is_error = response.r#type.as_deref() == Some("Error")
+                        || response.err_msg.is_some()
+                        || response.error.is_some()
+                        || response.err_code.is_some();
+                    if is_error {
+                        let message = response
+                            .description
+                            .or(response.err_msg)
+                            .or(response.error)
+                            .or(response.code)
+                            .or(response.err_code)
+                            .unwrap_or_else(|| "Unknown Deepgram realtime error".to_string());
                         emit_transcript_preview(&reader_app, String::new(), 0.0, 0.0, 0.0);
                         reader_shutdown.store(true, Ordering::SeqCst);
                         return Err(anyhow!("Deepgram realtime error: {}", message));
@@ -882,6 +909,7 @@ fn flush_flux_turn<R: Runtime>(
             emit_transcript_update(app, trimmed.to_string(), start_ms, end_ms, 0.85, false);
         }
     }
+    emit_transcript_preview(app, String::new(), 0.0, 0.0, 0.0);
 }
 
 impl<R: Runtime> RealtimeSegmentBuffer<R> {

--- a/frontend/src-tauri/src/audio/deepgram.rs
+++ b/frontend/src-tauri/src/audio/deepgram.rs
@@ -1,0 +1,1362 @@
+use anyhow::{anyhow, Context, Result};
+use futures_util::{SinkExt, StreamExt};
+use log::{error, info, warn};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, Ordering},
+    Arc,
+};
+use std::time::Duration;
+use tauri::{AppHandle, Emitter, Manager, Runtime};
+use tokio::sync::{mpsc, Mutex};
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{client::IntoClientRequest, http::HeaderValue, Message},
+};
+use tokio_util::codec::{BytesCodec, FramedRead};
+
+use crate::api::TranscriptSegment;
+use crate::database::repositories::setting::SettingsRepository;
+use crate::state::AppState;
+
+use super::recording_state::AudioChunk;
+use super::transcription::TranscriptUpdate;
+
+pub const PROVIDER: &str = "deepgram";
+const LISTEN_V1_REST_URL: &str = "https://api.deepgram.com/v1/listen";
+const REALTIME_V1_WS_URL: &str = "wss://api.deepgram.com/v1/listen";
+const REALTIME_V2_WS_URL: &str = "wss://api.deepgram.com/v2/listen";
+const PCM_SAMPLE_RATE: u32 = 16_000;
+
+static REALTIME_SEQUENCE_COUNTER: AtomicU64 = AtomicU64::new(0);
+static REALTIME_SPEECH_DETECTED_EMITTED: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Clone)]
+pub struct DeepgramClient {
+    api_key: String,
+    http: reqwest::Client,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DeepgramWord {
+    #[serde(default)]
+    pub word: String,
+    #[serde(default)]
+    pub start: f64,
+    #[serde(default)]
+    pub end: f64,
+    #[serde(default)]
+    pub confidence: Option<f32>,
+    #[serde(default)]
+    pub speaker: Option<usize>,
+    #[serde(default)]
+    pub punctuated_word: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeepgramAlternative {
+    #[serde(default)]
+    pub transcript: String,
+    #[serde(default)]
+    pub confidence: Option<f32>,
+    #[serde(default)]
+    pub words: Vec<DeepgramWord>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeepgramChannel {
+    #[serde(default)]
+    pub alternatives: Vec<DeepgramAlternative>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeepgramLiveResponse {
+    #[serde(default)]
+    pub r#type: Option<String>,
+    #[serde(default)]
+    pub event: Option<String>,
+    #[serde(default)]
+    pub turn_index: Option<usize>,
+    #[serde(default)]
+    pub channel: Option<DeepgramChannel>,
+    #[serde(default)]
+    pub is_final: Option<bool>,
+    #[serde(default)]
+    pub speech_final: Option<bool>,
+    #[serde(default)]
+    pub audio_window_start: Option<f64>,
+    #[serde(default)]
+    pub audio_window_end: Option<f64>,
+    #[serde(default)]
+    pub start: Option<f64>,
+    #[serde(default)]
+    pub end: Option<f64>,
+    #[serde(default)]
+    pub duration: Option<f64>,
+    // Top-level fields for Flux TurnInfo format
+    #[serde(default)]
+    pub transcript: Option<String>,
+    #[serde(default)]
+    pub words: Vec<DeepgramWord>,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub err_code: Option<String>,
+    #[serde(default)]
+    pub err_msg: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeepgramPrerecordedResponse {
+    #[serde(default)]
+    pub results: Option<DeepgramPrerecordedResults>,
+    #[serde(default)]
+    pub err_code: Option<String>,
+    #[serde(default)]
+    pub err_msg: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeepgramPrerecordedResults {
+    #[serde(default)]
+    pub channels: Vec<DeepgramChannel>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DeepgramTranscript {
+    pub text: String,
+    pub words: Vec<DeepgramWord>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AudioTimeMapEntry {
+    pub stream_start_ms: f64,
+    pub stream_end_ms: f64,
+    pub original_start_ms: f64,
+    pub original_end_ms: f64,
+}
+
+#[derive(Debug, Clone)]
+struct MappedRealtimeToken {
+    text: String,
+    start_ms: f64,
+    end_ms: f64,
+    confidence: Option<f32>,
+    speaker: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
+struct FluxTurnState {
+    turn_index: usize,
+    words: Vec<DeepgramWord>,
+    transcript: Option<String>,
+    start_sec: Option<f64>,
+    end_sec: Option<f64>,
+    is_flushed: bool,
+}
+
+struct RealtimeSegmentBuffer<R: Runtime> {
+    app: AppHandle<R>,
+    tokens: Vec<MappedRealtimeToken>,
+}
+
+pub fn build_realtime_ws_url(model: &str, language: Option<&str>) -> String {
+    let is_flux = model.to_lowercase().contains("flux");
+    if is_flux {
+        let mut params = vec![
+            format!("model={}", model),
+            "encoding=linear16".to_string(),
+            format!("sample_rate={}", PCM_SAMPLE_RATE),
+        ];
+
+        if let Some(lang) = language {
+            let trimmed = lang.trim();
+            if !trimmed.is_empty()
+                && trimmed != "auto"
+                && trimmed != "auto-translate"
+                && trimmed != "detect"
+            {
+                params.push(format!("language_hint={}", trimmed));
+            }
+        }
+
+        format!("{}?{}", REALTIME_V2_WS_URL, params.join("&"))
+    } else {
+        let mut params = vec![
+            format!("model={}", model),
+            "encoding=linear16".to_string(),
+            format!("sample_rate={}", PCM_SAMPLE_RATE),
+            "channels=1".to_string(),
+            "punctuate=true".to_string(),
+            "interim_results=true".to_string(),
+            "smart_format=true".to_string(),
+        ];
+
+        match language {
+            Some(lang)
+                if !lang.trim().is_empty()
+                    && lang != "auto"
+                    && lang != "auto-translate"
+                    && lang != "detect" =>
+            {
+                params.push(format!("language={}", lang.trim()));
+            }
+            _ => {
+                params.push("language=multi".to_string());
+            }
+        }
+
+        format!("{}?{}", REALTIME_V1_WS_URL, params.join("&"))
+    }
+}
+
+pub fn build_prerecorded_url(model: &str, language: Option<&str>) -> String {
+    let effective_model = if model.to_lowercase().contains("flux") {
+        crate::config::DEFAULT_DEEPGRAM_ASYNC_MODEL
+    } else {
+        model
+    };
+
+    let mut params = vec![
+        format!("model={}", effective_model),
+        "smart_format=true".to_string(),
+        "diarize=true".to_string(),
+        "punctuate=true".to_string(),
+    ];
+
+    match language {
+        Some(lang)
+            if !lang.trim().is_empty()
+                && lang != "auto"
+                && lang != "auto-translate"
+                && lang != "detect" =>
+        {
+            params.push(format!("language={}", lang.trim()));
+        }
+        _ => {
+            params.push("detect_language=true".to_string());
+        }
+    }
+
+    format!("{}?{}", LISTEN_V1_REST_URL, params.join("&"))
+}
+
+impl DeepgramClient {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            api_key,
+            http: reqwest::Client::new(),
+        }
+    }
+
+    pub async fn transcribe_file_with_progress<F, C>(
+        &self,
+        path: &Path,
+        model: Option<String>,
+        language: Option<String>,
+        _client_reference_id: &str,
+        mut progress: F,
+        mut should_cancel: C,
+    ) -> Result<DeepgramTranscript>
+    where
+        F: FnMut(u32, &str),
+        C: FnMut() -> bool,
+    {
+        ensure_not_cancelled(&mut should_cancel)?;
+        progress(10, "Reading audio file for Deepgram transcription");
+
+        let file = tokio::fs::File::open(path)
+            .await
+            .with_context(|| format!("Failed to open audio file: {}", path.display()))?;
+        let metadata = file
+            .metadata()
+            .await
+            .with_context(|| format!("Failed to get audio metadata: {}", path.display()))?;
+        let stream = FramedRead::new(file, BytesCodec::new())
+            .map(|result| result.map(|bytes| bytes.freeze()));
+        let body = reqwest::Body::wrap_stream(stream);
+
+        let model_name = model
+            .filter(|m| !m.trim().is_empty() && !m.to_lowercase().contains("flux"))
+            .unwrap_or_else(|| crate::config::DEFAULT_DEEPGRAM_ASYNC_MODEL.to_string());
+
+        let url = build_prerecorded_url(&model_name, language.as_deref());
+        info!("Sending Deepgram transcription request to {}", url);
+
+        progress(25, "Uploading audio to Deepgram");
+        let content_type = "application/octet-stream";
+
+        let response = self
+            .http
+            .post(&url)
+            .header("Authorization", format!("Token {}", self.api_key))
+            .header("Content-Type", content_type)
+            .header("Content-Length", metadata.len().to_string())
+            .body(body)
+            .send()
+            .await
+            .context("Failed to send transcription request to Deepgram")?;
+
+        ensure_not_cancelled(&mut should_cancel)?;
+        progress(65, "Processing Deepgram response");
+
+        let response = ensure_success(response, "transcribe audio").await?;
+        let payload: DeepgramPrerecordedResponse = response
+            .json()
+            .await
+            .context("Failed to parse Deepgram response")?;
+
+        if let Some(msg) = payload.err_msg.or(payload.err_code) {
+            return Err(anyhow!("Deepgram transcription error: {}", msg));
+        }
+
+        let (text, words) = if let Some(results) = payload.results {
+            if let Some(channel) = results.channels.first() {
+                if let Some(alt) = channel.alternatives.first() {
+                    (alt.transcript.clone(), alt.words.clone())
+                } else {
+                    (String::new(), Vec::new())
+                }
+            } else {
+                (String::new(), Vec::new())
+            }
+        } else {
+            (String::new(), Vec::new())
+        };
+
+        progress(90, "Deepgram transcription completed");
+        Ok(DeepgramTranscript { text, words })
+    }
+}
+
+pub async fn configured_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<String> {
+    let app_state = app
+        .try_state::<AppState>()
+        .ok_or_else(|| anyhow!("App state not available"))?;
+
+    let stored_key =
+        SettingsRepository::get_transcript_api_key(app_state.db_manager.pool(), PROVIDER)
+            .await
+            .context("Failed to read Deepgram API key from settings")?;
+
+    let key = stored_key
+        .filter(|key| !key.trim().is_empty())
+        .or_else(|| std::env::var("DEEPGRAM_API_KEY").ok())
+        .unwrap_or_default();
+
+    if key.trim().is_empty() {
+        return Err(anyhow!(
+            "Deepgram API key is not configured. Add it in Transcription settings or set DEEPGRAM_API_KEY."
+        ));
+    }
+
+    Ok(key)
+}
+
+pub async fn validate_configured_api_key<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+    configured_api_key(app)
+        .await
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+pub async fn client_from_config<R: Runtime>(app: &AppHandle<R>) -> Result<DeepgramClient> {
+    Ok(DeepgramClient::new(configured_api_key(app).await?))
+}
+
+pub fn deepgram_words_to_transcript_tuples(words: &[DeepgramWord]) -> Vec<(String, f64, f64)> {
+    let mut segments = Vec::new();
+    let mut current_text = String::new();
+    let mut current_start_ms = 0.0;
+    let mut current_end_ms = 0.0;
+    let mut current_speaker: Option<usize> = None;
+
+    for word in words {
+        let display_word = word.punctuated_word.as_deref().unwrap_or(&word.word);
+        if display_word.trim().is_empty() {
+            continue;
+        }
+
+        let word_start_ms = word.start.max(0.0) * 1000.0;
+        let word_end_ms = (word.end * 1000.0).max(word_start_ms);
+        let speaker_changed = current_speaker.is_some() && word.speaker != current_speaker;
+        let long_gap = !current_text.is_empty() && word_start_ms - current_end_ms > 1500.0;
+        let long_segment =
+            word_start_ms - current_start_ms > 30_000.0 && ends_sentence(&current_text);
+
+        if !current_text.is_empty() && (speaker_changed || long_gap || long_segment) {
+            push_transcript_tuple(
+                &mut segments,
+                std::mem::take(&mut current_text),
+                current_start_ms,
+                current_end_ms,
+            );
+            current_speaker = None;
+        }
+
+        if current_text.is_empty() {
+            current_start_ms = word_start_ms;
+            current_speaker = word.speaker;
+        } else {
+            current_text.push(' ');
+        }
+
+        current_text.push_str(display_word.trim());
+        current_end_ms = word_end_ms;
+    }
+
+    push_transcript_tuple(
+        &mut segments,
+        current_text,
+        current_start_ms,
+        current_end_ms,
+    );
+    segments
+}
+
+pub fn deepgram_words_to_transcript_segments(words: &[DeepgramWord]) -> Vec<TranscriptSegment> {
+    super::common::create_transcript_segments(&deepgram_words_to_transcript_tuples(words))
+}
+
+pub fn transcript_to_segments(
+    transcript: &DeepgramTranscript,
+    fallback_duration_seconds: f64,
+) -> Vec<TranscriptSegment> {
+    let mut segments = deepgram_words_to_transcript_segments(&transcript.words);
+    if segments.is_empty() && !transcript.text.trim().is_empty() {
+        segments.push(TranscriptSegment {
+            id: format!("transcript-{}", uuid::Uuid::new_v4()),
+            text: transcript.text.trim().to_string(),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            audio_start_time: Some(0.0),
+            audio_end_time: Some(fallback_duration_seconds),
+            duration: Some(fallback_duration_seconds),
+        });
+    }
+    segments
+}
+
+pub fn map_stream_ms_to_original(entries: &[AudioTimeMapEntry], stream_ms: f64) -> f64 {
+    if entries.is_empty() {
+        return stream_ms;
+    }
+
+    if let Some(entry) = entries
+        .iter()
+        .find(|entry| stream_ms >= entry.stream_start_ms && stream_ms <= entry.stream_end_ms)
+    {
+        let stream_duration = (entry.stream_end_ms - entry.stream_start_ms).max(1.0);
+        let original_duration = (entry.original_end_ms - entry.original_start_ms).max(0.0);
+        let offset_ratio = ((stream_ms - entry.stream_start_ms) / stream_duration).clamp(0.0, 1.0);
+        return entry.original_start_ms + original_duration * offset_ratio;
+    }
+
+    if stream_ms < entries[0].stream_start_ms {
+        return entries[0].original_start_ms;
+    }
+
+    let last = entries.last().expect("entries is not empty");
+    last.original_end_ms + (stream_ms - last.stream_end_ms).max(0.0)
+}
+
+pub async fn run_realtime_transcription<R: Runtime>(
+    app: AppHandle<R>,
+    transcription_receiver: mpsc::UnboundedReceiver<AudioChunk>,
+) -> Result<(), String> {
+    REALTIME_SPEECH_DETECTED_EMITTED.store(false, Ordering::SeqCst);
+
+    let api_key = configured_api_key(&app).await.map_err(|e| e.to_string())?;
+    let language = crate::get_language_preference_internal();
+
+    let model =
+        match crate::api::api::api_get_transcript_config(app.clone(), app.clone().state(), None)
+            .await
+        {
+            Ok(Some(config)) if config.provider == PROVIDER && !config.model.trim().is_empty() => {
+                config.model
+            }
+            _ => crate::config::DEFAULT_DEEPGRAM_REALTIME_MODEL.to_string(),
+        };
+
+    let ws_url = build_realtime_ws_url(&model, language.as_deref());
+    info!(
+        "Connecting to Deepgram realtime transcription at {}",
+        ws_url
+    );
+
+    let mut request = ws_url
+        .clone()
+        .into_client_request()
+        .map_err(|e| format!("Failed to build Deepgram WebSocket request: {}", e))?;
+    let auth_header = HeaderValue::from_str(&format!("Token {}", api_key))
+        .map_err(|e| format!("Failed to build Deepgram auth header: {}", e))?;
+    request.headers_mut().insert("Authorization", auth_header);
+
+    let (ws_stream, _) = connect_async(request)
+        .await
+        .map_err(|e| format!("Failed to connect to Deepgram realtime API: {}", e))?;
+    let (mut write, mut read) = ws_stream.split();
+
+    let time_map = Arc::new(Mutex::new(Vec::<AudioTimeMapEntry>::new()));
+    let stream_cursor_ms = Arc::new(Mutex::new(0.0f64));
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    let writer_time_map = time_map.clone();
+    let writer_cursor = stream_cursor_ms.clone();
+    let writer_shutdown = shutdown.clone();
+    let writer_handle = tokio::spawn(async move {
+        let mut receiver = transcription_receiver;
+        let mut ping_interval = tokio::time::interval(Duration::from_secs(10));
+        let mut shutdown_interval = tokio::time::interval(Duration::from_millis(250));
+
+        loop {
+            tokio::select! {
+                _ = shutdown_interval.tick() => {
+                    if writer_shutdown.load(Ordering::SeqCst) {
+                        break;
+                    }
+                }
+                _ = ping_interval.tick() => {
+                    let keepalive = serde_json::json!({ "type": "KeepAlive" });
+                    if let Err(e) = write.send(Message::Text(keepalive.to_string())).await {
+                        return Err(anyhow!("Failed to send KeepAlive to Deepgram realtime API: {}", e));
+                    }
+                }
+                maybe_chunk = receiver.recv() => {
+                    let Some(chunk) = maybe_chunk else {
+                        break;
+                    };
+
+                    if chunk.data.is_empty() {
+                        continue;
+                    }
+
+                    let original_start_ms = chunk.timestamp * 1000.0;
+                    let original_duration_ms =
+                        chunk.data.len() as f64 / chunk.sample_rate as f64 * 1000.0;
+                    let original_end_ms = original_start_ms + original_duration_ms;
+
+                    let pcm_samples = if chunk.sample_rate != PCM_SAMPLE_RATE {
+                        super::audio_processing::resample_audio(&chunk.data, chunk.sample_rate, PCM_SAMPLE_RATE)
+                    } else {
+                        chunk.data
+                    };
+
+                    if pcm_samples.is_empty() {
+                        continue;
+                    }
+
+                    let duration_ms = pcm_samples.len() as f64 / PCM_SAMPLE_RATE as f64 * 1000.0;
+
+                    {
+                        let mut cursor = writer_cursor.lock().await;
+                        let entry = AudioTimeMapEntry {
+                            stream_start_ms: *cursor,
+                            stream_end_ms: *cursor + duration_ms,
+                            original_start_ms,
+                            original_end_ms,
+                        };
+                        *cursor += duration_ms;
+                        writer_time_map.lock().await.push(entry);
+                    }
+
+                    let bytes = f32_to_pcm16le(&pcm_samples);
+                    write
+                        .send(Message::Binary(bytes))
+                        .await
+                        .map_err(|e| anyhow!("Failed to send audio to Deepgram realtime API: {}", e))?;
+                }
+            }
+        }
+
+        let close_stream = serde_json::json!({ "type": "CloseStream" });
+        let _ = write.send(Message::Text(close_stream.to_string())).await;
+        let _ = write.send(Message::Binary(Vec::new())).await;
+        Ok::<(), anyhow::Error>(())
+    });
+
+    let reader_time_map = time_map.clone();
+    let reader_shutdown = shutdown.clone();
+    let reader_app = app.clone();
+    let reader_handle = tokio::spawn(async move {
+        let mut buffer = RealtimeSegmentBuffer::new(reader_app.clone());
+        let mut current_flux_turn: Option<FluxTurnState> = None;
+
+        while let Some(message) = read.next().await {
+            let message = match message {
+                Ok(message) => message,
+                Err(e) => {
+                    emit_transcript_preview(&reader_app, String::new(), 0.0, 0.0, 0.0);
+                    reader_shutdown.store(true, Ordering::SeqCst);
+                    return Err(anyhow!("Deepgram realtime WebSocket error: {}", e));
+                }
+            };
+
+            match message {
+                Message::Text(text) => {
+                    let response: DeepgramLiveResponse = match serde_json::from_str(&text) {
+                        Ok(response) => response,
+                        Err(e) => {
+                            warn!(
+                                "Failed to parse Deepgram realtime response: {} ({})",
+                                e, text
+                            );
+                            continue;
+                        }
+                    };
+
+                    if let Some(message) = response.err_msg.or(response.error).or(response.err_code)
+                    {
+                        emit_transcript_preview(&reader_app, String::new(), 0.0, 0.0, 0.0);
+                        reader_shutdown.store(true, Ordering::SeqCst);
+                        return Err(anyhow!("Deepgram realtime error: {}", message));
+                    }
+
+                    // Flux TurnInfo v2 protocol vs Nova Results v1 protocol
+                    let is_flux_turn = response.r#type.as_deref() == Some("TurnInfo")
+                        || response.event.is_some()
+                        || response.turn_index.is_some()
+                        || (!response.words.is_empty() && response.channel.is_none())
+                        || (response.transcript.is_some() && response.channel.is_none());
+
+                    if is_flux_turn {
+                        let turn_idx = response.turn_index.unwrap_or_else(|| {
+                            current_flux_turn
+                                .as_ref()
+                                .map(|t| t.turn_index)
+                                .unwrap_or(0)
+                        });
+
+                        let entries = reader_time_map.lock().await.clone();
+
+                        if let Some(prev) = current_flux_turn.as_mut() {
+                            if prev.turn_index != turn_idx {
+                                if !prev.is_flushed {
+                                    flush_flux_turn(&reader_app, &entries, prev);
+                                    prev.is_flushed = true;
+                                }
+                                *prev = FluxTurnState {
+                                    turn_index: turn_idx,
+                                    words: Vec::new(),
+                                    transcript: None,
+                                    start_sec: None,
+                                    end_sec: None,
+                                    is_flushed: false,
+                                };
+                            }
+                        } else {
+                            current_flux_turn = Some(FluxTurnState {
+                                turn_index: turn_idx,
+                                words: Vec::new(),
+                                transcript: None,
+                                start_sec: None,
+                                end_sec: None,
+                                is_flushed: false,
+                            });
+                        }
+
+                        let turn = current_flux_turn.as_mut().unwrap();
+
+                        if !response.words.is_empty() {
+                            turn.words = response.words;
+                        }
+                        if let Some(ref text) = response.transcript {
+                            if !text.is_empty() {
+                                turn.transcript = Some(text.clone());
+                            }
+                        }
+                        if response.audio_window_start.is_some() || response.start.is_some() {
+                            let s = response.audio_window_start.or(response.start);
+                            if turn.start_sec.is_none()
+                                || s.unwrap_or(0.0) < turn.start_sec.unwrap_or(0.0)
+                            {
+                                turn.start_sec = s;
+                            }
+                        }
+                        if response.audio_window_end.is_some() || response.end.is_some() {
+                            turn.end_sec = response.audio_window_end.or(response.end);
+                        }
+
+                        let is_eot = response.event.as_deref() == Some("EndOfTurn");
+                        if is_eot && !turn.is_flushed {
+                            flush_flux_turn(&reader_app, &entries, turn);
+                            turn.is_flushed = true;
+                        } else {
+                            emit_flux_turn_preview(&reader_app, &entries, turn);
+                        }
+                        continue;
+                    }
+
+                    // Standard Deepgram v1 Nova Results protocol
+                    let Some(channel) = response.channel else {
+                        continue;
+                    };
+                    let Some(alternative) = channel.alternatives.first() else {
+                        continue;
+                    };
+
+                    let entries = reader_time_map.lock().await.clone();
+                    let tokens = if !alternative.words.is_empty() {
+                        alternative
+                            .words
+                            .iter()
+                            .map(|word| {
+                                let display_word =
+                                    word.punctuated_word.as_deref().unwrap_or(&word.word);
+                                let word_start_stream_ms = word.start.max(0.0) * 1000.0;
+                                let word_end_stream_ms =
+                                    (word.end * 1000.0).max(word_start_stream_ms);
+                                let start_ms =
+                                    map_stream_ms_to_original(&entries, word_start_stream_ms);
+                                let end_ms =
+                                    map_stream_ms_to_original(&entries, word_end_stream_ms)
+                                        .max(start_ms);
+                                MappedRealtimeToken {
+                                    text: display_word.to_string(),
+                                    start_ms,
+                                    end_ms,
+                                    confidence: word.confidence.or(alternative.confidence),
+                                    speaker: word.speaker,
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                    } else if !alternative.transcript.trim().is_empty() {
+                        let stream_start_ms = response.start.unwrap_or(0.0) * 1000.0;
+                        let stream_end_ms =
+                            stream_start_ms + (response.duration.unwrap_or(0.0) * 1000.0);
+                        let start_ms = map_stream_ms_to_original(&entries, stream_start_ms);
+                        let end_ms =
+                            map_stream_ms_to_original(&entries, stream_end_ms).max(start_ms);
+                        vec![MappedRealtimeToken {
+                            text: alternative.transcript.clone(),
+                            start_ms,
+                            end_ms,
+                            confidence: alternative.confidence,
+                            speaker: None,
+                        }]
+                    } else {
+                        Vec::new()
+                    };
+
+                    if response.is_final.unwrap_or(false) {
+                        buffer.ingest(tokens);
+                        if response.speech_final.unwrap_or(false) {
+                            buffer.flush();
+                        }
+                        buffer.emit_preview(&[]);
+                    } else {
+                        buffer.emit_preview(&tokens);
+                    }
+                }
+                Message::Close(_) => break,
+                _ => {}
+            }
+        }
+
+        if let Some(ref mut turn) = current_flux_turn {
+            if !turn.is_flushed {
+                let entries = reader_time_map.lock().await.clone();
+                flush_flux_turn(&reader_app, &entries, turn);
+                turn.is_flushed = true;
+            }
+        }
+        buffer.flush();
+        emit_transcript_preview(&reader_app, String::new(), 0.0, 0.0, 0.0);
+        reader_shutdown.store(true, Ordering::SeqCst);
+        Ok::<(), anyhow::Error>(())
+    });
+
+    let writer_result = writer_handle
+        .await
+        .map_err(|e| format!("Deepgram realtime writer task failed: {}", e))?;
+    if let Err(e) = writer_result {
+        shutdown.store(true, Ordering::SeqCst);
+        emit_transcription_error(&app, e.to_string());
+        return Err(e.to_string());
+    }
+
+    let mut reader_handle = reader_handle;
+    match tokio::time::timeout(Duration::from_secs(30), &mut reader_handle).await {
+        Ok(join_result) => {
+            let reader_result =
+                join_result.map_err(|e| format!("Deepgram realtime reader task failed: {}", e))?;
+            if let Err(e) = reader_result {
+                emit_transcription_error(&app, e.to_string());
+                return Err(e.to_string());
+            }
+        }
+        Err(_) => {
+            reader_handle.abort();
+            warn!("Timed out waiting for Deepgram realtime final response");
+        }
+    }
+
+    info!("Deepgram realtime transcription task completed");
+    Ok(())
+}
+
+fn emit_flux_turn_preview<R: Runtime>(
+    app: &AppHandle<R>,
+    entries: &[AudioTimeMapEntry],
+    turn: &FluxTurnState,
+) {
+    let text = flux_turn_preview_text(turn);
+
+    let Some(text) = text else {
+        return;
+    };
+
+    let stream_start_ms = turn
+        .words
+        .first()
+        .map(|word| word.start.max(0.0) * 1000.0)
+        .or(turn.start_sec.map(|start| start.max(0.0) * 1000.0))
+        .unwrap_or(0.0);
+    let stream_end_ms = turn
+        .words
+        .last()
+        .map(|word| word.end.max(0.0) * 1000.0)
+        .or(turn.end_sec.map(|end| end.max(0.0) * 1000.0))
+        .unwrap_or(stream_start_ms);
+    let start_ms = map_stream_ms_to_original(entries, stream_start_ms);
+    let end_ms = map_stream_ms_to_original(entries, stream_end_ms).max(start_ms);
+    let confidence = average_confidence(turn.words.iter().filter_map(|word| word.confidence));
+
+    emit_speech_detected(app);
+    emit_transcript_preview(app, text, start_ms, end_ms, confidence);
+}
+
+fn flux_turn_preview_text(turn: &FluxTurnState) -> Option<String> {
+    turn.transcript
+        .as_deref()
+        .filter(|text| !text.trim().is_empty())
+        .map(str::trim)
+        .map(str::to_string)
+        .or_else(|| {
+            let joined = turn
+                .words
+                .iter()
+                .map(|word| word.punctuated_word.as_deref().unwrap_or(&word.word).trim())
+                .filter(|word| !word.is_empty())
+                .collect::<Vec<_>>()
+                .join(" ");
+            (!joined.is_empty()).then_some(joined)
+        })
+}
+
+fn flush_flux_turn<R: Runtime>(
+    app: &AppHandle<R>,
+    entries: &[AudioTimeMapEntry],
+    turn: &FluxTurnState,
+) {
+    if !turn.words.is_empty() {
+        let tuples = deepgram_words_to_transcript_tuples(&turn.words);
+        let confidence = average_confidence(turn.words.iter().filter_map(|w| w.confidence));
+        for (text, stream_start_ms, stream_end_ms) in tuples {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let start_ms = map_stream_ms_to_original(entries, stream_start_ms);
+            let end_ms = map_stream_ms_to_original(entries, stream_end_ms).max(start_ms);
+            emit_transcript_update(
+                app,
+                trimmed.to_string(),
+                start_ms,
+                end_ms,
+                confidence,
+                false,
+            );
+        }
+    } else if let Some(ref text) = turn.transcript {
+        let trimmed = text.trim();
+        if !trimmed.is_empty() {
+            let stream_start_ms = turn.start_sec.unwrap_or(0.0).max(0.0) * 1000.0;
+            let stream_end_ms = turn
+                .end_sec
+                .map(|e| e * 1000.0)
+                .unwrap_or(stream_start_ms + 1000.0);
+            let start_ms = map_stream_ms_to_original(entries, stream_start_ms);
+            let end_ms = map_stream_ms_to_original(entries, stream_end_ms).max(start_ms);
+            emit_transcript_update(app, trimmed.to_string(), start_ms, end_ms, 0.85, false);
+        }
+    }
+}
+
+impl<R: Runtime> RealtimeSegmentBuffer<R> {
+    fn new(app: AppHandle<R>) -> Self {
+        Self {
+            app,
+            tokens: Vec::new(),
+        }
+    }
+
+    fn ingest(&mut self, tokens: Vec<MappedRealtimeToken>) {
+        for token in tokens {
+            if token.text.trim().is_empty() {
+                continue;
+            }
+
+            let gap = self
+                .tokens
+                .last()
+                .map(|last| token.start_ms - last.end_ms > 1200.0)
+                .unwrap_or(false);
+            let speaker_changed = self
+                .tokens
+                .last()
+                .map(|last| last.speaker != token.speaker)
+                .unwrap_or(false);
+
+            if !self.tokens.is_empty() && (gap || speaker_changed) {
+                self.flush();
+            }
+
+            self.tokens.push(token);
+
+            if self
+                .tokens
+                .last()
+                .map(|last| ends_sentence(&last.text))
+                .unwrap_or(false)
+            {
+                self.flush();
+            }
+        }
+    }
+
+    fn emit_preview(&self, interim_tokens: &[MappedRealtimeToken]) {
+        let tokens = self
+            .tokens
+            .iter()
+            .chain(interim_tokens.iter())
+            .collect::<Vec<_>>();
+
+        if tokens.is_empty() {
+            emit_transcript_preview(&self.app, String::new(), 0.0, 0.0, 0.0);
+            return;
+        }
+
+        let text = mapped_preview_text(&tokens);
+        if text.is_empty() {
+            return;
+        }
+
+        let start_ms = tokens.first().map(|token| token.start_ms).unwrap_or(0.0);
+        let end_ms = tokens
+            .last()
+            .map(|token| token.end_ms)
+            .unwrap_or(start_ms)
+            .max(start_ms);
+        let confidence = average_confidence(tokens.iter().filter_map(|token| token.confidence));
+
+        emit_speech_detected(&self.app);
+        emit_transcript_preview(&self.app, text, start_ms, end_ms, confidence);
+    }
+
+    fn flush(&mut self) {
+        if self.tokens.is_empty() {
+            return;
+        }
+
+        let mut text = String::new();
+        for token in &self.tokens {
+            if !text.is_empty() && !token.text.starts_with(|c: char| c.is_ascii_punctuation()) {
+                text.push(' ');
+            }
+            text.push_str(token.text.trim());
+        }
+        let text = text.trim().to_string();
+
+        if text.is_empty() {
+            self.tokens.clear();
+            return;
+        }
+
+        emit_speech_detected(&self.app);
+
+        let start_ms = self
+            .tokens
+            .first()
+            .map(|token| token.start_ms)
+            .unwrap_or(0.0);
+        let end_ms = self
+            .tokens
+            .last()
+            .map(|token| token.end_ms)
+            .unwrap_or(start_ms);
+        let confidence =
+            average_confidence(self.tokens.iter().filter_map(|token| token.confidence));
+        emit_transcript_update(&self.app, text, start_ms, end_ms, confidence, false);
+        self.tokens.clear();
+    }
+}
+
+fn mapped_preview_text(tokens: &[&MappedRealtimeToken]) -> String {
+    tokens
+        .iter()
+        .map(|token| token.text.trim())
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn emit_speech_detected<R: Runtime>(app: &AppHandle<R>) {
+    if REALTIME_SPEECH_DETECTED_EMITTED
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        let _ = app.emit(
+            "speech-detected",
+            serde_json::json!({ "message": "Speech activity detected" }),
+        );
+    }
+}
+
+fn emit_transcript_update<R: Runtime>(
+    app: &AppHandle<R>,
+    text: String,
+    start_ms: f64,
+    end_ms: f64,
+    confidence: f32,
+    is_partial: bool,
+) {
+    let sequence_id = REALTIME_SEQUENCE_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let audio_start_time = start_ms / 1000.0;
+    let audio_end_time = end_ms.max(start_ms) / 1000.0;
+    let duration = (audio_end_time - audio_start_time).max(0.0);
+
+    let update = TranscriptUpdate {
+        text,
+        timestamp: chrono::Local::now().format("%H:%M:%S").to_string(),
+        source: "Audio".to_string(),
+        sequence_id,
+        chunk_start_time: audio_start_time,
+        is_partial,
+        confidence,
+        audio_start_time,
+        audio_end_time,
+        duration,
+    };
+
+    if let Err(e) = app.emit("transcript-update", &update) {
+        error!("Failed to emit Deepgram transcript update: {}", e);
+    }
+}
+
+fn emit_transcript_preview<R: Runtime>(
+    app: &AppHandle<R>,
+    text: String,
+    start_ms: f64,
+    end_ms: f64,
+    confidence: f32,
+) {
+    let audio_start_time = start_ms / 1000.0;
+    let audio_end_time = end_ms.max(start_ms) / 1000.0;
+    let update = TranscriptUpdate {
+        text,
+        timestamp: chrono::Local::now().format("%H:%M:%S").to_string(),
+        source: "Audio".to_string(),
+        sequence_id: REALTIME_SEQUENCE_COUNTER.load(Ordering::SeqCst),
+        chunk_start_time: audio_start_time,
+        is_partial: true,
+        confidence,
+        audio_start_time,
+        audio_end_time,
+        duration: (audio_end_time - audio_start_time).max(0.0),
+    };
+
+    if let Err(e) = app.emit("transcript-preview", &update) {
+        error!("Failed to emit Deepgram transcript preview: {}", e);
+    }
+}
+
+fn emit_transcription_error<R: Runtime>(app: &AppHandle<R>, error: String) {
+    let _ = app.emit(
+        "transcription-error",
+        serde_json::json!({
+            "error": error,
+            "userMessage": "Deepgram transcription failed. Check your API key and network connection.",
+            "actionable": true
+        }),
+    );
+}
+
+fn f32_to_pcm16le(samples: &[f32]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(samples.len() * 2);
+    for sample in samples {
+        let clamped = sample.clamp(-1.0, 1.0);
+        let pcm = (clamped * i16::MAX as f32) as i16;
+        bytes.extend_from_slice(&pcm.to_le_bytes());
+    }
+    bytes
+}
+
+async fn ensure_success(response: reqwest::Response, action: &str) -> Result<reqwest::Response> {
+    if response.status().is_success() {
+        return Ok(response);
+    }
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .unwrap_or_else(|_| "<empty response>".to_string());
+    Err(anyhow!(
+        "Deepgram {} failed (HTTP {}): {}",
+        action,
+        status,
+        truncate_for_error(&body)
+    ))
+}
+
+fn ensure_not_cancelled<C>(should_cancel: &mut C) -> Result<()>
+where
+    C: FnMut() -> bool,
+{
+    if should_cancel() {
+        Err(anyhow!("Operation cancelled"))
+    } else {
+        Ok(())
+    }
+}
+
+fn push_transcript_tuple(
+    segments: &mut Vec<(String, f64, f64)>,
+    text: String,
+    start_ms: f64,
+    end_ms: f64,
+) {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+
+    segments.push((trimmed.to_string(), start_ms, end_ms.max(start_ms)));
+}
+
+fn average_confidence(values: impl Iterator<Item = f32>) -> f32 {
+    let mut sum = 0.0;
+    let mut count = 0usize;
+    for value in values {
+        sum += value;
+        count += 1;
+    }
+
+    if count == 0 {
+        0.85
+    } else {
+        sum / count as f32
+    }
+}
+
+fn ends_sentence(text: &str) -> bool {
+    text.trim_end()
+        .chars()
+        .last()
+        .map(|c| matches!(c, '.' | '!' | '?' | '\n'))
+        .unwrap_or(false)
+}
+
+fn truncate_for_error(text: &str) -> String {
+    const MAX_LEN: usize = 500;
+    if text.len() <= MAX_LEN {
+        return text.to_string();
+    }
+
+    let mut end = MAX_LEN;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &text[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_realtime_ws_url_nova() {
+        let url = build_realtime_ws_url("nova-3", Some("en"));
+        assert!(url.starts_with(REALTIME_V1_WS_URL));
+        assert!(url.contains("model=nova-3"));
+        assert!(url.contains("language=en"));
+        assert!(url.contains("channels=1"));
+        assert!(url.contains("smart_format=true"));
+
+        let auto_url = build_realtime_ws_url("nova-3", None);
+        assert!(auto_url.contains("language=multi"));
+    }
+
+    #[test]
+    fn test_build_realtime_ws_url_flux() {
+        let url = build_realtime_ws_url("flux-general-multi", Some("en"));
+        assert!(url.starts_with(REALTIME_V2_WS_URL));
+        assert!(url.contains("model=flux-general-multi"));
+        assert!(url.contains("language_hint=en"));
+        assert!(!url.contains("channels="));
+        assert!(!url.contains("punctuate="));
+
+        let auto_url = build_realtime_ws_url("flux-general-multi", None);
+        assert!(!auto_url.contains("language_hint"));
+        assert!(!auto_url.contains("channels="));
+    }
+
+    #[test]
+    fn test_build_prerecorded_url() {
+        let url = build_prerecorded_url("nova-3", Some("en"));
+        assert!(url.starts_with(LISTEN_V1_REST_URL));
+        assert!(url.contains("model=nova-3"));
+        assert!(url.contains("language=en"));
+
+        let auto_url = build_prerecorded_url("nova-3", Some("auto"));
+        assert!(auto_url.contains("detect_language=true"));
+
+        let flux_url = build_prerecorded_url("flux-general-multi", Some("en"));
+        assert!(flux_url.contains("model=nova-3"));
+    }
+
+    #[test]
+    fn test_flux_turn_info_parsing() {
+        let json_flux = r#"{
+            "type": "TurnInfo",
+            "event": "Update",
+            "transcript": "Hello from Flux",
+            "words": [
+                {
+                    "word": "Hello",
+                    "start": 0.1,
+                    "end": 0.5,
+                    "confidence": 0.98,
+                    "speaker": 0,
+                    "punctuated_word": "Hello"
+                },
+                {
+                    "word": "from",
+                    "start": 0.6,
+                    "end": 0.8,
+                    "confidence": 0.99,
+                    "speaker": 0,
+                    "punctuated_word": "from"
+                },
+                {
+                    "word": "Flux",
+                    "start": 0.85,
+                    "end": 1.2,
+                    "confidence": 0.97,
+                    "speaker": 0,
+                    "punctuated_word": "Flux."
+                }
+            ]
+        }"#;
+
+        let response: DeepgramLiveResponse = serde_json::from_str(json_flux).unwrap();
+        assert_eq!(response.r#type.as_deref(), Some("TurnInfo"));
+        assert_eq!(response.words.len(), 3);
+        let tuples = deepgram_words_to_transcript_tuples(&response.words);
+        assert_eq!(tuples.len(), 1);
+        assert_eq!(tuples[0].0, "Hello from Flux.");
+    }
+
+    #[test]
+    fn test_flux_preview_uses_latest_turn_transcript() {
+        let turn = FluxTurnState {
+            turn_index: 2,
+            words: Vec::new(),
+            transcript: Some("  live Flux preview  ".to_string()),
+            start_sec: Some(1.0),
+            end_sec: Some(2.0),
+            is_flushed: false,
+        };
+
+        assert_eq!(
+            flux_turn_preview_text(&turn).as_deref(),
+            Some("live Flux preview")
+        );
+    }
+
+    #[test]
+    fn test_nova_preview_combines_stable_and_interim_tokens() {
+        let stable = MappedRealtimeToken {
+            text: "stable".to_string(),
+            start_ms: 0.0,
+            end_ms: 200.0,
+            confidence: Some(0.9),
+            speaker: None,
+        };
+        let interim = MappedRealtimeToken {
+            text: "interim".to_string(),
+            start_ms: 200.0,
+            end_ms: 400.0,
+            confidence: Some(0.8),
+            speaker: None,
+        };
+
+        assert_eq!(mapped_preview_text(&[&stable, &interim]), "stable interim");
+    }
+
+    #[test]
+    fn test_deepgram_words_to_transcript_tuples() {
+        let words = vec![
+            DeepgramWord {
+                word: "Hello".to_string(),
+                start: 0.0,
+                end: 0.5,
+                confidence: Some(0.95),
+                speaker: Some(0),
+                punctuated_word: Some("Hello.".to_string()),
+            },
+            DeepgramWord {
+                word: "How".to_string(),
+                start: 2.5,
+                end: 2.8,
+                confidence: Some(0.9),
+                speaker: Some(0),
+                punctuated_word: Some("How".to_string()),
+            },
+            DeepgramWord {
+                word: "are".to_string(),
+                start: 2.9,
+                end: 3.1,
+                confidence: Some(0.9),
+                speaker: Some(0),
+                punctuated_word: Some("are".to_string()),
+            },
+            DeepgramWord {
+                word: "you".to_string(),
+                start: 3.2,
+                end: 3.5,
+                confidence: Some(0.95),
+                speaker: Some(0),
+                punctuated_word: Some("you?".to_string()),
+            },
+        ];
+
+        let segments = deepgram_words_to_transcript_tuples(&words);
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].0, "Hello.");
+        assert_eq!(segments[1].0, "How are you?");
+    }
+
+    #[test]
+    fn test_map_stream_ms_to_original() {
+        let entries = vec![
+            AudioTimeMapEntry {
+                stream_start_ms: 0.0,
+                stream_end_ms: 1000.0,
+                original_start_ms: 5000.0,
+                original_end_ms: 6000.0,
+            },
+            AudioTimeMapEntry {
+                stream_start_ms: 1000.0,
+                stream_end_ms: 2000.0,
+                original_start_ms: 10000.0,
+                original_end_ms: 11000.0,
+            },
+        ];
+
+        assert_eq!(map_stream_ms_to_original(&entries, 500.0), 5500.0);
+        assert_eq!(map_stream_ms_to_original(&entries, 1500.0), 10500.0);
+    }
+}

--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -266,6 +266,7 @@ pub async fn start_import<R: Runtime>(
     IMPORT_CANCELLED.store(false, Ordering::SeqCst);
 
     let use_parakeet = provider.as_deref() == Some("parakeet");
+    let use_deepgram = provider.as_deref() == Some(super::deepgram::PROVIDER);
     let result = run_import(
         app.clone(),
         source_path,
@@ -277,7 +278,9 @@ pub async fn start_import<R: Runtime>(
     .await;
 
     // Unload the engine after the batch job (success, failure, or cancellation)
-    super::common::unload_engine_after_batch(use_parakeet).await;
+    if !use_deepgram {
+        super::common::unload_engine_after_batch(use_parakeet).await;
+    }
 
     // Guard will automatically clear flag on drop
     // No need for manual: IMPORT_IN_PROGRESS.store(false, Ordering::SeqCst);
@@ -330,6 +333,7 @@ async fn run_import<R: Runtime>(
 
     // Determine which provider to use (default to whisper)
     let use_parakeet = provider.as_deref() == Some("parakeet");
+    let use_deepgram = provider.as_deref() == Some(super::deepgram::PROVIDER);
 
     emit_progress(&app, "copying", 5, "Creating meeting folder...");
 
@@ -368,6 +372,86 @@ async fn run_import<R: Runtime>(
         // Cleanup: remove the meeting folder
         let _ = std::fs::remove_dir_all(&meeting_folder);
         return Err(anyhow!("Import cancelled"));
+    }
+
+    if use_deepgram {
+        emit_progress(&app, "transcribing", 15, "Preparing Deepgram transcription...");
+        let duration_seconds = match extract_duration_from_metadata(&dest_path) {
+            Ok(duration) => duration,
+            Err(e) => {
+                warn!("Deepgram import metadata duration failed: {}, decoding duration", e);
+                let decoded = tokio::task::spawn_blocking({
+                    let path = dest_path.clone();
+                    move || decode_audio_file(&path)
+                })
+                .await
+                .map_err(|e| anyhow!("Decode task join error: {}", e))??;
+                decoded.duration_seconds
+            }
+        };
+
+        let client = super::deepgram::client_from_config(&app).await?;
+        let app_for_progress = app.clone();
+        let client_reference_id = format!("import:{}", title);
+        let transcript = client
+            .transcribe_file_with_progress(
+                &dest_path,
+                model.clone(),
+                language.clone(),
+                &client_reference_id,
+                move |provider_progress, message| {
+                    let overall_progress = 15 + ((provider_progress as f32 * 0.70) as u32);
+                    emit_progress(&app_for_progress, "transcribing", overall_progress.min(85), message);
+                },
+                || IMPORT_CANCELLED.load(Ordering::SeqCst),
+            )
+            .await?;
+
+        if IMPORT_CANCELLED.load(Ordering::SeqCst) {
+            let _ = std::fs::remove_dir_all(&meeting_folder);
+            return Err(anyhow!("Import cancelled"));
+        }
+
+        emit_progress(&app, "saving", 85, "Creating meeting...");
+        let segments = super::deepgram::transcript_to_segments(&transcript, duration_seconds);
+
+        let app_state = app
+            .try_state::<AppState>()
+            .ok_or_else(|| anyhow!("App state not available"))?;
+
+        let meeting_id = create_meeting_with_transcripts(
+            app_state.db_manager.pool(),
+            &title,
+            &segments,
+            meeting_folder.to_string_lossy().to_string(),
+        )
+        .await?;
+
+        emit_progress(&app, "saving", 90, "Writing transcript files...");
+
+        if let Err(e) = write_transcripts_json(&meeting_folder, &segments) {
+            warn!("Failed to write transcripts.json: {}", e);
+        }
+
+        if let Err(e) = write_import_metadata(
+            &meeting_folder,
+            &meeting_id,
+            &title,
+            duration_seconds,
+            &dest_filename,
+            "import",
+        ) {
+            warn!("Failed to write metadata.json: {}", e);
+        }
+
+        emit_progress(&app, "complete", 100, "Import complete");
+
+        return Ok(ImportResult {
+            meeting_id,
+            title,
+            segments_count: segments.len(),
+            duration_seconds,
+        });
     }
 
     emit_progress(&app, "decoding", 15, "Decoding audio file...");

--- a/frontend/src-tauri/src/audio/mod.rs
+++ b/frontend/src-tauri/src/audio/mod.rs
@@ -4,6 +4,7 @@ pub mod decoder;
 pub mod encode;
 pub mod ffmpeg;
 pub mod vad;
+pub mod deepgram;
 
 // Modularized device management
 pub mod devices;
@@ -118,4 +119,3 @@ pub use decoder::{decode_audio_file, DecodedAudio};
 
 // Export audio constants
 pub use constants::AUDIO_EXTENSIONS;
-

--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -13,6 +13,12 @@ use super::recording_state::{AudioChunk, AudioError, RecordingState, DeviceType}
 use super::audio_processing::{audio_to_mono, LoudnessNormalizer, NoiseSuppressionProcessor, HighPassFilter};
 use super::vad::{ContinuousVadProcessor};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TranscriptionPipelineMode {
+    VadSpeechOnly,
+    ContinuousMixed,
+}
+
 /// Ring buffer for synchronized audio mixing
 /// Accumulates samples from mic and system streams until we have aligned windows
 struct AudioMixerRingBuffer {
@@ -694,6 +700,8 @@ pub struct AudioPipeline {
     mixer: ProfessionalAudioMixer,
     // Recording sender for pre-mixed audio
     recording_sender_for_mixed: Option<mpsc::UnboundedSender<AudioChunk>>,
+    transcription_mode: TranscriptionPipelineMode,
+    mixed_transcription_next_timestamp: Option<f64>,
 }
 
 impl AudioPipeline {
@@ -707,6 +715,7 @@ impl AudioPipeline {
         mic_device_kind: super::device_detection::InputDeviceKind,
         system_device_name: String,
         system_device_kind: super::device_detection::InputDeviceKind,
+        send_continuous_transcription: bool,
     ) -> Self {
         // Log device characteristics for adaptive buffering
         info!("🎛️ AudioPipeline initializing with device characteristics:");
@@ -760,6 +769,12 @@ impl AudioPipeline {
             ring_buffer,
             mixer,
             recording_sender_for_mixed: None,  // Will be set by manager
+            transcription_mode: if send_continuous_transcription {
+                TranscriptionPipelineMode::ContinuousMixed
+            } else {
+                TranscriptionPipelineMode::VadSpeechOnly
+            },
+            mixed_transcription_next_timestamp: None,
         }
     }
 
@@ -831,37 +846,60 @@ impl AudioPipeline {
                             // Previous 2x gain was causing excessive limiting/distortion
                             let mixed_with_gain = mixed_clean;
 
-                            // STEP 3: Send mixed audio for transcription (VAD + Whisper)
-                            match self.vad_processor.process_audio(&mixed_with_gain) {
-                                Ok(speech_segments) => {
-                                    for segment in speech_segments {
-                                        let duration_ms = segment.end_timestamp_ms - segment.start_timestamp_ms;
+                            // Local engines receive VAD speech segments. Realtime cloud
+                            // providers receive continuous mixed audio for endpointing.
+                            if self.transcription_mode == TranscriptionPipelineMode::ContinuousMixed {
+                                let duration = mixed_with_gain.len() as f64 / self.sample_rate as f64;
+                                let timestamp = self
+                                    .mixed_transcription_next_timestamp
+                                    .unwrap_or(chunk.timestamp);
+                                self.mixed_transcription_next_timestamp = Some(timestamp + duration);
 
-                                        if segment.samples.len() >= 800 {  // Minimum 50ms at 16kHz - matches Parakeet capability
-                                            info!("📤 Sending VAD segment: {:.1}ms, {} samples",
-                                                  duration_ms, segment.samples.len());
+                                let transcription_chunk = AudioChunk {
+                                    data: mixed_with_gain.clone(),
+                                    sample_rate: self.sample_rate,
+                                    timestamp,
+                                    chunk_id: self.chunk_id_counter,
+                                    device_type: DeviceType::Microphone,
+                                };
 
-                                            let transcription_chunk = AudioChunk {
-                                                data: segment.samples,
-                                                sample_rate: 16000,
-                                                timestamp: segment.start_timestamp_ms / 1000.0,
-                                                chunk_id: self.chunk_id_counter,
-                                                device_type: DeviceType::Microphone,  // Mixed audio
-                                            };
+                                if let Err(e) = self.transcription_sender.send(transcription_chunk) {
+                                    warn!("Failed to send continuous transcription chunk: {}", e);
+                                } else {
+                                    self.chunk_id_counter += 1;
+                                }
+                            } else {
+                                match self.vad_processor.process_audio(&mixed_with_gain) {
+                                    Ok(speech_segments) => {
+                                        for segment in speech_segments {
+                                            let duration_ms = segment.end_timestamp_ms - segment.start_timestamp_ms;
 
-                                            if let Err(e) = self.transcription_sender.send(transcription_chunk) {
-                                                warn!("Failed to send VAD segment: {}", e);
+                                            if segment.samples.len() >= 800 {  // Minimum 50ms at 16kHz - matches Parakeet capability
+                                                info!("📤 Sending VAD segment: {:.1}ms, {} samples",
+                                                      duration_ms, segment.samples.len());
+
+                                                let transcription_chunk = AudioChunk {
+                                                    data: segment.samples,
+                                                    sample_rate: 16000,
+                                                    timestamp: segment.start_timestamp_ms / 1000.0,
+                                                    chunk_id: self.chunk_id_counter,
+                                                    device_type: DeviceType::Microphone,  // Mixed audio
+                                                };
+
+                                                if let Err(e) = self.transcription_sender.send(transcription_chunk) {
+                                                    warn!("Failed to send VAD segment: {}", e);
+                                                } else {
+                                                    self.chunk_id_counter += 1;
+                                                }
                                             } else {
-                                                self.chunk_id_counter += 1;
+                                                debug!("⏭️ Dropping short VAD segment: {:.1}ms ({} samples < 800)",
+                                                       duration_ms, segment.samples.len());
                                             }
-                                        } else {
-                                            debug!("⏭️ Dropping short VAD segment: {:.1}ms ({} samples < 800)",
-                                                   duration_ms, segment.samples.len());
                                         }
                                     }
-                                }
-                                Err(e) => {
-                                    warn!("⚠️ VAD error: {}", e);
+                                    Err(e) => {
+                                        warn!("⚠️ VAD error: {}", e);
+                                    }
                                 }
                             }
 
@@ -890,8 +928,9 @@ impl AudioPipeline {
             }
         }
 
-        // Flush any remaining VAD segments
-        self.flush_remaining_audio()?;
+        if self.transcription_mode == TranscriptionPipelineMode::VadSpeechOnly {
+            self.flush_remaining_audio()?;
+        }
 
         info!("VAD-driven audio pipeline ended");
         Ok(())
@@ -966,6 +1005,7 @@ impl AudioPipelineManager {
         mic_device_kind: super::device_detection::InputDeviceKind,
         system_device_name: String,
         system_device_kind: super::device_detection::InputDeviceKind,
+        send_continuous_transcription: bool,
     ) -> Result<()> {
         // Log device information for adaptive buffering
         info!("🎙️ Starting pipeline with device info:");
@@ -989,6 +1029,7 @@ impl AudioPipelineManager {
             mic_device_kind,
             system_device_name,
             system_device_kind,
+            send_continuous_transcription,
         );
 
         // CRITICAL FIX: Connect recording sender to receive pre-mixed audio

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -105,6 +105,8 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
         return Err(validation_error);
     }
     info!("✅ Transcription model validation passed");
+    let send_continuous_transcription =
+        transcription::is_deepgram_transcription_provider(&app).await;
 
     // Async-first approach - no more blocking operations!
     info!("🚀 Starting async recording initialization");
@@ -234,7 +236,12 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
 
     // Start recording with resolved devices (replaces start_recording_with_defaults_and_auto_save call)
     let transcription_receiver = manager
-        .start_recording(microphone_device, system_device, auto_save)
+        .start_recording(
+            microphone_device,
+            system_device,
+            auto_save,
+            send_continuous_transcription,
+        )
         .await
         .map_err(|e| format!("Failed to start recording: {}", e))?;
 
@@ -351,6 +358,8 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
         return Err(validation_error);
     }
     info!("✅ Transcription model validation passed");
+    let send_continuous_transcription =
+        transcription::is_deepgram_transcription_provider(&app).await;
 
     // Parse devices
     let mic_device = if let Some(ref name) = mic_device_name {
@@ -405,7 +414,12 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
 
     // Start recording with specified devices and auto_save setting
     let transcription_receiver = manager
-        .start_recording(mic_device, system_device, auto_save)
+        .start_recording(
+            mic_device,
+            system_device,
+            auto_save,
+            send_continuous_transcription,
+        )
         .await
         .map_err(|e| format!("Failed to start recording: {}", e))?;
 
@@ -646,6 +660,9 @@ pub async fn stop_recording<R: Runtime>(
     };
 
     match config.as_deref() {
+        Some("deepgram") => {
+            info!("☁️ Deepgram provider used, no local model unload needed");
+        }
         Some("parakeet") => {
             info!("🦜 Unloading Parakeet model...");
             let engine_clone = {

--- a/frontend/src-tauri/src/audio/recording_manager.rs
+++ b/frontend/src-tauri/src/audio/recording_manager.rs
@@ -60,11 +60,13 @@ impl RecordingManager {
     /// * `microphone_device` - Optional microphone device to use
     /// * `system_device` - Optional system audio device to use
     /// * `auto_save` - Whether to save audio checkpoints (true) or just transcripts/metadata (false)
+    /// * `send_continuous_transcription` - Stream mixed audio without local VAD segmentation
     pub async fn start_recording(
         &mut self,
         microphone_device: Option<Arc<AudioDevice>>,
         system_device: Option<Arc<AudioDevice>>,
         auto_save: bool,
+        send_continuous_transcription: bool,
     ) -> Result<mpsc::UnboundedReceiver<AudioChunk>> {
         info!("Starting recording manager (auto_save: {})", auto_save);
 
@@ -116,6 +118,7 @@ impl RecordingManager {
             mic_kind,
             sys_name,
             sys_kind,
+            send_continuous_transcription,
         )?;
 
         // Give the pipeline a moment to fully initialize before starting streams
@@ -186,7 +189,7 @@ impl RecordingManager {
             }
 
             // Start recording with selected devices and auto_save setting
-            self.start_recording(microphone_device, system_device, auto_save).await
+            self.start_recording(microphone_device, system_device, auto_save, false).await
         }
 
         #[cfg(not(target_os = "macos"))]
@@ -221,7 +224,7 @@ impl RecordingManager {
                 return Err(anyhow::anyhow!("No microphone device available"));
             }
 
-            self.start_recording(microphone_device, system_device, auto_save).await
+            self.start_recording(microphone_device, system_device, auto_save, false).await
         }
     }
 

--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -102,10 +102,13 @@ pub async fn start_retranscription<R: Runtime>(
     RETRANSCRIPTION_CANCELLED.store(false, Ordering::SeqCst);
 
     let use_parakeet = provider.as_deref() == Some("parakeet");
+    let use_deepgram = provider.as_deref() == Some(super::deepgram::PROVIDER);
     let result = run_retranscription(app.clone(), meeting_id.clone(), meeting_folder_path, language, model, provider).await;
 
     // Unload the engine after the batch job (success, failure, or cancellation)
-    super::common::unload_engine_after_batch(use_parakeet).await;
+    if !use_deepgram {
+        super::common::unload_engine_after_batch(use_parakeet).await;
+    }
 
     // Guard will automatically clear flag on drop
     // No need for manual: RETRANSCRIPTION_IN_PROGRESS.store(false, Ordering::SeqCst);
@@ -182,11 +185,126 @@ async fn run_retranscription<R: Runtime>(
 
     // Determine which provider to use (default to whisper)
     let use_parakeet = provider.as_deref() == Some("parakeet");
+    let use_deepgram = provider.as_deref() == Some(super::deepgram::PROVIDER);
 
     info!(
         "Starting retranscription for meeting {} with language {:?}, model {:?}, provider {:?}",
         meeting_id, language, model, provider
     );
+
+    if use_deepgram {
+        emit_progress(&app, &meeting_id, "transcribing", 5, "Preparing Deepgram transcription...");
+        let duration_seconds = match super::import::validate_audio_file(&audio_path) {
+            Ok(info) => info.duration_seconds,
+            Err(e) => {
+                warn!("Deepgram retranscription metadata duration failed: {}, decoding duration", e);
+                let decoded = tokio::task::spawn_blocking({
+                    let path = audio_path.clone();
+                    move || decode_audio_file(&path)
+                })
+                .await
+                .map_err(|e| anyhow!("Decode task panicked: {}", e))??;
+                decoded.duration_seconds
+            }
+        };
+
+        let client = super::deepgram::client_from_config(&app).await?;
+        let app_for_progress = app.clone();
+        let meeting_id_for_progress = meeting_id.clone();
+        let client_reference_id = format!("retranscription:{}", meeting_id);
+        let transcript = client
+            .transcribe_file_with_progress(
+                &audio_path,
+                model.clone(),
+                language.clone(),
+                &client_reference_id,
+                move |provider_progress, message| {
+                    let overall_progress = 5 + ((provider_progress as f32 * 0.75) as u32);
+                    emit_progress(
+                        &app_for_progress,
+                        &meeting_id_for_progress,
+                        "transcribing",
+                        overall_progress.min(80),
+                        message,
+                    );
+                },
+                || RETRANSCRIPTION_CANCELLED.load(Ordering::SeqCst),
+            )
+            .await?;
+
+        if RETRANSCRIPTION_CANCELLED.load(Ordering::SeqCst) {
+            return Err(anyhow!("Retranscription cancelled"));
+        }
+
+        emit_progress(&app, &meeting_id, "saving", 80, "Saving transcripts...");
+        let segments = super::deepgram::transcript_to_segments(&transcript, duration_seconds);
+
+        let app_state = app
+            .try_state::<AppState>()
+            .ok_or_else(|| anyhow!("App state not available"))?;
+
+        let pool = app_state.db_manager.pool();
+        let mut conn = pool.acquire().await.map_err(|e| anyhow!("DB error: {}", e))?;
+        let mut tx = sqlx::Connection::begin(&mut *conn)
+            .await
+            .map_err(|e| anyhow!("Failed to start transaction: {}", e))?;
+
+        sqlx::query("DELETE FROM transcripts WHERE meeting_id = ?")
+            .bind(&meeting_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| anyhow!("Failed to delete existing transcripts: {}", e))?;
+
+        for segment in &segments {
+            sqlx::query(
+                "INSERT INTO transcripts (id, meeting_id, transcript, timestamp, audio_start_time, audio_end_time, duration)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)"
+            )
+            .bind(&segment.id)
+            .bind(&meeting_id)
+            .bind(&segment.text)
+            .bind(&segment.timestamp)
+            .bind(segment.audio_start_time)
+            .bind(segment.audio_end_time)
+            .bind(segment.duration)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| anyhow!("Failed to insert transcript: {}", e))?;
+        }
+
+        tx.commit().await
+            .map_err(|e| anyhow!("Failed to commit transaction: {}", e))?;
+
+        emit_progress(&app, &meeting_id, "saving", 90, "Writing transcript files...");
+
+        if let Err(e) = write_transcripts_json(&folder_path, &segments) {
+            warn!("Failed to write transcripts.json: {}", e);
+        }
+
+        let audio_filename = audio_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("audio.mp4")
+            .to_string();
+
+        if let Err(e) = write_retranscription_metadata(
+            &folder_path,
+            &meeting_id,
+            duration_seconds,
+            &audio_filename,
+        ) {
+            warn!("Failed to update metadata.json: {}", e);
+        }
+
+        emit_progress(&app, &meeting_id, "complete", 100, "Retranscription complete");
+
+        return Ok(RetranscriptionResult {
+            meeting_id,
+            segments_count: segments.len(),
+            duration_seconds,
+            language,
+        });
+    }
 
     // Emit progress: decoding
     emit_progress(&app, &meeting_id, "decoding", 5, "Decoding audio file...");

--- a/frontend/src-tauri/src/audio/transcription/engine.rs
+++ b/frontend/src-tauri/src/audio/transcription/engine.rs
@@ -135,10 +135,23 @@ pub async fn validate_transcription_model_ready<R: Runtime>(app: &AppHandle<R>) 
                 }
             }
         }
+        "deepgram" => {
+            info!("🔍 Validating Deepgram API key...");
+            match crate::audio::deepgram::validate_configured_api_key(app).await {
+                Ok(()) => {
+                    info!("✅ Deepgram API key is configured");
+                    Ok(())
+                }
+                Err(e) => {
+                    warn!("❌ Deepgram validation failed: {}", e);
+                    Err(e)
+                }
+            }
+        }
         other => {
             warn!("❌ Unsupported transcription provider for local recording: {}", other);
             Err(format!(
-                "Provider '{}' is not supported for local transcription. Please select 'localWhisper' or 'parakeet'.",
+                "Provider '{}' is not supported for recording. Please select 'localWhisper', 'parakeet', or 'deepgram'.",
                 other
             ))
         }
@@ -212,10 +225,24 @@ pub async fn get_or_init_transcription_engine<R: Runtime>(
                 }
             }
         }
+        "deepgram" => {
+            Err("Deepgram realtime transcription is handled by the Deepgram streaming worker".to_string())
+        }
         "localWhisper" | _ => {
             info!("🎤 Initializing Whisper transcription engine");
             let whisper_engine = get_or_init_whisper(app).await?;
             Ok(TranscriptionEngine::Whisper(whisper_engine))
+        }
+    }
+}
+
+pub async fn is_deepgram_transcription_provider<R: Runtime>(app: &AppHandle<R>) -> bool {
+    match crate::api::api::api_get_transcript_config(app.clone(), app.clone().state(), None).await {
+        Ok(Some(config)) => config.provider == crate::audio::deepgram::PROVIDER,
+        Ok(None) => false,
+        Err(e) => {
+            warn!("⚠️ Failed to read transcript config while checking Deepgram provider: {}", e);
+            false
         }
     }
 }

--- a/frontend/src-tauri/src/audio/transcription/mod.rs
+++ b/frontend/src-tauri/src/audio/transcription/mod.rs
@@ -16,7 +16,8 @@ pub use engine::{
     TranscriptionEngine,
     validate_transcription_model_ready,
     get_or_init_transcription_engine,
-    get_or_init_whisper
+    get_or_init_whisper,
+    is_deepgram_transcription_provider
 };
 pub use worker::{
     start_transcription_task,

--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -49,6 +49,24 @@ pub fn start_transcription_task<R: Runtime>(
     tokio::spawn(async move {
         info!("🚀 Starting optimized parallel transcription task - guaranteeing zero chunk loss");
 
+        if super::engine::is_deepgram_transcription_provider(&app).await {
+            info!("☁️ Starting Deepgram realtime transcription task");
+            if let Err(e) = crate::audio::deepgram::run_realtime_transcription(
+                app.clone(),
+                transcription_receiver,
+            )
+            .await
+            {
+                error!("Deepgram realtime transcription failed: {}", e);
+                let _ = app.emit("transcription-error", serde_json::json!({
+                    "error": e,
+                    "userMessage": "Deepgram transcription failed. Check your API key and network connection.",
+                    "actionable": true
+                }));
+            }
+            return;
+        }
+
         // Initialize transcription engine (Whisper or Parakeet based on config)
         let transcription_engine = match super::engine::get_or_init_transcription_engine(&app).await {
             Ok(engine) => engine,

--- a/frontend/src-tauri/src/config.rs
+++ b/frontend/src-tauri/src/config.rs
@@ -11,6 +11,12 @@ pub const DEFAULT_WHISPER_MODEL: &str = "large-v3-turbo";
 /// This is the quantized version optimized for speed.
 pub const DEFAULT_PARAKEET_MODEL: &str = "parakeet-tdt-0.6b-v3-int8";
 
+/// Default Deepgram model for realtime cloud transcription.
+pub const DEFAULT_DEEPGRAM_REALTIME_MODEL: &str = "nova-3";
+
+/// Default Deepgram model for async cloud transcription of existing files.
+pub const DEFAULT_DEEPGRAM_ASYNC_MODEL: &str = "nova-3";
+
 /// Whisper model catalog with metadata for all supported models.
 /// Used by both WhisperEngine::discover_models() and discover_models_standalone().
 ///

--- a/frontend/src/app/_components/TranscriptPanel.tsx
+++ b/frontend/src/app/_components/TranscriptPanel.tsx
@@ -31,23 +31,31 @@ export function TranscriptPanel({
   showModal
 }: TranscriptPanelProps) {
   // Contexts
-  const { transcripts, transcriptContainerRef, copyTranscript } = useTranscripts();
+  const { transcripts, livePreview, transcriptContainerRef, copyTranscript } = useTranscripts();
   const { transcriptModelConfig } = useConfig();
   const { isRecording, isPaused } = useRecordingState();
   const { checkPermissions, isChecking, hasSystemAudio, hasMicrophone } = usePermissionCheck();
   const isLinux = useIsLinux();
 
   // Convert transcripts to segments for virtualized view
-  const segments = useMemo(() =>
-    transcripts.map(t => ({
+  const segments = useMemo(() => {
+    const committed = transcripts.map(t => ({
       id: t.id,
       timestamp: t.audio_start_time ?? 0,
       endTime: t.audio_end_time,
       text: t.text,
       confidence: t.confidence,
-    })),
-    [transcripts]
-  );
+    }));
+
+    return livePreview ? [...committed, {
+      id: livePreview.id,
+      timestamp: livePreview.audio_start_time ?? 0,
+      endTime: livePreview.audio_end_time,
+      text: livePreview.text,
+      confidence: livePreview.confidence,
+      isPreview: true,
+    }] : committed;
+  }, [transcripts, livePreview]);
 
   return (
     <div ref={transcriptContainerRef} className="w-full border-r border-gray-200 bg-white flex flex-col overflow-y-auto">

--- a/frontend/src/components/TranscriptSettings.tsx
+++ b/frontend/src/components/TranscriptSettings.tsx
@@ -36,14 +36,14 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
     useEffect(() => {
         if (transcriptModelConfig.provider === 'localWhisper' || transcriptModelConfig.provider === 'parakeet') {
             setApiKey(null);
+        } else {
+            fetchApiKey(transcriptModelConfig.provider);
         }
     }, [transcriptModelConfig.provider]);
 
     const fetchApiKey = async (provider: string) => {
         try {
-
             const data = await invoke('api_get_transcript_api_key', { provider }) as string;
-
             setApiKey(data || '');
         } catch (err) {
             console.error('Error fetching API key:', err);
@@ -53,12 +53,28 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
     const modelOptions = {
         localWhisper: [], // Model selection handled by ModelManager component
         parakeet: [], // Model selection handled by ParakeetModelManager component
-        deepgram: ['nova-2-phonecall'],
+        deepgram: ['nova-3', 'flux-general-multi', 'nova-2', 'nova-2-meeting', 'nova-2-general'],
         elevenLabs: ['eleven_multilingual_v2'],
         groq: ['llama-3.3-70b-versatile'],
         openai: ['gpt-4o'],
     };
-    const requiresApiKey = transcriptModelConfig.provider === 'deepgram' || transcriptModelConfig.provider === 'elevenLabs' || transcriptModelConfig.provider === 'openai' || transcriptModelConfig.provider === 'groq';
+    const requiresApiKey = uiProvider === 'deepgram' || uiProvider === 'elevenLabs' || uiProvider === 'openai' || uiProvider === 'groq';
+
+    const saveCloudConfig = async (
+        provider: TranscriptModelProps['provider'],
+        model: string,
+        key: string | null,
+    ) => {
+        try {
+            await invoke('api_save_transcript_config', {
+                provider,
+                model,
+                apiKey: key || null,
+            });
+        } catch (error) {
+            console.error('Failed to save transcript provider:', error);
+        }
+    };
 
     const handleInputClick = () => {
         if (isApiKeyLocked) {
@@ -109,11 +125,23 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                         <div className="flex space-x-2 mx-1">
                             <Select
                                 value={uiProvider}
-                                onValueChange={(value) => {
+                                onValueChange={async (value) => {
                                     const provider = value as TranscriptModelProps['provider'];
                                     setUiProvider(provider);
                                     if (provider !== 'localWhisper' && provider !== 'parakeet') {
-                                        fetchApiKey(provider);
+                                        let currentKey: string | null = null;
+                                        try {
+                                            const data = await invoke('api_get_transcript_api_key', { provider }) as string;
+                                            currentKey = data || '';
+                                            setApiKey(currentKey);
+                                        } catch (err) {
+                                            console.error('Error fetching API key:', err);
+                                            setApiKey(null);
+                                        }
+                                        const model = modelOptions[provider][0];
+                                        const nextConfig = { ...transcriptModelConfig, provider, model, apiKey: currentKey };
+                                        setTranscriptModelConfig(nextConfig);
+                                        await saveCloudConfig(provider, model, currentKey);
                                     }
                                 }}
                             >
@@ -123,8 +151,8 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                 <SelectContent>
                                     <SelectItem value="parakeet">⚡ Parakeet (Recommended - Real-time / Accurate)</SelectItem>
                                     <SelectItem value="localWhisper">🏠 Local Whisper (High Accuracy)</SelectItem>
-                                    {/* <SelectItem value="deepgram">☁️ Deepgram (Backup)</SelectItem>
-                                    <SelectItem value="elevenLabs">☁️ ElevenLabs</SelectItem>
+                                    <SelectItem value="deepgram">☁️ Deepgram (Cloud)</SelectItem>
+                                    {/* <SelectItem value="elevenLabs">☁️ ElevenLabs</SelectItem>
                                     <SelectItem value="groq">☁️ Groq</SelectItem>
                                     <SelectItem value="openai">☁️ OpenAI</SelectItem> */}
                                 </SelectContent>
@@ -136,6 +164,7 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                     onValueChange={(value) => {
                                         const model = value as TranscriptModelProps['model'];
                                         setTranscriptModelConfig({ ...transcriptModelConfig, provider: uiProvider, model });
+                                        saveCloudConfig(uiProvider, model, apiKey);
                                     }}
                                 >
                                     <SelectTrigger className='focus:ring-1 focus:ring-blue-500 focus:border-blue-500'>
@@ -185,6 +214,18 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
                                         }`}
                                     value={apiKey || ''}
                                     onChange={(e) => setApiKey(e.target.value)}
+                                    onBlur={() => {
+                                        if (requiresApiKey) {
+                                            const model = transcriptModelConfig.model || modelOptions[uiProvider][0];
+                                            saveCloudConfig(uiProvider, model, apiKey);
+                                            setTranscriptModelConfig({
+                                                ...transcriptModelConfig,
+                                                provider: uiProvider,
+                                                model,
+                                                apiKey,
+                                            });
+                                        }
+                                    }}
                                     disabled={isApiKeyLocked}
                                     onClick={handleInputClick}
                                     placeholder="Enter your API key"
@@ -224,7 +265,6 @@ export function TranscriptSettings({ transcriptModelConfig, setTranscriptModelCo
         </div >
     )
 }
-
 
 
 

--- a/frontend/src/components/VirtualizedTranscriptView.tsx
+++ b/frontend/src/components/VirtualizedTranscriptView.tsx
@@ -70,6 +70,7 @@ const TranscriptSegment = memo(function TranscriptSegment({
     text,
     confidence,
     isStreaming,
+    isPreview,
     showConfidence,
 }: {
     id: string;
@@ -77,12 +78,13 @@ const TranscriptSegment = memo(function TranscriptSegment({
     text: string;
     confidence?: number;
     isStreaming: boolean;
+    isPreview: boolean;
     showConfidence: boolean;
 }) {
     const displayText = cleanStopWords(text) || (text.trim() === '' ? '[Silence]' : text);
 
     return (
-        <div id={`segment-${id}`} className="mb-3">
+        <div id={`segment-${id}`} className="mb-3" aria-live={isPreview ? "polite" : undefined}>
             <div className="flex items-start gap-2">
                 <Tooltip>
                     <TooltipTrigger>
@@ -97,9 +99,9 @@ const TranscriptSegment = memo(function TranscriptSegment({
                     </TooltipContent>
                 </Tooltip>
                 <div className="flex-1">
-                    {isStreaming ? (
+                    {isStreaming || isPreview ? (
                         <div className="bg-gray-100 border border-gray-200 rounded-lg px-3 py-2">
-                            <p className="text-base text-gray-800 leading-relaxed">{displayText}</p>
+                            <p className={`text-base leading-relaxed ${isPreview ? 'text-gray-500 italic' : 'text-gray-800'}`}>{displayText}</p>
                         </div>
                     ) : (
                         <p className="text-base text-gray-800 leading-relaxed">{displayText}</p>
@@ -274,7 +276,7 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                     >
                         {virtualizer.getVirtualItems().map((virtualRow) => {
                             const segment = segments[virtualRow.index];
-                            const isStreaming = streamingSegmentId === segment.id;
+                            const isStreaming = !segment.isPreview && streamingSegmentId === segment.id;
 
                             return (
                                 <div
@@ -292,9 +294,10 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                                     <TranscriptSegment
                                         id={segment.id}
                                         timestamp={segment.timestamp}
-                                        text={getDisplayText(segment)}
+                                        text={segment.isPreview ? segment.text : getDisplayText(segment)}
                                         confidence={segment.confidence}
                                         isStreaming={isStreaming}
+                                        isPreview={segment.isPreview ?? false}
                                         showConfidence={showConfidence}
                                     />
                                 </div>
@@ -336,7 +339,7 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                 <>
                     <div className="space-y-1">
                         {segments.map((segment) => {
-                            const isStreaming = streamingSegmentId === segment.id;
+                            const isStreaming = !segment.isPreview && streamingSegmentId === segment.id;
 
                             return (
                                 <motion.div
@@ -348,9 +351,10 @@ export const VirtualizedTranscriptView: React.FC<VirtualizedTranscriptViewProps>
                                     <TranscriptSegment
                                         id={segment.id}
                                         timestamp={segment.timestamp}
-                                        text={getDisplayText(segment)}
+                                        text={segment.isPreview ? segment.text : getDisplayText(segment)}
                                         confidence={segment.confidence}
                                         isStreaming={isStreaming}
+                                        isPreview={segment.isPreview ?? false}
                                         showConfidence={showConfidence}
                                     />
                                 </motion.div>

--- a/frontend/src/constants/modelDefaults.ts
+++ b/frontend/src/constants/modelDefaults.ts
@@ -16,10 +16,23 @@ export const DEFAULT_WHISPER_MODEL = 'large-v3-turbo';
 export const DEFAULT_PARAKEET_MODEL = 'parakeet-tdt-0.6b-v3-int8';
 
 /**
+ * Default Deepgram model for realtime cloud transcription.
+ */
+export const DEFAULT_DEEPGRAM_REALTIME_MODEL = 'nova-3';
+
+/**
+ * Default Deepgram model for imported audio and retranscription.
+ */
+export const DEFAULT_DEEPGRAM_ASYNC_MODEL = 'nova-3';
+
+/**
  * Model defaults by provider type
  */
 export const MODEL_DEFAULTS = {
   whisper: DEFAULT_WHISPER_MODEL,
   localWhisper: DEFAULT_WHISPER_MODEL,
   parakeet: DEFAULT_PARAKEET_MODEL,
+  deepgram: DEFAULT_DEEPGRAM_REALTIME_MODEL,
 } as const;
+
+export const DEFAULT_TRANSCRIPTION_MODELS = MODEL_DEFAULTS;

--- a/frontend/src/contexts/TranscriptContext.tsx
+++ b/frontend/src/contexts/TranscriptContext.tsx
@@ -10,6 +10,7 @@ import { indexedDBService } from '@/services/indexedDBService';
 
 interface TranscriptContextType {
   transcripts: Transcript[];
+  livePreview: Transcript | null;
   transcriptsRef: MutableRefObject<Transcript[]>
   addTranscript: (update: TranscriptUpdate) => void;
   copyTranscript: () => void;
@@ -26,6 +27,7 @@ const TranscriptContext = createContext<TranscriptContextType | undefined>(undef
 
 export function TranscriptProvider({ children }: { children: ReactNode }) {
   const [transcripts, setTranscripts] = useState<Transcript[]>([]);
+  const [livePreview, setLivePreview] = useState<Transcript | null>(null);
   const [meetingTitle, setMeetingTitle] = useState('+ New Call');
   const [currentMeetingId, setCurrentMeetingId] = useState<string | null>(null);
 
@@ -93,6 +95,7 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
 
         // Listen for recording-started event
         unlistenRecordingStarted = await recordingService.onRecordingStarted(async () => {
+          setLivePreview(null);
           try {
             // Generate unique meeting ID
             const meetingId = `meeting-${Date.now()}`;
@@ -144,6 +147,7 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
 
         // Listen for recording-stopped event
         unlistenRecordingStopped = await recordingService.onRecordingStopped(async (payload) => {
+          setLivePreview(null);
           try {
             if (currentMeetingId) {
               // Update folder path in IndexedDB
@@ -180,6 +184,7 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
   // Main transcript buffering logic with sequence_id ordering
   useEffect(() => {
     let unlistenFn: (() => void) | undefined;
+    let unlistenPreviewFn: (() => void) | undefined;
     let transcriptCounter = 0;
     let transcriptBuffer = new Map<number, Transcript>();
     let lastProcessedSequence = 0;
@@ -285,7 +290,24 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
     const setupListener = async () => {
       try {
         console.log('🔥 Setting up MAIN transcript listener during component initialization...');
+        unlistenPreviewFn = await transcriptService.onTranscriptPreview((update) => {
+          const text = update.text.trim();
+          setLivePreview(text ? {
+            id: 'live-transcript-preview',
+            text,
+            timestamp: update.timestamp,
+            sequence_id: update.sequence_id,
+            chunk_start_time: update.chunk_start_time,
+            is_partial: true,
+            confidence: update.confidence,
+            audio_start_time: update.audio_start_time,
+            audio_end_time: update.audio_end_time,
+            duration: update.duration,
+          } : null);
+        });
+
         unlistenFn = await transcriptService.onTranscriptUpdate((update) => {
+          setLivePreview(null);
           const now = Date.now();
           console.log('🎯 MAIN LISTENER: Received transcript update:', {
             sequence_id: update.sequence_id,
@@ -355,6 +377,10 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
         unlistenFn();
         console.log('🧹 CLEANUP: MAIN transcript listener cleaned up');
       }
+      if (unlistenPreviewFn) {
+        unlistenPreviewFn();
+      }
+      setLivePreview(null);
     };
   }, [currentMeetingId]); // Add currentMeetingId dependency
 
@@ -406,6 +432,7 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
 
   // Manual transcript update handler (for RecordingControls component)
   const addTranscript = useCallback((update: TranscriptUpdate) => {
+    setLivePreview(null);
     console.log('🎯 addTranscript called with:', {
       sequence_id: update.sequence_id,
       text: update.text.substring(0, 50) + '...',
@@ -483,6 +510,7 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
   // Clear transcripts (used when starting new recording)
   const clearTranscripts = useCallback(() => {
     setTranscripts([]);
+    setLivePreview(null);
     // Don't clear currentMeetingId here - it will be set by recording-started event
   }, []);
 
@@ -511,6 +539,7 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
 
   const value: TranscriptContextType = {
     transcripts,
+    livePreview,
     transcriptsRef,
     addTranscript,
     copyTranscript,

--- a/frontend/src/hooks/useTranscriptionModels.ts
+++ b/frontend/src/hooks/useTranscriptionModels.ts
@@ -8,7 +8,7 @@ export interface RawModelInfo {
 }
 
 export interface ModelOption {
-  provider: 'whisper' | 'parakeet';
+  provider: 'whisper' | 'parakeet' | 'deepgram';
   name: string;
   displayName: string;
   size_mb: number;
@@ -77,6 +77,39 @@ export function useTranscriptionModels(transcriptModelConfig: TranscriptModelCon
       console.error('Failed to fetch Parakeet models:', err);
     }
 
+    allModels.push(
+      {
+        provider: 'deepgram',
+        name: 'nova-3',
+        displayName: '☁️ Deepgram: nova-3',
+        size_mb: 0,
+      },
+      {
+        provider: 'deepgram',
+        name: 'flux-general-multi',
+        displayName: '☁️ Deepgram: flux-general-multi',
+        size_mb: 0,
+      },
+      {
+        provider: 'deepgram',
+        name: 'nova-2',
+        displayName: '☁️ Deepgram: nova-2',
+        size_mb: 0,
+      },
+      {
+        provider: 'deepgram',
+        name: 'nova-2-meeting',
+        displayName: '☁️ Deepgram: nova-2-meeting',
+        size_mb: 0,
+      },
+      {
+        provider: 'deepgram',
+        name: 'nova-2-general',
+        displayName: '☁️ Deepgram: nova-2-general',
+        size_mb: 0,
+      },
+    );
+
     setAvailableModels(allModels);
 
     // Set default model based on user's saved configuration
@@ -85,11 +118,16 @@ export function useTranscriptionModels(transcriptModelConfig: TranscriptModelCon
 
     // Try to match the configured model
     // Note: 'localWhisper' in config maps to 'whisper' provider in model list
-    const configuredMatch = allModels.find(
-      (m) =>
-        (configuredProvider === 'localWhisper' && m.provider === 'whisper' && m.name === configuredModel) ||
-        (configuredProvider === 'parakeet' && m.provider === 'parakeet' && m.name === configuredModel)
-    );
+    const configuredMatch =
+      allModels.find(
+        (m) =>
+          (configuredProvider === 'localWhisper' && m.provider === 'whisper' && m.name === configuredModel) ||
+          (configuredProvider === 'parakeet' && m.provider === 'parakeet' && m.name === configuredModel) ||
+          (configuredProvider === 'deepgram' && m.provider === 'deepgram' && m.name === configuredModel),
+      ) ||
+      allModels.find(
+        (m) => configuredProvider === 'deepgram' && m.provider === 'deepgram',
+      );
 
     // Only set default model if user hasn't manually selected one
     if (!userSelectedRef.current) {

--- a/frontend/src/services/transcriptService.ts
+++ b/frontend/src/services/transcriptService.ts
@@ -59,6 +59,13 @@ export class TranscriptService {
     });
   }
 
+  /** Listen for an ephemeral live preview. Preview events are never persisted. */
+  async onTranscriptPreview(callback: (update: TranscriptUpdate) => void): Promise<UnlistenFn> {
+    return listen<TranscriptUpdate>('transcript-preview', (event) => {
+      callback(event.payload);
+    });
+  }
+
   /**
    * Listen for transcription-complete event
    * @param callback - Function to call when transcription processing is complete

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -107,4 +107,5 @@ export interface TranscriptSegmentData {
   endTime?: number; // audio_end_time in seconds
   text: string;
   confidence?: number;
+  isPreview?: boolean;
 }


### PR DESCRIPTION
## Summary

- add Deepgram as a standalone transcription provider on top of main
- support realtime Nova 3, Flux, and Nova 2 model variants
- stream continuous mixed audio to Deepgram while preserving the local VAD pipeline
- show ephemeral interim transcripts and hot-replace them with finalized segments
- support Deepgram for imported audio and retranscription
- keep Soniox code and ancestry out of this PR

## Models

- nova-3
- flux-general-multi
- nova-2
- nova-2-meeting
- nova-2-general

Flux uses the v2 realtime endpoint. File import/retranscription falls back to Nova 3 because Flux is realtime-only.

## Validation

- cargo test -p meetily audio::deepgram -- --nocapture — 8 passed
- pnpm build — passed
- Tauri CoreML production build with updater artifacts disabled — passed
- built app installed at /Applications/meetily d.app
