### PR TITLE
fix(vad): stabilize live segmentation and final timestamps

### DIFF
--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -52,9 +52,10 @@ impl Drop for ImportGuard {
 }
 
 /// VAD redemption time in milliseconds - bridges natural pauses in speech
-/// Batch processing needs longer redemption (2000ms) than live pipeline (400ms)
-/// because the entire file is processed at once by VAD, and 400ms fragments
-/// speech at every natural sentence/topic pause (500ms-2s)
+/// Batch processing needs longer redemption (2000ms) than the live pipeline
+/// (500ms) because the entire file is processed at once by VAD with no
+/// latency requirement, and short redemption fragments speech at every
+/// natural sentence/topic pause (500ms-2s)
 const VAD_REDEMPTION_TIME_MS: u32 = 2000;
 
 /// Maximum file size: 20GB (prevents OOM and excessive processing time)

--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -13,6 +13,15 @@ use super::recording_state::{AudioChunk, AudioError, RecordingState, DeviceType}
 use super::audio_processing::{audio_to_mono, LoudnessNormalizer, NoiseSuppressionProcessor, HighPassFilter};
 use super::vad::{ContinuousVadProcessor};
 
+/// How long a silence must last before the VAD closes a speech segment, and
+/// therefore how long the audio clips handed to the ASR engine are.
+///
+/// Kept equal to `import.rs::VAD_REDEMPTION_TIME_MS` and
+/// `retranscription.rs::VAD_REDEMPTION_TIME_MS` so that live recording and
+/// offline re-transcription of the same audio segment identically. Raising this
+/// trades live-transcript latency for longer, more accurate ASR requests.
+const VAD_REDEMPTION_TIME_MS: u32 = 2000;
+
 /// Ring buffer for synchronized audio mixing
 /// Accumulates samples from mic and system streams until we have aligned windows
 struct AudioMixerRingBuffer {
@@ -719,16 +728,34 @@ impl AudioPipeline {
         // For now, we log it for monitoring and potential optimization
         let _ = (mic_device_name, mic_device_kind, system_device_name, system_device_kind);
 
-        // Create VAD processor with balanced redemption time for speech accumulation
-        // The VAD processor now handles 48kHz->16kHz resampling internally
-        // This bridges natural pauses without excessive fragmentation
-        // For mac os core audio, 900ms, for windows 400ms seems good
-
-        let redemption_time = if cfg!(target_os = "macos") { 400 } else { 400 };
-
-        let vad_processor = match ContinuousVadProcessor::new(sample_rate, redemption_time) {
+        // Create VAD processor. The VAD processor handles 48kHz->16kHz resampling
+        // internally.
+        //
+        // Redemption time is how long a silence must last before the VAD closes a
+        // speech segment, so it decides how long the audio clips handed to the ASR
+        // engine are. Conversational speech pauses constantly for breath and
+        // mid-sentence thought, and every pause longer than this becomes a segment
+        // boundary and therefore a separate transcription request.
+        //
+        // This was 400ms, which fragmented a 26-minute meeting into 322 requests with
+        // a median length of 3.5s. Whisper is a fixed 30-second-window model: below
+        // that it zero-pads the window and leans on its language-model prior, which
+        // was trained on web subtitles, so short clips come back as memorised
+        // boilerplate ("subscribe to the channel", "thank you") instead of speech.
+        // Measured on a real recording, 47% of segment boundaries sat in the
+        // 0.42-0.75s range that a longer redemption simply bridges.
+        //
+        // 2000ms matches what the offline paths already use (see
+        // `import.rs::VAD_REDEMPTION_TIME_MS` and
+        // `retranscription.rs::VAD_REDEMPTION_TIME_MS`), so live and batch
+        // transcription now segment identically. It costs up to ~1.6s of extra
+        // live-transcript latency at the end of each utterance.
+        let vad_processor = match ContinuousVadProcessor::new(sample_rate, VAD_REDEMPTION_TIME_MS) {
             Ok(processor) => {
-                info!("VAD-driven pipeline: VAD segments will be sent directly to Whisper (no time-based accumulation)");
+                info!(
+                    "VAD-driven pipeline: segments dispatched per speech burst (redemption_time={}ms)",
+                    VAD_REDEMPTION_TIME_MS
+                );
                 processor
             }
             Err(e) => {

--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -16,11 +16,15 @@ use super::vad::{ContinuousVadProcessor};
 /// How long a silence must last before the VAD closes a speech segment, and
 /// therefore how long the audio clips handed to the ASR engine are.
 ///
-/// Kept equal to `import.rs::VAD_REDEMPTION_TIME_MS` and
-/// `retranscription.rs::VAD_REDEMPTION_TIME_MS` so that live recording and
-/// offline re-transcription of the same audio segment identically. Raising this
-/// trades live-transcript latency for longer, more accurate ASR requests.
-const VAD_REDEMPTION_TIME_MS: u32 = 2000;
+/// Live-path policy: 500ms (matches the established Meetily Pro live policy).
+/// The batch paths (`import.rs` / `retranscription.rs`) use 2000ms instead —
+/// they have no latency requirement, so they optimize purely for ASR request
+/// length. The live path cannot: with continuous audio (e.g. a podcast played
+/// as system audio) a 2000ms redemption keeps one VAD segment open
+/// indefinitely, withholds live transcript emission, and overruns the
+/// accumulated-speech-buffer warning threshold. Bounded live segmentation
+/// during continuous speech is tracked separately in #756.
+const VAD_REDEMPTION_TIME_MS: u32 = 500;
 
 /// Ring buffer for synchronized audio mixing
 /// Accumulates samples from mic and system streams until we have aligned windows
@@ -743,13 +747,14 @@ impl AudioPipeline {
         // was trained on web subtitles, so short clips come back as memorised
         // boilerplate ("subscribe to the channel", "thank you") instead of speech.
         // Measured on a real recording, 47% of segment boundaries sat in the
-        // 0.42-0.75s range that a longer redemption simply bridges.
+        // 0.42-0.75s range that a longer redemption bridges.
         //
-        // 2000ms matches what the offline paths already use (see
-        // `import.rs::VAD_REDEMPTION_TIME_MS` and
-        // `retranscription.rs::VAD_REDEMPTION_TIME_MS`), so live and batch
-        // transcription now segment identically. It costs up to ~1.6s of extra
-        // live-transcript latency at the end of each utterance.
+        // 500ms is the live-path policy (see the constant's doc comment). The
+        // batch value (2000ms, `import.rs`/`retranscription.rs`) was tried here
+        // first, but under continuous system audio it kept a VAD segment open
+        // indefinitely and withheld live transcript emission, so live and batch
+        // deliberately diverge. Bounded live segments under continuous speech
+        // are tracked in #756.
         let vad_processor = match ContinuousVadProcessor::new(sample_rate, VAD_REDEMPTION_TIME_MS) {
             Ok(processor) => {
                 info!(
@@ -1103,5 +1108,17 @@ impl AudioPipelineManager {
 impl Default for AudioPipelineManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_live_vad_redemption_matches_pro_policy() {
+        // Live path uses 500ms (Meetily Pro live policy) so transcript
+        // emission stays bounded under continuous audio; the batch paths
+        // (import.rs / retranscription.rs) use 2000ms. See #679 and #756.
+        assert_eq!(VAD_REDEMPTION_TIME_MS, 500);
     }
 }

--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -1116,9 +1116,9 @@ mod tests {
 
     #[test]
     fn test_live_vad_redemption_matches_pro_policy() {
-        // Live path uses 500ms (Meetily Pro live policy) so transcript
-        // emission stays bounded under continuous audio; the batch paths
-        // (import.rs / retranscription.rs) use 2000ms. See #679 and #756.
+        // Live uses the established 500ms pause policy; it does not bound
+        // uninterrupted speech. Batch import/retranscription use 2000ms.
+        // See #679 and #756.
         assert_eq!(VAD_REDEMPTION_TIME_MS, 500);
     }
 }

--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -46,9 +46,10 @@ impl Drop for RetranscriptionGuard {
 }
 
 /// VAD redemption time in milliseconds - bridges natural pauses in speech
-/// Batch processing needs longer redemption (2000ms) than live pipeline (400ms)
-/// because the entire file is processed at once by VAD, and 400ms fragments
-/// speech at every natural sentence/topic pause (500ms-2s)
+/// Batch processing needs longer redemption (2000ms) than the live pipeline
+/// (500ms) because the entire file is processed at once by VAD with no
+/// latency requirement, and short redemption fragments speech at every
+/// natural sentence/topic pause (500ms-2s)
 const VAD_REDEMPTION_TIME_MS: u32 = 2000;
 
 /// Progress update emitted during retranscription

--- a/frontend/src-tauri/src/audio/vad.rs
+++ b/frontend/src-tauri/src/audio/vad.rs
@@ -44,11 +44,11 @@ impl ContinuousVadProcessor {
         config.positive_speech_threshold = 0.50;  // Silero default - good for continuous speech
         config.negative_speech_threshold = 0.35;  // Silero default - allows natural pauses
 
-        // Use the caller's redemption_time uncapped, so long continuous speech stays
-        // in one segment. The batch paths (`import.rs`, `retranscription.rs`) pass
-        // 2000ms; the live path (`pipeline.rs`) passes 500ms because it must keep
-        // emitting transcript segments during continuous audio. Values well below
-        // that fragment natural speech at every mid-sentence breath.
+        // Use the caller's redemption time without additional capping. The batch
+        // paths (`import.rs`, `retranscription.rs`) pass 2000ms to bridge natural
+        // pauses; the live path (`pipeline.rs`) passes 500ms to reduce pause-induced
+        // latency. A qualifying silence is still required; bounded uninterrupted-
+        // speech delivery is tracked in #756.
         config.redemption_time = Duration::from_millis(redemption_time_ms as u64);
         config.pre_speech_pad = Duration::from_millis(300);   // Pre-speech padding for context
         config.post_speech_pad = Duration::from_millis(400);  // Increased: more context at end
@@ -168,6 +168,8 @@ impl ContinuousVadProcessor {
               self.in_speech, self.current_speech.len(), self.buffer.len(), self.speech_segments.len());
 
         let mut completed_segments = Vec::new();
+        // Preserve the real post-resampling endpoint before padding the final VAD frame.
+        let real_end_sample = self.processed_samples + self.buffer.len();
 
         // Process any remaining buffered audio
         if !self.buffer.is_empty() {
@@ -185,9 +187,9 @@ impl ContinuousVadProcessor {
 
         // Force end any ongoing speech
         if self.in_speech && !self.current_speech.is_empty() {
-            // processed_samples and speech_start_sample always count 16kHz samples (post-resampling)
-            let start_ms = (self.speech_start_sample as f64 / 16000.0) * 1000.0;
-            let end_ms = (self.processed_samples as f64 / 16000.0) * 1000.0;
+            let start_ms =
+                (self.speech_start_sample as f64 / VAD_SAMPLE_RATE as f64) * 1000.0;
+            let end_ms = (real_end_sample as f64 / VAD_SAMPLE_RATE as f64) * 1000.0;
 
             debug!("VAD flush: Force-ending speech - start={}ms, end={}ms, duration={}ms, samples={}",
                   start_ms, end_ms, end_ms - start_ms, self.current_speech.len());
@@ -682,6 +684,12 @@ mod tests {
                 seg.start_timestamp_ms <= audio_duration_ms,
                 "Segment {i} starts at {:.0}ms, beyond the {:.0}ms of audio supplied",
                 seg.start_timestamp_ms,
+                audio_duration_ms
+            );
+            assert!(
+                seg.end_timestamp_ms <= audio_duration_ms,
+                "Segment {i} ends at {:.0}ms, beyond the {:.0}ms of audio supplied",
+                seg.end_timestamp_ms,
                 audio_duration_ms
             );
             assert!(

--- a/frontend/src-tauri/src/audio/vad.rs
+++ b/frontend/src-tauri/src/audio/vad.rs
@@ -4,6 +4,10 @@ use log::{debug, info, warn};
 use std::collections::VecDeque;
 use std::time::Duration;
 
+/// Silero VAD only operates at 16kHz; input is resampled to this rate, and every
+/// sample count and timestamp inside this module is expressed in it.
+const VAD_SAMPLE_RATE: u32 = 16000;
+
 /// Represents a complete speech segment detected by VAD
 #[derive(Debug, Clone)]
 pub struct SpeechSegment {
@@ -30,9 +34,6 @@ pub struct ContinuousVadProcessor {
 
 impl ContinuousVadProcessor {
     pub fn new(input_sample_rate: u32, redemption_time_ms: u32) -> Result<Self> {
-        // Silero VAD MUST use 16kHz - this is hardcoded requirement
-        const VAD_SAMPLE_RATE: u32 = 16000;
-
         // Use STRICT settings to prevent silence from reaching Whisper
         let mut config = VadConfig::default();
         config.sample_rate = VAD_SAMPLE_RATE as usize;
@@ -43,9 +44,10 @@ impl ContinuousVadProcessor {
         config.positive_speech_threshold = 0.50;  // Silero default - good for continuous speech
         config.negative_speech_threshold = 0.35;  // Silero default - allows natural pauses
 
-        // CRITICAL FIX: Removed redemption_time capping to support long continuous speech
-        // Previous: capped at 400ms, causing VAD to fragment 5-second speech into 40ms segments
-        // New: Use full redemption_time from pipeline (2000ms) to bridge natural pauses
+        // Use the caller's redemption_time uncapped, so long continuous speech stays
+        // in one segment. Callers pass 2000ms (see `pipeline.rs`, `import.rs` and
+        // `retranscription.rs`); shorter values fragment natural speech at every
+        // mid-sentence breath.
         config.redemption_time = Duration::from_millis(redemption_time_ms as u64);
         config.pre_speech_pad = Duration::from_millis(300);   // Pre-speech padding for context
         config.post_speech_pad = Duration::from_millis(400);  // Increased: more context at end
@@ -236,11 +238,16 @@ impl ContinuousVadProcessor {
                         self.last_logged_state = true;
                     }
                     self.in_speech = true;
-                    // Silero's timestamp_ms is already session-absolute (derived from its own
-                    // processed_duration), so it must NOT be offset by processed_samples —
-                    // adding them double-counts and yields start times past the end of the audio.
-                    // Convert ms to samples at the 16kHz VAD processing rate.
-                    self.speech_start_sample = timestamp_ms * 16000 / 1000;
+                    // `timestamp_ms` is ALREADY session-absolute: silero computes it as
+                    // `processed_duration() - pre_speech_pad`, where `processed_duration()`
+                    // is every sample the network has seen this session. Adding our own
+                    // session-absolute `processed_samples` to it double-counted the
+                    // position, producing a start timestamp of roughly 2x the true one.
+                    //
+                    // The only reader is the end-of-recording flush below, so the bug
+                    // surfaced once per recording, on the final segment — which landed at
+                    // ~2x the file duration and sorted to the end of the transcript.
+                    self.speech_start_sample = timestamp_ms * VAD_SAMPLE_RATE as usize / 1000;
                     self.current_speech.clear();
                 }
                 VadTransition::SpeechEnd { start_timestamp_ms, end_timestamp_ms, samples } => {
@@ -594,5 +601,94 @@ mod tests {
             assert!(duration_ms >= 200.0, "Segment {} too short: {:.0}ms", i, duration_ms);
         }
     }
-}
+    /// Leading silence, then speech that runs to the end of the buffer.
+    ///
+    /// This is the shape that matters for the flush path: an utterance that begins
+    /// late in a long session and is still in progress when recording stops.
+    fn generate_late_speech_audio(
+        silence_seconds: f32,
+        speech_seconds: f32,
+        sample_rate: u32,
+    ) -> Vec<f32> {
+        let silence_samples = (silence_seconds * sample_rate as f32) as usize;
+        let speech = generate_test_audio_with_speech(speech_seconds, sample_rate);
 
+        let mut samples = vec![0.0f32; silence_samples];
+        samples.extend_from_slice(&speech);
+        samples
+    }
+
+    /// `speech_start_sample` records where the current utterance began, so it can
+    /// never point past the number of samples the VAD has actually seen.
+    ///
+    /// It used to, because it was computed as `processed_samples + timestamp_ms` where
+    /// silero's `timestamp_ms` is ALREADY session-absolute
+    /// (`processed_duration() - pre_speech_pad`), which doubled the position. The only
+    /// reader is the force-end branch in `flush()`, so in production the corruption
+    /// escaped as one phantom segment per recording, timestamped past the end of the
+    /// audio. The error grows with how late the utterance starts, which is why it took
+    /// a long recording to surface.
+    #[test]
+    fn test_speech_start_sample_never_exceeds_processed_samples() {
+        // 20s of silence, then 3s of speech still running when the buffer ends.
+        let audio = generate_late_speech_audio(20.0, 3.0, 16000);
+
+        let mut processor =
+            ContinuousVadProcessor::new(16000, 2000).expect("Failed to create processor");
+        processor
+            .process_audio(&audio)
+            .expect("process_audio failed");
+
+        assert!(
+            processor.in_speech,
+            "expected to still be mid-speech at the end of the buffer; the invariant \
+             below would not be exercised otherwise"
+        );
+
+        assert!(
+            processor.speech_start_sample <= processor.processed_samples,
+            "speech_start_sample ({}) is past processed_samples ({}) - \
+             session-absolute timestamp double-count regression. \
+             In seconds: start={:.2}s vs processed={:.2}s",
+            processor.speech_start_sample,
+            processor.processed_samples,
+            processor.speech_start_sample as f64 / VAD_SAMPLE_RATE as f64,
+            processor.processed_samples as f64 / VAD_SAMPLE_RATE as f64,
+        );
+    }
+
+    /// Whatever `flush()` emits must also lie inside the audio that was supplied.
+    #[test]
+    fn test_flush_segment_timestamps_stay_within_audio_duration() {
+        let audio = generate_late_speech_audio(20.0, 3.0, 16000);
+        let audio_duration_ms = (audio.len() as f64 / 16000.0) * 1000.0;
+
+        let mut processor =
+            ContinuousVadProcessor::new(16000, 2000).expect("Failed to create processor");
+
+        let mut segments = processor
+            .process_audio(&audio)
+            .expect("process_audio failed");
+        let flushed = processor.flush().expect("flush failed");
+        assert!(
+            !flushed.is_empty(),
+            "flush() emitted nothing, so the force-end path under test never ran"
+        );
+        segments.extend(flushed);
+
+        for (i, seg) in segments.iter().enumerate() {
+            assert!(
+                seg.start_timestamp_ms <= audio_duration_ms,
+                "Segment {i} starts at {:.0}ms, beyond the {:.0}ms of audio supplied",
+                seg.start_timestamp_ms,
+                audio_duration_ms
+            );
+            assert!(
+                seg.end_timestamp_ms >= seg.start_timestamp_ms,
+                "Segment {i} ends before it starts: {:.0}ms -> {:.0}ms",
+                seg.start_timestamp_ms,
+                seg.end_timestamp_ms
+            );
+        }
+    }
+}

--- a/frontend/src-tauri/src/audio/vad.rs
+++ b/frontend/src-tauri/src/audio/vad.rs
@@ -187,15 +187,36 @@ impl ContinuousVadProcessor {
 
         // Force end any ongoing speech
         if self.in_speech && !self.current_speech.is_empty() {
+            let real_sample_count = real_end_sample
+                .checked_sub(self.speech_start_sample)
+                .filter(|count| *count > 0)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "VAD flush invariant violated: active speech interval [{}, {}) is empty or reversed",
+                        self.speech_start_sample,
+                        real_end_sample
+                    )
+                })?;
+            let active_speech = self.session.get_current_speech();
+            if active_speech.len() < real_sample_count {
+                return Err(anyhow!(
+                    "VAD flush invariant violated: Silero active speech buffer has {} samples, but [{}, {}) requires {}",
+                    active_speech.len(),
+                    self.speech_start_sample,
+                    real_end_sample,
+                    real_sample_count
+                ));
+            }
+            let samples = active_speech[..real_sample_count].to_vec();
             let start_ms =
                 (self.speech_start_sample as f64 / VAD_SAMPLE_RATE as f64) * 1000.0;
             let end_ms = (real_end_sample as f64 / VAD_SAMPLE_RATE as f64) * 1000.0;
 
             debug!("VAD flush: Force-ending speech - start={}ms, end={}ms, duration={}ms, samples={}",
-                  start_ms, end_ms, end_ms - start_ms, self.current_speech.len());
+                  start_ms, end_ms, end_ms - start_ms, samples.len());
 
             let segment = SpeechSegment {
-                samples: self.current_speech.clone(),
+                samples,
                 start_timestamp_ms: start_ms,
                 end_timestamp_ms: end_ms,
                 confidence: 0.8, // Estimated confidence for forced end
@@ -660,44 +681,97 @@ mod tests {
         );
     }
 
-    /// Whatever `flush()` emits must also lie inside the audio that was supplied.
+    /// A forced segment's timestamps and samples must describe the same real audio interval.
     #[test]
     fn test_flush_segment_timestamps_stay_within_audio_duration() {
         let audio = generate_late_speech_audio(20.0, 3.0, 16000);
-        let audio_duration_ms = (audio.len() as f64 / 16000.0) * 1000.0;
+        let audio_duration_ms = (audio.len() as f64 / VAD_SAMPLE_RATE as f64) * 1000.0;
+
+        assert_eq!(audio.len(), 368_000);
+        assert_eq!(
+            audio.len() % 480,
+            320,
+            "fixture must require 160 samples of terminal VAD padding"
+        );
 
         let mut processor =
             ContinuousVadProcessor::new(16000, 2000).expect("Failed to create processor");
 
-        let mut segments = processor
+        let segments = processor
             .process_audio(&audio)
             .expect("process_audio failed");
-        let flushed = processor.flush().expect("flush failed");
         assert!(
-            !flushed.is_empty(),
-            "flush() emitted nothing, so the force-end path under test never ran"
+            segments.is_empty(),
+            "process_audio completed a segment, so flush() would not exercise force-end"
         );
-        segments.extend(flushed);
+        assert!(
+            processor.in_speech,
+            "expected to still be mid-speech before flush()"
+        );
 
-        for (i, seg) in segments.iter().enumerate() {
-            assert!(
-                seg.start_timestamp_ms <= audio_duration_ms,
-                "Segment {i} starts at {:.0}ms, beyond the {:.0}ms of audio supplied",
-                seg.start_timestamp_ms,
-                audio_duration_ms
-            );
-            assert!(
-                seg.end_timestamp_ms <= audio_duration_ms,
-                "Segment {i} ends at {:.0}ms, beyond the {:.0}ms of audio supplied",
-                seg.end_timestamp_ms,
-                audio_duration_ms
-            );
-            assert!(
-                seg.end_timestamp_ms >= seg.start_timestamp_ms,
-                "Segment {i} ends before it starts: {:.0}ms -> {:.0}ms",
-                seg.start_timestamp_ms,
-                seg.end_timestamp_ms
-            );
-        }
+        let flushed = processor.flush().expect("flush failed");
+        assert_eq!(
+            flushed.len(),
+            1,
+            "force-end must emit exactly one segment"
+        );
+
+        let segment = &flushed[0];
+        let start_sample = ((segment.start_timestamp_ms / 1000.0)
+            * VAD_SAMPLE_RATE as f64)
+            .round() as usize;
+
+        assert!(
+            segment.start_timestamp_ms <= audio_duration_ms,
+            "segment starts at {:.0}ms, beyond the {:.0}ms of audio supplied",
+            segment.start_timestamp_ms,
+            audio_duration_ms
+        );
+        assert_eq!(
+            segment.end_timestamp_ms, 23_000.0,
+            "forced segment must end at the real audio endpoint"
+        );
+        assert!(
+            segment.end_timestamp_ms <= audio_duration_ms,
+            "segment ends at {:.0}ms, beyond the {:.0}ms of audio supplied",
+            segment.end_timestamp_ms,
+            audio_duration_ms
+        );
+        assert!(
+            segment.end_timestamp_ms >= segment.start_timestamp_ms,
+            "segment ends before it starts: {:.0}ms -> {:.0}ms",
+            segment.start_timestamp_ms,
+            segment.end_timestamp_ms
+        );
+        assert_eq!(
+            segment.samples.as_slice(),
+            &audio[start_sample..],
+            "forced payload must contain the exact real audio interval named by its timestamps"
+        );
+        assert_eq!(segment.samples.len(), audio.len() - start_sample);
+
+        let timestamp_sample_count = (((segment.end_timestamp_ms
+            - segment.start_timestamp_ms)
+            / 1000.0)
+            * VAD_SAMPLE_RATE as f64)
+            .round() as usize;
+        assert_eq!(
+            timestamp_sample_count,
+            segment.samples.len(),
+            "timestamp duration and payload length must describe the same sample interval"
+        );
+
+        let payload_end_ms = segment.start_timestamp_ms
+            + (segment.samples.len() as f64 / VAD_SAMPLE_RATE as f64) * 1000.0;
+        assert!(
+            (payload_end_ms - segment.end_timestamp_ms).abs() < 0.001,
+            "payload ends at {payload_end_ms:.3}ms, timestamp ends at {:.3}ms",
+            segment.end_timestamp_ms
+        );
+
+        assert!(
+            processor.flush().expect("second flush failed").is_empty(),
+            "flush() must not emit the same forced segment twice"
+        );
     }
 }

--- a/frontend/src-tauri/src/audio/vad.rs
+++ b/frontend/src-tauri/src/audio/vad.rs
@@ -45,9 +45,10 @@ impl ContinuousVadProcessor {
         config.negative_speech_threshold = 0.35;  // Silero default - allows natural pauses
 
         // Use the caller's redemption_time uncapped, so long continuous speech stays
-        // in one segment. Callers pass 2000ms (see `pipeline.rs`, `import.rs` and
-        // `retranscription.rs`); shorter values fragment natural speech at every
-        // mid-sentence breath.
+        // in one segment. The batch paths (`import.rs`, `retranscription.rs`) pass
+        // 2000ms; the live path (`pipeline.rs`) passes 500ms because it must keep
+        // emitting transcript segments during continuous audio. Values well below
+        // that fragment natural speech at every mid-sentence breath.
         config.redemption_time = Duration::from_millis(redemption_time_ms as u64);
         config.pre_speech_pad = Duration::from_millis(300);   // Pre-speech padding for context
         config.post_speech_pad = Duration::from_millis(400);  // Increased: more context at end


### PR DESCRIPTION
## Summary

- Carries forward @Hus-Mek's focused VAD contribution from #679, preserving the original commits and attribution.
- Uses the established 500 ms live redemption policy while import and retranscription remain at 2000 ms.
- Keeps VAD start timestamps session-absolute and preserves the real post-resampling endpoint before padding the final Silero inference frame.
- Strengthens regression coverage so a forced final segment satisfies `start <= end <= audio duration`.
- Clarifies that 500 ms does not guarantee bounded delivery during uninterrupted speech; that remains tracked in #756.

## Context

This draft supersedes #679 after incorporating the remaining correction requested in [the final review comment](https://github.com/Zackriya-Solutions/meetily/pull/679#issuecomment-5492691211). It addresses the final-segment timestamp failure reported in #399 without including transcript cleanup or the bounded-segment work from #756.

Closes #399.

## Verification

- `cargo test --lib audio::vad::tests::test_flush_segment_timestamps_stay_within_audio_duration` — 1 passed
- `cargo test --lib audio::vad` — 7 passed
- `cargo test --lib audio::pipeline` — 1 passed
- `cargo check --lib` — passed with pre-existing warnings only