### PR TITLE
fix(transcription): shared cross-provider hallucination filtering (follow-up to #679)

### DIFF
--- a/frontend/src-tauri/src/audio/transcription/mod.rs
+++ b/frontend/src-tauri/src/audio/transcription/mod.rs
@@ -6,10 +6,12 @@ pub mod provider;
 pub mod whisper_provider;
 pub mod parakeet_provider;
 pub mod engine;
+pub mod text_cleanup;
 pub mod worker;
 
 // Re-export commonly used types
 pub use provider::{TranscriptionError, TranscriptionProvider, TranscriptResult};
+pub use text_cleanup::{clean_transcript_text, is_meaningless_output};
 pub use whisper_provider::WhisperProvider;
 pub use parakeet_provider::ParakeetProvider;
 pub use engine::{

--- a/frontend/src-tauri/src/audio/transcription/text_cleanup.rs
+++ b/frontend/src-tauri/src/audio/transcription/text_cleanup.rs
@@ -67,43 +67,28 @@ const BOILERPLATE_PATTERNS: &[&str] = &[
     "لا تنسوا الاشتراك",
 ];
 
-/// Standalone filler that is only ever a hallucination when it constitutes the
-/// entire segment. Unlike [`BOILERPLATE_PATTERNS`] these are matched against the
-/// whole trimmed string, because the same words are legitimate mid-sentence.
-///
-/// Whisper's Arabic "شكرا" attractor is the direct analogue of its English
-/// "Thank you." attractor on near-silent input.
-const STANDALONE_FILLER: &[&str] = &[
-    // English
-    "thank you",
-    "thank you.",
-    "thanks",
-    "you",
-    "bye",
-    "okay",
-    // Arabic — "thank you" in its common orthographic variants
-    "شكرا",
-    "شكراً",
-    "شكرا.",
-    "شكراً.",
-    "شكرا لك",
-    "شكراً لك",
-    "شكرا لكم",
-    "شكراً لكم",
-    "شكرا جزيلا",
-    "شكراً جزيلاً",
-];
-
-/// Strip trailing punctuation and Arabic tatweel so orthographic variants of the
-/// same filler word collapse to one form for comparison.
-fn normalize_for_filler_match(text: &str) -> String {
-    text.trim()
-        .trim_end_matches(|c: char| matches!(c, '.' | '!' | '?' | '،' | '؟' | '۔' | ',' | ' '))
-        .replace('\u{0640}', "") // ARABIC TATWEEL
-        .to_lowercase()
-}
+// DELIBERATELY ABSENT: a denylist of standalone filler words such as "thank you",
+// "okay", "thanks" or Arabic "شكرا".
+//
+// Whisper does hallucinate exactly those on near-silent input, so filtering them
+// is tempting. But they are also completely ordinary meeting speech, and *nothing
+// in the text distinguishes the two cases* — "شكرا" produced from 300ms of silence
+// and "شكرا" produced from someone actually saying it are byte-identical.
+//
+// Dropping them by text therefore trades a cosmetic annoyance (a stray "thanks" in
+// the transcript) for a semantic one (a participant's answer silently missing).
+// Issue #675 is the maintainers reporting that exact failure for "OK" / "Yes" /
+// "Thanks", so a text-only filler list here would compound a known bug.
+//
+// Short-clip hallucination is instead handled where the evidence actually lives:
+// the provider layer, using Whisper's own `avg_logprob` / `compression_ratio`
+// scores. Only unambiguous multi-word boilerplate — phrases that never occur in a
+// meeting — is filtered by text.
 
 /// True when `text` is a whole-segment hallucination rather than speech.
+///
+/// Conservative by construction: it must be possible to tell from the text alone,
+/// with no plausible reading in which the text is genuine speech.
 pub fn is_meaningless_output(text: &str) -> bool {
     let trimmed = text.trim();
     if trimmed.is_empty() {
@@ -114,14 +99,6 @@ pub fn is_meaningless_output(text: &str) -> bool {
     if BOILERPLATE_PATTERNS
         .iter()
         .any(|pattern| lower.contains(pattern))
-    {
-        return true;
-    }
-
-    let normalized = normalize_for_filler_match(trimmed);
-    if STANDALONE_FILLER
-        .iter()
-        .any(|filler| normalized == normalize_for_filler_match(filler))
     {
         return true;
     }
@@ -232,18 +209,20 @@ pub fn clean_transcript_text(text: &str) -> String {
         return trimmed.to_string();
     }
 
+    // Judge degeneracy on the ORIGINAL text. A segment that is overwhelmingly one
+    // repeated word is a decoder loop whatever that word happens to be, so this
+    // catches "شكرا شكرا شكرا شكرا شكرا" without needing to know what "شكرا" means.
+    // Measuring after collapsing would hide it: collapsing leaves one word, and one
+    // word has a repetition ratio of zero.
+    if calculate_repetition_ratio(trimmed) > MAX_REPETITION_RATIO {
+        return String::new();
+    }
+
     let cleaned_words = remove_word_repetitions(&words);
     let cleaned_words = remove_phrase_repetitions(&cleaned_words);
 
     let final_text = cleaned_words.join(" ");
     if calculate_repetition_ratio(&final_text) > MAX_REPETITION_RATIO {
-        return String::new();
-    }
-
-    // Re-check after collapsing: a repeated hallucination such as
-    // "شكرا شكرا شكرا" only becomes recognisable as standalone filler once the
-    // repetition has been removed.
-    if is_meaningless_output(&final_text) {
         return String::new();
     }
 
@@ -267,15 +246,29 @@ mod tests {
         assert_eq!(clean_transcript_text("ترجمة نانسي قنقر"), "");
     }
 
+    /// Regression guard for issue #675: short acknowledgements are real speech and
+    /// must survive. Whisper does hallucinate these on near-silent input, but the
+    /// text cannot tell the two apart, so dropping them here would silently delete a
+    /// participant's answer. That case is handled at the provider layer using
+    /// Whisper's own confidence scores instead.
     #[test]
-    fn drops_standalone_arabic_thank_you_in_all_orthographies() {
-        for variant in ["شكرا", "شكراً", "شكرا لك", "شكراً جزيلاً", "شكرا."] {
+    fn keeps_short_acknowledgements_issue_675() {
+        for reply in [
+            "OK", "Yes", "No", "Sure", "Got it", "Thanks", "Okay.", "Bye",
+            "شكرا", "شكراً", "شكرا لك", "نعم", "طيب", "لا",
+        ] {
             assert_eq!(
-                clean_transcript_text(variant),
-                "",
-                "expected {variant:?} to be filtered"
+                clean_transcript_text(reply),
+                reply,
+                "expected the short reply {reply:?} to survive cleaning"
             );
         }
+    }
+
+    #[test]
+    fn keeps_tatweel_stretched_words() {
+        // Tatweel stretches a word without changing it; it is still real speech.
+        assert_eq!(clean_transcript_text("شكـــرا"), "شكـــرا");
     }
 
     #[test]
@@ -345,9 +338,4 @@ mod tests {
         assert!(is_meaningless_output("............."));
     }
 
-    #[test]
-    fn tatweel_variants_normalize_to_the_same_filler() {
-        // ARABIC TATWEEL stretches a word without changing it.
-        assert_eq!(clean_transcript_text("شكـــرا"), "");
-    }
 }

--- a/frontend/src-tauri/src/audio/transcription/text_cleanup.rs
+++ b/frontend/src-tauri/src/audio/transcription/text_cleanup.rs
@@ -1,0 +1,353 @@
+// audio/transcription/text_cleanup.rs
+//
+// Shared post-processing for ASR output, applied to EVERY transcription engine.
+//
+// These routines previously lived as private associated functions on
+// `WhisperEngine`, so they only ran for local Whisper. Parakeet and the
+// trait-based providers stored raw model output, which meant Whisper's
+// well-known subtitle-corpus hallucinations were filtered on one code path and
+// persisted verbatim on the others.
+//
+// The denylist was also English-only, so the filter silently applied to English
+// meetings and not to any other language. Whisper emits the same class of
+// artifact in whatever language it decided it was hearing, so the patterns are
+// grouped by language below and every group is always checked.
+
+use std::collections::{HashMap, HashSet};
+
+/// Minimum words before repetition analysis is meaningful.
+const MIN_WORDS_FOR_REPETITION_CHECK: usize = 3;
+/// Minimum words before phrase-level repetition analysis is meaningful.
+const MIN_WORDS_FOR_PHRASE_CHECK: usize = 4;
+/// Longest phrase length considered when collapsing repeated phrases.
+const MAX_PHRASE_LEN: usize = 5;
+/// Above this share of repeated words the output is treated as degenerate.
+const MAX_REPETITION_RATIO: f32 = 0.7;
+/// A short string built from this few distinct characters is not speech.
+const MAX_UNIQUE_CHARS_FOR_JUNK: usize = 3;
+/// Only apply the distinct-character heuristic above this length.
+const MIN_LEN_FOR_UNIQUE_CHAR_CHECK: usize = 10;
+
+/// Subtitle/voice-over boilerplate that Whisper reproduces from its training
+/// data when handed audio with little or no speech in it. Matched
+/// case-insensitively as a substring.
+///
+/// English entries are the original list. The remaining entries were collected
+/// from real recordings; the Arabic ones in particular are what a
+/// Whisper-transcribed Arabic meeting fills near-silent segments with.
+const BOILERPLATE_PATTERNS: &[&str] = &[
+    // --- English ---
+    "thank you for watching",
+    "thanks for watching",
+    "like and subscribe",
+    "please subscribe",
+    "subscribe to the channel",
+    "music playing",
+    "applause",
+    "laughter",
+    "um um um",
+    "uh uh uh",
+    "ah ah ah",
+    // --- Arabic ---
+    // "subscribe to the channel" / "and subscribe to the channel"
+    "اشتركوا في القناة",
+    "اشترك في القناة",
+    "نشترك في القناة",
+    "اشتركوا بالقناة",
+    // "translation by ..." / "subtitles by ..." subtitler credits
+    "ترجمة نانسي قنقر",
+    "ترجمة نانسي",
+    "ترجمة وتعديل",
+    "ترجمة الفيديو",
+    "تمت الترجمة",
+    // ad / outro boilerplate
+    "استمتعوا بالإنترنت",
+    "شكرا على المشاهدة",
+    "شكراً على المشاهدة",
+    "لا تنسوا الاشتراك",
+];
+
+/// Standalone filler that is only ever a hallucination when it constitutes the
+/// entire segment. Unlike [`BOILERPLATE_PATTERNS`] these are matched against the
+/// whole trimmed string, because the same words are legitimate mid-sentence.
+///
+/// Whisper's Arabic "شكرا" attractor is the direct analogue of its English
+/// "Thank you." attractor on near-silent input.
+const STANDALONE_FILLER: &[&str] = &[
+    // English
+    "thank you",
+    "thank you.",
+    "thanks",
+    "you",
+    "bye",
+    "okay",
+    // Arabic — "thank you" in its common orthographic variants
+    "شكرا",
+    "شكراً",
+    "شكرا.",
+    "شكراً.",
+    "شكرا لك",
+    "شكراً لك",
+    "شكرا لكم",
+    "شكراً لكم",
+    "شكرا جزيلا",
+    "شكراً جزيلاً",
+];
+
+/// Strip trailing punctuation and Arabic tatweel so orthographic variants of the
+/// same filler word collapse to one form for comparison.
+fn normalize_for_filler_match(text: &str) -> String {
+    text.trim()
+        .trim_end_matches(|c: char| matches!(c, '.' | '!' | '?' | '،' | '؟' | '۔' | ',' | ' '))
+        .replace('\u{0640}', "") // ARABIC TATWEEL
+        .to_lowercase()
+}
+
+/// True when `text` is a whole-segment hallucination rather than speech.
+pub fn is_meaningless_output(text: &str) -> bool {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+
+    let lower = trimmed.to_lowercase();
+    if BOILERPLATE_PATTERNS
+        .iter()
+        .any(|pattern| lower.contains(pattern))
+    {
+        return true;
+    }
+
+    let normalized = normalize_for_filler_match(trimmed);
+    if STANDALONE_FILLER
+        .iter()
+        .any(|filler| normalized == normalize_for_filler_match(filler))
+    {
+        return true;
+    }
+
+    // A long string drawn from a handful of distinct characters is not speech.
+    let unique_chars: HashSet<char> = trimmed.chars().collect();
+    if unique_chars.len() <= MAX_UNIQUE_CHARS_FOR_JUNK
+        && trimmed.len() > MIN_LEN_FOR_UNIQUE_CHAR_CHECK
+    {
+        return true;
+    }
+
+    false
+}
+
+/// Collapse runs of an identical repeated word down to a single instance.
+fn remove_word_repetitions<'a>(words: &'a [&'a str]) -> Vec<&'a str> {
+    let mut cleaned_words = Vec::new();
+    let mut i = 0;
+
+    while i < words.len() {
+        let current_word = words[i];
+        let mut repeat_count = 1;
+
+        while i + repeat_count < words.len() && words[i + repeat_count] == current_word {
+            repeat_count += 1;
+        }
+
+        cleaned_words.push(current_word);
+        i += repeat_count;
+    }
+
+    cleaned_words
+}
+
+/// Collapse an immediately repeated phrase (2..=5 words) down to one instance.
+fn remove_phrase_repetitions<'a>(words: &'a [&'a str]) -> Vec<&'a str> {
+    if words.len() < MIN_WORDS_FOR_PHRASE_CHECK {
+        return words.to_vec();
+    }
+
+    let mut final_words = Vec::new();
+    let mut i = 0;
+
+    while i < words.len() {
+        let mut phrase_found = false;
+
+        for phrase_len in 2..=std::cmp::min(MAX_PHRASE_LEN, (words.len() - i) / 2) {
+            if i + phrase_len * 2 <= words.len() {
+                let phrase1 = &words[i..i + phrase_len];
+                let phrase2 = &words[i + phrase_len..i + phrase_len * 2];
+
+                if phrase1 == phrase2 {
+                    final_words.extend_from_slice(phrase1);
+                    i += phrase_len * 2;
+                    phrase_found = true;
+                    break;
+                }
+            }
+        }
+
+        if !phrase_found {
+            final_words.push(words[i]);
+            i += 1;
+        }
+    }
+
+    final_words
+}
+
+/// Share of words that are repeats of an earlier word, in 0.0..=1.0.
+fn calculate_repetition_ratio(text: &str) -> f32 {
+    let words: Vec<&str> = text.split_whitespace().collect();
+    if words.len() < MIN_WORDS_FOR_PHRASE_CHECK {
+        return 0.0;
+    }
+
+    let mut word_counts = HashMap::new();
+    for word in &words {
+        *word_counts.entry(word.to_lowercase()).or_insert(0usize) += 1;
+    }
+
+    let total_words = words.len() as f32;
+    let repeated_words: usize = word_counts
+        .values()
+        .map(|&count| count.saturating_sub(1))
+        .sum();
+
+    repeated_words as f32 / total_words
+}
+
+/// Clean one segment of ASR output. Returns an empty string when the segment
+/// should be discarded entirely.
+///
+/// Safe to call on output from any engine and in any language.
+pub fn clean_transcript_text(text: &str) -> String {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    if is_meaningless_output(trimmed) {
+        return String::new();
+    }
+
+    let words: Vec<&str> = trimmed.split_whitespace().collect();
+    if words.len() < MIN_WORDS_FOR_REPETITION_CHECK {
+        return trimmed.to_string();
+    }
+
+    let cleaned_words = remove_word_repetitions(&words);
+    let cleaned_words = remove_phrase_repetitions(&cleaned_words);
+
+    let final_text = cleaned_words.join(" ");
+    if calculate_repetition_ratio(&final_text) > MAX_REPETITION_RATIO {
+        return String::new();
+    }
+
+    // Re-check after collapsing: a repeated hallucination such as
+    // "شكرا شكرا شكرا" only becomes recognisable as standalone filler once the
+    // repetition has been removed.
+    if is_meaningless_output(&final_text) {
+        return String::new();
+    }
+
+    final_text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- the artifacts this module exists to remove -------------------------
+
+    #[test]
+    fn drops_arabic_subscribe_boilerplate() {
+        assert_eq!(clean_transcript_text("اشتركوا في القناة"), "");
+        assert_eq!(clean_transcript_text("ونشترك في القناة"), "");
+    }
+
+    #[test]
+    fn drops_arabic_subtitler_credit() {
+        assert_eq!(clean_transcript_text("ترجمة نانسي قنقر"), "");
+    }
+
+    #[test]
+    fn drops_standalone_arabic_thank_you_in_all_orthographies() {
+        for variant in ["شكرا", "شكراً", "شكرا لك", "شكراً جزيلاً", "شكرا."] {
+            assert_eq!(
+                clean_transcript_text(variant),
+                "",
+                "expected {variant:?} to be filtered"
+            );
+        }
+    }
+
+    #[test]
+    fn drops_english_boilerplate_as_before() {
+        assert_eq!(clean_transcript_text("Thanks for watching!"), "");
+        assert_eq!(clean_transcript_text("Please subscribe"), "");
+    }
+
+    // --- and what it must NOT remove ---------------------------------------
+
+    #[test]
+    fn keeps_arabic_thank_you_inside_a_real_sentence() {
+        let sentence = "شكرا لك على هذا العرض الممتاز سنراجعه غدا";
+        assert_eq!(clean_transcript_text(sentence), sentence);
+    }
+
+    #[test]
+    fn keeps_ordinary_arabic_speech() {
+        let sentence = "الرسائل هذه لابد أن يكون فيها أربع أشياء";
+        assert_eq!(clean_transcript_text(sentence), sentence);
+    }
+
+    #[test]
+    fn keeps_code_switched_arabic_english() {
+        let sentence = "لازم تكون في كل رسالة اللي هي four components";
+        assert_eq!(clean_transcript_text(sentence), sentence);
+    }
+
+    #[test]
+    fn keeps_short_genuine_replies() {
+        // Two words, below the repetition threshold — must pass through.
+        assert_eq!(clean_transcript_text("نعم صحيح"), "نعم صحيح");
+    }
+
+    // --- repetition behaviour ---------------------------------------------
+
+    #[test]
+    fn collapses_repeated_words() {
+        assert_eq!(
+            clean_transcript_text("the cat cat cat sat down"),
+            "the cat sat down"
+        );
+    }
+
+    #[test]
+    fn collapses_repeated_phrases() {
+        assert_eq!(
+            clean_transcript_text("we need to adopt we need to adopt this change"),
+            "we need to adopt this change"
+        );
+    }
+
+    #[test]
+    fn discards_fully_degenerate_repetition() {
+        assert_eq!(clean_transcript_text("شكرا شكرا شكرا شكرا شكرا"), "");
+    }
+
+    #[test]
+    fn empty_and_whitespace_are_empty() {
+        assert_eq!(clean_transcript_text(""), "");
+        assert_eq!(clean_transcript_text("   \n "), "");
+    }
+
+    #[test]
+    fn single_character_runs_are_junk() {
+        assert!(is_meaningless_output("aaaaaaaaaaaaaa"));
+        assert!(is_meaningless_output("............."));
+    }
+
+    #[test]
+    fn tatweel_variants_normalize_to_the_same_filler() {
+        // ARABIC TATWEEL stretches a word without changing it.
+        assert_eq!(clean_transcript_text("شكـــرا"), "");
+    }
+}

--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -479,7 +479,8 @@ async fn transcribe_chunk_with_provider<R: Runtime>(
         TranscriptionEngine::Parakeet(parakeet_engine) => {
             match parakeet_engine.transcribe_audio(speech_samples).await {
                 Ok(text) => {
-                    let cleaned_text = text.trim().to_string();
+                    // Same hallucination filtering the local-Whisper path gets.
+                    let cleaned_text = super::text_cleanup::clean_transcript_text(&text);
                     if cleaned_text.is_empty() {
                         return Ok((String::new(), None, false));
                     }
@@ -518,7 +519,10 @@ async fn transcribe_chunk_with_provider<R: Runtime>(
 
             match provider.transcribe(speech_samples, language).await {
                 Ok(result) => {
-                    let cleaned_text = result.text.trim().to_string();
+                    // Same hallucination filtering the local-Whisper path gets.
+                    // Cloud providers hand back Whisper's subtitle-corpus artifacts
+                    // verbatim, so this is where they get removed.
+                    let cleaned_text = super::text_cleanup::clean_transcript_text(&result.text);
                     if cleaned_text.is_empty() {
                         return Ok((String::new(), result.confidence, result.is_partial));
                     }

--- a/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
+++ b/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
@@ -398,155 +398,6 @@ impl WhisperEngine {
         self.current_context.read().await.is_some()
     }
     
-    // Enhanced function to clean repetitive text patterns and meaningless outputs
-    fn clean_repetitive_text(text: &str) -> String {
-        if text.is_empty() {
-            return String::new();
-        }
-
-        // Check for obviously meaningless patterns first
-        if Self::is_meaningless_output(text) {
-            // Performance optimization: reduce meaningless output logging to debug level
-            perf_debug!("Detected meaningless output, returning empty: '{}'", text);
-            return String::new();
-        }
-
-        let words: Vec<&str> = text.split_whitespace().collect();
-        if words.len() < 3 {
-            return text.to_string();
-        }
-
-        // Enhanced repetition detection with sliding window
-        let cleaned_words = Self::remove_word_repetitions(&words);
-
-        // Remove phrase repetitions with more sophisticated detection
-        let cleaned_words = Self::remove_phrase_repetitions(&cleaned_words);
-
-        // Check for overall repetition ratio
-        let final_text = cleaned_words.join(" ");
-        if Self::calculate_repetition_ratio(&final_text) > 0.7 {
-            // Performance optimization: reduce repetition ratio logging to debug level
-            perf_debug!("High repetition ratio detected, filtering out: '{}'", final_text);
-            return String::new();
-        }
-
-        final_text
-    }
-
-    // Check for obviously meaningless patterns
-    fn is_meaningless_output(text: &str) -> bool {
-        let text_lower = text.to_lowercase();
-
-        // Check for common meaningless patterns
-        let meaningless_patterns = [
-            "thank you for watching",
-            "thanks for watching",
-            "like and subscribe",
-            "music playing",
-            "applause",
-            "laughter",
-            "um um um",
-            "uh uh uh",
-            "ah ah ah",
-        ];
-
-        for pattern in &meaningless_patterns {
-            if text_lower.contains(pattern) {
-                return true;
-            }
-        }
-
-        // Check if text is mostly the same character or very short repetitive patterns
-        let unique_chars: HashSet<char> = text.chars().collect();
-        if unique_chars.len() <= 3 && text.len() > 10 {
-            return true;
-        }
-
-        false
-    }
-
-    // Enhanced word repetition removal
-    fn remove_word_repetitions<'a>(words: &'a [&'a str]) -> Vec<&'a str> {
-        let mut cleaned_words = Vec::new();
-        let mut i = 0;
-
-        while i < words.len() {
-            let current_word = words[i];
-            let mut repeat_count = 1;
-
-            // Count consecutive repetitions of the same word
-            while i + repeat_count < words.len() && words[i + repeat_count] == current_word {
-                repeat_count += 1;
-            }
-
-            // Be more aggressive: if word is repeated 2+ times, only keep one instance
-            if repeat_count >= 2 {
-                cleaned_words.push(current_word);
-                i += repeat_count;
-            } else {
-                cleaned_words.push(current_word);
-                i += 1;
-            }
-        }
-
-        cleaned_words
-    }
-
-    // Enhanced phrase repetition removal with variable length detection
-    fn remove_phrase_repetitions<'a>(words: &'a [&'a str]) -> Vec<&'a str> {
-        if words.len() < 4 {
-            return words.to_vec();
-        }
-
-        let mut final_words = Vec::new();
-        let mut i = 0;
-
-        while i < words.len() {
-            let mut phrase_found = false;
-
-            // Check for 2-word to 5-word phrase repetitions
-            for phrase_len in 2..=std::cmp::min(5, (words.len() - i) / 2) {
-                if i + phrase_len * 2 <= words.len() {
-                    let phrase1 = &words[i..i + phrase_len];
-                    let phrase2 = &words[i + phrase_len..i + phrase_len * 2];
-
-                    if phrase1 == phrase2 {
-                        // Add the phrase once and skip the repetition
-                        final_words.extend_from_slice(phrase1);
-                        i += phrase_len * 2;
-                        phrase_found = true;
-                        break;
-                    }
-                }
-            }
-
-            if !phrase_found {
-                final_words.push(words[i]);
-                i += 1;
-            }
-        }
-
-        final_words
-    }
-
-    // Calculate repetition ratio in text
-    fn calculate_repetition_ratio(text: &str) -> f32 {
-        let words: Vec<&str> = text.split_whitespace().collect();
-        if words.len() < 4 {
-            return 0.0;
-        }
-
-        let mut word_counts = HashMap::new();
-        for word in &words {
-            *word_counts.entry(word.to_lowercase()).or_insert(0) += 1;
-        }
-
-        let total_words = words.len() as f32;
-        let repeated_words: usize = word_counts.values().map(|&count| if count > 1 { count - 1 } else { 0 }).sum();
-
-        repeated_words as f32 / total_words
-    }
-    
     /// Transcribe audio with streaming support for partial results and adaptive quality
     pub async fn transcribe_audio_with_confidence(&self, audio_data: Vec<f32>, language: Option<String>) -> Result<(String, f32, bool)> {
         let ctx_lock = self.current_context.read().await;
@@ -654,7 +505,8 @@ impl WhisperEngine {
         }
 
         let final_result = result.trim().to_string();
-        let cleaned_result = Self::clean_repetitive_text(&final_result);
+        let cleaned_result =
+            crate::audio::transcription::text_cleanup::clean_transcript_text(&final_result);
 
         let avg_confidence = if segment_count > 0 {
             total_confidence / segment_count as f32
@@ -814,7 +666,8 @@ impl WhisperEngine {
         let final_result = result.trim().to_string();
 
         // Check for repetition loops and clean them up
-        let cleaned_result = Self::clean_repetitive_text(&final_result);
+        let cleaned_result =
+            crate::audio::transcription::text_cleanup::clean_transcript_text(&final_result);
 
         // Performance optimization: smart logging for transcription results
         if cleaned_result.is_empty() {


### PR DESCRIPTION
Follow-up to #679, split out per review so the VAD fix and this transcript-output policy change are reviewed independently.

## What this fixes

Hallucination filtering only ran on local Whisper, and only knew English.

`clean_repetitive_text` and `is_meaningless_output` were private associated functions on `WhisperEngine`. The Parakeet arm and the provider (cloud) arm in `worker.rs` both stored `result.text.trim()` verbatim, so they got no filtering at all. The denylist was also entirely English (`"thank you for watching"`, `"like and subscribe"`, `"applause"`).

Net effect: an English meeting got cleaned and a non-English meeting did not. A real 26-minute Arabic recording stored these unfiltered:

| stored text | what it is |
|---|---|
| `اشتركوا في القناة` | "subscribe to the channel" |
| `ترجمة نانسي قنقر` | a subtitler credit, on a 0.15 s clip |
| `شكرا` x14 | standalone - the Arabic analogue of Whisper's English "Thank you." attractor |

## What changed

- **new** `audio/transcription/text_cleanup.rs` - the cleanup routines extracted into one module and called from all three engine arms (local Whisper, Parakeet, remote providers), with Arabic patterns added alongside the English ones and grouped by language so further languages are additive.
- `whisper_engine.rs` - the now-shared code removed; delegates to the new module. (This is why the diff is move-heavy: ~155 lines relocated out of here.)
- `worker.rs` - the Parakeet and provider arms now call `text_cleanup::clean_transcript_text` instead of storing raw text. **No change to the confidence gate** - the `0.3` threshold removed by #681 is not touched or reintroduced here.
- `transcription/mod.rs` - registers the new module.

### Behaviour, and the #675 correction

An earlier version of this work (in the original #679) included a standalone-filler denylist that dropped `"thank you"`, `"okay"`, `"thanks"`, `"you"`, `"bye"` and Arabic `شكرا` when they were a whole segment. That was **reverted** before this split: nothing in the text distinguishes `شكرا` decoded from 300 ms of silence from `شكرا` a participant actually said, so the list traded a cosmetic problem for a semantic one - and #675 is that exact failure already reported. Short-clip hallucination belongs in the provider layer gating on Whisper's own `avg_logprob` / `compression_ratio`, not in a text denylist.

What this PR filters by text is only **unambiguous multi-word boilerplate** (`اشتركوا في القناة`, subtitler credits, `thanks for watching`, `like and subscribe`) - phrases no meeting contains, so there is no genuine reading to lose.

Degenerate repetition is still caught language-agnostically: the repetition ratio is measured on the **original** text rather than after collapsing (measuring after collapsing hid it - a collapsed run leaves one word, ratio zero). `شكرا شكرا شكرا شكرا شكرا` is still discarded without the code needing to know what the word means.

## Verification

```
$ cargo test --lib text_cleanup

running 14 tests
test audio::transcription::text_cleanup::tests::drops_arabic_subscribe_boilerplate ... ok
test audio::transcription::text_cleanup::tests::drops_arabic_subtitler_credit ... ok
test audio::transcription::text_cleanup::tests::drops_english_boilerplate_as_before ... ok
test audio::transcription::text_cleanup::tests::empty_and_whitespace_are_empty ... ok
test audio::transcription::text_cleanup::tests::discards_fully_degenerate_repetition ... ok
test audio::transcription::text_cleanup::tests::keeps_arabic_thank_you_inside_a_real_sentence ... ok
test audio::transcription::text_cleanup::tests::collapses_repeated_phrases ... ok
test audio::transcription::text_cleanup::tests::collapses_repeated_words ... ok
test audio::transcription::text_cleanup::tests::keeps_code_switched_arabic_english ... ok
test audio::transcription::text_cleanup::tests::keeps_ordinary_arabic_speech ... ok
test audio::transcription::text_cleanup::tests::keeps_short_acknowledgements_issue_675 ... ok
test audio::transcription::text_cleanup::tests::keeps_short_genuine_replies ... ok
test audio::transcription::text_cleanup::tests::keeps_tatweel_stretched_words ... ok
test audio::transcription::text_cleanup::tests::single_character_runs_are_junk ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 212 filtered out
```

`keeps_short_acknowledgements_issue_675` asserts that `OK`, `Yes`, `No`, `Sure`, `Got it`, `Thanks`, `Okay.`, `Bye` plus `شكرا`, `شكراً`, `شكرا لك`, `نعم`, `طيب`, `لا` and a tatweel-stretched `شكـــرا` all survive cleaning unchanged - i.e. this PR does not make #675 worse from a second direction.

The 14 tests cover both directions deliberately: the artifacts that must be removed, and ordinary Arabic, code-switched Arabic/English, and short genuine replies that must survive.

## Note on diff size

The diff is ~506 changed lines, but ~155 of the deletions are code relocated verbatim out of `whisper_engine.rs` into the new module; net new logic is small. Happy to split further if you'd prefer the extraction and the cross-provider wiring in separate commits, but they don't stand alone cleanly.
