### PR TITLE
feat: add optional PocketStation system audio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "annotate-snippets"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+dependencies = [
+ "anstyle",
+ "unicode-width",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,7 +370,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -442,10 +452,11 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
+ "annotate-snippets",
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -685,7 +696,7 @@ checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -760,7 +771,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -781,7 +792,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec 1.15.1",
- "target-lexicon",
+ "target-lexicon 0.12.16",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4ece8474b5f766c63426647e7b4b316b67431ade1036a8313cee24a03ae917"
+dependencies = [
+ "smallvec 1.15.1",
+ "target-lexicon 0.13.5",
 ]
 
 [[package]]
@@ -1007,6 +1028,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-sys"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+checksum = "b9b4739a805a62757a83e5654fa3faabec0442666b263bb2287d5a8185bfd953"
 dependencies = [
  "bindgen 0.72.1",
 ]
@@ -2312,7 +2339,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2329,7 +2356,7 @@ dependencies = [
  "libc",
  "pango-sys",
  "pkg-config",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2343,7 +2370,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pkg-config",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2369,7 +2396,7 @@ dependencies = [
  "gdk-sys",
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
  "x11",
 ]
 
@@ -2459,7 +2486,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
  "winapi",
 ]
 
@@ -2507,7 +2534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
 dependencies = [
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2524,7 +2551,7 @@ checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2563,7 +2590,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pango-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3153,15 +3180,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3187,7 +3205,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3442,6 +3460,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "libspa"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882f7427e7989dcc9d388b7f05c4630390a1d7696f9ffa469cd4a7a48f0b4c40"
+dependencies = [
+ "bitflags 2.11.1",
+ "cc",
+ "cookie-factory",
+ "libc",
+ "libspa-sys",
+ "nom 8.0.0",
+ "rustix 1.1.4",
+ "system-deps 7.0.8",
+]
+
+[[package]]
+name = "libspa-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b6e17bdaf63ed0d5e4144022624032b41fd9733112e8c74ac26fc9bf1291924"
+dependencies = [
+ "bindgen 0.72.1",
+ "cc",
+ "system-deps 7.0.8",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3643,6 +3688,7 @@ dependencies = [
  "objc",
  "once_cell",
  "ort",
+ "pocketstation",
  "posthog-rs",
  "rand 0.8.6",
  "rayon",
@@ -3895,6 +3941,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4417,7 +4472,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -4554,6 +4609,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "pipewire"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde71084c4e25959d68f1ea54daa75e5ecdb338e5caf0b5510143b79baa32d5c"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "libspa",
+ "libspa-sys",
+ "pipewire-sys",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "pipewire-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce653f53e63e5b93853218092ee9a8906a5d082c92f3f1db26316955dd63ce0"
+dependencies = [
+ "bindgen 0.72.1",
+ "libspa-sys",
+ "system-deps 7.0.8",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4651,6 +4731,27 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "pocketstation"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb23694072ba182d17175e966fe75c67a18632de517e7d78d6197af3d23a127"
+dependencies = [
+ "cc",
+ "hound",
+ "libc",
+ "libloading 0.8.9",
+ "pipewire",
+ "rtrb",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "wasapi",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -5254,6 +5355,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "rtrb"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fae8ee26b0371a29a77d2b2d6b3ae13aa81def6f9bf1b1b92a32d279a5e709b7"
 
 [[package]]
 name = "rubato"
@@ -5982,7 +6089,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -6534,10 +6641,23 @@ version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
- "cfg-expr",
+ "cfg-expr 0.15.8",
  "heck 0.5.0",
  "pkg-config",
  "toml 0.8.2",
+ "version-compare",
+]
+
+[[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr 0.20.9",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 1.1.2+spec-1.1.0",
  "version-compare",
 ]
 
@@ -6614,6 +6734,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tauri"
@@ -7617,6 +7743,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7795,6 +7927,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
+]
+
+[[package]]
+name = "wasapi"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80c3aa5d6b0e7acc3ea10cb19c334df0c8d825060f14a30d9e3b03385e6e5175"
+dependencies = [
+ "log",
+ "num-integer",
+ "thiserror 2.0.18",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8005,7 +8150,7 @@ dependencies = [
  "libc",
  "pkg-config",
  "soup3-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -8201,15 +8346,37 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -8219,6 +8386,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8240,6 +8416,19 @@ dependencies = [
  "windows-implement 0.57.0",
  "windows-interface 0.57.0",
  "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -8277,7 +8466,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -8285,6 +8485,17 @@ name = "windows-implement"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8307,6 +8518,17 @@ name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8347,10 +8569,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -8371,6 +8612,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8515,6 +8766,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -206,6 +206,25 @@ For more details, see the [Architecture documentation](docs/architecture.md).
 
 If you want to contribute to Meetily or build it from source, you'll need to have Rust and Node.js installed. For detailed build instructions, please see the [Building from Source guide](docs/BUILDING.md).
 
+### Try PocketStation capture
+
+Meetily can use [PocketStation](https://github.com/pocketstation-io/pocketstation)
+for system-audio capture on Windows and Linux. This is an optional build;
+Meetily's current capture methods remain the default, including its microphone
+capture and macOS implementation.
+
+```bash
+cd frontend
+MEETILY_CAPTURE=pocketstation ./dev-gpu.sh
+```
+
+Open Meetily's audio settings and choose **PocketStation** under **System Audio
+Backend**. The system-audio choice enters Meetily's existing mixing, VAD,
+transcription, and recording code. Use Meetily's current Rust toolchain.
+
+See the [build guide](docs/BUILDING.md#pocketstation-capture) for Windows and
+manual build commands.
+
 ## Meetily Pro
 
 <p align="center">

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -2,6 +2,49 @@
 
 This guide provides detailed instructions for building Meetily from source on different operating systems.
 
+## PocketStation capture
+
+PocketStation is an optional system-audio method for Windows and Linux. It
+feeds 48 kHz mono audio into Meetily's existing `AudioChunk` processing.
+Meetily continues to capture the selected microphone and own mixing, VAD,
+transcription, storage, and the interface. The existing macOS capture methods
+are unchanged.
+
+PocketStation is disabled in normal builds. Prepare the `llama-helper` sidecar
+with the normal Meetily build script, and set the capture option before starting
+Tauri:
+
+```bash
+cd frontend
+MEETILY_CAPTURE=pocketstation ./dev-gpu.sh
+```
+
+In PowerShell:
+
+```powershell
+cd frontend
+$env:MEETILY_CAPTURE = "pocketstation"
+pnpm run tauri:dev
+```
+
+You can also compile the Rust application directly after preparing its
+sidecar:
+
+```bash
+cargo check -p meetily --features pocketstation-capture
+```
+
+Choose **PocketStation** under **System Audio Backend**. The selected microphone
+continues through Meetily's current capture code. The system-audio choice
+captures the complete output mix; it can include notifications and unrelated
+applications. Capture failures are reported through Meetily's existing
+recording error event, and stopping a recording joins the PocketStation Session
+before Meetily finishes the audio pipeline.
+
+Use the current Meetily methods when testing a specific output device. The
+PocketStation system-audio Source follows the host's current output mix rather
+than Meetily's output-device name.
+
 <details>
 <summary>Linux</summary>
 

--- a/frontend/scripts/tauri-auto.js
+++ b/frontend/scripts/tauri-auto.js
@@ -47,11 +47,23 @@ if (platform === 'linux' && feature === 'cuda') {
   env.CMAKE_POSITION_INDEPENDENT_CODE = 'ON';
 }
 
+const features = [];
+if (feature && feature !== 'none') {
+  features.push(feature);
+}
+if (process.env.MEETILY_CAPTURE) {
+  if (process.env.MEETILY_CAPTURE !== 'pocketstation') {
+    console.error('MEETILY_CAPTURE must be "pocketstation" when it is set');
+    process.exit(1);
+  }
+  features.push('pocketstation-capture');
+}
+
 // Build the tauri command
 let tauriCmd = `tauri ${command}`;
-if (feature && feature !== 'none') {
-  tauriCmd += ` -- --features ${feature}`;
-  console.log(`🚀 Running: tauri ${command} with features: ${feature}`);
+if (features.length > 0) {
+  tauriCmd += ` -- --features ${features.join(',')}`;
+  console.log(`🚀 Running: tauri ${command} with features: ${features.join(', ')}`);
 } else {
   console.log(`🚀 Running: tauri ${command} (CPU-only mode)`);
 }

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ default = ["platform-default"]  # Automatically enables best backend per platfor
 
 # Platform-appropriate defaults - see target-specific dependencies below
 platform-default = []
+pocketstation-capture = ["dep:pocketstation"]
 
 # Manual GPU acceleration options (for power users to override defaults)
 metal = ["whisper-rs/metal"]       # macOS: Apple Metal GPU (Auto-enabled on macOS)
@@ -68,7 +69,6 @@ anyhow = "1.0"
 once_cell = "1.17.1"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 posthog-rs = "0.3.7"
-
 # Cross-platform audio capture
 cpal = "0.15.3"
 
@@ -186,6 +186,7 @@ whisper-rs = { version = "0.13.2", features = ["raw-api", "metal", "coreml"] }
 [target.'cfg(target_os = "windows")'.dependencies]
 whisper-rs = { version = "0.13.2", features = ["raw-api"] }
 futures-channel = "0.3.31"
+pocketstation = { version = "=1.1.10", default-features = false, features = ["wasapi-capture"], optional = true }
 
 # Linux-specific dependencies
 # Default: CPU-only build (no BLAS)
@@ -197,6 +198,7 @@ futures-channel = "0.3.31"
 [target.'cfg(target_os = "linux")'.dependencies]
 whisper-rs = { version = "0.13.2", features = ["raw-api"] }
 futures-channel = "0.3.31"
+pocketstation = { version = "=1.1.10", default-features = false, features = ["pipewire-capture"], optional = true }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/frontend/src-tauri/src/audio/capture/backend_config.rs
+++ b/frontend/src-tauri/src/audio/capture/backend_config.rs
@@ -16,6 +16,13 @@ pub enum AudioCaptureBackend {
     /// Uses direct Core Audio API with aggregate device + tap
     #[cfg(target_os = "macos")]
     CoreAudio,
+
+    /// PocketStation system-audio capture on Windows and Linux.
+    #[cfg(all(
+        feature = "pocketstation-capture",
+        any(target_os = "windows", target_os = "linux")
+    ))]
+    PocketStation,
 }
 
 impl AudioCaptureBackend {
@@ -25,6 +32,11 @@ impl AudioCaptureBackend {
             AudioCaptureBackend::ScreenCaptureKit => "ScreenCaptureKit",
             #[cfg(target_os = "macos")]
             AudioCaptureBackend::CoreAudio => "Core Audio",
+            #[cfg(all(
+                feature = "pocketstation-capture",
+                any(target_os = "windows", target_os = "linux")
+            ))]
+            AudioCaptureBackend::PocketStation => "PocketStation",
         }
     }
 
@@ -38,6 +50,13 @@ impl AudioCaptureBackend {
             AudioCaptureBackend::CoreAudio => {
                 "Direct Core Audio API - Lower latency, more control over audio pipeline"
             }
+            #[cfg(all(
+                feature = "pocketstation-capture",
+                any(target_os = "windows", target_os = "linux")
+            ))]
+            AudioCaptureBackend::PocketStation => {
+                "Capture system audio with PocketStation on Windows and Linux"
+            }
         }
     }
 
@@ -47,6 +66,11 @@ impl AudioCaptureBackend {
             "screencapturekit" => Some(AudioCaptureBackend::ScreenCaptureKit),
             #[cfg(target_os = "macos")]
             "coreaudio" | "core_audio" => Some(AudioCaptureBackend::CoreAudio),
+            #[cfg(all(
+                feature = "pocketstation-capture",
+                any(target_os = "windows", target_os = "linux")
+            ))]
+            "pocketstation" => Some(AudioCaptureBackend::PocketStation),
             _ => None,
         }
     }
@@ -57,6 +81,11 @@ impl AudioCaptureBackend {
             AudioCaptureBackend::ScreenCaptureKit => "screencapturekit".to_string(),
             #[cfg(target_os = "macos")]
             AudioCaptureBackend::CoreAudio => "coreaudio".to_string(),
+            #[cfg(all(
+                feature = "pocketstation-capture",
+                any(target_os = "windows", target_os = "linux")
+            ))]
+            AudioCaptureBackend::PocketStation => "pocketstation".to_string(),
         }
     }
 
@@ -69,7 +98,13 @@ impl AudioCaptureBackend {
 
         #[cfg(not(target_os = "macos"))]
         {
-            vec![AudioCaptureBackend::ScreenCaptureKit]
+            let mut backends = vec![AudioCaptureBackend::ScreenCaptureKit];
+            #[cfg(all(
+                feature = "pocketstation-capture",
+                any(target_os = "windows", target_os = "linux")
+            ))]
+            backends.push(AudioCaptureBackend::PocketStation);
+            backends
         }
     }
 
@@ -158,6 +193,11 @@ mod tests {
         assert_eq!(AudioCaptureBackend::ScreenCaptureKit.to_string(), "screencapturekit");
         #[cfg(target_os = "macos")]
         assert_eq!(AudioCaptureBackend::CoreAudio.to_string(), "coreaudio");
+        #[cfg(all(
+            feature = "pocketstation-capture",
+            any(target_os = "windows", target_os = "linux")
+        ))]
+        assert_eq!(AudioCaptureBackend::PocketStation.to_string(), "pocketstation");
     }
 
     #[test]
@@ -177,6 +217,14 @@ mod tests {
                 Some(AudioCaptureBackend::CoreAudio)
             );
         }
+        #[cfg(all(
+            feature = "pocketstation-capture",
+            any(target_os = "windows", target_os = "linux")
+        ))]
+        assert_eq!(
+            AudioCaptureBackend::from_string("pocketstation"),
+            Some(AudioCaptureBackend::PocketStation)
+        );
     }
 
     #[test]
@@ -186,6 +234,11 @@ mod tests {
 
         #[cfg(target_os = "macos")]
         assert!(backends.contains(&AudioCaptureBackend::CoreAudio));
+        #[cfg(all(
+            feature = "pocketstation-capture",
+            any(target_os = "windows", target_os = "linux")
+        ))]
+        assert!(backends.contains(&AudioCaptureBackend::PocketStation));
     }
 
     #[test]

--- a/frontend/src-tauri/src/audio/capture/mod.rs
+++ b/frontend/src-tauri/src/audio/capture/mod.rs
@@ -4,6 +4,12 @@ pub mod microphone;
 pub mod system;
 pub mod backend_config;
 
+#[cfg(all(
+    feature = "pocketstation-capture",
+    any(target_os = "windows", target_os = "linux")
+))]
+pub mod pocketstation;
+
 #[cfg(target_os = "macos")]
 pub mod core_audio;
 

--- a/frontend/src-tauri/src/audio/capture/pocketstation.rs
+++ b/frontend/src-tauri/src/audio/capture/pocketstation.rs
@@ -1,0 +1,204 @@
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{mpsc, Arc};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use pocketstation::connector::{
+    Connector, ConnectorError, ConnectorErrorCode, ConnectorErrorStage, ConnectorRetryability,
+};
+use pocketstation::{AudioFrameDuration, Session, SessionEventKind, SessionEventReceive, Source};
+
+use crate::audio::recording_state::{AudioChunk, AudioError, DeviceType, RecordingState};
+
+const START_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Runs PocketStation capture while Meetily keeps ownership of processing,
+/// transcription, recording, and the user interface.
+pub struct PocketStationCapture {
+    stop: Arc<AtomicBool>,
+    worker: Option<JoinHandle<Result<()>>>,
+}
+
+impl PocketStationCapture {
+    pub fn start(state: Arc<RecordingState>) -> Result<Self> {
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker_stop = Arc::clone(&stop);
+        let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+        let worker = std::thread::Builder::new()
+            .name("meetily-pocketstation-capture".to_string())
+            .spawn(move || run_capture(state, worker_stop, ready_tx))?;
+
+        match ready_rx.recv_timeout(START_TIMEOUT) {
+            Ok(Ok(())) => Ok(Self {
+                stop,
+                worker: Some(worker),
+            }),
+            Ok(Err(error)) => {
+                let _ = worker.join();
+                Err(anyhow!(error))
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                stop.store(true, Ordering::Release);
+                let _ = worker.join();
+                Err(anyhow!(
+                    "PocketStation did not start within {} seconds",
+                    START_TIMEOUT.as_secs()
+                ))
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                let outcome = worker.join();
+                Err(anyhow!("PocketStation stopped during startup: {outcome:?}"))
+            }
+        }
+    }
+
+    pub fn stop(&mut self) -> Result<()> {
+        self.stop.store(true, Ordering::Release);
+        if let Some(worker) = self.worker.take() {
+            match worker.join() {
+                Ok(result) => result,
+                Err(_) => Err(anyhow!("PocketStation capture thread panicked")),
+            }
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for PocketStationCapture {
+    fn drop(&mut self) {
+        let _ = self.stop();
+    }
+}
+
+fn run_capture(
+    state: Arc<RecordingState>,
+    stop: Arc<AtomicBool>,
+    ready: mpsc::SyncSender<std::result::Result<(), String>>,
+) -> Result<()> {
+    let session = Session::builder()
+        .audio_frame_duration(AudioFrameDuration::Ms10)
+        .build();
+    let chunk_id = Arc::new(AtomicU64::new(0));
+    let destination = meetily_destination(
+        &session,
+        Arc::clone(&state),
+        DeviceType::System,
+        Arc::clone(&chunk_id),
+    )?;
+    session.capture(Source::system_audio())?.send(destination)?;
+
+    let mut running = match session.start() {
+        Ok(running) => running,
+        Err(error) => {
+            let message = format!("PocketStation could not start capture: {error}");
+            let _ = ready.send(Err(message.clone()));
+            return Err(anyhow!(message));
+        }
+    };
+    let _ = ready.send(Ok(()));
+
+    let mut runtime_error = None;
+    while !stop.load(Ordering::Acquire) {
+        if let SessionEventReceive::Event(event) = running.try_recv_event() {
+            match event.kind() {
+                SessionEventKind::Source(_)
+                | SessionEventKind::Endpoint(_)
+                | SessionEventKind::Rollback(_)
+                | SessionEventKind::Finalization(_) => {
+                    runtime_error = Some(format!(
+                        "PocketStation reported a capture failure: {:?}",
+                        event.kind()
+                    ));
+                    break;
+                }
+                SessionEventKind::Lifecycle(_) | SessionEventKind::Terminal(_) => {}
+            }
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    if let Some(error) = runtime_error {
+        let outcome = running.cancel();
+        state.report_error(AudioError::StreamFailed);
+        if !outcome.is_success() {
+            return Err(anyhow!(
+                "{error}; PocketStation did not cancel cleanly: {outcome:?}"
+            ));
+        }
+        return Err(anyhow!(error));
+    }
+    let outcome = running.stop();
+    if !outcome.is_success() {
+        return Err(anyhow!("PocketStation did not stop cleanly: {outcome:?}"));
+    }
+    Ok(())
+}
+
+fn meetily_destination(
+    session: &Session,
+    state: Arc<RecordingState>,
+    device_type: DeviceType,
+    chunk_id: Arc<AtomicU64>,
+) -> Result<pocketstation::EndpointHandle> {
+    let connector = Connector::from_audio_fn(move |frame| {
+        if !state.is_recording() {
+            return Ok(());
+        }
+
+        let samples = mono_samples(frame.samples(), frame.channels())?;
+        state
+            .send_audio_chunk(AudioChunk {
+                data: samples,
+                sample_rate: frame.sample_rate_hz(),
+                timestamp: state.get_recording_duration().unwrap_or(0.0),
+                chunk_id: chunk_id.fetch_add(1, Ordering::Relaxed),
+                device_type: device_type.clone(),
+            })
+            .map_err(|error| delivery_error(error.to_string()))
+    })?;
+    Ok(session.destination(connector)?)
+}
+
+fn mono_samples(samples: &[f32], channels: u8) -> std::result::Result<Vec<f32>, ConnectorError> {
+    let channels = usize::from(channels);
+    if channels == 0 {
+        return Err(delivery_error("PocketStation returned no audio channels"));
+    }
+
+    let frames = samples.chunks_exact(channels);
+    if !frames.remainder().is_empty() {
+        return Err(delivery_error(
+            "PocketStation returned an incomplete audio frame",
+        ));
+    }
+
+    Ok(frames
+        .map(|frame| frame.iter().copied().sum::<f32>() / channels as f32)
+        .collect())
+}
+
+fn delivery_error(message: impl Into<String>) -> ConnectorError {
+    ConnectorError::new(
+        ConnectorErrorCode::new("meetily.audio_pipeline_unavailable")
+            .expect("the Meetily Connector error code is valid"),
+        ConnectorErrorStage::Delivery,
+        ConnectorRetryability::Retryable,
+        message,
+    )
+    .expect("the Meetily Connector error message is valid")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mono_samples;
+
+    #[test]
+    fn stereo_frames_are_downmixed_before_meetily_receives_them() {
+        assert_eq!(
+            mono_samples(&[1.0, -1.0, 0.5, 0.5], 2).expect("valid stereo audio"),
+            vec![0.0, 0.5]
+        );
+    }
+}

--- a/frontend/src-tauri/src/audio/recording_manager.rs
+++ b/frontend/src-tauri/src/audio/recording_manager.rs
@@ -14,6 +14,11 @@ use super::pipeline::AudioPipelineManager;
 use super::stream::AudioStreamManager;
 use super::recording_saver::RecordingSaver;
 use super::device_monitor::{AudioDeviceMonitor, DeviceEvent};
+#[cfg(all(
+    feature = "pocketstation-capture",
+    any(target_os = "windows", target_os = "linux")
+))]
+use super::capture::{get_current_backend, AudioCaptureBackend};
 
 /// Stream manager type enumeration
 pub enum StreamManagerType {
@@ -230,6 +235,18 @@ impl RecordingManager {
         // Pass auto_save to control whether audio checkpoints are created
         let recording_sender = self.recording_saver.start_accumulation(auto_save);
 
+        #[cfg(all(
+            feature = "pocketstation-capture",
+            any(target_os = "windows", target_os = "linux")
+        ))]
+        let uses_pocketstation_system_audio =
+            get_current_backend() == AudioCaptureBackend::PocketStation;
+        #[cfg(not(all(
+            feature = "pocketstation-capture",
+            any(target_os = "windows", target_os = "linux")
+        )))]
+        let uses_pocketstation_system_audio = false;
+
         // Start recording state first
         self.state.start_recording()?;
 
@@ -244,7 +261,12 @@ impl RecordingManager {
             ("No Microphone".to_string(), super::device_detection::InputDeviceKind::Unknown)
         };
 
-        let (sys_name, sys_kind) = if let Some(ref sys) = system_device {
+        let (sys_name, sys_kind) = if uses_pocketstation_system_audio {
+            (
+                "PocketStation system audio".to_string(),
+                super::device_detection::InputDeviceKind::Unknown,
+            )
+        } else if let Some(ref sys) = system_device {
             let device_kind = super::device_detection::InputDeviceKind::detect(&sys.name, 512, 48000);
             (sys.name.clone(), device_kind)
         } else {
@@ -254,7 +276,11 @@ impl RecordingManager {
         // Update recording metadata with device information
         self.recording_saver.set_device_info(
             microphone_device.as_ref().map(|d| d.name.clone()),
-            system_device.as_ref().map(|d| d.name.clone())
+            if uses_pocketstation_system_audio {
+                Some("PocketStation system audio".to_string())
+            } else {
+                system_device.as_ref().map(|d| d.name.clone())
+            }
         );
 
         // Start the audio processing pipeline with FFmpeg adaptive mixer
@@ -301,7 +327,12 @@ impl RecordingManager {
 
         // Start device monitoring to detect disconnects
         if let Some(ref mut monitor) = self.device_monitor {
-            if let Err(e) = monitor.start_monitoring(microphone_device, system_device) {
+            let monitored_system_device = if uses_pocketstation_system_audio {
+                None
+            } else {
+                system_device
+            };
+            if let Err(e) = monitor.start_monitoring(microphone_device, monitored_system_device) {
                 warn!("Failed to start device monitoring: {}", e);
                 // Non-fatal - continue without monitoring
             } else {

--- a/frontend/src-tauri/src/audio/recording_preferences.rs
+++ b/frontend/src-tauri/src/audio/recording_preferences.rs
@@ -8,7 +8,6 @@ use anyhow::Result;
 #[cfg(target_os = "macos")]
 use log::error;
 
-#[cfg(target_os = "macos")]
 use crate::audio::capture::AudioCaptureBackend;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -20,7 +19,6 @@ pub struct RecordingPreferences {
     pub preferred_mic_device: Option<String>,
     #[serde(default)]
     pub preferred_system_device: Option<String>,
-    #[cfg(target_os = "macos")]
     #[serde(default)]
     pub system_audio_backend: Option<String>,
 }
@@ -33,8 +31,7 @@ impl Default for RecordingPreferences {
             file_format: "mp4".to_string(),
             preferred_mic_device: None,
             preferred_system_device: None,
-            #[cfg(target_os = "macos")]
-            system_audio_backend: Some("coreaudio".to_string()),
+            system_audio_backend: Some(AudioCaptureBackend::default().to_string()),
         }
     }
 }
@@ -110,12 +107,8 @@ pub async fn load_recording_preferences<R: Runtime>(
         match serde_json::from_value::<RecordingPreferences>(value.clone()) {
             Ok(mut p) => {
                 info!("Loaded recording preferences from store");
-                // Update macOS backend to current value if needed
-                #[cfg(target_os = "macos")]
-                {
-                    let backend = crate::audio::capture::get_current_backend();
-                    p.system_audio_backend = Some(backend.to_string());
-                }
+                let backend = crate::audio::capture::get_current_backend();
+                p.system_audio_backend = Some(backend.to_string());
                 p
             }
             Err(e) => {
@@ -163,7 +156,6 @@ pub async fn save_recording_preferences<R: Runtime>(
     info!("Successfully persisted recording preferences to disk");
 
     // Save backend preference to global config
-    #[cfg(target_os = "macos")]
     if let Some(backend_str) = &preferences.system_audio_backend {
         if let Some(backend) = AudioCaptureBackend::from_string(backend_str) {
             info!("Setting audio capture backend to: {:?}", backend);
@@ -259,89 +251,42 @@ pub async fn select_recording_folder<R: Runtime>(
 /// Get available audio capture backends for the current platform
 #[tauri::command]
 pub async fn get_available_audio_backends() -> Result<Vec<String>, String> {
-    #[cfg(target_os = "macos")]
-    {
-        let backends = crate::audio::capture::get_available_backends();
-        Ok(backends.iter().map(|b| b.to_string()).collect())
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        // Only ScreenCaptureKit available on non-macOS
-        Ok(vec!["screencapturekit".to_string()])
-    }
+    let backends = crate::audio::capture::get_available_backends();
+    Ok(backends.iter().map(|backend| backend.to_string()).collect())
 }
 
 /// Get current audio capture backend
 #[tauri::command]
 pub async fn get_current_audio_backend() -> Result<String, String> {
-    #[cfg(target_os = "macos")]
-    {
-        let backend = crate::audio::capture::get_current_backend();
-        Ok(backend.to_string())
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        Ok("screencapturekit".to_string())
-    }
+    Ok(crate::audio::capture::get_current_backend().to_string())
 }
 
 /// Set audio capture backend
 #[tauri::command]
 pub async fn set_audio_backend(backend: String) -> Result<(), String> {
+    let backend_enum = AudioCaptureBackend::from_string(&backend)
+        .ok_or_else(|| format!("Audio backend is not available: {backend}"))?;
+
     #[cfg(target_os = "macos")]
-    {
-        use crate::audio::capture::AudioCaptureBackend;
+    if backend_enum == AudioCaptureBackend::CoreAudio {
         use crate::audio::permissions::{
             check_screen_recording_permission, request_screen_recording_permission,
         };
-
-        let backend_enum = AudioCaptureBackend::from_string(&backend)
-            .ok_or_else(|| format!("Invalid backend: {}", backend))?;
-
-        // If switching to Core Audio, log information about Audio Capture permission
-        if backend_enum == AudioCaptureBackend::CoreAudio {
-            info!("🔐 Core Audio backend requires Audio Capture permission (macOS 14.4+)");
-            info!("📍 Permission dialog will appear automatically when recording starts");
-
-            // Check if permission is already granted (this is informational only)
-            if !check_screen_recording_permission() {
-                warn!("⚠️  Audio Capture permission may not be granted");
-
-                // Attempt to open System Settings (opens System Settings)
-                if let Err(e) = request_screen_recording_permission() {
-                    error!("Failed to open System Settings: {}", e);
-                }
-
-                return Err(
-                    "Core Audio requires Audio Capture permission. \
-                    The permission dialog will appear when you start recording. \
-                    If already denied, enable it in System Settings → Privacy & Security → Audio Capture, \
-                    then restart the app.".to_string()
-                );
+        info!("Core Audio requires Audio Capture permission on macOS 14.4 and later");
+        if !check_screen_recording_permission() {
+            if let Err(error) = request_screen_recording_permission() {
+                error!("Failed to open System Settings: {error}");
             }
-
-            info!(
-                "✅ Core Audio backend selected - permission check will occur at recording start"
+            return Err(
+                "Allow Audio Capture in System Settings → Privacy & Security, then restart Meetily"
+                    .to_string(),
             );
         }
-
-        info!("Setting audio backend to: {:?}", backend_enum);
-        crate::audio::capture::set_current_backend(backend_enum);
-        Ok(())
     }
 
-    #[cfg(not(target_os = "macos"))]
-    {
-        if backend != "screencapturekit" {
-            return Err(format!(
-                "Backend {} not available on this platform",
-                backend
-            ));
-        }
-        Ok(())
-    }
+    info!("Setting audio backend to: {backend_enum:?}");
+    crate::audio::capture::set_current_backend(backend_enum);
+    Ok(())
 }
 
 /// Get backend information (name and description)
@@ -354,34 +299,12 @@ pub struct BackendInfo {
 
 #[tauri::command]
 pub async fn get_audio_backend_info() -> Result<Vec<BackendInfo>, String> {
-    #[cfg(target_os = "macos")]
-    {
-        use crate::audio::capture::AudioCaptureBackend;
-
-        let backends = vec![
-            BackendInfo {
-                id: AudioCaptureBackend::ScreenCaptureKit.to_string(),
-                name: AudioCaptureBackend::ScreenCaptureKit.name().to_string(),
-                description: AudioCaptureBackend::ScreenCaptureKit
-                    .description()
-                    .to_string(),
-            },
-            BackendInfo {
-                id: AudioCaptureBackend::CoreAudio.to_string(),
-                name: AudioCaptureBackend::CoreAudio.name().to_string(),
-                description: AudioCaptureBackend::CoreAudio.description().to_string(),
-            },
-        ];
-        Ok(backends)
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        Ok(vec![BackendInfo {
-            id: "screencapturekit".to_string(),
-            name: "ScreenCaptureKit".to_string(),
-            description: "Default system audio capture".to_string(),
-        }])
-    }
+    Ok(crate::audio::capture::get_available_backends()
+        .into_iter()
+        .map(|backend| BackendInfo {
+            id: backend.to_string(),
+            name: backend.name().to_string(),
+            description: backend.description().to_string(),
+        })
+        .collect())
 }
-

--- a/frontend/src-tauri/src/audio/stream.rs
+++ b/frontend/src-tauri/src/audio/stream.rs
@@ -356,6 +356,11 @@ impl AudioStream {
 pub struct AudioStreamManager {
     microphone_stream: Option<AudioStream>,
     system_stream: Option<AudioStream>,
+    #[cfg(all(
+        feature = "pocketstation-capture",
+        any(target_os = "windows", target_os = "linux")
+    ))]
+    pocketstation: Option<super::capture::pocketstation::PocketStationCapture>,
     state: Arc<RecordingState>,
 }
 
@@ -367,6 +372,11 @@ impl AudioStreamManager {
         Self {
             microphone_stream: None,
             system_stream: None,
+            #[cfg(all(
+                feature = "pocketstation-capture",
+                any(target_os = "windows", target_os = "linux")
+            ))]
+            pocketstation: None,
             state,
         }
     }
@@ -400,30 +410,66 @@ impl AudioStreamManager {
             info!("ℹ️ No microphone device specified, skipping microphone stream");
         }
 
-        // Start system audio stream
-        if let Some(sys_device) = system_device {
-            info!("🔊 Creating system audio stream: {} (backend: {:?})", sys_device.name, backend);
-            match AudioStream::create(sys_device.clone(), self.state.clone(), DeviceType::System, recording_sender.clone()).await {
-                Ok(stream) => {
-                    self.state.set_system_device(sys_device);
-                    self.system_stream = Some(stream);
-                    info!("✅ System audio stream created with {:?} backend", backend);
-                }
-                Err(e) => {
-                    warn!("⚠️ Failed to create system audio stream: {}", e);
-                    // Don't fail if only system audio fails
-                }
-            }
+        #[cfg(all(
+            feature = "pocketstation-capture",
+            any(target_os = "windows", target_os = "linux")
+        ))]
+        if backend == AudioCaptureBackend::PocketStation {
+            self.pocketstation = Some(
+                super::capture::pocketstation::PocketStationCapture::start(Arc::clone(
+                    &self.state,
+                ))?,
+            );
+            info!("PocketStation system audio started");
+        } else if let Some(system_device) = system_device {
+            self.start_system_stream(system_device, recording_sender.clone(), backend)
+                .await;
         } else {
-            info!("ℹ️ No system device specified, skipping system audio stream");
+            info!("No system audio device was selected");
+        }
+
+        #[cfg(not(all(
+            feature = "pocketstation-capture",
+            any(target_os = "windows", target_os = "linux")
+        )))]
+        if let Some(system_device) = system_device {
+            self.start_system_stream(system_device, recording_sender.clone(), backend)
+                .await;
+        } else {
+            info!("No system audio device was selected");
         }
 
         // Ensure at least one stream was created
-        if self.microphone_stream.is_none() && self.system_stream.is_none() {
+        if !self.has_active_streams() {
             return Err(anyhow::anyhow!("No audio streams could be created"));
         }
 
         Ok(())
+    }
+
+    async fn start_system_stream(
+        &mut self,
+        device: Arc<AudioDevice>,
+        recording_sender: Option<mpsc::UnboundedSender<super::recording_state::AudioChunk>>,
+        backend: AudioCaptureBackend,
+    ) {
+        match AudioStream::create(
+            Arc::clone(&device),
+            Arc::clone(&self.state),
+            DeviceType::System,
+            recording_sender,
+        )
+        .await
+        {
+            Ok(stream) => {
+                self.state.set_system_device(device);
+                self.system_stream = Some(stream);
+                info!("System audio stream created with {:?}", backend);
+            }
+            Err(error) => {
+                warn!("Failed to create system audio stream: {}", error);
+            }
+        }
     }
 
     /// Stop all audio streams
@@ -431,6 +477,16 @@ impl AudioStreamManager {
         info!("Stopping all audio streams");
 
         let mut errors = Vec::new();
+
+        #[cfg(all(
+            feature = "pocketstation-capture",
+            any(target_os = "windows", target_os = "linux")
+        ))]
+        if let Some(mut capture) = self.pocketstation.take() {
+            if let Err(error) = capture.stop() {
+                errors.push(error);
+            }
+        }
 
         // Stop microphone stream
         if let Some(mic_stream) = self.microphone_stream.take() {
@@ -477,12 +533,29 @@ impl AudioStreamManager {
         if self.system_stream.is_some() {
             count += 1;
         }
+        #[cfg(all(
+            feature = "pocketstation-capture",
+            any(target_os = "windows", target_os = "linux")
+        ))]
+        if self.pocketstation.is_some() {
+            count += 1;
+        }
         count
     }
 
     /// Check if any streams are active
     pub fn has_active_streams(&self) -> bool {
-        self.microphone_stream.is_some() || self.system_stream.is_some()
+        let active = self.microphone_stream.is_some() || self.system_stream.is_some();
+        #[cfg(all(
+            feature = "pocketstation-capture",
+            any(target_os = "windows", target_os = "linux")
+        ))]
+        return active || self.pocketstation.is_some();
+        #[cfg(not(all(
+            feature = "pocketstation-capture",
+            any(target_os = "windows", target_os = "linux")
+        )))]
+        active
     }
 }
 

--- a/frontend/src/components/AudioBackendSelector.tsx
+++ b/frontend/src/components/AudioBackendSelector.tsx
@@ -176,7 +176,7 @@ export function AudioBackendSelector({
 
       <div className="text-xs text-gray-500 space-y-1">
         <p>• Backend selection only affects system audio capture</p>
-        <p>• Microphone always uses the default method</p>
+        <p>• Microphone always uses the selected Meetily input device</p>
         <p>• Changes apply to new recording sessions</p>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Adds PocketStation as an optional system-audio method on Windows and Linux. Meetily keeps its current microphone capture, mixer, VAD, transcription, storage, and interface. Its current capture methods remain the default, and the macOS implementation is unchanged.

This directly addresses the missing Linux system-audio implementation reported in #701 without changing Meetily's transcription behavior.

## Use

```bash
cd frontend
MEETILY_CAPTURE=pocketstation ./dev-gpu.sh
```

Then choose **PocketStation** under **System Audio Backend**. On PowerShell, set `$env:MEETILY_CAPTURE = "pocketstation"` before starting Tauri.

## Implementation

- installs PocketStation `1.1.10` from crates.io only when `pocketstation-capture` is enabled;
- uses native WASAPI on Windows and PipeWire on Linux;
- captures the complete output mix through `Source::system_audio()`;
- requests 10 ms, 48 kHz frames and downmixes stereo to Meetily's existing mono `AudioChunk` input;
- preserves Meetily's recording clock so microphone and system chunks reach its mixer on the same timeline;
- starts and joins the PocketStation Session with each Meetily recording;
- reports PocketStation startup and runtime failures through Meetily's current recording error handling;
- does not require Meetily to resolve an output device before PocketStation system audio can start.

## Verification

- exact integration commit: `523b018875fbfe6b4b29eea8e4c708c244d3977a`
- [Windows and Ubuntu matrix](https://github.com/Raphjacksun7/meetily/actions/runs/33890160065): `cargo check` and the stereo-to-mono adapter test passed with `pocketstation-capture` enabled
- focused backend configuration tests passed locally
- Next.js production build passed locally

The Windows and Ubuntu jobs verify clean-checkout compilation and the adapter's audio conversion. They do not claim physical-device performance or transcription accuracy. PocketStation's system-audio Source has separate physical macOS and automated Windows/Linux native-capture evidence, but this PR does not replace Meetily's macOS capture implementation.

This does not address #756; that issue concerns Meetily's VAD segmentation after audio has already entered its processing code.
