### PR TITLE
fix(parakeet): harden recovery after PR #682

### DIFF
--- a/frontend/src-tauri/src/parakeet_engine/commands.rs
+++ b/frontend/src-tauri/src/parakeet_engine/commands.rs
@@ -1,8 +1,7 @@
-use crate::parakeet_engine::{ModelInfo, ModelStatus, ParakeetEngine, DownloadProgress};
+use crate::parakeet_engine::{DownloadProgress, ModelInfo, ParakeetEngine};
 use std::path::PathBuf;
-use std::sync::Mutex;
-use std::sync::Arc;
-use tauri::{command, Emitter, AppHandle, Manager, Runtime};
+use std::sync::{Arc, Mutex};
+use tauri::{command, AppHandle, Emitter, Manager, Runtime};
 
 // Global parakeet engine
 pub static PARAKEET_ENGINE: Mutex<Option<Arc<ParakeetEngine>>> = Mutex::new(None);
@@ -508,30 +507,9 @@ pub async fn parakeet_retry_download<R: Runtime>(
         guard.as_ref().cloned()
     };
 
-    if let Some(engine) = engine {
-        // DEFENSIVE: Ensure clean state before retry
-        // This handles any edge cases where error handler didn't complete
-        {
-            let mut active = engine.active_downloads.write().await;
-            if active.contains(&model_name) {
-                log::warn!("Retry: Model {} was still in active downloads, removing", model_name);
-                active.remove(&model_name);
-            }
-        }
-
-        // DEFENSIVE: Force model status to Missing to allow fresh download
-        {
-            let mut models = engine.available_models.write().await;
-            if let Some(model) = models.get_mut(&model_name) {
-                log::info!("Retry: Resetting model {} status from {:?} to Missing", model_name, model.status);
-                model.status = ModelStatus::Missing;
-            }
-        }
-
-        // Rediscover models to refresh state based on disk files
-        let _ = engine.discover_models().await;
-
-        // Call regular download (emits events)
+    if engine.is_some() {
+        // 重试必须复用常规下载入口的原子 active 注册；旧 worker 退出前不能强删标记，
+        // 否则取消后立即重试会让两个任务并发写入同一个 artifact。
         parakeet_download_model(app_handle, model_name).await
     } else {
         Err("Parakeet engine not initialized".to_string())

--- a/frontend/src-tauri/src/parakeet_engine/commands.rs
+++ b/frontend/src-tauri/src/parakeet_engine/commands.rs
@@ -1,3 +1,4 @@
+use crate::parakeet_engine::parakeet_engine::{is_download_cancelled, CancelDownloadOutcome};
 use crate::parakeet_engine::{DownloadProgress, ModelInfo, ParakeetEngine};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -443,18 +444,34 @@ pub async fn parakeet_download_model<R: Runtime>(
 
                 Ok(())
             }
-            Err(e) => {
-                // Emit error event
-                if let Err(emit_e) = app_handle.emit(
+            Err(error) if is_download_cancelled(&error) => {
+                if let Err(emit_error) = app_handle.emit(
+                    "parakeet-model-download-progress",
+                    serde_json::json!({
+                        "modelName": model_name,
+                        "progress": 0,
+                        "status": "cancelled"
+                    }),
+                ) {
+                    log::error!(
+                        "Failed to emit Parakeet cancellation event: {}",
+                        emit_error
+                    );
+                }
+                log::info!("Parakeet download cancelled: {}", model_name);
+                Ok(())
+            }
+            Err(error) => {
+                if let Err(emit_error) = app_handle.emit(
                     "parakeet-model-download-error",
                     serde_json::json!({
                         "modelName": model_name,
-                        "error": e.to_string()
+                        "error": error.to_string()
                     }),
                 ) {
-                    log::error!("Failed to emit parakeet download error event: {}", emit_e);
+                    log::error!("Failed to emit parakeet download error event: {}", emit_error);
                 }
-                Err(format!("Failed to download Parakeet model: {}", e))
+                Err(format!("Failed to download Parakeet model: {}", error))
             }
         }
     } else {
@@ -463,36 +480,19 @@ pub async fn parakeet_download_model<R: Runtime>(
 }
 
 #[command]
-pub async fn parakeet_cancel_download<R: Runtime>(
-    app_handle: AppHandle<R>,
+pub async fn parakeet_cancel_download(
     model_name: String,
-) -> Result<(), String> {
+) -> Result<CancelDownloadOutcome, String> {
     let engine = {
         let guard = PARAKEET_ENGINE.lock().unwrap();
         guard.as_ref().cloned()
     };
 
-    if let Some(engine) = engine {
-        engine
-            .cancel_download(&model_name)
-            .await
-            .map_err(|e| format!("Failed to cancel Parakeet download: {}", e))?;
-
-        // Emit cancellation event to update UI (global toast and component state)
-        let _ = app_handle.emit(
-            "parakeet-model-download-progress",
-            serde_json::json!({
-                "modelName": model_name,
-                "progress": 0,
-                "status": "cancelled"
-            }),
-        );
-
-        log::info!("Parakeet download cancelled: {}", model_name);
-        Ok(())
-    } else {
-        Err("Parakeet engine not initialized".to_string())
-    }
+    let engine = engine.ok_or_else(|| "Parakeet engine not initialized".to_string())?;
+    engine
+        .cancel_download(&model_name)
+        .await
+        .map_err(|error| format!("Failed to cancel Parakeet download: {}", error))
 }
 
 #[command]
@@ -508,8 +508,8 @@ pub async fn parakeet_retry_download<R: Runtime>(
     };
 
     if engine.is_some() {
-        // 重试必须复用常规下载入口的原子 active 注册；旧 worker 退出前不能强删标记，
-        // 否则取消后立即重试会让两个任务并发写入同一个 artifact。
+        // Retry uses the normal download entrypoint, whose owner reservation rejects
+        // a second writer until cancellation cleanup has completed.
         parakeet_download_model(app_handle, model_name).await
     } else {
         Err("Parakeet engine not initialized".to_string())

--- a/frontend/src-tauri/src/parakeet_engine/parakeet_engine.rs
+++ b/frontend/src-tauri/src/parakeet_engine/parakeet_engine.rs
@@ -1,17 +1,18 @@
 use crate::parakeet_engine::model::ParakeetModel;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs;
 use tokio::io::{AsyncWriteExt, BufWriter};
 use std::time::{Duration, Instant};
-use tokio::sync::RwLock;
+use tokio::sync::{watch, Mutex, RwLock};
 use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
 
 /// Quantization type for Parakeet models
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum QuantizationType {
     FP32,   // Full precision
     Int8,   // 8-bit integer quantization (faster)
@@ -80,6 +81,139 @@ pub struct ModelInfo {
     pub description: String,
 }
 
+#[derive(Clone, Copy)]
+struct ArtifactSpec {
+    filename: &'static str,
+    exact_bytes: u64,
+}
+
+struct ModelSpec {
+    name: &'static str,
+    size_mb: u32,
+    quantization: QuantizationType,
+    speed: &'static str,
+    description: &'static str,
+    source_base_url: &'static str,
+    artifacts: &'static [ArtifactSpec],
+}
+
+impl ModelSpec {
+    fn exact_bytes(&self) -> u64 {
+        self.artifacts.iter().map(|artifact| artifact.exact_bytes).sum()
+    }
+}
+
+const PARAKEET_V3_ARTIFACTS: &[ArtifactSpec] = &[
+    ArtifactSpec { filename: "encoder-model.int8.onnx", exact_bytes: 652_183_999 },
+    ArtifactSpec { filename: "decoder_joint-model.int8.onnx", exact_bytes: 18_202_004 },
+    ArtifactSpec { filename: "nemo128.onnx", exact_bytes: 139_764 },
+    ArtifactSpec { filename: "vocab.txt", exact_bytes: 93_939 },
+];
+
+const PARAKEET_V2_ARTIFACTS: &[ArtifactSpec] = &[
+    ArtifactSpec { filename: "encoder-model.int8.onnx", exact_bytes: 652_184_014 },
+    ArtifactSpec { filename: "decoder_joint-model.int8.onnx", exact_bytes: 8_998_286 },
+    ArtifactSpec { filename: "nemo128.onnx", exact_bytes: 139_764 },
+    ArtifactSpec { filename: "vocab.txt", exact_bytes: 9_384 },
+];
+
+const PARAKEET_MODEL_SPECS: &[ModelSpec] = &[
+    ModelSpec {
+        name: "parakeet-tdt-0.6b-v3-int8",
+        size_mb: 670,
+        quantization: QuantizationType::Int8,
+        speed: "Ultra Fast (v3)",
+        description: "Real time on M4 Max, latest version with int8 quantization",
+        source_base_url: "https://meetily.towardsgeneralintelligence.com/models/parakeet-tdt-0.6b-v3-onnx",
+        artifacts: PARAKEET_V3_ARTIFACTS,
+    },
+    ModelSpec {
+        name: "parakeet-tdt-0.6b-v2-int8",
+        size_mb: 661,
+        quantization: QuantizationType::Int8,
+        speed: "Fast (v2)",
+        description: "Previous version with int8 quantization, good balance of speed and accuracy",
+        source_base_url: "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v2-onnx/resolve/0bbb45a3365852604aef28b538a8f066f4ccaa85",
+        artifacts: PARAKEET_V2_ARTIFACTS,
+    },
+];
+
+fn find_model_spec(model_name: &str) -> Option<&'static ModelSpec> {
+    PARAKEET_MODEL_SPECS
+        .iter()
+        .find(|spec| spec.name == model_name)
+}
+
+struct ActiveDownload {
+    cancellation: CancellationToken,
+    completion: watch::Sender<bool>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Download cancelled by user")]
+pub(crate) struct DownloadCancelled;
+
+pub(crate) fn is_download_cancelled(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<DownloadCancelled>().is_some()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CancelDownloadOutcome {
+    Cancelled,
+    Pending,
+}
+
+const CANCEL_DOWNLOAD_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[cfg(test)]
+struct DownloadStateTestHook {
+    finalization_ready: tokio::sync::Notify,
+    continue_finalization: tokio::sync::Notify,
+}
+
+enum ContentRange {
+    Range { start: u64, end: u64, total: u64 },
+    Unsatisfied { total: u64 },
+}
+
+fn parse_content_range(value: &reqwest::header::HeaderValue) -> Result<ContentRange> {
+    let value = value
+        .to_str()
+        .map_err(|e| anyhow!("Invalid Content-Range header encoding: {}", e))?;
+    let value = value
+        .strip_prefix("bytes ")
+        .ok_or_else(|| anyhow!("Content-Range must use bytes: {}", value))?;
+
+    if let Some(total) = value.strip_prefix("*/") {
+        return total
+            .parse()
+            .map(|total| ContentRange::Unsatisfied { total })
+            .map_err(|e| anyhow!("Invalid unsatisfied Content-Range total: {}", e));
+    }
+
+    let (range, total) = value
+        .split_once('/')
+        .ok_or_else(|| anyhow!("Malformed Content-Range: {}", value))?;
+    let (start, end) = range
+        .split_once('-')
+        .ok_or_else(|| anyhow!("Malformed Content-Range range: {}", value))?;
+    let start = start
+        .parse()
+        .map_err(|e| anyhow!("Invalid Content-Range start: {}", e))?;
+    let end = end
+        .parse()
+        .map_err(|e| anyhow!("Invalid Content-Range end: {}", e))?;
+    let total = total
+        .parse()
+        .map_err(|e| anyhow!("Invalid Content-Range total: {}", e))?;
+    if start > end {
+        return Err(anyhow!("Content-Range start exceeds end: {}", value));
+    }
+
+    Ok(ContentRange::Range { start, end, total })
+}
+
 #[derive(Debug)]
 pub enum ParakeetEngineError {
     ModelNotLoaded,
@@ -116,9 +250,9 @@ pub struct ParakeetEngine {
     current_model: Arc<RwLock<Option<ParakeetModel>>>,
     current_model_name: Arc<RwLock<Option<String>>>,
     pub(crate) available_models: Arc<RwLock<HashMap<String, ModelInfo>>>,
-    cancelled_downloads: Arc<RwLock<HashSet<String>>>, // Models with pending cancellation requests
-    // Active downloads tracking to prevent concurrent downloads
-    pub(crate) active_downloads: Arc<RwLock<HashSet<String>>>, // Set of models currently being downloaded
+    active_downloads: Arc<Mutex<HashMap<String, Arc<ActiveDownload>>>>,
+    #[cfg(test)]
+    download_state_test_hook: Mutex<Option<Arc<DownloadStateTestHook>>>,
 }
 
 impl ParakeetEngine {
@@ -157,98 +291,58 @@ impl ParakeetEngine {
             current_model: Arc::new(RwLock::new(None)),
             current_model_name: Arc::new(RwLock::new(None)),
             available_models: Arc::new(RwLock::new(HashMap::new())),
-            cancelled_downloads: Arc::new(RwLock::new(HashSet::new())),
-            // Initialize active downloads tracking
-            active_downloads: Arc::new(RwLock::new(HashSet::new())),
+            active_downloads: Arc::new(Mutex::new(HashMap::new())),
+            #[cfg(test)]
+            download_state_test_hook: Mutex::new(None),
         })
     }
 
-    /// Discover available Parakeet models
+    #[cfg(test)]
+    async fn test_hook(&self) -> Option<Arc<DownloadStateTestHook>> {
+        self.download_state_test_hook.lock().await.clone()
+    }
+
+    /// Discover available Parakeet models.
     pub async fn discover_models(&self) -> Result<Vec<ModelInfo>> {
-        let models_dir = &self.models_dir;
-        let mut models = Vec::new();
+        let mut models = Vec::with_capacity(PARAKEET_MODEL_SPECS.len());
 
-        // Parakeet model configurations
-        // Model name format: parakeet-tdt-0.6b-v{version}-{quantization}
-        // Sizes match actual download sizes (encoder + decoder + preprocessor + vocab)
-        let model_configs = [
-            ("parakeet-tdt-0.6b-v3-int8", 670, QuantizationType::Int8, "Ultra Fast (v3)", "Real time on M4 Max, latest version with int8 quantization"),
-            ("parakeet-tdt-0.6b-v2-int8", 661, QuantizationType::Int8, "Fast (v2)", "Previous version with int8 quantization, good balance of speed and accuracy"),
-        ];
-
-        // Get active downloads to override status
-        let active_downloads = self.active_downloads.read().await;
-
-        for (name, size_mb, quantization, speed, description) in model_configs {
-            let model_path = models_dir.join(name);
-
-            // Check if model is currently downloading
-            let status = if active_downloads.contains(name) {
-                // If downloading, preserve that status regardless of file system
-                // We don't know the exact progress here without more state, but 0 is safe fallback
-                // The progress events will update the UI
+        for spec in PARAKEET_MODEL_SPECS {
+            let model_path = self.models_dir.join(spec.name);
+            let is_downloading = self.active_downloads.lock().await.contains_key(spec.name);
+            let status = if is_downloading {
                 ModelStatus::Downloading { progress: 0 }
             } else if model_path.exists() {
-                // Check for required ONNX files
-                let required_files = match quantization {
-                    QuantizationType::Int8 => vec![
-                        "encoder-model.int8.onnx",
-                        "decoder_joint-model.int8.onnx",
-                        "nemo128.onnx",
-                        "vocab.txt",
-                    ],
-                    QuantizationType::FP32 => vec![
-                        "encoder-model.onnx",
-                        "decoder_joint-model.onnx",
-                        "nemo128.onnx",
-                        "vocab.txt",
-                    ],
-                };
-
-                let all_files_exist = required_files.iter().all(|file| {
-                    model_path.join(file).exists()
-                });
-
-                if all_files_exist {
-                    // Validate model by checking file sizes
-                    match self.validate_model_directory(&model_path).await {
-                        Ok(_) => ModelStatus::Available,
-                        Err(_) => {
-                            log::warn!("Model directory {} appears corrupted", name);
-                            // Calculate total size of existing files
-                            let mut total_size = 0u64;
-                            for file in required_files {
-                                if let Ok(metadata) = std::fs::metadata(model_path.join(file)) {
-                                    total_size += metadata.len();
-                                }
-                            }
-                            ModelStatus::Corrupted {
-                                file_size: total_size,
-                                expected_min_size: (size_mb as u64) * 1024 * 1024,
-                            }
+                match Self::validate_model_directory(&model_path, spec.artifacts) {
+                    Ok(()) => ModelStatus::Available,
+                    Err(error) => {
+                        let file_size = spec
+                            .artifacts
+                            .iter()
+                            .filter_map(|artifact| std::fs::metadata(model_path.join(artifact.filename)).ok())
+                            .map(|metadata| metadata.len())
+                            .sum();
+                        log::warn!("Model directory {} appears corrupted: {}", spec.name, error);
+                        ModelStatus::Corrupted {
+                            file_size,
+                            expected_min_size: spec.exact_bytes(),
                         }
                     }
-                } else {
-                    ModelStatus::Missing
                 }
             } else {
                 ModelStatus::Missing
             };
 
-            let model_info = ModelInfo {
-                name: name.to_string(),
+            models.push(ModelInfo {
+                name: spec.name.to_string(),
                 path: model_path,
-                size_mb: size_mb as u32,
-                quantization: quantization.clone(),
-                speed: speed.to_string(),
+                size_mb: spec.size_mb,
+                quantization: spec.quantization,
+                speed: spec.speed.to_string(),
                 status,
-                description: description.to_string(),
-            };
-
-            models.push(model_info);
+                description: spec.description.to_string(),
+            });
         }
 
-        // Update internal cache
         let mut available_models = self.available_models.write().await;
         available_models.clear();
         for model in &models {
@@ -258,92 +352,22 @@ impl ParakeetEngine {
         Ok(models)
     }
 
-    /// Validate model directory by checking if all required files exist AND have valid sizes
-    async fn validate_model_directory(&self, model_dir: &PathBuf) -> Result<()> {
-        // Check if vocab.txt exists and is readable
-        let vocab_path = model_dir.join("vocab.txt");
-        if !vocab_path.exists() {
-            return Err(anyhow!("vocab.txt not found"));
-        }
-
-        // Determine which files to check based on what exists
-        let is_int8 = model_dir.join("encoder-model.int8.onnx").exists();
-        let is_fp32 = model_dir.join("encoder-model.onnx").exists();
-
-        if !is_int8 && !is_fp32 {
-            return Err(anyhow!("No ONNX model files found"));
-        }
-
-        // Check preprocessor
-        if !model_dir.join("nemo128.onnx").exists() {
-            return Err(anyhow!("Preprocessor (nemo128.onnx) not found"));
-        }
-
-        // Define minimum file sizes (90% of expected to allow some variance)
-        // These are critical to catch partial downloads that would crash on load
-        let expected_sizes: Vec<(&str, u64)> = if is_int8 {
-            vec![
-                ("encoder-model.int8.onnx", 580_000_000),    // ~652 MB, min 580 MB (89%)
-                ("decoder_joint-model.int8.onnx", 8_000_000), // ~18 MB, min 8 MB
-                ("nemo128.onnx", 100_000),                    // ~140 KB, min 100 KB
-                ("vocab.txt", 5_000),                         // ~94 KB, min 5 KB
-            ]
-        } else {
-            vec![
-                ("encoder-model.onnx", 2_200_000_000),        // ~2.44 GB, min 2.2 GB
-                ("decoder_joint-model.onnx", 65_000_000),     // ~72 MB, min 65 MB
-                ("nemo128.onnx", 100_000),                    // ~140 KB, min 100 KB
-                ("vocab.txt", 5_000),                         // ~94 KB, min 5 KB
-            ]
-        };
-
-        // Validate each file exists AND has sufficient size
-        for (filename, min_size) in expected_sizes {
-            let file_path = model_dir.join(filename);
-            if !file_path.exists() {
-                return Err(anyhow!("{} not found", filename));
-            }
-
-            match std::fs::metadata(&file_path) {
-                Ok(metadata) => {
-                    let actual_size = metadata.len();
-                    if actual_size < min_size {
-                        return Err(anyhow!(
-                            "{} is incomplete: {} bytes (expected at least {} bytes)",
-                            filename,
-                            actual_size,
-                            min_size
-                        ));
-                    }
-                }
-                Err(e) => {
-                    return Err(anyhow!("Failed to read {} metadata: {}", filename, e));
-                }
+    fn validate_model_directory(model_dir: &Path, artifacts: &[ArtifactSpec]) -> Result<()> {
+        for artifact in artifacts {
+            let path = model_dir.join(artifact.filename);
+            let metadata = std::fs::metadata(&path)
+                .map_err(|error| anyhow!("Failed to read {} metadata: {}", artifact.filename, error))?;
+            if metadata.len() != artifact.exact_bytes {
+                return Err(anyhow!(
+                    "{} has {} bytes, expected exactly {} bytes",
+                    artifact.filename,
+                    metadata.len(),
+                    artifact.exact_bytes
+                ));
             }
         }
 
         Ok(())
-    }
-
-    /// Count bytes that can be reused by the per-file skip/resume logic.
-    async fn existing_artifact_bytes(
-        model_dir: &Path,
-        filenames: &[&str],
-        expected_sizes: &HashMap<&str, u64>,
-    ) -> u64 {
-        let mut reusable_bytes = 0;
-        for filename in filenames {
-            let file_path = model_dir.join(filename);
-            if let (Ok(metadata), Some(expected_size)) =
-                (fs::metadata(&file_path).await, expected_sizes.get(filename))
-            {
-                // 这些尺寸是近似值，只能用于进度估算，不能据此删除文件；
-                // 缺失、偏小或版本变化后的偏大 artifact 都交给逐文件下载/校验流程处理。
-                reusable_bytes += metadata.len().min(*expected_size);
-            }
-        }
-
-        reusable_bytes
     }
 
     /// Load a Parakeet model
@@ -499,707 +523,1159 @@ impl ParakeetEngine {
         }
     }
 
-    /// Download a Parakeet model from HuggingFace (backward-compatible wrapper)
+    /// Download a Parakeet model from HuggingFace (backward-compatible wrapper).
     pub async fn download_model(
         &self,
         model_name: &str,
         progress_callback: Option<Box<dyn Fn(u8) + Send>>,
     ) -> Result<()> {
-        // Wrap simple callback to use detailed version
-        let detailed_callback: Option<Box<dyn Fn(DownloadProgress) + Send>> =
-            progress_callback.map(|cb| {
-                Box::new(move |p: DownloadProgress| cb(p.percent)) as Box<dyn Fn(DownloadProgress) + Send>
-            });
+        let detailed_callback = progress_callback.map(|callback| {
+            Box::new(move |progress: DownloadProgress| callback(progress.percent))
+                as Box<dyn Fn(DownloadProgress) + Send>
+        });
         self.download_model_detailed(model_name, detailed_callback).await
     }
 
-    /// Download a Parakeet model with detailed progress (MB/speed/resume support)
+    /// Download a catalogued Parakeet model with detailed progress.
     pub async fn download_model_detailed(
         &self,
         model_name: &str,
         progress_callback: Option<Box<dyn Fn(DownloadProgress) + Send>>,
     ) -> Result<()> {
-        log::info!("Starting download for Parakeet model: {}", model_name);
+        let model_info = self
+            .available_models
+            .read()
+            .await
+            .get(model_name)
+            .cloned()
+            .ok_or_else(|| anyhow!("Model {} not found", model_name))?;
+        let spec = find_model_spec(model_name)
+            .ok_or_else(|| anyhow!("Unsupported Parakeet model: {}", model_name))?;
 
-        // 检查与注册必须在同一写锁内完成，避免两个重试任务同时通过检查并写入同一个 artifact。
-        {
-            let mut active = self.active_downloads.write().await;
-            if active.contains(model_name) {
-                log::warn!(
-                    "Download already in progress for Parakeet model: {}",
-                    model_name
-                );
-                return Err(anyhow!(
-                    "Download already in progress for model: {}",
-                    model_name
-                ));
-            }
-
-            // cancel_download 采用相同的 active -> cancelled 锁顺序；因此这里清理的只能是
-            // 上一次任务留下的请求，新取消请求会在注册完成后写入，不会被启动流程吞掉。
-            self.cancelled_downloads.write().await.remove(model_name);
-            active.insert(model_name.to_string());
-        }
-
-        let result = self
-            .download_model_detailed_inner(model_name, progress_callback)
-            .await;
-
-        // active 标记由最外层统一释放，确保 TLS、代理、文件 I/O 和取消等所有返回路径
-        // 都不会遗留“already in progress”，也不会在 worker 尚未退出时过早允许重试。
-        if result.is_err() {
-            let mut models = self.available_models.write().await;
-            if let Some(model) = models.get_mut(model_name) {
-                model.status = ModelStatus::Missing;
-            }
-        }
-        self.active_downloads.write().await.remove(model_name);
-
-        result
+        self.download_model_detailed_from_source(
+            model_name,
+            &model_info.path,
+            spec.source_base_url,
+            spec.artifacts,
+            progress_callback,
+        )
+        .await
     }
 
-    async fn download_model_detailed_inner(
+    async fn reserve_active_download(&self, model_name: &str) -> Result<Arc<ActiveDownload>> {
+        let mut active_downloads = self.active_downloads.lock().await;
+        if active_downloads.contains_key(model_name) {
+            return Err(anyhow!("Download already in progress for model: {}", model_name));
+        }
+
+        let (completion, _) = watch::channel(false);
+        let active_download = Arc::new(ActiveDownload {
+            cancellation: CancellationToken::new(),
+            completion,
+        });
+        active_downloads.insert(model_name.to_string(), Arc::clone(&active_download));
+        Ok(active_download)
+    }
+
+    async fn set_downloading_status(&self, model_name: &str, progress: u8) {
+        let mut models = self.available_models.write().await;
+        if let Some(model) = models.get_mut(model_name) {
+            model.status = ModelStatus::Downloading { progress };
+        }
+    }
+
+    fn in_flight_progress(
+        downloaded_bytes: u64,
+        total_bytes: u64,
+        speed_mbps: f64,
+    ) -> DownloadProgress {
+        let mut progress = DownloadProgress::new(downloaded_bytes, total_bytes, speed_mbps);
+        progress.percent = progress.percent.min(99);
+        progress
+    }
+
+
+    async fn send_download_request(
+        &self,
+        client: &reqwest::Client,
+        file_url: &str,
+        range_start: Option<u64>,
+        active_download: &ActiveDownload,
+    ) -> Result<reqwest::Response> {
+        let mut request = client.get(file_url);
+        if let Some(range_start) = range_start {
+            request = request.header(reqwest::header::RANGE, format!("bytes={range_start}-"));
+        }
+
+        tokio::select! {
+            biased;
+            _ = active_download.cancellation.cancelled() => Err(DownloadCancelled.into()),
+            response = request.send() => response
+                .map_err(|error| anyhow!("Failed to start download for {}: {}", file_url, error)),
+        }
+    }
+
+    fn declared_content_length(response: &reqwest::Response) -> Result<Option<u64>> {
+        response
+            .headers()
+            .get(reqwest::header::CONTENT_LENGTH)
+            .map(|value| {
+                value
+                    .to_str()
+                    .map_err(|error| anyhow!("Invalid Content-Length header encoding: {}", error))?
+                    .parse()
+                    .map_err(|error| anyhow!("Invalid Content-Length header: {}", error))
+            })
+            .transpose()
+    }
+
+    fn validate_full_response(response: &reqwest::Response, exact_bytes: u64) -> Result<()> {
+        if response.status() != reqwest::StatusCode::OK {
+            return Err(anyhow!(
+                "Expected full 200 response, received {}",
+                response.status()
+            ));
+        }
+        if let Some(content_length) = Self::declared_content_length(response)? {
+            if content_length != exact_bytes {
+                return Err(anyhow!(
+                    "Full response declared {} bytes, expected {}",
+                    content_length,
+                    exact_bytes
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_partial_response(
+        response: &reqwest::Response,
+        expected_start: u64,
+        exact_bytes: u64,
+    ) -> Result<()> {
+        if response.status() != reqwest::StatusCode::PARTIAL_CONTENT {
+            return Err(anyhow!(
+                "Expected partial 206 response, received {}",
+                response.status()
+            ));
+        }
+        let content_range = response
+            .headers()
+            .get(reqwest::header::CONTENT_RANGE)
+            .ok_or_else(|| anyhow!("Partial response is missing Content-Range"))?;
+        let ContentRange::Range { start, end, total } = parse_content_range(content_range)? else {
+            return Err(anyhow!("Partial response has an unsatisfied Content-Range"));
+        };
+        if start != expected_start || end != exact_bytes - 1 || total != exact_bytes {
+            return Err(anyhow!(
+                "Partial response range {}-{} / {} does not match {}-{} / {}",
+                start,
+                end,
+                total,
+                expected_start,
+                exact_bytes - 1,
+                exact_bytes
+            ));
+        }
+        let expected_length = end
+            .checked_sub(start)
+            .and_then(|length| length.checked_add(1))
+            .ok_or_else(|| anyhow!("Partial response range length overflow"))?;
+        if let Some(content_length) = Self::declared_content_length(response)? {
+            if content_length != expected_length {
+                return Err(anyhow!(
+                    "Partial response declared {} bytes, expected {}",
+                    content_length,
+                    expected_length
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_unsatisfied_response(response: &reqwest::Response, exact_bytes: u64) -> Result<()> {
+        if response.status() != reqwest::StatusCode::RANGE_NOT_SATISFIABLE {
+            return Err(anyhow!(
+                "Expected range-not-satisfiable 416 response, received {}",
+                response.status()
+            ));
+        }
+        let content_range = response
+            .headers()
+            .get(reqwest::header::CONTENT_RANGE)
+            .ok_or_else(|| anyhow!("416 response is missing Content-Range"))?;
+        match parse_content_range(content_range)? {
+            ContentRange::Unsatisfied { total } if total == exact_bytes => Ok(()),
+            ContentRange::Unsatisfied { total } => Err(anyhow!(
+                "416 response reports {} total bytes, expected {}",
+                total,
+                exact_bytes
+            )),
+            ContentRange::Range { .. } => Err(anyhow!("416 response has a satisfied Content-Range")),
+        }
+    }
+
+    async fn download_model_detailed_from_source(
         &self,
         model_name: &str,
+        model_dir: &Path,
+        base_url: &str,
+        artifacts: &[ArtifactSpec],
         progress_callback: Option<Box<dyn Fn(DownloadProgress) + Send>>,
     ) -> Result<()> {
-        // Get model info
-        let model_info = {
-            let models = self.available_models.read().await;
-            match models.get(model_name).cloned() {
-                Some(info) => info,
-                None => return Err(anyhow!("Model {} not found", model_name)),
-            }
+        let active_download = self.reserve_active_download(model_name).await?;
+        self.set_downloading_status(model_name, 0).await;
+
+        let result = self
+            .download_artifacts(
+                model_name,
+                model_dir,
+                base_url,
+                artifacts,
+                &active_download,
+                progress_callback,
+            )
+            .await;
+        let (result, progress_callback) = match result {
+            Ok((progress, progress_callback)) => (Ok(progress), progress_callback),
+            Err(error) => (Err(error), None),
         };
 
-        // Update model status to downloading
-        {
-            let mut models = self.available_models.write().await;
-            if let Some(model) = models.get_mut(model_name) {
-                model.status = ModelStatus::Downloading { progress: 0 };
-            }
+        self.finish_download(
+            model_name,
+            model_dir,
+            artifacts,
+            &active_download,
+            result,
+            progress_callback,
+        )
+        .await
+    }
+
+    async fn download_artifacts(
+        &self,
+        model_name: &str,
+        model_dir: &Path,
+        base_url: &str,
+        artifacts: &[ArtifactSpec],
+        active_download: &ActiveDownload,
+        progress_callback: Option<Box<dyn Fn(DownloadProgress) + Send>>,
+    ) -> Result<(DownloadProgress, Option<Box<dyn Fn(DownloadProgress) + Send>>)> {
+        if active_download.cancellation.is_cancelled() {
+            return Err(DownloadCancelled.into());
         }
+        fs::create_dir_all(model_dir)
+            .await
+            .map_err(|error| anyhow!("Failed to create model directory: {}", error))?;
 
-        // HuggingFace base URL for Parakeet models (version-specific)
-        let base_url = if model_name.contains("-v2-") {
-            "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v2-onnx/resolve/main"
-        } else {
-            // Default to v3 for v3 models
-            "https://meetily.towardsgeneralintelligence.com/models/parakeet-tdt-0.6b-v3-onnx"
-        };
-
-        // Determine which files to download based on quantization
-        let files_to_download = match model_info.quantization {
-            QuantizationType::Int8 => vec![
-                "encoder-model.int8.onnx",
-                "decoder_joint-model.int8.onnx",
-                "nemo128.onnx",
-                "vocab.txt",
-            ],
-            QuantizationType::FP32 => vec![
-                "encoder-model.onnx",
-                "decoder_joint-model.onnx",
-                "nemo128.onnx",
-                "vocab.txt",
-            ],
-        };
-
-        // Create model directory
-        let model_dir = &model_info.path;
-        if !model_dir.exists() {
-            if let Err(e) = fs::create_dir_all(model_dir).await {
-                return Err(anyhow!("Failed to create model directory: {}", e));
-            }
-        }
-
-        // Optimized HTTP client for large file downloads
         let client = reqwest::Client::builder()
-            .tcp_nodelay(true)              // Disable Nagle's algorithm for better streaming
-            .pool_max_idle_per_host(1)      // Keep connection alive
-            .timeout(Duration::from_secs(3600))  // 1 hour timeout for large files
+            .tcp_nodelay(true)
+            .pool_max_idle_per_host(1)
+            .timeout(Duration::from_secs(3600))
             .connect_timeout(Duration::from_secs(30))
             .build()
-            .map_err(|e| anyhow!("Failed to create HTTP client: {}", e))?;
+            .map_err(|error| anyhow!("Failed to create HTTP client: {}", error))?;
+        let total_bytes: u64 = artifacts.iter().map(|artifact| artifact.exact_bytes).sum();
+        let download_started = Instant::now();
+        let mut confirmed_bytes = 0u64;
+        let mut streamed_bytes = 0u64;
+        let mut bytes_since_report = 0u64;
+        let mut last_report = Instant::now();
+        let mut last_percent = 0u8;
 
-        let total_files = files_to_download.len();
+        for artifact in artifacts {
+            if active_download.cancellation.is_cancelled() {
+                return Err(DownloadCancelled.into());
+            }
 
-        // Calculate total download size for weighted progress
-        // Note: These are approximate sizes based on HuggingFace repo inspection
-        let file_sizes: std::collections::HashMap<&str, u64> = match model_info.quantization {
-            QuantizationType::Int8 => {
-                if model_name.contains("-v2-") {
-                    // V2 model sizes
-                    [
-                        ("encoder-model.int8.onnx", 652_000_000u64),       // 652 MB
-                        ("decoder_joint-model.int8.onnx", 9_000_000u64),   // 9 MB
-                        ("nemo128.onnx", 140_000u64),                      // 140 KB
-                        ("vocab.txt", 9_380u64),                           // 9.38 KB
-                    ].iter().cloned().collect()
-                } else {
-                    // V3 model sizes (default)
-                    [
-                        ("encoder-model.int8.onnx", 652_000_000u64),       // 652 MB
-                        ("decoder_joint-model.int8.onnx", 18_200_000u64),  // 18.2 MB
-                        ("nemo128.onnx", 140_000u64),                      // 140 KB
-                        ("vocab.txt", 93_900u64),                          // 93.9 KB
-                    ].iter().cloned().collect()
+            let file_path = model_dir.join(artifact.filename);
+            let local_bytes = match fs::metadata(&file_path).await {
+                Ok(metadata) => metadata.len(),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => 0,
+                Err(error) => {
+                    return Err(anyhow!(
+                        "Failed to read {} metadata: {}",
+                        artifact.filename,
+                        error
+                    ));
                 }
-            }
-            QuantizationType::FP32 => {
-                // FP32 model sizes (encoder has .onnx + .onnx.data)
-                [
-                    ("encoder-model.onnx", 41_800_000u64 + 2_440_000_000u64), // 41.8 MB + 2.44 GB
-                    ("decoder_joint-model.onnx", 72_500_000u64),               // 72.5 MB
-                    ("nemo128.onnx", 140_000u64),                              // 140 KB
-                    ("vocab.txt", 93_900u64),                                  // 93.9 KB
-                ].iter().cloned().collect()
-            }
-        };
-
-        // Calculate total expected download size
-        let total_size_bytes: u64 = files_to_download.iter()
-            .filter_map(|f| file_sizes.get(*f))
-            .copied()
-            .sum();
-
-        // 只读取现有 artifact 来计算续传进度；单个文件失败时不再删除已完成的兄弟文件。
-        let already_downloaded =
-            Self::existing_artifact_bytes(model_dir, &files_to_download, &file_sizes).await;
-
-        let mut total_downloaded: u64 = already_downloaded;
-
-        // Timing for speed calculation
-        let download_start_time = Instant::now();
-        let mut last_report_time = Instant::now();
-        let mut bytes_since_last_report: u64 = 0;
-        let mut last_reported_progress: u8 = 0;
-
-        log::info!(
-            "Starting weighted download for {} files, total size: {:.2} MB (already downloaded: {:.2} MB)",
-            total_files,
-            total_size_bytes as f64 / 1_048_576.0,
-            already_downloaded as f64 / 1_048_576.0
-        );
-
-        for (index, filename) in files_to_download.iter().enumerate() {
-            let file_url = format!("{}/{}", base_url, filename);
-            let file_path = model_dir.join(filename);
-
-            // Check for existing partial file to resume
-            let existing_size: u64 = if file_path.exists() {
-                fs::metadata(&file_path).await.map(|m| m.len()).unwrap_or(0)
-            } else {
-                0
             };
 
-            let expected_size = file_sizes.get(*filename).copied().unwrap_or(0);
-
-            // Skip if file is already complete (with 1% tolerance for size variations)
-            let size_tolerance = (expected_size as f64 * 0.99) as u64;
-            if existing_size >= size_tolerance && expected_size > 0 {
-                log::info!(
-                    "Skipping complete file: {} ({:.2} MB, expected: {:.2} MB)",
-                    filename,
-                    existing_size as f64 / 1_048_576.0,
-                    expected_size as f64 / 1_048_576.0
-                );
+            if local_bytes == artifact.exact_bytes {
+                confirmed_bytes = confirmed_bytes
+                    .checked_add(artifact.exact_bytes)
+                    .ok_or_else(|| anyhow!("Progress overflow while skipping {}", artifact.filename))?;
+                let progress = Self::in_flight_progress(confirmed_bytes, total_bytes, 0.0);
+                if let Some(callback) = &progress_callback {
+                    callback(progress.clone());
+                }
+                self.set_downloading_status(model_name, progress.percent).await;
+                last_percent = progress.percent;
+                last_report = Instant::now();
                 continue;
             }
 
-            log::info!("Downloading file {}/{}: {} (resuming from {} bytes)", index + 1, total_files, filename, existing_size);
+            let file_url = format!("{}/{}", base_url.trim_end_matches('/'), artifact.filename);
+            let range_start = (local_bytes > 0 && local_bytes < artifact.exact_bytes)
+                .then_some(local_bytes);
+            let response = self
+                .send_download_request(&client, &file_url, range_start, active_download)
+                .await?;
 
-            // Build request with optional Range header for resume
-            let mut request = client.get(&file_url);
-            if existing_size > 0 {
-                request = request.header("Range", format!("bytes={}-", existing_size));
-                log::info!("Resuming download from byte {}", existing_size);
-            }
-
-            let mut response = request.send().await
-                .map_err(|e| {
-                    anyhow!("Failed to start download for {}: {}", filename, e)
-                })?;
-
-            // Handle response status
-            let (file_total_size, resuming) = if response.status() == reqwest::StatusCode::PARTIAL_CONTENT {
-                // Server supports resume, get remaining size
-                let remaining = response.content_length().unwrap_or(0);
-                log::info!("Server supports resume, remaining: {} bytes", remaining);
-                (existing_size + remaining, true)
-            } else if response.status().is_success() {
-                // Fresh download or server doesn't support resume
-                if existing_size > 0 {
-                    log::warn!("Server doesn't support resume for {}, starting fresh download", filename);
-                }
-                (response.content_length().unwrap_or(0), false)
-            } else if response.status() == reqwest::StatusCode::RANGE_NOT_SATISFIABLE {
-                // 416: Range not satisfiable - file complete or invalid range
-                log::warn!("Server returned 416 Range Not Satisfiable for {}", filename);
-
-                let size_tolerance = (expected_size as f64 * 0.99) as u64;
-                if existing_size >= size_tolerance && expected_size > 0 {
-                    // File is complete - skip it
-                    log::info!("File {} complete ({} bytes). Skipping.", filename, existing_size);
-                    continue;
-                } else {
-                    // File incomplete but server won't accept range - delete and retry
-                    log::warn!(
-                        "File {} incomplete ({}/{} bytes). Deleting and retrying.",
-                        filename, existing_size, expected_size
-                    );
-
-                    if let Err(e) = fs::remove_file(&file_path).await {
-                        return Err(anyhow!("Failed to delete incomplete file {}: {}", filename, e));
+            let (response, mut artifact_bytes, append) = match range_start {
+                Some(range_start) => match response.status() {
+                    reqwest::StatusCode::PARTIAL_CONTENT => {
+                        Self::validate_partial_response(&response, range_start, artifact.exact_bytes)?;
+                        confirmed_bytes = confirmed_bytes
+                            .checked_add(range_start)
+                            .ok_or_else(|| anyhow!("Progress overflow while resuming {}", artifact.filename))?;
+                        let progress =
+                            Self::in_flight_progress(confirmed_bytes, total_bytes, 0.0);
+                        if let Some(callback) = &progress_callback {
+                            callback(progress.clone());
+                        }
+                        self.set_downloading_status(model_name, progress.percent).await;
+                        last_percent = progress.percent;
+                        last_report = Instant::now();
+                        (response, range_start, true)
                     }
-
-                    // Retry without Range header
-                    log::info!("Retrying {} without resume", filename);
-                    response = client.get(&file_url).send().await
-                        .map_err(|e| anyhow!("Retry failed for {}: {}", filename, e))?;
-
-                    if !response.status().is_success() {
-                        return Err(anyhow!("Retry failed for {} with status: {}", filename, response.status()));
+                    reqwest::StatusCode::OK => {
+                        Self::validate_full_response(&response, artifact.exact_bytes)?;
+                        (response, 0, false)
                     }
-
-                    (response.content_length().unwrap_or(0), false)
-                }
-            } else {
-                // Other errors
-                return Err(anyhow!("Download failed for {} with status: {}", filename, response.status()));
+                    reqwest::StatusCode::RANGE_NOT_SATISFIABLE => {
+                        Self::validate_unsatisfied_response(&response, artifact.exact_bytes)?;
+                        let retry = self
+                            .send_download_request(&client, &file_url, None, active_download)
+                            .await?;
+                        Self::validate_full_response(&retry, artifact.exact_bytes)?;
+                        (retry, 0, false)
+                    }
+                    status => {
+                        return Err(anyhow!(
+                            "Download failed for {} with status {}",
+                            artifact.filename,
+                            status
+                        ));
+                    }
+                },
+                None => match response.status() {
+                    reqwest::StatusCode::OK => {
+                        Self::validate_full_response(&response, artifact.exact_bytes)?;
+                        (response, 0, false)
+                    }
+                    reqwest::StatusCode::PARTIAL_CONTENT => {
+                        Self::validate_partial_response(&response, 0, artifact.exact_bytes)?;
+                        (response, 0, false)
+                    }
+                    status => {
+                        return Err(anyhow!(
+                            "Download failed for {} with status {}",
+                            artifact.filename,
+                            status
+                        ));
+                    }
+                },
             };
 
-            // Open file for writing (append if resuming, create new if not)
-            let file = if resuming {
+            if active_download.cancellation.is_cancelled() {
+                return Err(DownloadCancelled.into());
+            }
+            let file = if append {
                 fs::OpenOptions::new()
                     .append(true)
                     .open(&file_path)
                     .await
-                    .map_err(|e| anyhow!("Failed to open file for resume {}: {}", filename, e))?
+                    .map_err(|error| anyhow!("Failed to open {} for resume: {}", artifact.filename, error))?
             } else {
-                fs::File::create(&file_path)
+                fs::OpenOptions::new()
+                    .create(true)
+                    .truncate(true)
+                    .write(true)
+                    .open(&file_path)
                     .await
-                    .map_err(|e| anyhow!("Failed to create file {}: {}", filename, e))?
+                    .map_err(|error| anyhow!("Failed to replace {}: {}", artifact.filename, error))?
             };
-
-            // Use buffered writer for better I/O performance (8MB buffer)
             let mut writer = BufWriter::with_capacity(8 * 1024 * 1024, file);
-
-            // Stream download
             use futures_util::StreamExt;
             let mut stream = response.bytes_stream();
-            let mut file_downloaded = if resuming { existing_size } else { 0u64 };
 
             loop {
-                // Check for cancellation before processing chunk
-                {
-                    let cancelled_downloads = self.cancelled_downloads.read().await;
-                    if cancelled_downloads.contains(model_name) {
-                        log::info!("Download cancelled for {}", model_name);
-                        // Flush and keep partial file for resume on next attempt
-                        let _ = writer.flush().await;
-                        drop(writer);
-                        return Err(anyhow!("Download cancelled by user"));
+                let next_chunk = tokio::select! {
+                    biased;
+                    _ = active_download.cancellation.cancelled() => {
+                        writer.flush().await.map_err(|error| {
+                            anyhow!("Failed to preserve {} during cancellation: {}", artifact.filename, error)
+                        })?;
+                        return Err(DownloadCancelled.into());
                     }
-                }
-
-                // Add per-chunk timeout (30 seconds) to detect stalled connections
-                let next_result = timeout(Duration::from_secs(30), stream.next()).await;
-
-                let chunk = match next_result {
-                    // Timeout - no data received for 30 seconds
+                    chunk = timeout(Duration::from_secs(30), stream.next()) => chunk,
+                };
+                let chunk = match next_chunk {
                     Err(_) => {
-                        log::warn!("Download timeout for {}: no data received for 30 seconds", model_name);
-                        let _ = writer.flush().await;
-
-                        // Update model status to Missing so retry can work
-                        {
-                            let mut models = self.available_models.write().await;
-                            if let Some(model) = models.get_mut(model_name) {
-                                model.status = ModelStatus::Missing;
-                            }
-                        }
-
-                        return Err(anyhow!("Download timeout - No data received for 30 seconds"));
-                    },
-                    // Stream ended
+                        writer.flush().await.map_err(|error| {
+                            anyhow!("Failed to preserve {} after timeout: {}", artifact.filename, error)
+                        })?;
+                        return Err(anyhow!(
+                            "Download timeout for {}: no data received for 30 seconds",
+                            artifact.filename
+                        ));
+                    }
                     Ok(None) => break,
-                    // Got chunk result
-                    Ok(Some(chunk_result)) => {
-                        match chunk_result {
-                            Ok(c) => c,
-                            // Detect error type for better user feedback
-                            Err(e) => {
-                                log::error!("Download error for {}: {:?}", model_name, e);
-                                let _ = writer.flush().await;
-
-                                // Update model status to Missing so retry can work
-                                {
-                                    let mut models = self.available_models.write().await;
-                                    if let Some(model) = models.get_mut(model_name) {
-                                        model.status = ModelStatus::Missing;
-                                    }
-                                }
-
-                                let error_msg = if e.is_timeout() {
-                                    "Connection timeout - Check your internet"
-                                } else if e.is_connect() {
-                                    "Connection failed - Check your internet"
-                                } else if e.is_body() {
-                                    "Stream interrupted - Network unstable"
-                                } else {
-                                    "Download error"
-                                };
-
-                                return Err(anyhow!("{}: {}", error_msg, e));
-                            }
-                        }
+                    Ok(Some(Err(error))) => {
+                        writer.flush().await.map_err(|flush_error| {
+                            anyhow!(
+                                "Failed to preserve {} after stream error: {}",
+                                artifact.filename,
+                                flush_error
+                            )
+                        })?;
+                        return Err(anyhow!("Download stream failed for {}: {}", artifact.filename, error));
                     }
+                    Ok(Some(Ok(chunk))) => chunk,
                 };
 
-                if let Err(e) = writer.write_all(&chunk).await {
-                    // Update model status to Missing so retry can work
-                    {
-                        let mut models = self.available_models.write().await;
-                        if let Some(model) = models.get_mut(model_name) {
-                            model.status = ModelStatus::Missing;
-                        }
-                    }
-
-                    return Err(anyhow!("Failed to write chunk to file: {}", e));
+                let chunk_bytes = chunk.len() as u64;
+                let next_artifact_bytes = artifact_bytes
+                    .checked_add(chunk_bytes)
+                    .ok_or_else(|| anyhow!("{} size overflow", artifact.filename))?;
+                if next_artifact_bytes > artifact.exact_bytes {
+                    writer.flush().await.map_err(|error| {
+                        anyhow!("Failed to preserve {} after overlong response: {}", artifact.filename, error)
+                    })?;
+                    return Err(anyhow!(
+                        "{} response exceeds its exact {} byte size",
+                        artifact.filename,
+                        artifact.exact_bytes
+                    ));
+                }
+                let next_confirmed_bytes = confirmed_bytes
+                    .checked_add(chunk_bytes)
+                    .ok_or_else(|| anyhow!("Progress overflow while downloading {}", artifact.filename))?;
+                if next_confirmed_bytes > total_bytes {
+                    return Err(anyhow!("Download progress exceeds the catalog total"));
                 }
 
-                let chunk_len = chunk.len() as u64;
-                file_downloaded += chunk_len;
-                total_downloaded += chunk_len;
-                bytes_since_last_report += chunk_len;
+                writer
+                    .write_all(&chunk)
+                    .await
+                    .map_err(|error| anyhow!("Failed to write {}: {}", artifact.filename, error))?;
+                artifact_bytes = next_artifact_bytes;
+                confirmed_bytes = next_confirmed_bytes;
+                streamed_bytes = streamed_bytes
+                    .checked_add(chunk_bytes)
+                    .ok_or_else(|| anyhow!("Streamed byte count overflow"))?;
+                bytes_since_report = bytes_since_report
+                    .checked_add(chunk_bytes)
+                    .ok_or_else(|| anyhow!("Progress byte count overflow"))?;
 
-                // Calculate weighted overall progress based on total bytes downloaded
-                let overall_progress = if total_size_bytes > 0 {
-                    ((total_downloaded as f64 / total_size_bytes as f64) * 100.0).min(99.0) as u8
-                } else {
-                    // Fallback to per-file progress if total size unknown
-                    ((index as f64 + (file_downloaded as f64 / file_total_size.max(1) as f64)) / total_files as f64 * 100.0) as u8
-                };
-
-                // Report every 1% progress change OR every 500ms for smooth UI updates
-                let elapsed_since_report = last_report_time.elapsed();
-                let progress_changed = overall_progress > last_reported_progress;
-                let time_threshold = elapsed_since_report >= Duration::from_millis(500);
-                let is_complete = file_downloaded >= file_total_size;
-
-                let should_report = progress_changed || time_threshold || is_complete;
-
-                if should_report {
-                    // Calculate download speed
-                    let speed_mbps = if elapsed_since_report.as_secs_f64() >= 0.1 {
-                        (bytes_since_last_report as f64 / (1024.0 * 1024.0)) / elapsed_since_report.as_secs_f64()
-                    } else {
-                        // Fallback to overall average speed
-                        let total_elapsed = download_start_time.elapsed().as_secs_f64();
-                        if total_elapsed > 0.0 {
-                            ((total_downloaded - already_downloaded) as f64 / (1024.0 * 1024.0)) / total_elapsed
-                        } else {
-                            0.0
-                        }
-                    };
-
-                    last_reported_progress = overall_progress;
-                    last_report_time = Instant::now();
-                    bytes_since_last_report = 0;
-
-                    // Create detailed progress and report
-                    let progress = DownloadProgress::new(total_downloaded, total_size_bytes, speed_mbps);
-                    if let Some(ref callback) = progress_callback {
-                        callback(progress);
-                    }
-
-                    // Update model status
-                    {
-                        let mut models = self.available_models.write().await;
-                        if let Some(model) = models.get_mut(model_name) {
-                            model.status = ModelStatus::Downloading { progress: overall_progress };
-                        }
-                    }
-                }
-            }
-
-            // Flush the buffered writer
-            if let Err(e) = writer.flush().await {
-                // Update model status to Missing so retry can work
+                let progress = Self::in_flight_progress(confirmed_bytes, total_bytes, 0.0);
+                let elapsed = last_report.elapsed();
+                if progress.percent > last_percent
+                    || elapsed >= Duration::from_millis(500)
+                    || artifact_bytes == artifact.exact_bytes
                 {
-                    let mut models = self.available_models.write().await;
-                    if let Some(model) = models.get_mut(model_name) {
-                        model.status = ModelStatus::Missing;
+                    let speed_mbps = if elapsed.as_secs_f64() > 0.0 {
+                        bytes_since_report as f64 / (1024.0 * 1024.0) / elapsed.as_secs_f64()
+                    } else {
+                        0.0
+                    };
+                    if let Some(callback) = &progress_callback {
+                        callback(Self::in_flight_progress(
+                            confirmed_bytes,
+                            total_bytes,
+                            speed_mbps,
+                        ));
                     }
+                    self.set_downloading_status(model_name, progress.percent).await;
+                    last_percent = progress.percent;
+                    last_report = Instant::now();
+                    bytes_since_report = 0;
                 }
-
-                return Err(anyhow!("Failed to flush file {}: {}", filename, e));
             }
 
-            log::info!(
-                "Completed download: {} ({:.2} MB, overall progress: {:.1}%)",
-                filename,
-                file_downloaded as f64 / 1_048_576.0,
-                (total_downloaded as f64 / total_size_bytes as f64) * 100.0
-            );
+            writer
+                .flush()
+                .await
+                .map_err(|error| anyhow!("Failed to flush {}: {}", artifact.filename, error))?;
+            drop(writer);
+
+            if active_download.cancellation.is_cancelled() {
+                return Err(DownloadCancelled.into());
+            }
+            let stored_bytes = fs::metadata(&file_path)
+                .await
+                .map_err(|error| anyhow!("Failed to read {} after download: {}", artifact.filename, error))?
+                .len();
+            if stored_bytes != artifact.exact_bytes {
+                return Err(anyhow!(
+                    "{} stored {} bytes, expected exactly {} bytes",
+                    artifact.filename,
+                    stored_bytes,
+                    artifact.exact_bytes
+                ));
+            }
         }
 
-        // Report 100% progress with final speed
-        let total_elapsed = download_start_time.elapsed().as_secs_f64();
-        let final_speed = if total_elapsed > 0.0 {
-            ((total_downloaded - already_downloaded) as f64 / (1024.0 * 1024.0)) / total_elapsed
+        if confirmed_bytes != total_bytes {
+            return Err(anyhow!(
+                "Download confirmed {} bytes, expected {} bytes",
+                confirmed_bytes,
+                total_bytes
+            ));
+        }
+        let elapsed = download_started.elapsed().as_secs_f64();
+        let speed_mbps = if elapsed > 0.0 {
+            streamed_bytes as f64 / (1024.0 * 1024.0) / elapsed
         } else {
             0.0
         };
-        let final_progress = DownloadProgress::new(total_size_bytes, total_size_bytes, final_speed);
-        if let Some(ref callback) = progress_callback {
-            callback(final_progress);
+        Ok((
+            DownloadProgress::new(total_bytes, total_bytes, speed_mbps),
+            progress_callback,
+        ))
+    }
+
+    async fn finish_download(
+        &self,
+        model_name: &str,
+        model_dir: &Path,
+        artifacts: &[ArtifactSpec],
+        active_download: &Arc<ActiveDownload>,
+        mut result: Result<DownloadProgress>,
+        progress_callback: Option<Box<dyn Fn(DownloadProgress) + Send>>,
+    ) -> Result<()> {
+        if result.is_ok() && !active_download.cancellation.is_cancelled() {
+            let final_progress = result.expect("successful transfer must carry final progress");
+            result = Self::validate_model_directory(model_dir, artifacts).map(|()| final_progress);
         }
 
-        // Update model status to available
-        {
-            let mut models = self.available_models.write().await;
-            if let Some(model) = models.get_mut(model_name) {
+        #[cfg(test)]
+        if let Some(hook) = self.test_hook().await {
+            hook.finalization_ready.notify_one();
+            hook.continue_finalization.notified().await;
+        }
+
+        let mut active_downloads = self.active_downloads.lock().await;
+        let owner_matches = matches!(
+            active_downloads.get(model_name),
+            Some(owner) if Arc::ptr_eq(owner, active_download)
+        );
+        if !owner_matches {
+            drop(active_downloads);
+            active_download.completion.send_replace(true);
+            return result.map(|_| ());
+        }
+
+        let cancellation_won = active_download.cancellation.is_cancelled()
+            || result
+                .as_ref()
+                .err()
+                .is_some_and(is_download_cancelled);
+        let mut models = self.available_models.write().await;
+        active_downloads.remove(model_name);
+        if let Some(model) = models.get_mut(model_name) {
+            if cancellation_won || result.is_err() {
+                model.status = ModelStatus::Missing;
+            } else {
                 model.status = ModelStatus::Available;
-                model.path = model_dir.clone();
+                model.path = model_dir.to_path_buf();
             }
         }
+        drop(models);
+        drop(active_downloads);
+        active_download.completion.send_replace(true);
 
-        self.cancelled_downloads.write().await.remove(model_name);
-
+        if cancellation_won {
+            return Err(DownloadCancelled.into());
+        }
+        let final_progress = result?;
+        if let Some(callback) = progress_callback {
+            callback(final_progress);
+        }
         log::info!("Download completed for Parakeet model: {}", model_name);
         Ok(())
     }
 
-    /// Cancel an ongoing model download
-    pub async fn cancel_download(&self, model_name: &str) -> Result<()> {
-        log::info!("Cancelling download for Parakeet model: {}", model_name);
+    /// Cancel an ongoing model download.
+    pub async fn cancel_download(&self, model_name: &str) -> Result<CancelDownloadOutcome> {
+        self.cancel_download_with_timeout(model_name, CANCEL_DOWNLOAD_CLEANUP_TIMEOUT)
+            .await
+    }
 
-        // 与下载注册保持 active -> cancelled 的固定锁顺序，关闭“刚注册就误清取消”的窗口。
-        // 没有活跃 worker 时无需留下会污染下一次下载的陈旧请求。
-        {
-            let active = self.active_downloads.read().await;
-            if active.contains(model_name) {
-                self.cancelled_downloads
-                    .write()
-                    .await
-                    .insert(model_name.to_string());
+    async fn cancel_download_with_timeout(
+        &self,
+        model_name: &str,
+        cleanup_timeout: Duration,
+    ) -> Result<CancelDownloadOutcome> {
+        let active_download = {
+            let active_downloads = self.active_downloads.lock().await;
+            let Some(active_download) = active_downloads.get(model_name).cloned() else {
+                return Ok(CancelDownloadOutcome::Cancelled);
+            };
+            active_download.cancellation.cancel();
+            active_download
+        };
+
+        let mut completion = active_download.completion.subscribe();
+        if !*completion.borrow() {
+            match timeout(cleanup_timeout, completion.changed()).await {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) => {
+                    return Err(anyhow!(
+                        "Download worker ended before completing cancellation cleanup"
+                    ));
+                }
+                Err(_) => return Ok(CancelDownloadOutcome::Pending),
             }
         }
 
-        // Update model status to Missing (so it can be retried)
-        {
-            let mut models = self.available_models.write().await;
-            if let Some(model) = models.get_mut(model_name) {
-                model.status = ModelStatus::Missing;
-            }
-        }
-
-        // 取消只发出停止信号，不提前释放 active 标记：旧任务 flush 并退出前，不允许重试任务并发写同一文件。
-        // 部分文件和已完整的兄弟文件都保留；整个模型目录仅能由显式的 delete_model 操作删除。
-
-        Ok(())
+        Ok(CancelDownloadOutcome::Cancelled)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crossbeam::queue::SegQueue;
     use tempfile::tempdir;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
 
-    const TEST_MODEL_NAME: &str = "parakeet-tdt-0.6b-v3-int8";
+    const TEST_MODEL_NAME: &str = "parakeet-test";
+    const SMALL_ARTIFACTS: &[ArtifactSpec] = &[
+        ArtifactSpec { filename: "encoder.bin", exact_bytes: 4 },
+        ArtifactSpec { filename: "decoder.bin", exact_bytes: 3 },
+        ArtifactSpec { filename: "nemo.bin", exact_bytes: 2 },
+        ArtifactSpec { filename: "vocab.txt", exact_bytes: 1 },
+    ];
 
-    #[tokio::test]
-    async fn missing_artifact_does_not_delete_existing_siblings() {
-        let temp_dir = tempdir().expect("create temporary models directory");
-        let model_dir = temp_dir.path().join(TEST_MODEL_NAME);
-        fs::create_dir_all(&model_dir)
-            .await
-            .expect("create model directory");
+    struct ExpectedResponse {
+        filename: &'static str,
+        range: Option<&'static str>,
+        status: &'static str,
+        content_length: Option<u64>,
+        content_range: Option<&'static str>,
+        body: &'static [u8],
+    }
 
-        // 缺失 vocab 时，其他文件可能是完整文件，也可能是可续传的部分文件；两者都不能被连带删除。
-        let existing_artifacts: [(&str, &[u8]); 3] = [
-            ("encoder-model.int8.onnx", b"encoder-partial"),
-            ("decoder_joint-model.int8.onnx", b"decoder-complete"),
-            ("nemo128.onnx", b"preprocessor-complete"),
-        ];
-        for (filename, contents) in existing_artifacts {
-            fs::write(model_dir.join(filename), contents)
-                .await
-                .expect("seed existing artifact");
+    fn response(
+        filename: &'static str,
+        range: Option<&'static str>,
+        status: &'static str,
+        body: &'static [u8],
+        content_range: Option<&'static str>,
+    ) -> ExpectedResponse {
+        ExpectedResponse {
+            filename,
+            range,
+            status,
+            content_length: Some(body.len() as u64),
+            content_range,
+            body,
         }
+    }
 
-        let expected_sizes = HashMap::from([
-            ("encoder-model.int8.onnx", 64),
-            (
-                "decoder_joint-model.int8.onnx",
-                b"decoder-complete".len() as u64,
-            ),
-            ("nemo128.onnx", b"preprocessor-complete".len() as u64),
-            ("vocab.txt", 32),
-        ]);
-        let filenames = [
-            "encoder-model.int8.onnx",
-            "decoder_joint-model.int8.onnx",
-            "nemo128.onnx",
-            "vocab.txt",
-        ];
+    async fn read_request(socket: &mut tokio::net::TcpStream) -> String {
+        let mut request = Vec::new();
+        let mut buffer = [0u8; 1024];
+        loop {
+            let read = socket.read(&mut buffer).await.expect("read request");
+            assert_ne!(read, 0, "request ended before its headers");
+            request.extend_from_slice(&buffer[..read]);
+            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                return String::from_utf8(request).expect("request is valid UTF-8");
+            }
+        }
+    }
 
-        let reusable_bytes =
-            ParakeetEngine::existing_artifact_bytes(&model_dir, &filenames, &expected_sizes).await;
-        let expected_reusable_bytes: u64 = existing_artifacts
-            .iter()
-            .map(|(_, contents)| contents.len() as u64)
-            .sum();
-        assert_eq!(reusable_bytes, expected_reusable_bytes);
+    async fn serve_requests(
+        expected_responses: Vec<ExpectedResponse>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback test server");
+        let address = listener.local_addr().expect("get loopback address");
+        let server = tokio::spawn(async move {
+            for expected in expected_responses {
+                let (mut socket, _) = listener.accept().await.expect("accept test request");
+                let request = read_request(&mut socket).await;
+                assert!(
+                    request.starts_with(&format!("GET /{} HTTP/", expected.filename)),
+                    "unexpected request path: {request}"
+                );
+                let requested_range = request.lines().find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("range").then_some(value.trim())
+                });
+                assert_eq!(requested_range, expected.range);
 
-        for (filename, contents) in existing_artifacts {
-            assert_eq!(
-                fs::read(model_dir.join(filename))
+                let mut headers = format!("HTTP/1.1 {}\r\nConnection: close\r\n", expected.status);
+                if let Some(content_length) = expected.content_length {
+                    headers.push_str(&format!("Content-Length: {content_length}\r\n"));
+                }
+                if let Some(content_range) = expected.content_range {
+                    headers.push_str(&format!("Content-Range: {content_range}\r\n"));
+                }
+                headers.push_str("\r\n");
+                socket
+                    .write_all(headers.as_bytes())
                     .await
-                    .expect("existing artifact must be preserved"),
-                contents
+                    .expect("write response headers");
+                socket
+                    .write_all(expected.body)
+                    .await
+                    .expect("write response body");
+            }
+        });
+
+        (format!("http://{address}"), server)
+    }
+
+    async fn test_engine() -> (tempfile::TempDir, Arc<ParakeetEngine>, PathBuf) {
+        let temp_dir = tempdir().expect("create temporary models directory");
+        let engine = Arc::new(
+            ParakeetEngine::new_with_models_dir(Some(temp_dir.path().to_path_buf()))
+                .expect("create Parakeet engine"),
+        );
+        let model_dir = engine.models_dir.join(TEST_MODEL_NAME);
+        engine.available_models.write().await.insert(
+            TEST_MODEL_NAME.to_string(),
+            ModelInfo {
+                name: TEST_MODEL_NAME.to_string(),
+                path: model_dir.clone(),
+                size_mb: 1,
+                quantization: QuantizationType::Int8,
+                speed: "test".to_string(),
+                status: ModelStatus::Missing,
+                description: "test model".to_string(),
+            },
+        );
+        (temp_dir, engine, model_dir)
+    }
+
+    async fn test_model_status(engine: &ParakeetEngine) -> ModelStatus {
+        engine
+            .available_models
+            .read()
+            .await
+            .get(TEST_MODEL_NAME)
+            .expect("test model remains registered")
+            .status
+            .clone()
+    }
+
+    #[tokio::test]
+    async fn directory_validation_requires_exact_artifact_sizes() {
+        let temp_dir = tempdir().expect("create temporary model directory");
+        for artifact in SMALL_ARTIFACTS {
+            fs::write(
+                temp_dir.path().join(artifact.filename),
+                vec![0; artifact.exact_bytes as usize],
+            )
+            .await
+            .expect("seed exact artifact");
+        }
+        assert!(ParakeetEngine::validate_model_directory(temp_dir.path(), SMALL_ARTIFACTS).is_ok());
+
+        fs::remove_file(temp_dir.path().join("vocab.txt"))
+            .await
+            .expect("remove required artifact");
+        assert!(ParakeetEngine::validate_model_directory(temp_dir.path(), SMALL_ARTIFACTS).is_err());
+
+        fs::write(temp_dir.path().join("vocab.txt"), [])
+            .await
+            .expect("restore undersized artifact");
+        fs::write(temp_dir.path().join("encoder.bin"), [0; 3])
+            .await
+            .expect("seed one-byte-short artifact");
+        assert!(ParakeetEngine::validate_model_directory(temp_dir.path(), SMALL_ARTIFACTS).is_err());
+
+        fs::write(temp_dir.path().join("encoder.bin"), [0; 5])
+            .await
+            .expect("seed one-byte-oversized artifact");
+        assert!(ParakeetEngine::validate_model_directory(temp_dir.path(), SMALL_ARTIFACTS).is_err());
+    }
+
+    #[tokio::test]
+    async fn completed_sibling_survives_403_then_retry_resumes_partial() {
+        let (_temp_dir, engine, model_dir) = test_engine().await;
+        fs::create_dir_all(&model_dir).await.expect("create model directory");
+        fs::write(model_dir.join("encoder.bin"), b"ABCD")
+            .await
+            .expect("seed completed sibling");
+        fs::write(model_dir.join("decoder.bin"), b"X")
+            .await
+            .expect("seed resumable artifact");
+
+        let (base_url, server) = serve_requests(vec![response(
+            "decoder.bin",
+            Some("bytes=1-"),
+            "403 Forbidden",
+            b"",
+            None,
+        )])
+        .await;
+        let error = engine
+            .download_model_detailed_from_source(
+                TEST_MODEL_NAME,
+                &model_dir,
+                &base_url,
+                SMALL_ARTIFACTS,
+                None,
+            )
+            .await
+            .expect_err("403 must fail without destructive cleanup");
+        server.await.expect("join 403 server");
+        assert!(error.to_string().contains("403"));
+        assert_eq!(fs::read(model_dir.join("encoder.bin")).await.unwrap(), b"ABCD");
+        assert_eq!(fs::read(model_dir.join("decoder.bin")).await.unwrap(), b"X");
+        assert!(!engine.active_downloads.lock().await.contains_key(TEST_MODEL_NAME));
+
+        let (base_url, server) = serve_requests(vec![
+            response(
+                "decoder.bin",
+                Some("bytes=1-"),
+                "206 Partial Content",
+                b"YZ",
+                Some("bytes 1-2/3"),
+            ),
+            response("nemo.bin", None, "200 OK", b"NO", None),
+            response("vocab.txt", None, "200 OK", b"V", None),
+        ])
+        .await;
+        engine
+            .download_model_detailed_from_source(
+                TEST_MODEL_NAME,
+                &model_dir,
+                &base_url,
+                SMALL_ARTIFACTS,
+                None,
+            )
+            .await
+            .expect("retry resumes only the partial artifact");
+        server.await.expect("join retry server");
+
+        assert_eq!(fs::read(model_dir.join("encoder.bin")).await.unwrap(), b"ABCD");
+        assert_eq!(fs::read(model_dir.join("decoder.bin")).await.unwrap(), b"XYZ");
+        assert!(matches!(test_model_status(&engine).await, ModelStatus::Available));
+        assert!(!engine.active_downloads.lock().await.contains_key(TEST_MODEL_NAME));
+    }
+
+    #[tokio::test]
+    async fn near_complete_artifact_is_resumed_not_skipped() {
+        const ARTIFACTS: &[ArtifactSpec] = &[ArtifactSpec {
+            filename: "near.bin",
+            exact_bytes: 100,
+        }];
+        let (_temp_dir, engine, model_dir) = test_engine().await;
+        fs::create_dir_all(&model_dir).await.expect("create model directory");
+        fs::write(model_dir.join("near.bin"), vec![b'A'; 99])
+            .await
+            .expect("seed 99 percent artifact");
+
+        let (base_url, server) = serve_requests(vec![response(
+            "near.bin",
+            Some("bytes=99-"),
+            "206 Partial Content",
+            b"B",
+            Some("bytes 99-99/100"),
+        )])
+        .await;
+        engine
+            .download_model_detailed_from_source(
+                TEST_MODEL_NAME,
+                &model_dir,
+                &base_url,
+                ARTIFACTS,
+                None,
+            )
+            .await
+            .expect("99 percent artifact must resume");
+        server.await.expect("join resume server");
+        assert_eq!(
+            fs::metadata(model_dir.join("near.bin")).await.unwrap().len(),
+            100
+        );
+    }
+
+    #[tokio::test]
+    async fn range_ignored_replaces_partial_with_honest_progress() {
+        const ARTIFACTS: &[ArtifactSpec] = &[ArtifactSpec {
+            filename: "model.bin",
+            exact_bytes: 4,
+        }];
+        let (_temp_dir, engine, model_dir) = test_engine().await;
+        fs::create_dir_all(&model_dir).await.expect("create model directory");
+        fs::write(model_dir.join("model.bin"), b"zz")
+            .await
+            .expect("seed partial artifact");
+        let events = Arc::new(SegQueue::new());
+        let callback_events = Arc::clone(&events);
+
+        let (base_url, server) = serve_requests(vec![response(
+            "model.bin",
+            Some("bytes=2-"),
+            "200 OK",
+            b"ABCD",
+            None,
+        )])
+        .await;
+        engine
+            .download_model_detailed_from_source(
+                TEST_MODEL_NAME,
+                &model_dir,
+                &base_url,
+                ARTIFACTS,
+                Some(Box::new(move |progress| {
+                    callback_events.push(progress);
+                })),
+            )
+            .await
+            .expect("range-ignored response replaces the partial artifact");
+        server.await.expect("join range-ignored server");
+
+        let events: Vec<_> = std::iter::from_fn(|| events.pop()).collect();
+        assert_eq!(fs::read(model_dir.join("model.bin")).await.unwrap(), b"ABCD");
+        assert!(events.iter().all(|progress| progress.downloaded_bytes <= progress.total_bytes));
+        assert_eq!(events.last().expect("final event").percent, 100);
+        assert!(events[..events.len() - 1].iter().all(|progress| progress.percent < 100));
+    }
+
+    #[tokio::test]
+    async fn range_416_retries_fresh_with_honest_progress() {
+        const ARTIFACTS: &[ArtifactSpec] = &[ArtifactSpec {
+            filename: "model.bin",
+            exact_bytes: 4,
+        }];
+        let (_temp_dir, engine, model_dir) = test_engine().await;
+        fs::create_dir_all(&model_dir).await.expect("create model directory");
+        fs::write(model_dir.join("model.bin"), b"zz")
+            .await
+            .expect("seed partial artifact");
+        let events = Arc::new(SegQueue::new());
+        let callback_events = Arc::clone(&events);
+
+        let (base_url, server) = serve_requests(vec![
+            response(
+                "model.bin",
+                Some("bytes=2-"),
+                "416 Range Not Satisfiable",
+                b"",
+                Some("bytes */4"),
+            ),
+            response("model.bin", None, "200 OK", b"ABCD", None),
+        ])
+        .await;
+        engine
+            .download_model_detailed_from_source(
+                TEST_MODEL_NAME,
+                &model_dir,
+                &base_url,
+                ARTIFACTS,
+                Some(Box::new(move |progress| {
+                    callback_events.push(progress);
+                })),
+            )
+            .await
+            .expect("416 should retry without Range");
+        server.await.expect("join 416 server");
+
+        assert_eq!(fs::read(model_dir.join("model.bin")).await.unwrap(), b"ABCD");
+        assert!(std::iter::from_fn(|| events.pop())
+            .all(|progress| progress.downloaded_bytes <= progress.total_bytes));
+    }
+
+    #[tokio::test]
+    async fn invalid_or_short_response_never_publishes_available() {
+        const ARTIFACTS: &[ArtifactSpec] = &[
+            ArtifactSpec {
+                filename: "complete.bin",
+                exact_bytes: 1,
+            },
+            ArtifactSpec {
+                filename: "target.bin",
+                exact_bytes: 4,
+            },
+        ];
+        let cases = vec![
+            (
+                "malformed",
+                ExpectedResponse {
+                    filename: "target.bin",
+                    range: Some("bytes=1-"),
+                    status: "206 Partial Content",
+                    content_length: Some(3),
+                    content_range: Some("bytes invalid"),
+                    body: b"XYZ",
+                },
+            ),
+            (
+                "wrong-start",
+                ExpectedResponse {
+                    filename: "target.bin",
+                    range: Some("bytes=1-"),
+                    status: "206 Partial Content",
+                    content_length: Some(4),
+                    content_range: Some("bytes 0-3/4"),
+                    body: b"ABCD",
+                },
+            ),
+            (
+                "wrong-total",
+                ExpectedResponse {
+                    filename: "target.bin",
+                    range: Some("bytes=1-"),
+                    status: "206 Partial Content",
+                    content_length: Some(3),
+                    content_range: Some("bytes 1-3/5"),
+                    body: b"XYZ",
+                },
+            ),
+            (
+                "short",
+                ExpectedResponse {
+                    filename: "target.bin",
+                    range: Some("bytes=1-"),
+                    status: "200 OK",
+                    content_length: Some(4),
+                    content_range: None,
+                    body: b"ABC",
+                },
+            ),
+            (
+                "overlong",
+                ExpectedResponse {
+                    filename: "target.bin",
+                    range: Some("bytes=1-"),
+                    status: "200 OK",
+                    content_length: Some(5),
+                    content_range: None,
+                    body: b"ABCDE",
+                },
+            ),
+        ];
+
+        for (case_name, invalid_response) in cases {
+            let (_temp_dir, engine, model_dir) = test_engine().await;
+            fs::create_dir_all(&model_dir).await.expect("create model directory");
+            fs::write(model_dir.join("complete.bin"), b"C")
+                .await
+                .expect("seed completed sibling");
+            fs::write(model_dir.join("target.bin"), b"Z")
+                .await
+                .expect("seed retained prefix");
+
+            let (base_url, server) = serve_requests(vec![invalid_response]).await;
+            assert!(
+                engine
+                    .download_model_detailed_from_source(
+                        TEST_MODEL_NAME,
+                        &model_dir,
+                        &base_url,
+                        ARTIFACTS,
+                        None,
+                    )
+                    .await
+                    .is_err(),
+                "{case_name} response must fail"
             );
+            server.await.expect("join invalid-response server");
+            assert_eq!(fs::read(model_dir.join("complete.bin")).await.unwrap(), b"C");
+            assert!(!matches!(test_model_status(&engine).await, ModelStatus::Available));
+            assert!(!engine.active_downloads.lock().await.contains_key(TEST_MODEL_NAME));
         }
     }
 
     #[tokio::test]
-    async fn failed_download_releases_active_registration() {
-        let temp_dir = tempdir().expect("create temporary models directory");
-        let engine = ParakeetEngine::new_with_models_dir(Some(temp_dir.path().to_path_buf()))
-            .expect("create Parakeet engine");
-        let missing_model = "unknown-model";
-
-        let error = engine
-            .download_model_detailed(missing_model, None)
+    async fn pending_cancellation_keeps_owner_and_blocks_retry() {
+        let (_temp_dir, engine, model_dir) = test_engine().await;
+        fs::create_dir_all(&model_dir).await.expect("create model directory");
+        fs::write(model_dir.join("encoder.bin"), b"AB")
             .await
-            .expect_err("unknown model must fail before network access");
-
-        assert!(error.to_string().contains("not found"));
-        assert!(
-            !engine.active_downloads.read().await.contains(missing_model),
-            "outer cleanup must release active registration on every error path"
-        );
-    }
-
-    #[tokio::test]
-    async fn concurrent_retry_keeps_existing_active_registration() {
-        let temp_dir = tempdir().expect("create temporary models directory");
-        let engine = ParakeetEngine::new_with_models_dir(Some(temp_dir.path().to_path_buf()))
-            .expect("create Parakeet engine");
-        engine
-            .active_downloads
-            .write()
+            .expect("seed resumable prefix");
+        let owner = engine
+            .reserve_active_download(TEST_MODEL_NAME)
             .await
-            .insert(TEST_MODEL_NAME.to_string());
-
-        let error = engine
-            .download_model_detailed(TEST_MODEL_NAME, None)
-            .await
-            .expect_err("a second worker must not bypass active registration");
-
-        assert!(error.to_string().contains("already in progress"));
-        assert!(
-            engine
-                .active_downloads
-                .read()
-                .await
-                .contains(TEST_MODEL_NAME),
-            "the existing worker remains the owner of the active registration"
-        );
-    }
-
-    #[tokio::test]
-    async fn starting_another_model_preserves_pending_cancellation() {
-        let temp_dir = tempdir().expect("create temporary models directory");
-        let engine = ParakeetEngine::new_with_models_dir(Some(temp_dir.path().to_path_buf()))
-            .expect("create Parakeet engine");
-        engine
-            .active_downloads
-            .write()
-            .await
-            .insert(TEST_MODEL_NAME.to_string());
-        engine
-            .cancel_download(TEST_MODEL_NAME)
-            .await
-            .expect("record cancellation request");
-
-        let _ = engine.download_model_detailed("unknown-model", None).await;
-
-        assert!(
-            engine
-                .cancelled_downloads
-                .read()
-                .await
-                .contains(TEST_MODEL_NAME),
-            "starting another model must not consume this model's cancellation request"
-        );
-    }
-
-    #[tokio::test]
-    async fn rejected_retry_preserves_active_workers_cancellation() {
-        let temp_dir = tempdir().expect("create temporary models directory");
-        let engine = ParakeetEngine::new_with_models_dir(Some(temp_dir.path().to_path_buf()))
-            .expect("create Parakeet engine");
-        engine
-            .active_downloads
-            .write()
-            .await
-            .insert(TEST_MODEL_NAME.to_string());
-        engine
-            .cancel_download(TEST_MODEL_NAME)
-            .await
-            .expect("record cancellation request");
-
-        let _ = engine.download_model_detailed(TEST_MODEL_NAME, None).await;
-
-        assert!(
-            engine
-                .cancelled_downloads
-                .read()
-                .await
-                .contains(TEST_MODEL_NAME),
-            "a rejected retry must not clear the active worker's cancellation request"
-        );
-    }
-
-    #[tokio::test]
-    async fn cancellation_preserves_downloaded_artifacts_for_resume() {
-        let temp_dir = tempdir().expect("create temporary models directory");
-        let engine = ParakeetEngine::new_with_models_dir(Some(temp_dir.path().to_path_buf()))
-            .expect("create Parakeet engine");
-        let model_dir = engine.models_dir.join(TEST_MODEL_NAME);
-        fs::create_dir_all(&model_dir)
-            .await
-            .expect("create model directory");
-        let encoder_path = model_dir.join("encoder-model.int8.onnx");
-        fs::write(&encoder_path, b"downloaded-encoder")
-            .await
-            .expect("seed downloaded artifact");
-        engine
-            .active_downloads
-            .write()
-            .await
-            .insert(TEST_MODEL_NAME.to_string());
-
-        engine
-            .cancel_download(TEST_MODEL_NAME)
-            .await
-            .expect("cancel model download");
+            .expect("reserve initial owner");
 
         assert_eq!(
-            fs::read(encoder_path)
-                .await
-                .expect("cancellation must preserve resumable artifacts"),
-            b"downloaded-encoder"
-        );
-        assert!(
             engine
-                .active_downloads
-                .read()
+                .cancel_download_with_timeout(TEST_MODEL_NAME, Duration::from_millis(1))
                 .await
-                .contains(TEST_MODEL_NAME),
-            "the download worker owns the active registration until it exits"
+                .expect("request cancellation"),
+            CancelDownloadOutcome::Pending
         );
+        assert!(engine.reserve_active_download(TEST_MODEL_NAME).await.is_err());
+
+        let error = engine
+            .finish_download(
+                TEST_MODEL_NAME,
+                &model_dir,
+                SMALL_ARTIFACTS,
+                &owner,
+                Err(DownloadCancelled.into()),
+                None,
+            )
+            .await
+            .expect_err("cancelled owner must finish as cancellation");
+        assert!(is_download_cancelled(&error));
+        assert_eq!(fs::read(model_dir.join("encoder.bin")).await.unwrap(), b"AB");
+        assert!(!engine.active_downloads.lock().await.contains_key(TEST_MODEL_NAME));
+        assert!(engine.reserve_active_download(TEST_MODEL_NAME).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn cancellation_wins_before_terminal_commit() {
+        const ARTIFACTS: &[ArtifactSpec] = &[ArtifactSpec {
+            filename: "model.bin",
+            exact_bytes: 4,
+        }];
+        let (_temp_dir, engine, model_dir) = test_engine().await;
+        let hook = Arc::new(DownloadStateTestHook {
+            finalization_ready: tokio::sync::Notify::new(),
+            continue_finalization: tokio::sync::Notify::new(),
+        });
+        *engine.download_state_test_hook.lock().await = Some(Arc::clone(&hook));
+        let events = Arc::new(SegQueue::new());
+        let callback_events = Arc::clone(&events);
+
+        let (base_url, server) =
+            serve_requests(vec![response("model.bin", None, "200 OK", b"ABCD", None)]).await;
+        let download_engine = Arc::clone(&engine);
+        let download_dir = model_dir.clone();
+        let download = tokio::spawn(async move {
+            download_engine
+                .download_model_detailed_from_source(
+                    TEST_MODEL_NAME,
+                    &download_dir,
+                    &base_url,
+                    ARTIFACTS,
+                    Some(Box::new(move |progress| {
+                        callback_events.push(progress);
+                    })),
+                )
+                .await
+        });
+
+        hook.finalization_ready.notified().await;
+        assert_eq!(
+            engine
+                .cancel_download_with_timeout(TEST_MODEL_NAME, Duration::from_millis(1))
+                .await
+                .expect("request cancellation while finalization is paused"),
+            CancelDownloadOutcome::Pending
+        );
+        hook.continue_finalization.notify_one();
+
+        let error = download
+            .await
+            .expect("join download task")
+            .expect_err("cancellation must win before terminal commit");
+        server.await.expect("join cancellation server");
+        assert!(is_download_cancelled(&error));
+        assert!(std::iter::from_fn(|| events.pop()).all(|progress| progress.percent < 100));
+        assert!(matches!(test_model_status(&engine).await, ModelStatus::Missing));
+        assert!(!engine.active_downloads.lock().await.contains_key(TEST_MODEL_NAME));
     }
 }

--- a/frontend/src-tauri/src/parakeet_engine/parakeet_engine.rs
+++ b/frontend/src-tauri/src/parakeet_engine/parakeet_engine.rs
@@ -180,6 +180,13 @@ struct DownloadStateTestHook {
     continue_discovery: tokio::sync::Notify,
 }
 
+#[cfg(test)]
+struct ModelLifecycleTestHook {
+    load_started: tokio::sync::Notify,
+    continue_load: tokio::sync::Notify,
+    unload_attempted: tokio::sync::Notify,
+}
+
 enum ContentRange {
     Range { start: u64, end: u64, total: u64 },
     Unsatisfied { total: u64 },
@@ -257,10 +264,13 @@ pub struct ParakeetEngine {
     models_dir: PathBuf,
     current_model: Arc<RwLock<Option<ParakeetModel>>>,
     current_model_name: Arc<RwLock<Option<String>>>,
+    model_lifecycle_lock: Mutex<()>,
     pub(crate) available_models: Arc<RwLock<HashMap<String, ModelInfo>>>,
     active_downloads: Arc<Mutex<ActiveDownloadState>>,
     #[cfg(test)]
     download_state_test_hook: Mutex<Option<Arc<DownloadStateTestHook>>>,
+    #[cfg(test)]
+    model_lifecycle_test_hook: Mutex<Option<Arc<ModelLifecycleTestHook>>>,
 }
 
 impl ParakeetEngine {
@@ -298,16 +308,24 @@ impl ParakeetEngine {
             models_dir,
             current_model: Arc::new(RwLock::new(None)),
             current_model_name: Arc::new(RwLock::new(None)),
+            model_lifecycle_lock: Mutex::new(()),
             available_models: Arc::new(RwLock::new(HashMap::new())),
             active_downloads: Arc::new(Mutex::new(ActiveDownloadState::default())),
             #[cfg(test)]
             download_state_test_hook: Mutex::new(None),
+            #[cfg(test)]
+            model_lifecycle_test_hook: Mutex::new(None),
         })
     }
 
     #[cfg(test)]
     async fn test_hook(&self) -> Option<Arc<DownloadStateTestHook>> {
         self.download_state_test_hook.lock().await.clone()
+    }
+
+    #[cfg(test)]
+    async fn load_test_hook(&self) -> Option<Arc<ModelLifecycleTestHook>> {
+        self.model_lifecycle_test_hook.lock().await.clone()
     }
 
     /// Discover available Parakeet models.
@@ -412,33 +430,61 @@ impl ParakeetEngine {
 
     /// Load a Parakeet model
     pub async fn load_model(&self, model_name: &str) -> Result<()> {
-        let models = self.available_models.read().await;
-        let model_info = models
-            .get(model_name)
-            .ok_or_else(|| anyhow!("Model {} not found", model_name))?;
+        let model_info = {
+            let models = self.available_models.read().await;
+            models
+                .get(model_name)
+                .cloned()
+                .ok_or_else(|| anyhow!("Model {} not found", model_name))?
+        };
 
-        match model_info.status {
+        match &model_info.status {
             ModelStatus::Available => {
-                // Check if this model is already loaded
-                if let Some(current_model) = self.current_model_name.read().await.as_ref() {
-                    if current_model == model_name {
-                        log::info!("Parakeet model {} is already loaded, skipping reload", model_name);
-                        return Ok(());
-                    }
-
-                    // Unload current model before loading new one
-                    log::info!("Unloading current Parakeet model '{}' before loading '{}'", current_model, model_name);
-                    self.unload_model().await;
+                let _lifecycle_guard = self.model_lifecycle_lock.lock().await;
+                let current_model = self.current_model_name.read().await.clone();
+                if current_model.as_deref() == Some(model_name) {
+                    log::info!("Parakeet model {} is already loaded, skipping reload", model_name);
+                    return Ok(());
                 }
+
+                if let Some(current_model) = current_model {
+                    log::info!(
+                        "Unloading current Parakeet model '{}' before loading '{}'",
+                        current_model,
+                        model_name
+                    );
+                }
+                self.unload_model_locked().await;
 
                 log::info!("Loading Parakeet model: {}", model_name);
 
-                // Load model based on quantization type
                 let quantized = model_info.quantization == QuantizationType::Int8;
-                let model = ParakeetModel::new(&model_info.path, quantized)
-                    .map_err(|e| anyhow!("Failed to load Parakeet model {}: {}", model_name, e))?;
+                let model_path = model_info.path.clone();
+                #[cfg(test)]
+                let model_lifecycle_test_hook = self.load_test_hook().await;
+                #[cfg(test)]
+                let runtime_handle = tokio::runtime::Handle::current();
+                let model = tokio::task::spawn_blocking(move || {
+                    #[cfg(test)]
+                    if let Some(hook) = model_lifecycle_test_hook {
+                        hook.load_started.notify_one();
+                        runtime_handle.block_on(hook.continue_load.notified());
+                    }
+                    ParakeetModel::new(&model_path, quantized)
+                        .map_err(|error| error.to_string())
+                })
+                .await
+                .map_err(|error| {
+                    anyhow!(
+                        "Parakeet model load task failed for {}: {}",
+                        model_name,
+                        error
+                    )
+                })?
+                .map_err(|error| {
+                    anyhow!("Failed to load Parakeet model {}: {}", model_name, error)
+                })?;
 
-                // Update current model and model name
                 *self.current_model.write().await = Some(model);
                 *self.current_model_name.write().await = Some(model_name.to_string());
 
@@ -455,7 +501,7 @@ impl ParakeetEngine {
             ModelStatus::Downloading { .. } => {
                 Err(anyhow!("Parakeet model {} is currently downloading", model_name))
             }
-            ModelStatus::Error(ref err) => {
+            ModelStatus::Error(err) => {
                 Err(anyhow!("Parakeet model {} has error: {}", model_name, err))
             }
             ModelStatus::Corrupted { .. } => {
@@ -466,15 +512,20 @@ impl ParakeetEngine {
 
     /// Unload the current model
     pub async fn unload_model(&self) -> bool {
-        let mut model_guard = self.current_model.write().await;
-        let unloaded = model_guard.take().is_some();
+        #[cfg(test)]
+        if let Some(hook) = self.load_test_hook().await {
+            hook.unload_attempted.notify_one();
+        }
+        let _lifecycle_guard = self.model_lifecycle_lock.lock().await;
+        self.unload_model_locked().await
+    }
+
+    async fn unload_model_locked(&self) -> bool {
+        let unloaded = self.current_model.write().await.take().is_some();
         if unloaded {
             log::info!("Parakeet model unloaded");
         }
-
-        let mut model_name_guard = self.current_model_name.write().await;
-        model_name_guard.take();
-
+        self.current_model_name.write().await.take();
         unloaded
     }
 
@@ -1353,6 +1404,92 @@ mod tests {
             .await
             .expect("seed one-byte-oversized artifact");
         assert!(ParakeetEngine::validate_model_directory(temp_dir.path(), SMALL_ARTIFACTS).is_err());
+    }
+
+    #[tokio::test]
+    async fn loading_releases_available_models_and_serializes_unload() {
+        let (_temp_dir, engine, _model_dir) = test_engine().await;
+        engine
+            .available_models
+            .write()
+            .await
+            .get_mut(TEST_MODEL_NAME)
+            .expect("test model remains registered")
+            .status = ModelStatus::Available;
+        *engine.current_model_name.write().await = Some("previous-test-model".to_string());
+
+        let hook = Arc::new(ModelLifecycleTestHook {
+            load_started: tokio::sync::Notify::new(),
+            continue_load: tokio::sync::Notify::new(),
+            unload_attempted: tokio::sync::Notify::new(),
+        });
+        *engine.model_lifecycle_test_hook.lock().await = Some(Arc::clone(&hook));
+
+        let load_engine = Arc::clone(&engine);
+        let load = tokio::spawn(async move { load_engine.load_model(TEST_MODEL_NAME).await });
+        tokio::time::timeout(Duration::from_secs(1), hook.load_started.notified())
+            .await
+            .expect("model load must reach its blocking task");
+
+        {
+            let mut models = tokio::time::timeout(
+                Duration::from_secs(1),
+                engine.available_models.write(),
+            )
+            .await
+            .expect("model cache must remain writable during native loading");
+            models
+                .get_mut(TEST_MODEL_NAME)
+                .expect("test model remains registered")
+                .description = "updated while native load is paused".to_string();
+        }
+
+        let (unloaded_tx, mut unloaded_rx) = oneshot::channel();
+        let unload_engine = Arc::clone(&engine);
+        let unload = tokio::spawn(async move {
+            let unloaded = unload_engine.unload_model().await;
+            unloaded_tx
+                .send(unloaded)
+                .expect("unload receiver remains connected");
+        });
+        tokio::time::timeout(Duration::from_secs(1), hook.unload_attempted.notified())
+            .await
+            .expect("unload must reach the lifecycle boundary");
+        assert!(matches!(
+            unloaded_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+
+        hook.continue_load.notify_one();
+        tokio::time::timeout(Duration::from_secs(1), load)
+            .await
+            .expect("model load must finish after release")
+            .expect("join model load task")
+            .expect_err("empty model directory must fail loading");
+        assert!(
+            !tokio::time::timeout(Duration::from_secs(1), unloaded_rx)
+                .await
+                .expect("unload must finish after model load")
+                .expect("unload sender remains connected")
+        );
+        tokio::time::timeout(Duration::from_secs(1), unload)
+            .await
+            .expect("unload task must join")
+            .expect("join unload task");
+
+        assert_eq!(
+            engine
+                .available_models
+                .read()
+                .await
+                .get(TEST_MODEL_NAME)
+                .expect("test model remains registered")
+                .description,
+            "updated while native load is paused"
+        );
+        assert!(engine.current_model.read().await.is_none());
+        assert!(engine.current_model_name.read().await.is_none());
+        *engine.model_lifecycle_test_hook.lock().await = None;
     }
 
     #[tokio::test]

--- a/frontend/src-tauri/src/parakeet_engine/parakeet_engine.rs
+++ b/frontend/src-tauri/src/parakeet_engine/parakeet_engine.rs
@@ -1141,7 +1141,7 @@ mod tests {
     use tempfile::tempdir;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
-
+    use tokio::sync::oneshot;
     const TEST_MODEL_NAME: &str = "parakeet-test";
     const SMALL_ARTIFACTS: &[ArtifactSpec] = &[
         ArtifactSpec { filename: "encoder.bin", exact_bytes: 4 },
@@ -1157,6 +1157,7 @@ mod tests {
         content_length: Option<u64>,
         content_range: Option<&'static str>,
         body: &'static [u8],
+        release_after_body: Option<oneshot::Receiver<()>>,
     }
 
     fn response(
@@ -1173,6 +1174,7 @@ mod tests {
             content_length: Some(body.len() as u64),
             content_range,
             body,
+            release_after_body: None,
         }
     }
 
@@ -1226,6 +1228,9 @@ mod tests {
                     .write_all(expected.body)
                     .await
                     .expect("write response body");
+                if let Some(release_after_body) = expected.release_after_body {
+                    release_after_body.await.expect("release partial response");
+                }
             }
         });
 
@@ -1363,16 +1368,73 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn near_complete_artifact_is_resumed_not_skipped() {
+    async fn cancelled_near_complete_artifact_is_resumed_on_retry() {
         const ARTIFACTS: &[ArtifactSpec] = &[ArtifactSpec {
             filename: "near.bin",
             exact_bytes: 100,
         }];
+        const PREFIX: &[u8] = &[b'A'; 99];
+
         let (_temp_dir, engine, model_dir) = test_engine().await;
-        fs::create_dir_all(&model_dir).await.expect("create model directory");
-        fs::write(model_dir.join("near.bin"), vec![b'A'; 99])
+        let (release_tx, release_rx) = oneshot::channel();
+        let (progress_tx, progress_rx) = oneshot::channel();
+        let progress_tx = Arc::new(std::sync::Mutex::new(Some(progress_tx)));
+        let (base_url, server) = serve_requests(vec![ExpectedResponse {
+            filename: "near.bin",
+            range: None,
+            status: "200 OK",
+            content_length: Some(100),
+            content_range: None,
+            body: PREFIX,
+            release_after_body: Some(release_rx),
+        }])
+        .await;
+
+        let download_engine = Arc::clone(&engine);
+        let download_dir = model_dir.clone();
+        let download = tokio::spawn(async move {
+            download_engine
+                .download_model_detailed_from_source(
+                    TEST_MODEL_NAME,
+                    &download_dir,
+                    &base_url,
+                    ARTIFACTS,
+                    Some(Box::new(move |progress| {
+                        if progress.downloaded_bytes == 99 {
+                            if let Some(sender) = progress_tx
+                                .lock()
+                                .expect("lock progress sender")
+                                .take()
+                            {
+                                let _ = sender.send(());
+                            }
+                        }
+                    })),
+                )
+                .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), progress_rx)
             .await
-            .expect("seed 99 percent artifact");
+            .expect("receive near-complete progress")
+            .expect("progress sender remains connected");
+        assert_eq!(
+            engine
+                .cancel_download_with_timeout(TEST_MODEL_NAME, Duration::from_secs(5))
+                .await
+                .expect("cancel near-complete download"),
+            CancelDownloadOutcome::Cancelled
+        );
+        release_tx.send(()).expect("release partial response");
+        let error = download
+            .await
+            .expect("join cancelled download")
+            .expect_err("cancelled download must not succeed");
+        server.await.expect("join partial-response server");
+
+        assert!(is_download_cancelled(&error));
+        assert_eq!(fs::metadata(model_dir.join("near.bin")).await.unwrap().len(), 99);
+        assert!(matches!(test_model_status(&engine).await, ModelStatus::Missing));
 
         let (base_url, server) = serve_requests(vec![response(
             "near.bin",
@@ -1391,12 +1453,11 @@ mod tests {
                 None,
             )
             .await
-            .expect("99 percent artifact must resume");
-        server.await.expect("join resume server");
-        assert_eq!(
-            fs::metadata(model_dir.join("near.bin")).await.unwrap().len(),
-            100
-        );
+            .expect("retry resumes the cancelled near-complete artifact");
+        server.await.expect("join retry server");
+
+        assert_eq!(fs::metadata(model_dir.join("near.bin")).await.unwrap().len(), 100);
+        assert!(matches!(test_model_status(&engine).await, ModelStatus::Available));
     }
 
     #[tokio::test]
@@ -1508,6 +1569,7 @@ mod tests {
                     content_length: Some(3),
                     content_range: Some("bytes invalid"),
                     body: b"XYZ",
+                    release_after_body: None,
                 },
             ),
             (
@@ -1519,6 +1581,7 @@ mod tests {
                     content_length: Some(4),
                     content_range: Some("bytes 0-3/4"),
                     body: b"ABCD",
+                    release_after_body: None,
                 },
             ),
             (
@@ -1530,6 +1593,7 @@ mod tests {
                     content_length: Some(3),
                     content_range: Some("bytes 1-3/5"),
                     body: b"XYZ",
+                    release_after_body: None,
                 },
             ),
             (
@@ -1541,6 +1605,7 @@ mod tests {
                     content_length: Some(4),
                     content_range: None,
                     body: b"ABC",
+                    release_after_body: None,
                 },
             ),
             (
@@ -1552,6 +1617,7 @@ mod tests {
                     content_length: Some(5),
                     content_range: None,
                     body: b"ABCDE",
+                    release_after_body: None,
                 },
             ),
         ];

--- a/frontend/src-tauri/src/parakeet_engine/parakeet_engine.rs
+++ b/frontend/src-tauri/src/parakeet_engine/parakeet_engine.rs
@@ -2,7 +2,7 @@ use crate::parakeet_engine::model::ParakeetModel;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs;
 use tokio::io::{AsyncWriteExt, BufWriter};
@@ -116,7 +116,7 @@ pub struct ParakeetEngine {
     current_model: Arc<RwLock<Option<ParakeetModel>>>,
     current_model_name: Arc<RwLock<Option<String>>>,
     pub(crate) available_models: Arc<RwLock<HashMap<String, ModelInfo>>>,
-    cancel_download_flag: Arc<RwLock<Option<String>>>, // Model name being cancelled
+    cancelled_downloads: Arc<RwLock<HashSet<String>>>, // Models with pending cancellation requests
     // Active downloads tracking to prevent concurrent downloads
     pub(crate) active_downloads: Arc<RwLock<HashSet<String>>>, // Set of models currently being downloaded
 }
@@ -157,7 +157,7 @@ impl ParakeetEngine {
             current_model: Arc::new(RwLock::new(None)),
             current_model_name: Arc::new(RwLock::new(None)),
             available_models: Arc::new(RwLock::new(HashMap::new())),
-            cancel_download_flag: Arc::new(RwLock::new(None)),
+            cancelled_downloads: Arc::new(RwLock::new(HashSet::new())),
             // Initialize active downloads tracking
             active_downloads: Arc::new(RwLock::new(HashSet::new())),
         })
@@ -325,51 +325,25 @@ impl ParakeetEngine {
         Ok(())
     }
 
-    /// Clean incomplete model directory before download
-    /// Removes all files if directory exists but model is not Available
-    async fn clean_incomplete_model_directory(&self, model_dir: &PathBuf) -> Result<()> {
-        if !model_dir.exists() {
-            return Ok(()); // Nothing to clean
-        }
-
-        // Validate the directory
-        match self.validate_model_directory(model_dir).await {
-            Ok(_) => {
-                log::info!("Model directory is valid, no cleanup needed");
-                return Ok(());
-            }
-            Err(validation_error) => {
-                log::warn!(
-                    "Model directory exists but is invalid: {}. Cleaning up...",
-                    validation_error
-                );
-
-                // List and remove all files in the directory
-                let mut entries = fs::read_dir(model_dir).await
-                    .map_err(|e| anyhow!("Failed to read model directory: {}", e))?;
-
-                let mut removed_count = 0;
-                while let Some(entry) = entries.next_entry().await
-                    .map_err(|e| anyhow!("Failed to read directory entry: {}", e))?
-                {
-                    let path = entry.path();
-                    if path.is_file() {
-                        match fs::remove_file(&path).await {
-                            Ok(_) => {
-                                log::info!("Removed incomplete file: {:?}", path.file_name());
-                                removed_count += 1;
-                            }
-                            Err(e) => {
-                                log::warn!("Failed to remove file {:?}: {}", path, e);
-                            }
-                        }
-                    }
-                }
-
-                log::info!("Cleaned {} incomplete files from model directory", removed_count);
-                Ok(())
+    /// Count bytes that can be reused by the per-file skip/resume logic.
+    async fn existing_artifact_bytes(
+        model_dir: &Path,
+        filenames: &[&str],
+        expected_sizes: &HashMap<&str, u64>,
+    ) -> u64 {
+        let mut reusable_bytes = 0;
+        for filename in filenames {
+            let file_path = model_dir.join(filename);
+            if let (Ok(metadata), Some(expected_size)) =
+                (fs::metadata(&file_path).await, expected_sizes.get(filename))
+            {
+                // 这些尺寸是近似值，只能用于进度估算，不能据此删除文件；
+                // 缺失、偏小或版本变化后的偏大 artifact 都交给逐文件下载/校验流程处理。
+                reusable_bytes += metadata.len().min(*expected_size);
             }
         }
+
+        reusable_bytes
     }
 
     /// Load a Parakeet model
@@ -547,38 +521,54 @@ impl ParakeetEngine {
     ) -> Result<()> {
         log::info!("Starting download for Parakeet model: {}", model_name);
 
-        // Check if download is already in progress for this model
-        {
-            let active = self.active_downloads.read().await;
-            if active.contains(model_name) {
-                log::warn!("Download already in progress for Parakeet model: {}", model_name);
-                return Err(anyhow!("Download already in progress for model: {}", model_name));
-            }
-        }
-
-        // Add to active downloads
+        // 检查与注册必须在同一写锁内完成，避免两个重试任务同时通过检查并写入同一个 artifact。
         {
             let mut active = self.active_downloads.write().await;
+            if active.contains(model_name) {
+                log::warn!(
+                    "Download already in progress for Parakeet model: {}",
+                    model_name
+                );
+                return Err(anyhow!(
+                    "Download already in progress for model: {}",
+                    model_name
+                ));
+            }
+
+            // cancel_download 采用相同的 active -> cancelled 锁顺序；因此这里清理的只能是
+            // 上一次任务留下的请求，新取消请求会在注册完成后写入，不会被启动流程吞掉。
+            self.cancelled_downloads.write().await.remove(model_name);
             active.insert(model_name.to_string());
         }
 
-        // Clear any previous cancellation flag for this model
-        {
-            let mut cancel_flag = self.cancel_download_flag.write().await;
-            *cancel_flag = None;
-        }
+        let result = self
+            .download_model_detailed_inner(model_name, progress_callback)
+            .await;
 
+        // active 标记由最外层统一释放，确保 TLS、代理、文件 I/O 和取消等所有返回路径
+        // 都不会遗留“already in progress”，也不会在 worker 尚未退出时过早允许重试。
+        if result.is_err() {
+            let mut models = self.available_models.write().await;
+            if let Some(model) = models.get_mut(model_name) {
+                model.status = ModelStatus::Missing;
+            }
+        }
+        self.active_downloads.write().await.remove(model_name);
+
+        result
+    }
+
+    async fn download_model_detailed_inner(
+        &self,
+        model_name: &str,
+        progress_callback: Option<Box<dyn Fn(DownloadProgress) + Send>>,
+    ) -> Result<()> {
         // Get model info
         let model_info = {
             let models = self.available_models.read().await;
             match models.get(model_name).cloned() {
                 Some(info) => info,
-                None => {
-                    // Remove from active downloads on error
-                    let mut active = self.active_downloads.write().await;
-                    active.remove(model_name);
-                    return Err(anyhow!("Model {} not found", model_name));
-                }
+                None => return Err(anyhow!("Model {} not found", model_name)),
             }
         };
 
@@ -618,18 +608,8 @@ impl ParakeetEngine {
         let model_dir = &model_info.path;
         if !model_dir.exists() {
             if let Err(e) = fs::create_dir_all(model_dir).await {
-                // Remove from active downloads on error
-                let mut active = self.active_downloads.write().await;
-                active.remove(model_name);
                 return Err(anyhow!("Failed to create model directory: {}", e));
             }
-        }
-
-        // Clean up incomplete downloads before starting
-        log::info!("Checking for incomplete model files to clean up...");
-        if let Err(e) = self.clean_incomplete_model_directory(model_dir).await {
-            log::warn!("Failed to clean incomplete model directory: {}", e);
-            // Continue anyway - we'll handle errors during download
         }
 
         // Optimized HTTP client for large file downloads
@@ -682,20 +662,9 @@ impl ParakeetEngine {
             .copied()
             .sum();
 
-        // Check for existing downloads (complete or partial) to calculate resume offset
-        let mut already_downloaded: u64 = 0;
-        for filename in &files_to_download {
-            let file_path = model_dir.join(filename);
-            if file_path.exists() {
-                if let Ok(metadata) = fs::metadata(&file_path).await {
-                    let file_size = metadata.len();
-                    let expected_size = file_sizes.get(*filename).copied().unwrap_or(0);
-                    // Count all existing bytes (complete files capped at expected size, partial as-is)
-                    // This ensures progress starts from where we left off
-                    already_downloaded += file_size.min(expected_size);
-                }
-            }
-        }
+        // 只读取现有 artifact 来计算续传进度；单个文件失败时不再删除已完成的兄弟文件。
+        let already_downloaded =
+            Self::existing_artifact_bytes(model_dir, &files_to_download, &file_sizes).await;
 
         let mut total_downloaded: u64 = already_downloaded;
 
@@ -780,8 +749,6 @@ impl ParakeetEngine {
                     );
 
                     if let Err(e) = fs::remove_file(&file_path).await {
-                        let mut active = self.active_downloads.write().await;
-                        active.remove(model_name);
                         return Err(anyhow!("Failed to delete incomplete file {}: {}", filename, e));
                     }
 
@@ -791,8 +758,6 @@ impl ParakeetEngine {
                         .map_err(|e| anyhow!("Retry failed for {}: {}", filename, e))?;
 
                     if !response.status().is_success() {
-                        let mut active = self.active_downloads.write().await;
-                        active.remove(model_name);
                         return Err(anyhow!("Retry failed for {} with status: {}", filename, response.status()));
                     }
 
@@ -800,8 +765,6 @@ impl ParakeetEngine {
                 }
             } else {
                 // Other errors
-                let mut active = self.active_downloads.write().await;
-                active.remove(model_name);
                 return Err(anyhow!("Download failed for {} with status: {}", filename, response.status()));
             };
 
@@ -829,15 +792,12 @@ impl ParakeetEngine {
             loop {
                 // Check for cancellation before processing chunk
                 {
-                    let cancel_flag = self.cancel_download_flag.read().await;
-                    if cancel_flag.as_ref() == Some(&model_name.to_string()) {
+                    let cancelled_downloads = self.cancelled_downloads.read().await;
+                    if cancelled_downloads.contains(model_name) {
                         log::info!("Download cancelled for {}", model_name);
                         // Flush and keep partial file for resume on next attempt
                         let _ = writer.flush().await;
                         drop(writer);
-                        // Remove from active downloads on cancellation
-                        let mut active = self.active_downloads.write().await;
-                        active.remove(model_name);
                         return Err(anyhow!("Download cancelled by user"));
                     }
                 }
@@ -850,12 +810,6 @@ impl ParakeetEngine {
                     Err(_) => {
                         log::warn!("Download timeout for {}: no data received for 30 seconds", model_name);
                         let _ = writer.flush().await;
-
-                        // Remove from active downloads
-                        {
-                            let mut active = self.active_downloads.write().await;
-                            active.remove(model_name);
-                        }
 
                         // Update model status to Missing so retry can work
                         {
@@ -877,12 +831,6 @@ impl ParakeetEngine {
                             Err(e) => {
                                 log::error!("Download error for {}: {:?}", model_name, e);
                                 let _ = writer.flush().await;
-
-                                // Remove from active downloads
-                                {
-                                    let mut active = self.active_downloads.write().await;
-                                    active.remove(model_name);
-                                }
 
                                 // Update model status to Missing so retry can work
                                 {
@@ -909,12 +857,6 @@ impl ParakeetEngine {
                 };
 
                 if let Err(e) = writer.write_all(&chunk).await {
-                    // Remove from active downloads on error
-                    {
-                        let mut active = self.active_downloads.write().await;
-                        active.remove(model_name);
-                    }
-
                     // Update model status to Missing so retry can work
                     {
                         let mut models = self.available_models.write().await;
@@ -983,12 +925,6 @@ impl ParakeetEngine {
 
             // Flush the buffered writer
             if let Err(e) = writer.flush().await {
-                // Remove from active downloads on error
-                {
-                    let mut active = self.active_downloads.write().await;
-                    active.remove(model_name);
-                }
-
                 // Update model status to Missing so retry can work
                 {
                     let mut models = self.available_models.write().await;
@@ -1029,19 +965,7 @@ impl ParakeetEngine {
             }
         }
 
-        // Remove from active downloads on completion
-        {
-            let mut active = self.active_downloads.write().await;
-            active.remove(model_name);
-        }
-
-        // Clear cancellation flag on successful completion
-        {
-            let mut cancel_flag = self.cancel_download_flag.write().await;
-            if cancel_flag.as_ref() == Some(&model_name.to_string()) {
-                *cancel_flag = None;
-            }
-        }
+        self.cancelled_downloads.write().await.remove(model_name);
 
         log::info!("Download completed for Parakeet model: {}", model_name);
         Ok(())
@@ -1051,16 +975,16 @@ impl ParakeetEngine {
     pub async fn cancel_download(&self, model_name: &str) -> Result<()> {
         log::info!("Cancelling download for Parakeet model: {}", model_name);
 
-        // Set cancellation flag to interrupt the download loop
+        // 与下载注册保持 active -> cancelled 的固定锁顺序，关闭“刚注册就误清取消”的窗口。
+        // 没有活跃 worker 时无需留下会污染下一次下载的陈旧请求。
         {
-            let mut cancel_flag = self.cancel_download_flag.write().await;
-            *cancel_flag = Some(model_name.to_string());
-        }
-
-        // Remove from active downloads
-        {
-            let mut active = self.active_downloads.write().await;
-            active.remove(model_name);
+            let active = self.active_downloads.read().await;
+            if active.contains(model_name) {
+                self.cancelled_downloads
+                    .write()
+                    .await
+                    .insert(model_name.to_string());
+            }
         }
 
         // Update model status to Missing (so it can be retried)
@@ -1071,18 +995,211 @@ impl ParakeetEngine {
             }
         }
 
-        // Clean up partially downloaded files
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await; // Brief delay to let download loop exit
-
-        let model_path = self.models_dir.join(model_name);
-        if model_path.exists() {
-            if let Err(e) = fs::remove_dir_all(&model_path).await {
-                log::warn!("Failed to clean up cancelled download directory: {}", e);
-            } else {
-                log::info!("Cleaned up cancelled download directory: {}", model_path.display());
-            }
-        }
+        // 取消只发出停止信号，不提前释放 active 标记：旧任务 flush 并退出前，不允许重试任务并发写同一文件。
+        // 部分文件和已完整的兄弟文件都保留；整个模型目录仅能由显式的 delete_model 操作删除。
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    const TEST_MODEL_NAME: &str = "parakeet-tdt-0.6b-v3-int8";
+
+    #[tokio::test]
+    async fn missing_artifact_does_not_delete_existing_siblings() {
+        let temp_dir = tempdir().expect("create temporary models directory");
+        let model_dir = temp_dir.path().join(TEST_MODEL_NAME);
+        fs::create_dir_all(&model_dir)
+            .await
+            .expect("create model directory");
+
+        // 缺失 vocab 时，其他文件可能是完整文件，也可能是可续传的部分文件；两者都不能被连带删除。
+        let existing_artifacts: [(&str, &[u8]); 3] = [
+            ("encoder-model.int8.onnx", b"encoder-partial"),
+            ("decoder_joint-model.int8.onnx", b"decoder-complete"),
+            ("nemo128.onnx", b"preprocessor-complete"),
+        ];
+        for (filename, contents) in existing_artifacts {
+            fs::write(model_dir.join(filename), contents)
+                .await
+                .expect("seed existing artifact");
+        }
+
+        let expected_sizes = HashMap::from([
+            ("encoder-model.int8.onnx", 64),
+            (
+                "decoder_joint-model.int8.onnx",
+                b"decoder-complete".len() as u64,
+            ),
+            ("nemo128.onnx", b"preprocessor-complete".len() as u64),
+            ("vocab.txt", 32),
+        ]);
+        let filenames = [
+            "encoder-model.int8.onnx",
+            "decoder_joint-model.int8.onnx",
+            "nemo128.onnx",
+            "vocab.txt",
+        ];
+
+        let reusable_bytes =
+            ParakeetEngine::existing_artifact_bytes(&model_dir, &filenames, &expected_sizes).await;
+        let expected_reusable_bytes: u64 = existing_artifacts
+            .iter()
+            .map(|(_, contents)| contents.len() as u64)
+            .sum();
+        assert_eq!(reusable_bytes, expected_reusable_bytes);
+
+        for (filename, contents) in existing_artifacts {
+            assert_eq!(
+                fs::read(model_dir.join(filename))
+                    .await
+                    .expect("existing artifact must be preserved"),
+                contents
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_download_releases_active_registration() {
+        let temp_dir = tempdir().expect("create temporary models directory");
+        let engine = ParakeetEngine::new_with_models_dir(Some(temp_dir.path().to_path_buf()))
+            .expect("create Parakeet engine");
+        let missing_model = "unknown-model";
+
+        let error = engine
+            .download_model_detailed(missing_model, None)
+            .await
+            .expect_err("unknown model must fail before network access");
+
+        assert!(error.to_string().contains("not found"));
+        assert!(
+            !engine.active_downloads.read().await.contains(missing_model),
+            "outer cleanup must release active registration on every error path"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_retry_keeps_existing_active_registration() {
+        let temp_dir = tempdir().expect("create temporary models directory");
+        let engine = ParakeetEngine::new_with_models_dir(Some(temp_dir.path().to_path_buf()))
+            .expect("create Parakeet engine");
+        engine
+            .active_downloads
+            .write()
+            .await
+            .insert(TEST_MODEL_NAME.to_string());
+
+        let error = engine
+            .download_model_detailed(TEST_MODEL_NAME, None)
+            .await
+            .expect_err("a second worker must not bypass active registration");
+
+        assert!(error.to_string().contains("already in progress"));
+        assert!(
+            engine
+                .active_downloads
+                .read()
+                .await
+                .contains(TEST_MODEL_NAME),
+            "the existing worker remains the owner of the active registration"
+        );
+    }
+
+    #[tokio::test]
+    async fn starting_another_model_preserves_pending_cancellation() {
+        let temp_dir = tempdir().expect("create temporary models directory");
+        let engine = ParakeetEngine::new_with_models_dir(Some(temp_dir.path().to_path_buf()))
+            .expect("create Parakeet engine");
+        engine
+            .active_downloads
+            .write()
+            .await
+            .insert(TEST_MODEL_NAME.to_string());
+        engine
+            .cancel_download(TEST_MODEL_NAME)
+            .await
+            .expect("record cancellation request");
+
+        let _ = engine.download_model_detailed("unknown-model", None).await;
+
+        assert!(
+            engine
+                .cancelled_downloads
+                .read()
+                .await
+                .contains(TEST_MODEL_NAME),
+            "starting another model must not consume this model's cancellation request"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejected_retry_preserves_active_workers_cancellation() {
+        let temp_dir = tempdir().expect("create temporary models directory");
+        let engine = ParakeetEngine::new_with_models_dir(Some(temp_dir.path().to_path_buf()))
+            .expect("create Parakeet engine");
+        engine
+            .active_downloads
+            .write()
+            .await
+            .insert(TEST_MODEL_NAME.to_string());
+        engine
+            .cancel_download(TEST_MODEL_NAME)
+            .await
+            .expect("record cancellation request");
+
+        let _ = engine.download_model_detailed(TEST_MODEL_NAME, None).await;
+
+        assert!(
+            engine
+                .cancelled_downloads
+                .read()
+                .await
+                .contains(TEST_MODEL_NAME),
+            "a rejected retry must not clear the active worker's cancellation request"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_preserves_downloaded_artifacts_for_resume() {
+        let temp_dir = tempdir().expect("create temporary models directory");
+        let engine = ParakeetEngine::new_with_models_dir(Some(temp_dir.path().to_path_buf()))
+            .expect("create Parakeet engine");
+        let model_dir = engine.models_dir.join(TEST_MODEL_NAME);
+        fs::create_dir_all(&model_dir)
+            .await
+            .expect("create model directory");
+        let encoder_path = model_dir.join("encoder-model.int8.onnx");
+        fs::write(&encoder_path, b"downloaded-encoder")
+            .await
+            .expect("seed downloaded artifact");
+        engine
+            .active_downloads
+            .write()
+            .await
+            .insert(TEST_MODEL_NAME.to_string());
+
+        engine
+            .cancel_download(TEST_MODEL_NAME)
+            .await
+            .expect("cancel model download");
+
+        assert_eq!(
+            fs::read(encoder_path)
+                .await
+                .expect("cancellation must preserve resumable artifacts"),
+            b"downloaded-encoder"
+        );
+        assert!(
+            engine
+                .active_downloads
+                .read()
+                .await
+                .contains(TEST_MODEL_NAME),
+            "the download worker owns the active registration until it exits"
+        );
     }
 }

--- a/frontend/src-tauri/src/parakeet_engine/parakeet_engine.rs
+++ b/frontend/src-tauri/src/parakeet_engine/parakeet_engine.rs
@@ -149,6 +149,12 @@ struct ActiveDownload {
     completion: watch::Sender<bool>,
 }
 
+#[derive(Default)]
+struct ActiveDownloadState {
+    downloads: HashMap<String, Arc<ActiveDownload>>,
+    revision: u64,
+}
+
 #[derive(Debug, thiserror::Error)]
 #[error("Download cancelled by user")]
 pub(crate) struct DownloadCancelled;
@@ -170,6 +176,8 @@ const CANCEL_DOWNLOAD_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 struct DownloadStateTestHook {
     finalization_ready: tokio::sync::Notify,
     continue_finalization: tokio::sync::Notify,
+    discovery_scanned: tokio::sync::Notify,
+    continue_discovery: tokio::sync::Notify,
 }
 
 enum ContentRange {
@@ -250,7 +258,7 @@ pub struct ParakeetEngine {
     current_model: Arc<RwLock<Option<ParakeetModel>>>,
     current_model_name: Arc<RwLock<Option<String>>>,
     pub(crate) available_models: Arc<RwLock<HashMap<String, ModelInfo>>>,
-    active_downloads: Arc<Mutex<HashMap<String, Arc<ActiveDownload>>>>,
+    active_downloads: Arc<Mutex<ActiveDownloadState>>,
     #[cfg(test)]
     download_state_test_hook: Mutex<Option<Arc<DownloadStateTestHook>>>,
 }
@@ -291,7 +299,7 @@ impl ParakeetEngine {
             current_model: Arc::new(RwLock::new(None)),
             current_model_name: Arc::new(RwLock::new(None)),
             available_models: Arc::new(RwLock::new(HashMap::new())),
-            active_downloads: Arc::new(Mutex::new(HashMap::new())),
+            active_downloads: Arc::new(Mutex::new(ActiveDownloadState::default())),
             #[cfg(test)]
             download_state_test_hook: Mutex::new(None),
         })
@@ -304,52 +312,84 @@ impl ParakeetEngine {
 
     /// Discover available Parakeet models.
     pub async fn discover_models(&self) -> Result<Vec<ModelInfo>> {
-        let mut models = Vec::with_capacity(PARAKEET_MODEL_SPECS.len());
+        self.discover_models_from_specs(PARAKEET_MODEL_SPECS).await
+    }
 
-        for spec in PARAKEET_MODEL_SPECS {
-            let model_path = self.models_dir.join(spec.name);
-            let is_downloading = self.active_downloads.lock().await.contains_key(spec.name);
-            let status = if is_downloading {
-                ModelStatus::Downloading { progress: 0 }
-            } else if model_path.exists() {
-                match Self::validate_model_directory(&model_path, spec.artifacts) {
-                    Ok(()) => ModelStatus::Available,
-                    Err(error) => {
-                        let file_size = spec
-                            .artifacts
-                            .iter()
-                            .filter_map(|artifact| std::fs::metadata(model_path.join(artifact.filename)).ok())
-                            .map(|metadata| metadata.len())
-                            .sum();
-                        log::warn!("Model directory {} appears corrupted: {}", spec.name, error);
-                        ModelStatus::Corrupted {
-                            file_size,
-                            expected_min_size: spec.exact_bytes(),
+    async fn discover_models_from_specs(&self, specs: &[ModelSpec]) -> Result<Vec<ModelInfo>> {
+        loop {
+            let revision = self.active_downloads.lock().await.revision;
+            let mut models = Vec::with_capacity(specs.len());
+            let mut validation_errors = Vec::new();
+
+            for spec in specs {
+                let model_path = self.models_dir.join(spec.name);
+                let status = if model_path.exists() {
+                    match Self::validate_model_directory(&model_path, spec.artifacts) {
+                        Ok(()) => ModelStatus::Available,
+                        Err(error) => {
+                            let file_size = spec
+                                .artifacts
+                                .iter()
+                                .filter_map(|artifact| {
+                                    std::fs::metadata(model_path.join(artifact.filename)).ok()
+                                })
+                                .map(|metadata| metadata.len())
+                                .sum();
+                            validation_errors.push((spec.name, error));
+                            ModelStatus::Corrupted {
+                                file_size,
+                                expected_min_size: spec.exact_bytes(),
+                            }
                         }
                     }
-                }
-            } else {
-                ModelStatus::Missing
-            };
+                } else {
+                    ModelStatus::Missing
+                };
 
-            models.push(ModelInfo {
-                name: spec.name.to_string(),
-                path: model_path,
-                size_mb: spec.size_mb,
-                quantization: spec.quantization,
-                speed: spec.speed.to_string(),
-                status,
-                description: spec.description.to_string(),
+                models.push(ModelInfo {
+                    name: spec.name.to_string(),
+                    path: model_path,
+                    size_mb: spec.size_mb,
+                    quantization: spec.quantization,
+                    speed: spec.speed.to_string(),
+                    status,
+                    description: spec.description.to_string(),
+                });
+            }
+
+            #[cfg(test)]
+            if let Some(hook) = self.test_hook().await {
+                hook.discovery_scanned.notify_one();
+                hook.continue_discovery.notified().await;
+            }
+
+            let active_downloads = self.active_downloads.lock().await;
+            if active_downloads.revision != revision {
+                continue;
+            }
+
+            validation_errors.retain(|(model_name, _)| {
+                !active_downloads.downloads.contains_key(*model_name)
             });
-        }
+            for model in &mut models {
+                if active_downloads.downloads.contains_key(&model.name) {
+                    model.status = ModelStatus::Downloading { progress: 0 };
+                }
+            }
 
-        let mut available_models = self.available_models.write().await;
-        available_models.clear();
-        for model in &models {
-            available_models.insert(model.name.clone(), model.clone());
-        }
+            let mut available_models = self.available_models.write().await;
+            available_models.clear();
+            for model in &models {
+                available_models.insert(model.name.clone(), model.clone());
+            }
+            drop(available_models);
+            drop(active_downloads);
 
-        Ok(models)
+            for (model_name, error) in validation_errors {
+                log::warn!("Model directory {} appears corrupted: {}", model_name, error);
+            }
+            return Ok(models);
+        }
     }
 
     fn validate_model_directory(model_dir: &Path, artifacts: &[ArtifactSpec]) -> Result<()> {
@@ -564,7 +604,7 @@ impl ParakeetEngine {
 
     async fn reserve_active_download(&self, model_name: &str) -> Result<Arc<ActiveDownload>> {
         let mut active_downloads = self.active_downloads.lock().await;
-        if active_downloads.contains_key(model_name) {
+        if active_downloads.downloads.contains_key(model_name) {
             return Err(anyhow!("Download already in progress for model: {}", model_name));
         }
 
@@ -573,7 +613,10 @@ impl ParakeetEngine {
             cancellation: CancellationToken::new(),
             completion,
         });
-        active_downloads.insert(model_name.to_string(), Arc::clone(&active_download));
+        active_downloads
+            .downloads
+            .insert(model_name.to_string(), Arc::clone(&active_download));
+        active_downloads.revision = active_downloads.revision.wrapping_add(1);
         Ok(active_download)
     }
 
@@ -1058,7 +1101,7 @@ impl ParakeetEngine {
 
         let mut active_downloads = self.active_downloads.lock().await;
         let owner_matches = matches!(
-            active_downloads.get(model_name),
+            active_downloads.downloads.get(model_name),
             Some(owner) if Arc::ptr_eq(owner, active_download)
         );
         if !owner_matches {
@@ -1073,7 +1116,7 @@ impl ParakeetEngine {
                 .err()
                 .is_some_and(is_download_cancelled);
         let mut models = self.available_models.write().await;
-        active_downloads.remove(model_name);
+        active_downloads.downloads.remove(model_name);
         if let Some(model) = models.get_mut(model_name) {
             if cancellation_won || result.is_err() {
                 model.status = ModelStatus::Missing;
@@ -1082,6 +1125,7 @@ impl ParakeetEngine {
                 model.path = model_dir.to_path_buf();
             }
         }
+        active_downloads.revision = active_downloads.revision.wrapping_add(1);
         drop(models);
         drop(active_downloads);
         active_download.completion.send_replace(true);
@@ -1110,7 +1154,7 @@ impl ParakeetEngine {
     ) -> Result<CancelDownloadOutcome> {
         let active_download = {
             let active_downloads = self.active_downloads.lock().await;
-            let Some(active_download) = active_downloads.get(model_name).cloned() else {
+            let Some(active_download) = active_downloads.downloads.get(model_name).cloned() else {
                 return Ok(CancelDownloadOutcome::Cancelled);
             };
             active_download.cancellation.cancel();
@@ -1149,6 +1193,15 @@ mod tests {
         ArtifactSpec { filename: "nemo.bin", exact_bytes: 2 },
         ArtifactSpec { filename: "vocab.txt", exact_bytes: 1 },
     ];
+    const SMALL_MODEL_SPECS: &[ModelSpec] = &[ModelSpec {
+        name: TEST_MODEL_NAME,
+        size_mb: 1,
+        quantization: QuantizationType::Int8,
+        speed: "test",
+        description: "test model",
+        source_base_url: "",
+        artifacts: SMALL_ARTIFACTS,
+    }];
 
     struct ExpectedResponse {
         filename: &'static str,
@@ -1335,7 +1388,7 @@ mod tests {
         assert!(error.to_string().contains("403"));
         assert_eq!(fs::read(model_dir.join("encoder.bin")).await.unwrap(), b"ABCD");
         assert_eq!(fs::read(model_dir.join("decoder.bin")).await.unwrap(), b"X");
-        assert!(!engine.active_downloads.lock().await.contains_key(TEST_MODEL_NAME));
+        assert!(!engine.active_downloads.lock().await.downloads.contains_key(TEST_MODEL_NAME));
 
         let (base_url, server) = serve_requests(vec![
             response(
@@ -1364,7 +1417,7 @@ mod tests {
         assert_eq!(fs::read(model_dir.join("encoder.bin")).await.unwrap(), b"ABCD");
         assert_eq!(fs::read(model_dir.join("decoder.bin")).await.unwrap(), b"XYZ");
         assert!(matches!(test_model_status(&engine).await, ModelStatus::Available));
-        assert!(!engine.active_downloads.lock().await.contains_key(TEST_MODEL_NAME));
+        assert!(!engine.active_downloads.lock().await.downloads.contains_key(TEST_MODEL_NAME));
     }
 
     #[tokio::test]
@@ -1649,7 +1702,7 @@ mod tests {
             server.await.expect("join invalid-response server");
             assert_eq!(fs::read(model_dir.join("complete.bin")).await.unwrap(), b"C");
             assert!(!matches!(test_model_status(&engine).await, ModelStatus::Available));
-            assert!(!engine.active_downloads.lock().await.contains_key(TEST_MODEL_NAME));
+            assert!(!engine.active_downloads.lock().await.downloads.contains_key(TEST_MODEL_NAME));
         }
     }
 
@@ -1687,7 +1740,7 @@ mod tests {
             .expect_err("cancelled owner must finish as cancellation");
         assert!(is_download_cancelled(&error));
         assert_eq!(fs::read(model_dir.join("encoder.bin")).await.unwrap(), b"AB");
-        assert!(!engine.active_downloads.lock().await.contains_key(TEST_MODEL_NAME));
+        assert!(!engine.active_downloads.lock().await.downloads.contains_key(TEST_MODEL_NAME));
         assert!(engine.reserve_active_download(TEST_MODEL_NAME).await.is_ok());
     }
 
@@ -1701,6 +1754,8 @@ mod tests {
         let hook = Arc::new(DownloadStateTestHook {
             finalization_ready: tokio::sync::Notify::new(),
             continue_finalization: tokio::sync::Notify::new(),
+            discovery_scanned: tokio::sync::Notify::new(),
+            continue_discovery: tokio::sync::Notify::new(),
         });
         *engine.download_state_test_hook.lock().await = Some(Arc::clone(&hook));
         let events = Arc::new(SegQueue::new());
@@ -1742,6 +1797,83 @@ mod tests {
         assert!(is_download_cancelled(&error));
         assert!(std::iter::from_fn(|| events.pop()).all(|progress| progress.percent < 100));
         assert!(matches!(test_model_status(&engine).await, ModelStatus::Missing));
-        assert!(!engine.active_downloads.lock().await.contains_key(TEST_MODEL_NAME));
+        assert!(!engine.active_downloads.lock().await.downloads.contains_key(TEST_MODEL_NAME));
+    }
+
+    #[tokio::test]
+    async fn discovery_retries_when_download_finalizes_after_disk_scan() {
+        let (_temp_dir, engine, model_dir) = test_engine().await;
+        let hook = Arc::new(DownloadStateTestHook {
+            finalization_ready: tokio::sync::Notify::new(),
+            continue_finalization: tokio::sync::Notify::new(),
+            discovery_scanned: tokio::sync::Notify::new(),
+            continue_discovery: tokio::sync::Notify::new(),
+        });
+        *engine.download_state_test_hook.lock().await = Some(Arc::clone(&hook));
+
+        let discovery_engine = Arc::clone(&engine);
+        let discovery = tokio::spawn(async move {
+            discovery_engine
+                .discover_models_from_specs(SMALL_MODEL_SPECS)
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), hook.discovery_scanned.notified())
+            .await
+            .expect("discovery must finish its first disk scan");
+
+        fs::create_dir_all(&model_dir).await.expect("create model directory");
+        for artifact in SMALL_ARTIFACTS {
+            fs::write(
+                model_dir.join(artifact.filename),
+                vec![0; artifact.exact_bytes as usize],
+            )
+            .await
+            .expect("seed exact artifact");
+        }
+
+        let owner = engine
+            .reserve_active_download(TEST_MODEL_NAME)
+            .await
+            .expect("reserve download owner");
+        let finalization_engine = Arc::clone(&engine);
+        let finalization_dir = model_dir.clone();
+        let finalization_owner = Arc::clone(&owner);
+        let finalization = tokio::spawn(async move {
+            finalization_engine
+                .finish_download(
+                    TEST_MODEL_NAME,
+                    &finalization_dir,
+                    SMALL_ARTIFACTS,
+                    &finalization_owner,
+                    Ok(DownloadProgress::new(10, 10, 0.0)),
+                    None,
+                )
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), hook.finalization_ready.notified())
+            .await
+            .expect("finalization must reach its commit barrier");
+        hook.continue_finalization.notify_one();
+        tokio::time::timeout(Duration::from_secs(1), finalization)
+            .await
+            .expect("finalization must complete")
+            .expect("join finalization task")
+            .expect("successful download must finalize");
+
+        *engine.download_state_test_hook.lock().await = None;
+        hook.continue_discovery.notify_one();
+        let discovered = tokio::time::timeout(Duration::from_secs(1), discovery)
+            .await
+            .expect("discovery must complete")
+            .expect("join discovery task")
+            .expect("discovery must succeed");
+
+        let discovered_model = discovered
+            .iter()
+            .find(|model| model.name == TEST_MODEL_NAME)
+            .expect("test model must be discovered");
+        assert!(matches!(discovered_model.status, ModelStatus::Available));
+        assert!(matches!(test_model_status(&engine).await, ModelStatus::Available));
+        assert!(!engine.active_downloads.lock().await.downloads.contains_key(TEST_MODEL_NAME));
     }
 }

--- a/frontend/src/components/ParakeetModelManager.tsx
+++ b/frontend/src/components/ParakeetModelManager.tsx
@@ -30,6 +30,7 @@ export function ParakeetModelManager({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [initialized, setInitialized] = useState(false);
+  const [listenersReady, setListenersReady] = useState(false);
   const [downloadingModels, setDownloadingModels] = useState<Set<string>>(new Set());
   const [cancellingModels, setCancellingModels] = useState<Set<string>>(new Set());
 
@@ -39,6 +40,7 @@ export function ParakeetModelManager({
 
   // Progress throttle map to prevent rapid updates
   const progressThrottleRef = useRef<Map<string, { progress: number; timestamp: number }>>(new Map());
+  const latestStatusByModelRef = useRef<Map<string, ModelStatus>>(new Map());
   const clearCancellingModel = (modelName: string) => {
     setCancellingModels(prev => {
       const next = new Set(prev);
@@ -49,14 +51,17 @@ export function ParakeetModelManager({
 
   // Initialize and load models
   useEffect(() => {
-    if (initialized) return;
+    if (initialized || !listenersReady) return;
 
     const initializeModels = async () => {
       try {
         setLoading(true);
         await ParakeetAPI.init();
         const modelList = await ParakeetAPI.getAvailableModels();
-        setModels(modelList);
+        setModels(modelList.map(model => ({
+          ...model,
+          status: latestStatusByModelRef.current.get(model.name) ?? model.status
+        })));
 
         setInitialized(true);
       } catch (err) {
@@ -72,149 +77,176 @@ export function ParakeetModelManager({
     };
 
     initializeModels();
-  }, [initialized, selectedModel, onModelSelect]);
+  }, [initialized, listenersReady, selectedModel, onModelSelect]);
 
   // Set up event listeners for download progress
   useEffect(() => {
-    let unlistenProgress: (() => void) | null = null;
-    let unlistenComplete: (() => void) | null = null;
-    let unlistenError: (() => void) | null = null;
+    let disposed = false;
+    let registeredUnlisteners: Array<() => void> = [];
 
     const setupListeners = async () => {
       console.log('[ParakeetModelManager] Setting up event listeners...');
 
-      // Download progress with throttling
-      unlistenProgress = await listen<ParakeetDownloadProgressEvent>(
-        'parakeet-model-download-progress',
-        (event) => {
-          const { modelName, progress, status } = event.payload;
-          if (status === 'cancelled') {
-            progressThrottleRef.current.delete(modelName);
+      const registrations = await Promise.allSettled([
+        listen<ParakeetDownloadProgressEvent>(
+          'parakeet-model-download-progress',
+          (event) => {
+            const { modelName, progress, status } = event.payload;
+            if (status === 'cancelled') {
+              latestStatusByModelRef.current.set(modelName, 'Missing');
+              progressThrottleRef.current.delete(modelName);
+              clearCancellingModel(modelName);
+              setDownloadingModels(prev => {
+                const next = new Set(prev);
+                next.delete(modelName);
+                return next;
+              });
+              setModels(prevModels =>
+                prevModels.map(model =>
+                  model.name === modelName
+                    ? { ...model, status: 'Missing' as ModelStatus }
+                    : model
+                )
+              );
+              toast.info(`${getModelDisplayName(modelName)} download cancelled`, {
+                duration: 3000
+              });
+              return;
+            }
+
+            const modelStatus: ModelStatus = status === 'completed'
+              ? 'Available'
+              : { Downloading: { progress } };
+            latestStatusByModelRef.current.set(modelName, modelStatus);
+
+            const now = Date.now();
+            const throttleData = progressThrottleRef.current.get(modelName);
+            const shouldUpdate = !throttleData ||
+              now - throttleData.timestamp > 300 ||
+              Math.abs(progress - throttleData.progress) >= 5;
+
+            if (shouldUpdate) {
+              console.log(`[ParakeetModelManager] Progress update for ${modelName}: ${progress}%`);
+              progressThrottleRef.current.set(modelName, { progress, timestamp: now });
+              setModels(prevModels =>
+                prevModels.map(model =>
+                  model.name === modelName
+                    ? { ...model, status: modelStatus }
+                    : model
+                )
+              );
+            }
+          }
+        ),
+        listen<{ modelName: string }>(
+          'parakeet-model-download-complete',
+          (event) => {
+            const { modelName } = event.payload;
+            const displayInfo = getModelDisplayInfo(modelName);
+            const displayName = displayInfo?.friendlyName || modelName;
+            latestStatusByModelRef.current.set(modelName, 'Available');
             clearCancellingModel(modelName);
+
+            setModels(prevModels =>
+              prevModels.map(model =>
+                model.name === modelName
+                  ? { ...model, status: 'Available' as ModelStatus }
+                  : model
+              )
+            );
+
             setDownloadingModels(prev => {
-              const next = new Set(prev);
-              next.delete(modelName);
-              return next;
+              const newSet = new Set(prev);
+              newSet.delete(modelName);
+              return newSet;
             });
+
+            // Clean up throttle data
+            progressThrottleRef.current.delete(modelName);
+
+            toast.success(`${displayInfo?.icon || '✓'} ${displayName} ready!`, {
+              description: 'Model downloaded and ready to use',
+              duration: 4000
+            });
+
+            // Auto-select after download using stable refs
+            if (onModelSelectRef.current) {
+              onModelSelectRef.current(modelName);
+              if (autoSaveRef.current) {
+                saveModelSelection(modelName);
+              }
+            }
+          }
+        ),
+        listen<{ modelName: string; error: string }>(
+          'parakeet-model-download-error',
+          (event) => {
+            const { modelName, error } = event.payload;
+            const displayInfo = getModelDisplayInfo(modelName);
+            const displayName = displayInfo?.friendlyName || modelName;
+            latestStatusByModelRef.current.set(modelName, { Error: error });
+            clearCancellingModel(modelName);
+
             setModels(prevModels =>
               prevModels.map(model =>
                 model.name === modelName
-                  ? { ...model, status: 'Missing' as ModelStatus }
+                  ? { ...model, status: { Error: error } as ModelStatus }
                   : model
               )
             );
-            toast.info(`${getModelDisplayName(modelName)} download cancelled`, {
-              duration: 3000
+
+            setDownloadingModels(prev => {
+              const newSet = new Set(prev);
+              newSet.delete(modelName);
+              return newSet;
             });
-            return;
-          }
 
-          const now = Date.now();
-          const throttleData = progressThrottleRef.current.get(modelName);
-          const shouldUpdate = !throttleData ||
-            now - throttleData.timestamp > 300 ||
-            Math.abs(progress - throttleData.progress) >= 5;
+            // Clean up throttle data
+            progressThrottleRef.current.delete(modelName);
 
-          if (shouldUpdate) {
-            console.log(`[ParakeetModelManager] Progress update for ${modelName}: ${progress}%`);
-            progressThrottleRef.current.set(modelName, { progress, timestamp: now });
-            setModels(prevModels =>
-              prevModels.map(model =>
-                model.name === modelName
-                  ? { ...model, status: { Downloading: { progress } } as ModelStatus }
-                  : model
-              )
-            );
+            toast.error(`Failed to download ${displayName}`, {
+              description: error,
+              duration: 6000,
+              action: {
+                label: 'Retry',
+                onClick: () => downloadModel(modelName)
+              }
+            });
           }
-        }
+        )
+      ]);
+
+      const unlisteners = registrations.flatMap(result =>
+        result.status === 'fulfilled' ? [result.value] : []
+      );
+      const failedRegistration = registrations.find(
+        (result): result is PromiseRejectedResult => result.status === 'rejected'
       );
 
-      // Download complete
-      unlistenComplete = await listen<{ modelName: string }>(
-        'parakeet-model-download-complete',
-        (event) => {
-          const { modelName } = event.payload;
-          const displayInfo = getModelDisplayInfo(modelName);
-          const displayName = displayInfo?.friendlyName || modelName;
-          clearCancellingModel(modelName);
-
-          setModels(prevModels =>
-            prevModels.map(model =>
-              model.name === modelName
-                ? { ...model, status: 'Available' as ModelStatus }
-                : model
-            )
-          );
-
-          setDownloadingModels(prev => {
-            const newSet = new Set(prev);
-            newSet.delete(modelName);
-            return newSet;
-          });
-
-          // Clean up throttle data
-          progressThrottleRef.current.delete(modelName);
-
-          toast.success(`${displayInfo?.icon || '✓'} ${displayName} ready!`, {
-            description: 'Model downloaded and ready to use',
-            duration: 4000
-          });
-
-          // Auto-select after download using stable refs
-          if (onModelSelectRef.current) {
-            onModelSelectRef.current(modelName);
-            if (autoSaveRef.current) {
-              saveModelSelection(modelName);
-            }
-          }
+      if (disposed || failedRegistration) {
+        unlisteners.forEach(unlisten => unlisten());
+        if (!disposed && failedRegistration) {
+          const message = failedRegistration.reason instanceof Error
+            ? failedRegistration.reason.message
+            : typeof failedRegistration.reason === 'string'
+              ? failedRegistration.reason
+              : 'Failed to listen for Parakeet model updates';
+          setError(message);
+          setLoading(false);
         }
-      );
+        return;
+      }
 
-      // Download error
-      unlistenError = await listen<{ modelName: string; error: string }>(
-        'parakeet-model-download-error',
-        (event) => {
-          const { modelName, error } = event.payload;
-          const displayInfo = getModelDisplayInfo(modelName);
-          const displayName = displayInfo?.friendlyName || modelName;
-          clearCancellingModel(modelName);
-
-          setModels(prevModels =>
-            prevModels.map(model =>
-              model.name === modelName
-                ? { ...model, status: { Error: error } as ModelStatus }
-                : model
-            )
-          );
-
-          setDownloadingModels(prev => {
-            const newSet = new Set(prev);
-            newSet.delete(modelName);
-            return newSet;
-          });
-
-          // Clean up throttle data
-          progressThrottleRef.current.delete(modelName);
-
-          toast.error(`Failed to download ${displayName}`, {
-            description: error,
-            duration: 6000,
-            action: {
-              label: 'Retry',
-              onClick: () => downloadModel(modelName)
-            }
-          });
-        }
-      );
+      registeredUnlisteners = unlisteners;
+      setListenersReady(true);
     };
 
     setupListeners();
 
     return () => {
       console.log('[ParakeetModelManager] Cleaning up event listeners...');
-      if (unlistenProgress) unlistenProgress();
-      if (unlistenComplete) unlistenComplete();
-      if (unlistenError) unlistenError();
+      disposed = true;
+      registeredUnlisteners.forEach(unlisten => unlisten());
     };
   }, []); // Empty dependency array - listeners use refs for stable callbacks
 

--- a/frontend/src/components/ParakeetModelManager.tsx
+++ b/frontend/src/components/ParakeetModelManager.tsx
@@ -38,6 +38,11 @@ export function ParakeetModelManager({
   const onModelSelectRef = useRef(onModelSelect);
   const autoSaveRef = useRef(autoSave);
 
+  useEffect(() => {
+    onModelSelectRef.current = onModelSelect;
+    autoSaveRef.current = autoSave;
+  }, [onModelSelect, autoSave]);
+
   // Progress throttle map to prevent rapid updates
   const progressThrottleRef = useRef<Map<string, { progress: number; timestamp: number }>>(new Map());
   const latestStatusByModelRef = useRef<Map<string, ModelStatus>>(new Map());

--- a/frontend/src/components/ParakeetModelManager.tsx
+++ b/frontend/src/components/ParakeetModelManager.tsx
@@ -4,12 +4,13 @@ import { invoke } from '@tauri-apps/api/core';
 import { motion, AnimatePresence } from 'framer-motion';
 import { toast } from 'sonner';
 import {
-  ParakeetModelInfo,
   ModelStatus,
   ParakeetAPI,
+  ParakeetDownloadProgressEvent,
+  ParakeetModelInfo,
+  formatFileSize,
   getModelDisplayInfo,
-  getModelDisplayName,
-  formatFileSize
+  getModelDisplayName
 } from '../lib/parakeet';
 
 interface ParakeetModelManagerProps {
@@ -30,6 +31,7 @@ export function ParakeetModelManager({
   const [error, setError] = useState<string | null>(null);
   const [initialized, setInitialized] = useState(false);
   const [downloadingModels, setDownloadingModels] = useState<Set<string>>(new Set());
+  const [cancellingModels, setCancellingModels] = useState<Set<string>>(new Set());
 
   // Refs for stable callbacks
   const onModelSelectRef = useRef(onModelSelect);
@@ -37,12 +39,78 @@ export function ParakeetModelManager({
 
   // Progress throttle map to prevent rapid updates
   const progressThrottleRef = useRef<Map<string, { progress: number; timestamp: number }>>(new Map());
+  const cancellationReconciliationModelsRef = useRef<Set<string>>(new Set());
+  const cancellationReconcileTimersRef = useRef<Map<string, NodeJS.Timeout>>(new Map());
 
   // Update refs when props change
   useEffect(() => {
     onModelSelectRef.current = onModelSelect;
     autoSaveRef.current = autoSave;
   }, [onModelSelect, autoSave]);
+
+  const clearCancellationReconciliation = (modelName: string) => {
+    cancellationReconciliationModelsRef.current.delete(modelName);
+    const timer = cancellationReconcileTimersRef.current.get(modelName);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      cancellationReconcileTimersRef.current.delete(modelName);
+    }
+    setCancellingModels(prev => {
+      const next = new Set(prev);
+      next.delete(modelName);
+      return next;
+    });
+  };
+
+  const reconcileCancellation = (modelName: string) => {
+    if (cancellationReconciliationModelsRef.current.has(modelName)) return;
+
+    cancellationReconciliationModelsRef.current.add(modelName);
+    setCancellingModels(prev => new Set([...prev, modelName]));
+
+    const scheduleNextCheck = () => {
+      if (!cancellationReconciliationModelsRef.current.has(modelName)) return;
+      const timer = setTimeout(() => {
+        cancellationReconcileTimersRef.current.delete(modelName);
+        void reconcile();
+      }, 1000);
+      cancellationReconcileTimersRef.current.set(modelName, timer);
+    };
+
+    const reconcile = async () => {
+      try {
+        const modelList = await ParakeetAPI.getAvailableModels();
+        if (!cancellationReconciliationModelsRef.current.has(modelName)) return;
+
+        const model = modelList.find(candidate => candidate.name === modelName);
+        const isStillDownloading =
+          typeof model?.status === 'object' && 'Downloading' in model.status;
+        if (model && !isStillDownloading) {
+          clearCancellationReconciliation(modelName);
+          setDownloadingModels(prev => {
+            const next = new Set(prev);
+            next.delete(modelName);
+            return next;
+          });
+          setModels(modelList);
+          progressThrottleRef.current.delete(modelName);
+          toast.info(
+            model.status === 'Available'
+              ? `${getModelDisplayName(modelName)} download completed before cancellation`
+              : `${getModelDisplayName(modelName)} download cancelled`,
+            { duration: 3000 }
+          );
+          return;
+        }
+      } catch (err) {
+        console.warn('Failed to reconcile pending Parakeet cancellation:', err);
+      }
+
+      scheduleNextCheck();
+    };
+
+    void reconcile();
+  };
 
   // Initialize and load models
   useEffect(() => {
@@ -81,14 +149,18 @@ export function ParakeetModelManager({
       console.log('[ParakeetModelManager] Setting up event listeners...');
 
       // Download progress with throttling
-      unlistenProgress = await listen<{ modelName: string; progress: number }>(
+      unlistenProgress = await listen<ParakeetDownloadProgressEvent>(
         'parakeet-model-download-progress',
         (event) => {
-          const { modelName, progress } = event.payload;
+          const { modelName, progress, status } = event.payload;
+          if (status === 'cancelled') {
+            progressThrottleRef.current.delete(modelName);
+            reconcileCancellation(modelName);
+            return;
+          }
+
           const now = Date.now();
           const throttleData = progressThrottleRef.current.get(modelName);
-
-          // Throttle: only update if 300ms passed OR progress jumped by 5%+
           const shouldUpdate = !throttleData ||
             now - throttleData.timestamp > 300 ||
             Math.abs(progress - throttleData.progress) >= 5;
@@ -96,11 +168,10 @@ export function ParakeetModelManager({
           if (shouldUpdate) {
             console.log(`[ParakeetModelManager] Progress update for ${modelName}: ${progress}%`);
             progressThrottleRef.current.set(modelName, { progress, timestamp: now });
-
             setModels(prevModels =>
               prevModels.map(model =>
                 model.name === modelName
-                  ? { ...model, status: { Downloading: progress } as ModelStatus }
+                  ? { ...model, status: { Downloading: { progress } } as ModelStatus }
                   : model
               )
             );
@@ -115,6 +186,7 @@ export function ParakeetModelManager({
           const { modelName } = event.payload;
           const displayInfo = getModelDisplayInfo(modelName);
           const displayName = displayInfo?.friendlyName || modelName;
+          clearCancellationReconciliation(modelName);
 
           setModels(prevModels =>
             prevModels.map(model =>
@@ -155,6 +227,7 @@ export function ParakeetModelManager({
           const { modelName, error } = event.payload;
           const displayInfo = getModelDisplayInfo(modelName);
           const displayName = displayInfo?.friendlyName || modelName;
+          clearCancellationReconciliation(modelName);
 
           setModels(prevModels =>
             prevModels.map(model =>
@@ -192,6 +265,11 @@ export function ParakeetModelManager({
       if (unlistenProgress) unlistenProgress();
       if (unlistenComplete) unlistenComplete();
       if (unlistenError) unlistenError();
+      for (const timer of cancellationReconcileTimersRef.current.values()) {
+        clearTimeout(timer);
+      }
+      cancellationReconcileTimersRef.current.clear();
+      cancellationReconciliationModelsRef.current.clear();
     };
   }, []); // Empty dependency array - listeners use refs for stable callbacks
 
@@ -211,30 +289,18 @@ export function ParakeetModelManager({
     const displayInfo = getModelDisplayInfo(modelName);
     const displayName = displayInfo?.friendlyName || modelName;
 
+    setCancellingModels(prev => new Set([...prev, modelName]));
     try {
-      await ParakeetAPI.cancelDownload(modelName);
-
-      setDownloadingModels(prev => {
-        const newSet = new Set(prev);
-        newSet.delete(modelName);
-        return newSet;
-      });
-
-      setModels(prevModels =>
-        prevModels.map(model =>
-          model.name === modelName
-            ? { ...model, status: 'Missing' as ModelStatus }
-            : model
-        )
-      );
-
-      // Clean up throttle data
-      progressThrottleRef.current.delete(modelName);
-
-      toast.info(`${displayName} download cancelled`, {
-        duration: 3000
-      });
+      const outcome = await ParakeetAPI.cancelDownload(modelName);
+      reconcileCancellation(modelName);
+      if (outcome === 'pending') {
+        toast.info(`Cancelling ${displayName}...`, {
+          description: 'The download is still shutting down. Retry will be available when cleanup completes.',
+          duration: 4000
+        });
+      }
     } catch (err) {
+      clearCancellationReconciliation(modelName);
       console.error('Failed to cancel download:', err);
       toast.error('Failed to cancel download', {
         description: err instanceof Error ? err.message : 'Unknown error',
@@ -244,7 +310,8 @@ export function ParakeetModelManager({
   };
 
   const downloadModel = async (modelName: string) => {
-    if (downloadingModels.has(modelName)) return;
+    if (downloadingModels.has(modelName) || cancellingModels.has(modelName)) return;
+    clearCancellationReconciliation(modelName);
 
     const displayInfo = getModelDisplayInfo(modelName);
     const displayName = displayInfo?.friendlyName || modelName;
@@ -255,7 +322,7 @@ export function ParakeetModelManager({
       setModels(prevModels =>
         prevModels.map(model =>
           model.name === modelName
-            ? { ...model, status: { Downloading: 0 } as ModelStatus }
+            ? { ...model, status: { Downloading: { progress: 0 } } as ModelStatus }
             : model
         )
       );
@@ -372,6 +439,7 @@ export function ParakeetModelManager({
           onCancel={() => cancelDownload(recommendedModel.name)}
           onDelete={() => deleteModel(recommendedModel.name)}
           isDownloading={downloadingModels.has(recommendedModel.name)}
+          isCancelling={cancellingModels.has(recommendedModel.name)}
         />
       )}
 
@@ -393,6 +461,7 @@ export function ParakeetModelManager({
               onCancel={() => cancelDownload(model.name)}
               onDelete={() => deleteModel(model.name)}
               isDownloading={downloadingModels.has(model.name)}
+              isCancelling={cancellingModels.has(model.name)}
             />
           ))}
         </div>
@@ -422,6 +491,7 @@ interface ModelCardProps {
   onCancel: () => void;
   onDelete: () => void;
   isDownloading: boolean;
+  isCancelling: boolean;
 }
 
 function ModelCard({
@@ -432,7 +502,8 @@ function ModelCard({
   onDownload,
   onCancel,
   onDelete,
-  isDownloading
+  isDownloading,
+  isCancelling
 }: ModelCardProps) {
   const [isHovered, setIsHovered] = useState(false);
   const displayInfo = getModelDisplayInfo(model.name);
@@ -446,8 +517,9 @@ function ModelCard({
   const isCorrupted = typeof model.status === 'object' && 'Corrupted' in model.status;
   const downloadProgress =
     typeof model.status === 'object' && 'Downloading' in model.status
-      ? model.status.Downloading
+      ? model.status.Downloading.progress
       : null;
+  const displayedProgress = downloadProgress ?? 0;
 
   return (
     <motion.div
@@ -501,7 +573,7 @@ function ModelCard({
 
           {/* Status/Action */}
           <div className="ml-4 flex items-center gap-2">
-            {isAvailable && (
+            {isAvailable && !isCancelling && (
               <>
                 <div className="flex items-center gap-1.5 text-green-600">
                   <div className="w-2 h-2 bg-green-500 rounded-full"></div>
@@ -530,7 +602,7 @@ function ModelCard({
               </>
             )}
 
-            {isMissing && (
+            {isMissing && !isCancelling && (
               <button
                 onClick={(e) => {
                   e.stopPropagation();
@@ -542,7 +614,7 @@ function ModelCard({
               </button>
             )}
 
-            {downloadProgress === null && isError && (
+            {downloadProgress === null && isError && !isCancelling && (
               <button
                 onClick={(e) => {
                   e.stopPropagation();
@@ -554,7 +626,7 @@ function ModelCard({
               </button>
             )}
 
-            {isCorrupted && (
+            {isCorrupted && !isCancelling && (
               <div className="flex gap-2">
                 <button
                   onClick={(e) => {
@@ -580,7 +652,7 @@ function ModelCard({
         </div>
 
         {/* Full-width Download Progress Bar - PROMINENT */}
-        {downloadProgress !== null && (
+        {(downloadProgress !== null || isCancelling) && (
           <motion.div
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
@@ -589,32 +661,44 @@ function ModelCard({
           >
             <div className="flex items-center justify-between mb-2">
               <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-blue-600">Downloading...</span>
-                <span className="text-sm font-semibold text-blue-600">{Math.round(downloadProgress)}%</span>
+                <span className="text-sm font-medium text-blue-600">
+                  {isCancelling ? 'Cancelling…' : 'Downloading...'}
+                </span>
+                {!isCancelling && (
+                  <span className="text-sm font-semibold text-blue-600">
+                    {Math.round(displayedProgress)}%
+                  </span>
+                )}
               </div>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onCancel();
-                }}
-                className="text-xs text-gray-600 hover:text-red-600 font-medium transition-colors px-2 py-1 rounded hover:bg-red-50"
-                title="Cancel download"
-              >
-                Cancel
-              </button>
+              {isCancelling ? (
+                <span className="text-xs text-gray-500 font-medium px-2 py-1">
+                  Cancellation requested
+                </span>
+              ) : (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onCancel();
+                  }}
+                  className="text-xs text-gray-600 hover:text-red-600 font-medium transition-colors px-2 py-1 rounded hover:bg-red-50"
+                  title="Cancel download"
+                >
+                  Cancel
+                </button>
+              )}
             </div>
             <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
               <motion.div
                 className="h-full bg-gradient-to-r from-blue-500 to-blue-600 rounded-full"
                 initial={{ width: 0 }}
-                animate={{ width: `${downloadProgress}%` }}
+                animate={{ width: `${displayedProgress}%` }}
                 transition={{ duration: 0.3, ease: 'easeOut' }}
               />
             </div>
             <p className="text-xs text-gray-500 mt-1">
               {model.size_mb ? (
                 <>
-                  {formatFileSize(model.size_mb * downloadProgress / 100)} / {formatFileSize(model.size_mb)}
+                  {formatFileSize(model.size_mb * displayedProgress / 100)} / {formatFileSize(model.size_mb)}
                 </>
               ) : (
                 'Downloading...'

--- a/frontend/src/components/ParakeetModelManager.tsx
+++ b/frontend/src/components/ParakeetModelManager.tsx
@@ -39,77 +39,12 @@ export function ParakeetModelManager({
 
   // Progress throttle map to prevent rapid updates
   const progressThrottleRef = useRef<Map<string, { progress: number; timestamp: number }>>(new Map());
-  const cancellationReconciliationModelsRef = useRef<Set<string>>(new Set());
-  const cancellationReconcileTimersRef = useRef<Map<string, NodeJS.Timeout>>(new Map());
-
-  // Update refs when props change
-  useEffect(() => {
-    onModelSelectRef.current = onModelSelect;
-    autoSaveRef.current = autoSave;
-  }, [onModelSelect, autoSave]);
-
-  const clearCancellationReconciliation = (modelName: string) => {
-    cancellationReconciliationModelsRef.current.delete(modelName);
-    const timer = cancellationReconcileTimersRef.current.get(modelName);
-    if (timer !== undefined) {
-      clearTimeout(timer);
-      cancellationReconcileTimersRef.current.delete(modelName);
-    }
+  const clearCancellingModel = (modelName: string) => {
     setCancellingModels(prev => {
       const next = new Set(prev);
       next.delete(modelName);
       return next;
     });
-  };
-
-  const reconcileCancellation = (modelName: string) => {
-    if (cancellationReconciliationModelsRef.current.has(modelName)) return;
-
-    cancellationReconciliationModelsRef.current.add(modelName);
-    setCancellingModels(prev => new Set([...prev, modelName]));
-
-    const scheduleNextCheck = () => {
-      if (!cancellationReconciliationModelsRef.current.has(modelName)) return;
-      const timer = setTimeout(() => {
-        cancellationReconcileTimersRef.current.delete(modelName);
-        void reconcile();
-      }, 1000);
-      cancellationReconcileTimersRef.current.set(modelName, timer);
-    };
-
-    const reconcile = async () => {
-      try {
-        const modelList = await ParakeetAPI.getAvailableModels();
-        if (!cancellationReconciliationModelsRef.current.has(modelName)) return;
-
-        const model = modelList.find(candidate => candidate.name === modelName);
-        const isStillDownloading =
-          typeof model?.status === 'object' && 'Downloading' in model.status;
-        if (model && !isStillDownloading) {
-          clearCancellationReconciliation(modelName);
-          setDownloadingModels(prev => {
-            const next = new Set(prev);
-            next.delete(modelName);
-            return next;
-          });
-          setModels(modelList);
-          progressThrottleRef.current.delete(modelName);
-          toast.info(
-            model.status === 'Available'
-              ? `${getModelDisplayName(modelName)} download completed before cancellation`
-              : `${getModelDisplayName(modelName)} download cancelled`,
-            { duration: 3000 }
-          );
-          return;
-        }
-      } catch (err) {
-        console.warn('Failed to reconcile pending Parakeet cancellation:', err);
-      }
-
-      scheduleNextCheck();
-    };
-
-    void reconcile();
   };
 
   // Initialize and load models
@@ -155,7 +90,22 @@ export function ParakeetModelManager({
           const { modelName, progress, status } = event.payload;
           if (status === 'cancelled') {
             progressThrottleRef.current.delete(modelName);
-            reconcileCancellation(modelName);
+            clearCancellingModel(modelName);
+            setDownloadingModels(prev => {
+              const next = new Set(prev);
+              next.delete(modelName);
+              return next;
+            });
+            setModels(prevModels =>
+              prevModels.map(model =>
+                model.name === modelName
+                  ? { ...model, status: 'Missing' as ModelStatus }
+                  : model
+              )
+            );
+            toast.info(`${getModelDisplayName(modelName)} download cancelled`, {
+              duration: 3000
+            });
             return;
           }
 
@@ -186,7 +136,7 @@ export function ParakeetModelManager({
           const { modelName } = event.payload;
           const displayInfo = getModelDisplayInfo(modelName);
           const displayName = displayInfo?.friendlyName || modelName;
-          clearCancellationReconciliation(modelName);
+          clearCancellingModel(modelName);
 
           setModels(prevModels =>
             prevModels.map(model =>
@@ -227,7 +177,7 @@ export function ParakeetModelManager({
           const { modelName, error } = event.payload;
           const displayInfo = getModelDisplayInfo(modelName);
           const displayName = displayInfo?.friendlyName || modelName;
-          clearCancellationReconciliation(modelName);
+          clearCancellingModel(modelName);
 
           setModels(prevModels =>
             prevModels.map(model =>
@@ -265,11 +215,6 @@ export function ParakeetModelManager({
       if (unlistenProgress) unlistenProgress();
       if (unlistenComplete) unlistenComplete();
       if (unlistenError) unlistenError();
-      for (const timer of cancellationReconcileTimersRef.current.values()) {
-        clearTimeout(timer);
-      }
-      cancellationReconcileTimersRef.current.clear();
-      cancellationReconciliationModelsRef.current.clear();
     };
   }, []); // Empty dependency array - listeners use refs for stable callbacks
 
@@ -292,7 +237,6 @@ export function ParakeetModelManager({
     setCancellingModels(prev => new Set([...prev, modelName]));
     try {
       const outcome = await ParakeetAPI.cancelDownload(modelName);
-      reconcileCancellation(modelName);
       if (outcome === 'pending') {
         toast.info(`Cancelling ${displayName}...`, {
           description: 'The download is still shutting down. Retry will be available when cleanup completes.',
@@ -300,7 +244,7 @@ export function ParakeetModelManager({
         });
       }
     } catch (err) {
-      clearCancellationReconciliation(modelName);
+      clearCancellingModel(modelName);
       console.error('Failed to cancel download:', err);
       toast.error('Failed to cancel download', {
         description: err instanceof Error ? err.message : 'Unknown error',
@@ -311,7 +255,7 @@ export function ParakeetModelManager({
 
   const downloadModel = async (modelName: string) => {
     if (downloadingModels.has(modelName) || cancellingModels.has(modelName)) return;
-    clearCancellationReconciliation(modelName);
+    clearCancellingModel(modelName);
 
     const displayInfo = getModelDisplayInfo(modelName);
     const displayName = displayInfo?.friendlyName || modelName;

--- a/frontend/src/components/onboarding/steps/DownloadProgressStep.tsx
+++ b/frontend/src/components/onboarding/steps/DownloadProgressStep.tsx
@@ -8,10 +8,11 @@ import { useOnboarding } from '@/contexts/OnboardingContext';
 import { toast } from 'sonner';
 import { motion, AnimatePresence } from 'framer-motion';
 import { getSummaryModelSizeLabel, getSummaryModelSizeMb } from '@/lib/onboarding-summary-model';
+import type { ParakeetDownloadProgressEvent } from '@/lib/parakeet';
 
 const PARAKEET_MODEL = 'parakeet-tdt-0.6b-v3-int8';
 
-type DownloadStatus = 'waiting' | 'downloading' | 'completed' | 'error';
+type DownloadStatus = 'waiting' | 'downloading' | 'completed' | 'cancelled' | 'error';
 
 interface DownloadState {
   status: DownloadStatus;
@@ -195,16 +196,24 @@ export function DownloadProgressStep() {
 
   // Listen to Parakeet download progress
   useEffect(() => {
-    const unlistenProgress = listen<{
-      modelName: string;
-      progress: number;
-      downloaded_mb?: number;
-      total_mb?: number;
-      speed_mbps?: number;
-      status?: string;
-    }>('parakeet-model-download-progress', (event) => {
-      const { modelName, progress, downloaded_mb, total_mb, speed_mbps, status } = event.payload;
-      if (modelName === PARAKEET_MODEL) {
+    const unlistenProgress = listen<ParakeetDownloadProgressEvent>(
+      'parakeet-model-download-progress',
+      (event) => {
+        const { modelName, progress, downloaded_mb, total_mb, speed_mbps, status } = event.payload;
+        if (modelName !== PARAKEET_MODEL) return;
+
+        if (status === 'cancelled') {
+          setParakeetState((prev) => ({
+            ...prev,
+            status: 'cancelled',
+            progress: 0,
+            downloadedMb: 0,
+            speedMbps: 0,
+          }));
+          setParakeetDownloaded(false);
+          return;
+        }
+
         setParakeetState((prev) => ({
           ...prev,
           status: status === 'completed' ? 'completed' : 'downloading',
@@ -214,11 +223,11 @@ export function DownloadProgressStep() {
           speedMbps: speed_mbps ?? prev.speedMbps,
         }));
 
-        if (status === 'completed' || progress >= 100) {
+        if (status === 'completed') {
           setParakeetDownloaded(true);
         }
       }
-    });
+    );
 
     const unlistenComplete = listen<{ modelName: string }>(
       'parakeet-model-download-complete',
@@ -342,7 +351,10 @@ export function DownloadProgressStep() {
           status: 'completed',
           progress: 100,
         }));
-      } else if (!actuallyAvailable && parakeetState.status === 'error') {
+      } else if (
+        !actuallyAvailable &&
+        (parakeetState.status === 'error' || parakeetState.status === 'cancelled')
+      ) {
         toast.error('Transcription engine required', {
           description: 'Please retry the download before continuing.',
         });
@@ -420,6 +432,9 @@ export function DownloadProgressStep() {
           {state.status === 'error' && (
             <span className="text-sm text-red-500">Failed</span>
           )}
+          {state.status === 'cancelled' && (
+            <span className="text-sm text-gray-500">Cancelled</span>
+          )}
         </div>
       </div>
 
@@ -450,10 +465,12 @@ export function DownloadProgressStep() {
         </div>
       )}
 
-      {state.status === 'error' && state.error && (
+      {(state.status === 'error' || state.status === 'cancelled') && (
         <div className="mt-2 p-3 bg-red-50 border border-red-200 rounded-md">
-          <p className="text-sm text-red-600 font-medium">Download Error</p>
-          <p className="text-xs text-red-500 mt-1">{state.error}</p>
+          <p className="text-sm text-red-600 font-medium">
+            {state.status === 'cancelled' ? 'Download cancelled' : 'Download Error'}
+          </p>
+          {state.error && <p className="text-xs text-red-500 mt-1">{state.error}</p>}
           {(title === 'Transcription Engine' || title === 'Summary Engine') && (
             <button
               onClick={title === 'Transcription Engine' ? handleRetryDownload : handleRetrySummaryDownload}

--- a/frontend/src/components/shared/DownloadProgressToast.tsx
+++ b/frontend/src/components/shared/DownloadProgressToast.tsx
@@ -5,6 +5,7 @@ import { listen } from '@tauri-apps/api/event';
 import { toast } from 'sonner';
 import { X, Download, Check, Loader2, ArrowBigDownDash } from 'lucide-react';
 import { getDownloadTotalMb } from '@/lib/onboarding-summary-model';
+import type { ParakeetDownloadProgressEvent } from '@/lib/parakeet';
 
 interface DownloadProgress {
   modelName: string;
@@ -221,38 +222,30 @@ export function useDownloadProgressToast() {
 
   // Listen to Parakeet download events
   useEffect(() => {
-    const unlistenProgress = listen<{
-      modelName: string;
-      progress: number;
-      downloaded_mb?: number;
-      total_mb?: number;
-      speed_mbps?: number;
-      status?: string;
-    }>('parakeet-model-download-progress', (event) => {
-      const { modelName, progress, downloaded_mb, total_mb, speed_mbps, status } = event.payload;
+    const unlistenProgress = listen<ParakeetDownloadProgressEvent>(
+      'parakeet-model-download-progress',
+      (event) => {
+        const { modelName, progress, downloaded_mb, total_mb, speed_mbps, status } = event.payload;
+        const downloadData: DownloadProgress = {
+          modelName,
+          displayName: 'Transcription Model (Parakeet)',
+          progress,
+          downloadedMb: downloaded_mb ?? 0,
+          totalMb: total_mb ?? 670,
+          speedMbps: speed_mbps ?? 0,
+          status: status === 'cancelled'
+            ? 'cancelled'
+            : status === 'completed'
+              ? 'completed'
+              : 'downloading',
+        };
 
-      const downloadData: DownloadProgress = {
-        modelName,
-        displayName: 'Transcription Model (Parakeet)',
-        progress,
-        downloadedMb: downloaded_mb ?? 0,
-        totalMb: total_mb ?? 670,
-        speedMbps: speed_mbps ?? 0,
-        status: status === 'cancelled'
-          ? 'cancelled'
-          : status === 'completed' || progress >= 100
-          ? 'completed'
-          : 'downloading',
-      };
-
-      updateDownload(modelName, downloadData);
-
-      // Clean up cancelled downloads after delay to auto-dismiss toast
-      if (downloadData.status === 'cancelled') {
-        cleanupDownload(modelName, 6000); // 5s toast + 1s buffer
+        updateDownload(modelName, downloadData);
+        if (downloadData.status === 'cancelled') {
+          cleanupDownload(modelName, 6000);
+        }
       }
-      // Removed direct showDownloadToast call here, handled by effect
-    });
+    );
 
     const unlistenComplete = listen<{ modelName: string }>(
       'parakeet-model-download-complete',

--- a/frontend/src/contexts/OnboardingContext.tsx
+++ b/frontend/src/contexts/OnboardingContext.tsx
@@ -5,6 +5,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import type { PermissionStatus, OnboardingPermissions } from '@/types/onboarding';
 import { resolveOnboardingSummaryModelStatus } from '@/lib/onboarding-summary-model';
+import type { ParakeetDownloadProgressEvent } from '@/lib/parakeet';
 
 const PARAKEET_MODEL = 'parakeet-tdt-0.6b-v3-int8';
 
@@ -234,28 +235,34 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
 
   // Listen to Parakeet download progress
   useEffect(() => {
-    const unlisten = listen<{
-      modelName: string;
-      progress: number;
-      downloaded_mb?: number;
-      total_mb?: number;
-      speed_mbps?: number;
-      status?: string;
-    }>(
+    const unlisten = listen<ParakeetDownloadProgressEvent>(
       'parakeet-model-download-progress',
       (event) => {
         const { modelName, progress, downloaded_mb, total_mb, speed_mbps, status } = event.payload;
-        if (modelName === PARAKEET_MODEL) {
-          setParakeetProgress(progress);
+        if (modelName !== PARAKEET_MODEL) return;
+
+        if (status === 'cancelled') {
+          setIsBackgroundDownloading(false);
+          setParakeetDownloaded(false);
+          setParakeetProgress(0);
           setParakeetProgressInfo({
-            percent: progress,
-            downloadedMb: downloaded_mb ?? 0,
-            totalMb: total_mb ?? 0,
-            speedMbps: speed_mbps ?? 0,
+            percent: 0,
+            downloadedMb: 0,
+            totalMb: 0,
+            speedMbps: 0,
           });
-          if (status === 'completed' || progress >= 100) {
-            setParakeetDownloaded(true);
-          }
+          return;
+        }
+
+        setParakeetProgress(progress);
+        setParakeetProgressInfo({
+          percent: progress,
+          downloadedMb: downloaded_mb ?? 0,
+          totalMb: total_mb ?? 0,
+          speedMbps: speed_mbps ?? 0,
+        });
+        if (status === 'completed') {
+          setParakeetDownloaded(true);
         }
       }
     );

--- a/frontend/src/lib/parakeet.ts
+++ b/frontend/src/lib/parakeet.ts
@@ -17,9 +17,23 @@ export type ProcessingSpeed = 'Slow' | 'Medium' | 'Fast' | 'Very Fast' | 'Ultra 
 export type ModelStatus =
   | 'Available'
   | 'Missing'
-  | { Downloading: number }
+  | { Downloading: { progress: number } }
   | { Error: string }
   | { Corrupted: { file_size: number; expected_min_size: number } };
+
+export type CancelDownloadOutcome = 'cancelled' | 'pending';
+export type ParakeetDownloadEventStatus = 'downloading' | 'completed' | 'cancelled';
+
+export interface ParakeetDownloadProgressEvent {
+  modelName: string;
+  progress: number;
+  downloaded_bytes?: number;
+  total_bytes?: number;
+  downloaded_mb?: number;
+  total_mb?: number;
+  speed_mbps?: number;
+  status: ParakeetDownloadEventStatus;
+}
 
 export interface ParakeetEngineState {
   currentModel: string | null;
@@ -184,8 +198,8 @@ export class ParakeetAPI {
     await invoke('parakeet_download_model', { modelName });
   }
 
-  static async cancelDownload(modelName: string): Promise<void> {
-    await invoke('parakeet_cancel_download', { modelName });
+  static async cancelDownload(modelName: string): Promise<CancelDownloadOutcome> {
+    return await invoke('parakeet_cancel_download', { modelName });
   }
 
   static async deleteCorruptedModel(modelName: string): Promise<string> {


### PR DESCRIPTION
## Context

Follow-up to **#682**, addressing the recovery-path findings raised during review of the mitigation for **#662**.

PR #682 stopped a failed artifact download from deleting completed sibling artifacts and made active-download ownership atomic. This change preserves those guarantees while closing the remaining validation, resume, cancellation, and UI-state gaps.

## Changes

- Validate retained artifact lengths against the exact Parakeet V2/V3 catalog before treating any file as complete; a near-complete cancelled file cannot be marked available.
- Keep completed sibling artifacts and resumable partials across failed later-artifact requests; recover correctly from `403`, ignored `Range` requests, and `416` resume restarts without inflating aggregate progress.
- Keep worker ownership through cancellation cleanup. Cancellation now has a terminal outcome and the UI waits for it before exposing Retry, preventing a second writer from racing the original worker.
- Propagate typed download progress and cancellation events through the model manager, onboarding flow, and global download toast.
- Replace the affected Chinese comments with English comments.
- Add deterministic loopback HTTP regressions for near-complete Cancel → Retry validation, `403` → retry/resume sibling preservation, ignored `Range` fallback, `416` restart behavior, and cancellation/retry ownership races.

## Implementation note

This follow-up touches the download path end to end so recovery, cancellation, and visible model state remain consistent through retry.

The scope remains limited to the Parakeet download lifecycle. The additional detail is primarily deterministic regression coverage for recovery cases that are difficult to reproduce reliably against hosted artifacts.

## Scope

This hardens client-side recovery behavior identified in the #682 review. It does **not** resolve the separate upstream proxy/hosting cause of the underlying `403` failures; that remains tracked independently.

## Verification

```text
TAURI_CONFIG={"bundle":{"externalBin":[]}} cargo test -p meetily --lib -j 1 parakeet_engine::parakeet_engine::tests:: -- --nocapture
8 passed; 0 failed
```

`TAURI_CONFIG` only omits unavailable bundled sidecars for the local Rust test invocation. No formatter was run.

## Manual Test

1. Cancel / retry
   - Settings → Transcription → Parakeet model.
   - Start a download, then click Cancel.
   - Confirm it shows Cancelling… and does not expose Retry immediately.
   - After Download cancelled, click Download/Retry.
   - Confirm it completes and becomes Ready.
 2. Near-complete cancel
   - Repeat, but cancel close to completion.
   - Retry must finish normally; it must not become Ready immediately from an incomplete retained file.
 3. Onboarding
   - In a fresh onboarding flow, cancel Parakeet download.
   - Confirm it shows Cancelled, does not mark transcription ready, and requires retry before continuing with an available model.

## References

- Follow-up to #682
- Mitigates the recovery behavior reported in #662
