### PR TITLE
Fix microphone checks, summary progress, and Start button layout [skip ci]

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -103,9 +103,11 @@
         "@types/node": "^20",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
+        "@types/react-test-renderer": "18.3.1",
         "autoprefixer": "^10.0.1",
         "concurrently": "^8.2.2",
         "postcss": "^8",
+        "react-test-renderer": "18.3.1",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.7.2",
         "wait-on": "^7.2.0"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.5
         version: 18.3.7(@types/react@18.3.28)
+      '@types/react-test-renderer':
+        specifier: 18.3.1
+        version: 18.3.1
       autoprefixer:
         specifier: ^10.0.1
         version: 10.5.0(postcss@8.5.14)
@@ -207,6 +210,9 @@ importers:
       postcss:
         specifier: ^8
         version: 8.5.14
+      react-test-renderer:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
       tailwindcss:
         specifier: ^3.4.1
         version: 3.4.19
@@ -3496,6 +3502,22 @@ packages:
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+  '@types/react-test-renderer@18.3.1':
+    resolution: {integrity: sha512-vAhnk0tG2eGa37lkU9+s5SoroCsRI08xnsWFiAXOuPH2jqzMbcXvKExXViPi1P5fIklDeCvXqyrdmipFaSkZrA==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-shallow-renderer@16.15.0:
+    resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0
+
+  react-test-renderer@18.3.1:
+    resolution: {integrity: sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==}
+    peerDependencies:
+      react: ^18.3.1
 
 snapshots:
 
@@ -7520,3 +7542,22 @@ snapshots:
   zod@3.25.76: {}
 
   zwitch@2.0.4: {}
+
+  '@types/react-test-renderer@18.3.1':
+    dependencies:
+      '@types/react': 18.3.28
+
+  react-is@18.3.1: {}
+
+  react-shallow-renderer@16.15.0(react@18.3.1):
+    dependencies:
+      object-assign: 4.1.1
+      react: 18.3.1
+      react-is: 16.13.1
+
+  react-test-renderer@18.3.1(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-is: 18.3.1
+      react-shallow-renderer: 16.15.0(react@18.3.1)
+      scheduler: 0.23.2

--- a/frontend/src-tauri/src/audio/devices/discovery.rs
+++ b/frontend/src-tauri/src/audio/devices/discovery.rs
@@ -96,3 +96,68 @@ pub fn trigger_audio_permission() -> Result<bool> {
 
     Ok(true)
 }
+
+/// Verify the microphone is actually delivering audio (macOS permission check).
+///
+/// A macOS TCC denial can still let an input stream be *created*, but the audio
+/// callback then never fires. This builds a brief test stream and waits for the
+/// first callback: permission granted → fires in <100ms; denied → times out at
+/// 5s and returns Err. Building + playing the stream also triggers the system
+/// permission dialog if the state is notDetermined.
+///
+/// A denied mic fails the record-start path loudly instead of recording dead
+/// audio. Deliberately minimal: it checks the default
+/// input device and treats the first callback as "granted" (no sample-content
+/// inspection, no per-selected-device check).
+pub async fn verify_microphone_access() -> anyhow::Result<()> {
+    use log::{info, warn};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    tokio::task::spawn_blocking(|| {
+        let host = cpal::default_host();
+        let device = host
+            .default_input_device()
+            .ok_or_else(|| anyhow::anyhow!("No microphone device found"))?;
+
+        let config = device
+            .default_input_config()
+            .map_err(|e| anyhow::anyhow!("Failed to get microphone config: {}", e))?;
+
+        let callback_fired = Arc::new(AtomicBool::new(false));
+        let callback_fired_clone = callback_fired.clone();
+
+        let stream = device
+            .build_input_stream(
+                &config.into(),
+                move |_data: &[f32], _: &cpal::InputCallbackInfo| {
+                    callback_fired_clone.store(true, Ordering::SeqCst);
+                },
+                |err| warn!("[verify_microphone_access] test stream error: {}", err),
+                None,
+            )
+            .map_err(|e| anyhow::anyhow!("Cannot access microphone: {}", e))?;
+
+        stream
+            .play()
+            .map_err(|e| anyhow::anyhow!("Cannot start microphone: {}", e))?;
+
+        // Wait up to 5s for the first callback.
+        for _ in 0..50 {
+            if callback_fired.load(Ordering::SeqCst) {
+                drop(stream);
+                info!("[verify_microphone_access] microphone access verified");
+                return Ok(());
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        drop(stream);
+        Err(anyhow::anyhow!(
+            "Microphone permission not granted. Please allow microphone access in \
+             System Settings > Privacy & Security > Microphone, then try again."
+        ))
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Microphone verification task failed: {}", e))?
+}

--- a/frontend/src-tauri/src/audio/devices/discovery.rs
+++ b/frontend/src-tauri/src/audio/devices/discovery.rs
@@ -116,9 +116,11 @@ pub async fn verify_microphone_access() -> anyhow::Result<()> {
 
     tokio::task::spawn_blocking(|| {
         let host = cpal::default_host();
-        let device = host
-            .default_input_device()
-            .ok_or_else(|| anyhow::anyhow!("No microphone device found"))?;
+        let Some(device) = host.default_input_device() else {
+            // Let device resolution handle the existing system-audio-only fallback.
+            info!("[verify_microphone_access] No microphone device found; skipping access check");
+            return Ok(());
+        };
 
         let config = device
             .default_input_config()

--- a/frontend/src-tauri/src/audio/devices/mod.rs
+++ b/frontend/src-tauri/src/audio/devices/mod.rs
@@ -8,7 +8,7 @@ pub mod configuration;
 pub mod platform;
 
 // Re-export all public functions to preserve existing API
-pub use discovery::{list_audio_devices, trigger_audio_permission};
+pub use discovery::{list_audio_devices, trigger_audio_permission, verify_microphone_access};
 pub use microphone::{default_input_device, find_builtin_input_device};
 pub use speakers::{default_output_device, find_builtin_output_device};
 pub use configuration::{get_device_and_config, parse_audio_device, AudioDevice, DeviceType, DeviceControl, AudioTranscriptionEngine, LAST_AUDIO_CAPTURE};

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -287,6 +287,18 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
         "message": "Recording initialization started"
     })).map_err(|e| e.to_string())?;
 
+    // T12: verify the microphone is actually delivering audio before we start.
+    // A macOS TCC denial lets the input stream be created but never fires
+    // callbacks; without this the app records dead audio silently. Fails the
+    // start loudly (mapped to a permission Alert in the UI).
+    #[cfg(target_os = "macos")]
+    {
+        if let Err(e) = super::devices::verify_microphone_access().await {
+            error!("Microphone access verification failed: {}", e);
+            return Err(format!("Microphone access required: {}", e));
+        }
+    }
+
     // Async-first approach - no more blocking operations!
     info!("🚀 Starting async recording initialization");
 
@@ -461,6 +473,16 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
     app.emit("recording-starting", serde_json::json!({
         "message": "Recording initialization started"
     })).map_err(|e| e.to_string())?;
+
+    // T12: verify the microphone is actually delivering audio before we start
+    // (see the note on the other start path above).
+    #[cfg(target_os = "macos")]
+    {
+        if let Err(e) = super::devices::verify_microphone_access().await {
+            error!("Microphone access verification failed: {}", e);
+            return Err(format!("Microphone access required: {}", e));
+        }
+    }
 
     let mic_device = resolve_mic_or_default(&app, mic_device_name.as_deref());
 

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -237,34 +237,6 @@ fn resolve_system_or_default(requested_name: Option<&str>) -> Option<Arc<super::
     }
 }
 
-/// Wake idle audio hardware before checking microphone callbacks, and finish
-/// validation before creating any recording resources.
-#[cfg(target_os = "macos")]
-async fn prepare_audio_for_recording(
-    system_device: Option<&super::AudioDevice>,
-) -> Result<(), String> {
-    use cpal::traits::{DeviceTrait, HostTrait};
-
-    let wake_name = system_device
-        .map(|s| s.name.clone())
-        .or_else(|| {
-            cpal::default_host()
-                .default_output_device()
-                .and_then(|d| d.name().ok())
-        });
-    if let Some(name) = wake_name {
-        if let Err(e) = super::recording_manager::wake_audio_connection(&name).await {
-            warn!("[AUDIO_WAKE] Wake failed: {} — proceeding anyway", e);
-        }
-    }
-
-    if let Err(e) = super::devices::verify_microphone_access().await {
-        error!("Microphone access verification failed: {}", e);
-        return Err(format!("Microphone access required: {}", e));
-    }
-    Ok(())
-}
-
 // ============================================================================
 // RECORDING COMMANDS
 // ============================================================================
@@ -315,6 +287,24 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
         "message": "Recording initialization started"
     })).map_err(|e| e.to_string())?;
 
+    // T12: verify the microphone is actually delivering audio before we start.
+    // A macOS TCC denial lets the input stream be created but never fires
+    // callbacks; without this the app records dead audio silently. Fails the
+    // start loudly (mapped to a permission Alert in the UI).
+    #[cfg(target_os = "macos")]
+    {
+        if let Err(e) = super::devices::verify_microphone_access().await {
+            error!("Microphone access verification failed: {}", e);
+            return Err(format!("Microphone access required: {}", e));
+        }
+    }
+
+    // Async-first approach - no more blocking operations!
+    info!("🚀 Starting async recording initialization");
+
+    // Create new recording manager
+    let mut manager = RecordingManager::new();
+
     // Load recording preferences to get auto_save AND device preferences
     let (auto_save, preferred_mic_name, preferred_system_name) =
         match super::recording_preferences::load_recording_preferences(&app).await {
@@ -329,22 +319,9 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
             }
         };
 
-    #[cfg(not(target_os = "macos"))]
     let microphone_device = resolve_mic_or_default(&app, preferred_mic_name.as_deref());
 
     let system_device = resolve_system_or_default(preferred_system_name.as_deref());
-
-    #[cfg(target_os = "macos")]
-    prepare_audio_for_recording(system_device.as_deref()).await?;
-
-    #[cfg(target_os = "macos")]
-    let microphone_device = resolve_mic_or_default(&app, preferred_mic_name.as_deref());
-
-    // Async-first approach - no more blocking operations!
-    info!("🚀 Starting async recording initialization");
-
-    // Create new recording manager only after startup validation succeeds
-    let mut manager = RecordingManager::new();
 
     // Always ensure a meeting name is set so incremental saver initializes
     let effective_meeting_name = meeting_name.clone().unwrap_or_else(|| {
@@ -497,16 +474,19 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
         "message": "Recording initialization started"
     })).map_err(|e| e.to_string())?;
 
-    #[cfg(not(target_os = "macos"))]
+    // T12: verify the microphone is actually delivering audio before we start
+    // (see the note on the other start path above).
+    #[cfg(target_os = "macos")]
+    {
+        if let Err(e) = super::devices::verify_microphone_access().await {
+            error!("Microphone access verification failed: {}", e);
+            return Err(format!("Microphone access required: {}", e));
+        }
+    }
+
     let mic_device = resolve_mic_or_default(&app, mic_device_name.as_deref());
 
     let system_device = resolve_system_or_default(system_device_name.as_deref());
-
-    #[cfg(target_os = "macos")]
-    prepare_audio_for_recording(system_device.as_deref()).await?;
-
-    #[cfg(target_os = "macos")]
-    let mic_device = resolve_mic_or_default(&app, mic_device_name.as_deref());
 
     // Async-first approach for custom devices - no more blocking operations!
     info!("🚀 Starting async recording initialization with custom devices");

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -237,6 +237,34 @@ fn resolve_system_or_default(requested_name: Option<&str>) -> Option<Arc<super::
     }
 }
 
+/// Wake idle audio hardware before checking microphone callbacks, and finish
+/// validation before creating any recording resources.
+#[cfg(target_os = "macos")]
+async fn prepare_audio_for_recording(
+    system_device: Option<&super::AudioDevice>,
+) -> Result<(), String> {
+    use cpal::traits::{DeviceTrait, HostTrait};
+
+    let wake_name = system_device
+        .map(|s| s.name.clone())
+        .or_else(|| {
+            cpal::default_host()
+                .default_output_device()
+                .and_then(|d| d.name().ok())
+        });
+    if let Some(name) = wake_name {
+        if let Err(e) = super::recording_manager::wake_audio_connection(&name).await {
+            warn!("[AUDIO_WAKE] Wake failed: {} — proceeding anyway", e);
+        }
+    }
+
+    if let Err(e) = super::devices::verify_microphone_access().await {
+        error!("Microphone access verification failed: {}", e);
+        return Err(format!("Microphone access required: {}", e));
+    }
+    Ok(())
+}
+
 // ============================================================================
 // RECORDING COMMANDS
 // ============================================================================
@@ -287,24 +315,6 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
         "message": "Recording initialization started"
     })).map_err(|e| e.to_string())?;
 
-    // T12: verify the microphone is actually delivering audio before we start.
-    // A macOS TCC denial lets the input stream be created but never fires
-    // callbacks; without this the app records dead audio silently. Fails the
-    // start loudly (mapped to a permission Alert in the UI).
-    #[cfg(target_os = "macos")]
-    {
-        if let Err(e) = super::devices::verify_microphone_access().await {
-            error!("Microphone access verification failed: {}", e);
-            return Err(format!("Microphone access required: {}", e));
-        }
-    }
-
-    // Async-first approach - no more blocking operations!
-    info!("🚀 Starting async recording initialization");
-
-    // Create new recording manager
-    let mut manager = RecordingManager::new();
-
     // Load recording preferences to get auto_save AND device preferences
     let (auto_save, preferred_mic_name, preferred_system_name) =
         match super::recording_preferences::load_recording_preferences(&app).await {
@@ -319,9 +329,22 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
             }
         };
 
+    #[cfg(not(target_os = "macos"))]
     let microphone_device = resolve_mic_or_default(&app, preferred_mic_name.as_deref());
 
     let system_device = resolve_system_or_default(preferred_system_name.as_deref());
+
+    #[cfg(target_os = "macos")]
+    prepare_audio_for_recording(system_device.as_deref()).await?;
+
+    #[cfg(target_os = "macos")]
+    let microphone_device = resolve_mic_or_default(&app, preferred_mic_name.as_deref());
+
+    // Async-first approach - no more blocking operations!
+    info!("🚀 Starting async recording initialization");
+
+    // Create new recording manager only after startup validation succeeds
+    let mut manager = RecordingManager::new();
 
     // Always ensure a meeting name is set so incremental saver initializes
     let effective_meeting_name = meeting_name.clone().unwrap_or_else(|| {
@@ -474,19 +497,16 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
         "message": "Recording initialization started"
     })).map_err(|e| e.to_string())?;
 
-    // T12: verify the microphone is actually delivering audio before we start
-    // (see the note on the other start path above).
-    #[cfg(target_os = "macos")]
-    {
-        if let Err(e) = super::devices::verify_microphone_access().await {
-            error!("Microphone access verification failed: {}", e);
-            return Err(format!("Microphone access required: {}", e));
-        }
-    }
-
+    #[cfg(not(target_os = "macos"))]
     let mic_device = resolve_mic_or_default(&app, mic_device_name.as_deref());
 
     let system_device = resolve_system_or_default(system_device_name.as_deref());
+
+    #[cfg(target_os = "macos")]
+    prepare_audio_for_recording(system_device.as_deref()).await?;
+
+    #[cfg(target_os = "macos")]
+    let mic_device = resolve_mic_or_default(&app, mic_device_name.as_deref());
 
     // Async-first approach for custom devices - no more blocking operations!
     info!("🚀 Starting async recording initialization with custom devices");

--- a/frontend/src-tauri/src/audio/recording_manager.rs
+++ b/frontend/src-tauri/src/audio/recording_manager.rs
@@ -107,7 +107,7 @@ fn wake_audio_connection_sync(speaker_device_name: &str) -> Result<()> {
 /// should log the error and proceed if this fails; recording will still work,
 /// it just may have the 60-90s silent startup on BT.
 #[cfg(target_os = "macos")]
-async fn wake_audio_connection(speaker_device_name: &str) -> Result<()> {
+pub(super) async fn wake_audio_connection(speaker_device_name: &str) -> Result<()> {
     let name = speaker_device_name.to_string();
     tokio::task::spawn_blocking(move || {
         wake_audio_connection_sync(&name)
@@ -210,6 +210,9 @@ impl RecordingManager {
 
     /// Start recording with specified devices
     ///
+    /// On macOS, the command entry points wake audio and verify microphone
+    /// access before constructing the manager and calling this method.
+    ///
     /// # Arguments
     /// * `microphone_device` - Optional microphone device to use
     /// * `system_device` - Optional system audio device to use
@@ -271,26 +274,6 @@ impl RecordingManager {
             sys_name,
             sys_kind,
         )?;
-
-        // Wake the audio connection on macOS before opening capture streams.
-        // Without this, a deep-cold Bluetooth link can deliver no mic audio
-        // for the first 60-90 seconds of recording. Non-fatal on failure.
-        #[cfg(target_os = "macos")]
-        {
-            let wake_name = system_device
-                .as_ref()
-                .map(|s| s.name.clone())
-                .or_else(|| {
-                    cpal::default_host()
-                        .default_output_device()
-                        .and_then(|d| d.name().ok())
-                });
-            if let Some(name) = wake_name {
-                if let Err(e) = wake_audio_connection(&name).await {
-                    warn!("[AUDIO_WAKE] Wake failed: {} — proceeding anyway", e);
-                }
-            }
-        }
 
         // Give the pipeline a moment to fully initialize before starting streams
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;

--- a/frontend/src-tauri/src/audio/recording_manager.rs
+++ b/frontend/src-tauri/src/audio/recording_manager.rs
@@ -107,7 +107,7 @@ fn wake_audio_connection_sync(speaker_device_name: &str) -> Result<()> {
 /// should log the error and proceed if this fails; recording will still work,
 /// it just may have the 60-90s silent startup on BT.
 #[cfg(target_os = "macos")]
-pub(super) async fn wake_audio_connection(speaker_device_name: &str) -> Result<()> {
+async fn wake_audio_connection(speaker_device_name: &str) -> Result<()> {
     let name = speaker_device_name.to_string();
     tokio::task::spawn_blocking(move || {
         wake_audio_connection_sync(&name)
@@ -210,9 +210,6 @@ impl RecordingManager {
 
     /// Start recording with specified devices
     ///
-    /// On macOS, the command entry points wake audio and verify microphone
-    /// access before constructing the manager and calling this method.
-    ///
     /// # Arguments
     /// * `microphone_device` - Optional microphone device to use
     /// * `system_device` - Optional system audio device to use
@@ -274,6 +271,26 @@ impl RecordingManager {
             sys_name,
             sys_kind,
         )?;
+
+        // Wake the audio connection on macOS before opening capture streams.
+        // Without this, a deep-cold Bluetooth link can deliver no mic audio
+        // for the first 60-90 seconds of recording. Non-fatal on failure.
+        #[cfg(target_os = "macos")]
+        {
+            let wake_name = system_device
+                .as_ref()
+                .map(|s| s.name.clone())
+                .or_else(|| {
+                    cpal::default_host()
+                        .default_output_device()
+                        .and_then(|d| d.name().ok())
+                });
+            if let Some(name) = wake_name {
+                if let Err(e) = wake_audio_connection(&name).await {
+                    warn!("[AUDIO_WAKE] Wake failed: {} — proceeding anyway", e);
+                }
+            }
+        }
 
         // Give the pipeline a moment to fully initialize before starting streams
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;

--- a/frontend/src/app/meeting-details/page-content.tsx
+++ b/frontend/src/app/meeting-details/page-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
-import { MeetingSummary } from '@/types';
+import { MeetingSummary, SummaryProcessResponse } from '@/types';
 import { useSidebar } from '@/components/Sidebar/SidebarProvider';
 import Analytics from '@/lib/analytics';
 import { invoke } from '@tauri-apps/api/core';
@@ -22,6 +22,7 @@ import { useConfig } from '@/contexts/ConfigContext';
 export default function PageContent({
   meeting,
   summaryData,
+  initialSummary,
   shouldAutoGenerate = false,
   onAutoGenerateComplete,
   onMeetingUpdated,
@@ -36,6 +37,7 @@ export default function PageContent({
 }: {
   meeting: any;
   summaryData: MeetingSummary | null;
+  initialSummary: SummaryProcessResponse | null;
   shouldAutoGenerate?: boolean;
   onAutoGenerateComplete?: () => void;
   onMeetingUpdated?: () => Promise<void>;
@@ -115,6 +117,7 @@ export default function PageContent({
   };
 
   const summaryGeneration = useSummaryGeneration({
+    initialSummary,
     meeting,
     transcripts: meetingData.transcripts,
     modelConfig: modelConfig,
@@ -158,6 +161,7 @@ export default function PageContent({
   useEffect(() => {
     if (
       !shouldAutoGenerate
+      || summaryGeneration.summaryStatus !== 'idle'
       || isModelConfigLoading
       || meetingData.transcripts.length === 0
       || autoGenerationStartedMeetingIdRef.current === meeting.id
@@ -177,6 +181,7 @@ export default function PageContent({
     modelConfig.provider,
     modelConfig.model,
     summaryGeneration.handleGenerateSummary,
+    summaryGeneration.summaryStatus,
     onAutoGenerateComplete,
   ]);
 

--- a/frontend/src/app/meeting-details/page.tsx
+++ b/frontend/src/app/meeting-details/page.tsx
@@ -120,8 +120,8 @@ function MeetingDetailsContent() {
 
   // Sync meeting metadata from pagination hook to meeting details state
   useEffect(() => {
-    if (metadata && (!meetingId || meetingId === 'intro-call')) {
-      // If invalid meeting ID, don't sync
+    if (isLoadingTranscripts || !meetingId || meetingId === 'intro-call' || metadata?.id !== meetingId) {
+      // Keep the current view until the selected meeting's first transcript page is ready.
       return;
     }
 
@@ -141,7 +141,7 @@ function MeetingDetailsContent() {
       // Sync with sidebar context
       setCurrentMeeting({ id: metadata.id, title: metadata.title });
     }
-  }, [metadata, transcripts, meetingId, setCurrentMeeting]);
+  }, [metadata, transcripts, meetingId, isLoadingTranscripts, setCurrentMeeting]);
 
   // Handle transcript loading errors
   useEffect(() => {
@@ -264,7 +264,7 @@ function MeetingDetailsContent() {
   }
 
   // Show loading spinner while initial data loads
-  if ((isLoading || isLoadingTranscripts) || !meetingDetails || meetingDetails.id !== meetingId) {
+  if (isLoading || !meetingDetails || meetingDetails.id !== meetingId) {
     return <div className="flex items-center justify-center h-screen">
       <LoaderIcon className="animate-spin size-6 " />
     </div>;

--- a/frontend/src/app/meeting-details/page.tsx
+++ b/frontend/src/app/meeting-details/page.tsx
@@ -24,10 +24,11 @@ function MeetingDetailsContent() {
   const searchParams = useSearchParams();
   const meetingId = searchParams.get('id');
   const source = searchParams.get('source'); // Check if navigated from recording
-  const { setCurrentMeeting, refetchMeetings, stopSummaryPolling } = useSidebar();
+  const { setCurrentMeeting, refetchMeetings } = useSidebar();
   const { isAutoSummary } = useConfig(); // Get auto-summary toggle state
   const router = useRouter();
   const [meetingDetails, setMeetingDetails] = useState<MeetingDetailsResponse | null>(null);
+  const [summaryResponse, setSummaryResponse] = useState<SummaryProcessResponse | null>(null);
   const [meetingSummary, setMeetingSummary] = useState<MeetingSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -165,22 +166,13 @@ function MeetingDetailsContent() {
   useEffect(() => {
     setMeetingDetails(null);
     setMeetingSummary(null);
+    setSummaryResponse(null);
     setError(null);
     setIsLoading(true);
     // Reset auto-generation state to allow new meeting to be checked
     setHasCheckedAutoGen(false);
     setShouldAutoGenerate(false);
   }, [meetingId]);
-
-  // Cleanup: Stop polling when navigating away from a meeting
-  useEffect(() => {
-    return () => {
-      if (meetingId) {
-        console.log('Cleaning up: Stopping summary polling for meeting:', meetingId);
-        stopSummaryPolling(meetingId);
-      }
-    };
-  }, [meetingId, stopSummaryPolling]);
 
   useEffect(() => {
     console.log('MeetingDetails useEffect triggered - meetingId:', meetingId);
@@ -197,17 +189,22 @@ function MeetingDetailsContent() {
 
     setMeetingDetails(null);
     setMeetingSummary(null);
+    setSummaryResponse(null);
     setError(null);
     setIsLoading(true);
 
+    let cancelled = false;
     const fetchMeetingSummary = async () => {
       try {
         const response = await invoke<SummaryProcessResponse>('api_get_summary', {
           meetingId,
         });
+        if (cancelled) return;
+        setSummaryResponse(response);
         const summary = parseSummaryContent(response.data);
         setMeetingSummary(response.status === 'idle' ? null : summary);
       } catch (error) {
+        if (cancelled) return;
         console.error('FETCH SUMMARY: Error fetching meeting summary:', error);
         setMeetingSummary(null);
       }
@@ -217,11 +214,12 @@ function MeetingDetailsContent() {
       try {
         await fetchMeetingSummary();
       } finally {
-        setIsLoading(false);
+        if (!cancelled) setIsLoading(false);
       }
     };
 
     loadData();
+    return () => { cancelled = true; };
   }, [meetingId]);
 
   // Auto-generation check: runs when meeting is loaded with no summary
@@ -234,6 +232,8 @@ function MeetingDetailsContent() {
       // 4. Haven't checked yet
       if (
         meetingDetails &&
+        !isLoading &&
+        summaryResponse?.status === 'idle' &&
         meetingSummary === null &&
         meetingDetails.transcripts &&
         meetingDetails.transcripts.length > 0 &&
@@ -245,7 +245,7 @@ function MeetingDetailsContent() {
     };
 
     checkAutoGen();
-  }, [meetingDetails, meetingSummary, hasCheckedAutoGen, setupAutoGeneration]);
+  }, [meetingDetails, meetingSummary, summaryResponse, isLoading, hasCheckedAutoGen, setupAutoGeneration]);
 
   if (error) {
     return (
@@ -264,13 +264,15 @@ function MeetingDetailsContent() {
   }
 
   // Show loading spinner while initial data loads
-  if ((isLoading || isLoadingTranscripts) || !meetingDetails) {
+  if ((isLoading || isLoadingTranscripts) || !meetingDetails || meetingDetails.id !== meetingId) {
     return <div className="flex items-center justify-center h-screen">
       <LoaderIcon className="animate-spin size-6 " />
     </div>;
   }
 
   return <PageContent
+    key={meetingId}
+    initialSummary={summaryResponse}
     meeting={meetingDetails}
     summaryData={meetingSummary}
     shouldAutoGenerate={shouldAutoGenerate}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { motion } from 'framer-motion';
 import { RecordingControls } from '@/components/RecordingControls';
 import { useSidebar } from '@/components/Sidebar/SidebarProvider';
 import { usePermissionCheck } from '@/hooks/usePermissionCheck';
@@ -190,12 +189,7 @@ export default function Home() {
   const isProcessingStop = status === RecordingStatus.PROCESSING_TRANSCRIPTS || isProcessing;
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.3, ease: 'easeOut' }}
-      className="flex flex-col h-screen bg-gray-50"
-    >
+    <div className="flex flex-col h-screen bg-gray-50">
       {/* All Modals supported*/}
       <SettingsModals
         modals={modals}
@@ -260,6 +254,6 @@ export default function Home() {
           sidebarCollapsed={sidebarCollapsed}
         />
       </div>
-    </motion.div>
+    </div>
   );
 }

--- a/frontend/src/components/Sidebar/SidebarProvider.tsx
+++ b/frontend/src/components/Sidebar/SidebarProvider.tsx
@@ -231,16 +231,19 @@ export function SidebarProvider({ children }: { children: React.ReactNode }) {
             data: null,
             error: 'Summary generation timed out after 15 minutes. Please try again or check your model configuration.',
           });
-          stopSummaryPolling(meetingId, processId);
+          if (summaryPollsRef.current.get(meetingId) === entry) {
+            stopSummaryPolling(meetingId, processId);
+          }
           return;
         }
 
         const result = await invoke<SummaryProcessResponse>('api_get_summary', { meetingId });
         const current = summaryPollsRef.current.get(meetingId);
-        if (!current || current.processId !== processId || result.start !== processId) {
+        if (current !== entry || result.start !== processId) {
           return;
         }
         await onUpdate(result);
+        if (summaryPollsRef.current.get(meetingId) !== entry) return;
         if (
           result.status === 'completed'
           || result.status === 'error'
@@ -252,7 +255,7 @@ export function SidebarProvider({ children }: { children: React.ReactNode }) {
         }
       } catch (error) {
         const current = summaryPollsRef.current.get(meetingId);
-        if (!current || current.processId !== processId) {
+        if (current !== entry) {
           return;
         }
         await onUpdate({
@@ -264,10 +267,12 @@ export function SidebarProvider({ children }: { children: React.ReactNode }) {
           data: null,
           error: error instanceof Error ? error.message : 'Unknown error',
         });
-        stopSummaryPolling(meetingId, processId);
+        if (summaryPollsRef.current.get(meetingId) === entry) {
+          stopSummaryPolling(meetingId, processId);
+        }
       } finally {
         const current = summaryPollsRef.current.get(meetingId);
-        if (current?.processId === processId) {
+        if (current === entry) {
           current.inFlight = false;
         }
       }

--- a/frontend/src/components/Sidebar/SidebarProvider.tsx
+++ b/frontend/src/components/Sidebar/SidebarProvider.tsx
@@ -258,17 +258,22 @@ export function SidebarProvider({ children }: { children: React.ReactNode }) {
         if (current !== entry) {
           return;
         }
-        await onUpdate({
-          status: 'error',
-          meetingName: null,
-          meeting_id: meetingId,
-          start: processId,
-          end: null,
-          data: null,
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
-        if (summaryPollsRef.current.get(meetingId) === entry) {
-          stopSummaryPolling(meetingId, processId);
+        try {
+          await onUpdate({
+            status: 'error',
+            meetingName: null,
+            meeting_id: meetingId,
+            start: processId,
+            end: null,
+            data: null,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          });
+        } catch (callbackError) {
+          console.error('Failed to handle summary polling error:', callbackError);
+        } finally {
+          if (summaryPollsRef.current.get(meetingId) === entry) {
+            stopSummaryPolling(meetingId, processId);
+          }
         }
       } finally {
         const current = summaryPollsRef.current.get(meetingId);

--- a/frontend/src/hooks/meeting-details/useSummaryGeneration.ts
+++ b/frontend/src/hooks/meeting-details/useSummaryGeneration.ts
@@ -176,9 +176,17 @@ export function useSummaryGeneration({
       return;
     }
     if (pollingResult.status === 'cancelled') {
-      const existing = await invokeTauri<SummaryProcessResponse>('api_get_summary', {
-        meetingId: meeting.id,
-      });
+      let existing: SummaryProcessResponse;
+      try {
+        existing = await invokeTauri<SummaryProcessResponse>('api_get_summary', {
+          meetingId: meeting.id,
+        });
+      } catch (error) {
+        console.error('Failed to reload summary after cancellation:', error);
+        await failGeneration(generationId, isRegeneration,
+          'Summary generation was cancelled, but the saved summary could not be reloaded. Please reopen this meeting.');
+        return;
+      }
       if (!mountedRef.current || visibleMeetingIdRef.current !== meeting.id || generationId !== generationIdRef.current) {
         return;
       }
@@ -195,9 +203,17 @@ export function useSummaryGeneration({
       const errorMessage = pollingResult.error
         || `Summary ${isRegeneration ? 'regeneration' : 'generation'} failed`;
       if (isRegeneration) {
-        const existing = await invokeTauri<SummaryProcessResponse>('api_get_summary', {
-          meetingId: meeting.id,
-        });
+        let existing: SummaryProcessResponse;
+        try {
+          existing = await invokeTauri<SummaryProcessResponse>('api_get_summary', {
+            meetingId: meeting.id,
+          });
+        } catch (error) {
+          console.error('Failed to reload previous summary after generation failure:', error);
+          await failGeneration(generationId, isRegeneration,
+            `${errorMessage}. The saved summary could not be reloaded. Please reopen this meeting.`);
+          return;
+        }
         if (!mountedRef.current || visibleMeetingIdRef.current !== meeting.id || generationId !== generationIdRef.current) {
           return;
         }

--- a/frontend/src/hooks/meeting-details/useSummaryGeneration.ts
+++ b/frontend/src/hooks/meeting-details/useSummaryGeneration.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import {
   CancelSummaryResponse,
   MeetingSummary,
@@ -56,7 +56,17 @@ async function resolveSummaryLanguage(
 
 type SummaryStatus = 'idle' | 'processing' | 'summarizing' | 'regenerating' | 'completed' | 'error';
 
+function restoredSummaryStatus(response?: SummaryProcessResponse | null): SummaryStatus {
+  if (!response) return 'idle';
+  if (response.status === 'pending' || response.status === 'processing') return 'processing';
+  if (response.status === 'error' || response.status === 'failed') return 'error';
+  if (parseSummaryContent(response.data)) return 'completed';
+  if (response.status === 'completed') return 'error';
+  return 'idle';
+}
+
 interface UseSummaryGenerationProps {
+  initialSummary?: SummaryProcessResponse | null;
   meeting: {
     id: string;
     created_at: string;
@@ -72,6 +82,7 @@ interface UseSummaryGenerationProps {
 }
 
 export function useSummaryGeneration({
+  initialSummary,
   meeting,
   transcripts,
   modelConfig,
@@ -82,13 +93,23 @@ export function useSummaryGeneration({
   setAiSummary,
   onOpenModelSettings,
 }: UseSummaryGenerationProps) {
-  const [summaryStatus, setSummaryStatus] = useState<SummaryStatus>('idle');
-  const [summaryError, setSummaryError] = useState<string | null>(null);
+  const restored = initialSummary?.meeting_id === meeting.id ? initialSummary : null;
+  const [summaryStatus, setSummaryStatus] = useState<SummaryStatus>(() => restoredSummaryStatus(restored));
+  const [summaryError, setSummaryError] = useState<string | null>(() =>
+    restoredSummaryStatus(restored) === 'error'
+      ? restored?.error || 'Summary generation failed. Please retry.'
+      : null,
+  );
+  const mountedRef = useRef(true);
+  const visibleMeetingIdRef = useRef(meeting.id);
+  visibleMeetingIdRef.current = meeting.id;
   const generationIdRef = useRef(0);
   const activeProcessIdRef = useRef<string | null>(null);
   const trackedAttemptRef = useRef<{
     generationId: number;
     startedAt: number;
+    provider: ModelConfig['provider'];
+    model: ModelConfig['model'];
     finished: boolean;
   } | null>(null);
   const { startSummaryPolling, stopSummaryPolling } = useSidebar();
@@ -120,13 +141,152 @@ export function useSummaryGeneration({
     }
     attempt.finished = true;
     await Analytics.trackSummaryGenerationCompleted(
-      modelConfig.provider,
-      modelConfig.model,
+      attempt.provider,
+      attempt.model,
       outcome === 'ok' || outcome === 'fallback',
       (Date.now() - attempt.startedAt) / 1000,
       outcome === 'ok' ? undefined : outcome,
     );
-  }, [modelConfig]);
+  }, []);
+
+  const failGeneration = useCallback(async (
+    generationId: number,
+    isRegeneration: boolean,
+    message: string,
+    outcome: 'generation_error' | 'empty_result' = 'generation_error',
+  ) => {
+    if (!mountedRef.current || visibleMeetingIdRef.current !== meeting.id || generationId !== generationIdRef.current) {
+      return;
+    }
+    activeProcessIdRef.current = null;
+    setSummaryError(message);
+    setSummaryStatus('error');
+    toast.error(`Failed to ${isRegeneration ? 'regenerate' : 'generate'} summary`, {
+      description: message,
+    });
+    await finishGeneration(generationId, outcome);
+  }, [finishGeneration, meeting.id]);
+
+  const handlePollingResult = useCallback(async (
+    pollingResult: SummaryProcessResponse,
+    generationId: number,
+    isRegeneration: boolean,
+  ) => {
+    if (!mountedRef.current || visibleMeetingIdRef.current !== meeting.id || generationId !== generationIdRef.current) {
+      return;
+    }
+    if (pollingResult.status === 'cancelled') {
+      const existing = await invokeTauri<SummaryProcessResponse>('api_get_summary', {
+        meetingId: meeting.id,
+      });
+      if (!mountedRef.current || visibleMeetingIdRef.current !== meeting.id || generationId !== generationIdRef.current) {
+        return;
+      }
+      const restoredSummary = parseSummaryContent(existing.data);
+      setAiSummary(restoredSummary);
+      setSummaryStatus(restoredSummary ? 'completed' : 'idle');
+      setSummaryError(null);
+      activeProcessIdRef.current = null;
+      await finishGeneration(generationId, 'cancelled');
+      return;
+    }
+
+    if (pollingResult.status === 'error' || pollingResult.status === 'failed') {
+      const errorMessage = pollingResult.error
+        || `Summary ${isRegeneration ? 'regeneration' : 'generation'} failed`;
+      if (isRegeneration) {
+        const existing = await invokeTauri<SummaryProcessResponse>('api_get_summary', {
+          meetingId: meeting.id,
+        });
+        if (!mountedRef.current || visibleMeetingIdRef.current !== meeting.id || generationId !== generationIdRef.current) {
+          return;
+        }
+        const restoredSummary = parseSummaryContent(existing.data);
+        if (restoredSummary) {
+          setAiSummary(restoredSummary);
+          setSummaryStatus('completed');
+          setSummaryError(null);
+          toast.error('Failed to regenerate summary', {
+            description: `${errorMessage}. Your previous summary has been restored.`,
+          });
+          activeProcessIdRef.current = null;
+          await finishGeneration(generationId, 'generation_error');
+          return;
+        }
+      }
+      await failGeneration(generationId, isRegeneration, errorMessage);
+      return;
+    }
+
+    if (pollingResult.status === 'completed') {
+      const summary = parseSummaryContent(pollingResult.data);
+      if (!summary) {
+        await failGeneration(generationId, isRegeneration,
+          'Summary generation completed without visible content. Please retry.',
+          'empty_result',
+        );
+        return;
+      }
+      const metadata = readSummaryMetadata(pollingResult.data);
+      const meetingName = metadata.meetingName || pollingResult.meetingName;
+      if (meetingName) {
+        updateMeetingTitle(meetingName);
+      }
+      setAiSummary(summary);
+      setSummaryStatus('completed');
+      activeProcessIdRef.current = null;
+      setSummaryError(null);
+      if (metadata.normalizationFallback) {
+        toast.warning('Summary generated with fallback', {
+          description: 'English normalization failed, so the original sanitized summary was kept.',
+        });
+      } else {
+        toast.success('Summary generated successfully!', {
+          description: metadata.reasoningStripped
+            ? 'Your meeting summary is ready. Model reasoning was filtered out of the notes.'
+            : 'Your meeting summary is ready',
+          duration: 4000,
+        });
+      }
+      if (meetingName && onMeetingUpdated) {
+        await onMeetingUpdated();
+      }
+      await finishGeneration(
+        generationId,
+        metadata.normalizationFallback ? 'fallback' : 'ok',
+      );
+    }
+  }, [failGeneration, finishGeneration, meeting.id, onMeetingUpdated, setAiSummary, updateMeetingTitle]);
+
+  // Keep polling attached across ordinary rerenders without retaining stale view callbacks.
+  const pollingResultRef = useRef(handlePollingResult);
+  pollingResultRef.current = handlePollingResult;
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (activeProcessIdRef.current) {
+        stopSummaryPolling(meeting.id, activeProcessIdRef.current);
+      }
+    };
+  }, [meeting.id, stopSummaryPolling]);
+
+  useEffect(() => {
+    if (!initialSummary || initialSummary.meeting_id !== meeting.id) return;
+    const status = restoredSummaryStatus(initialSummary);
+    setSummaryStatus(status);
+    setSummaryError(status === 'error'
+      ? initialSummary.error || 'Summary generation failed. Please retry.'
+      : null);
+    if (status !== 'processing' || !initialSummary.start) return;
+
+    const generationId = ++generationIdRef.current;
+    activeProcessIdRef.current = initialSummary.start;
+    const isRegeneration = !!parseSummaryContent(initialSummary.data);
+    startSummaryPolling(meeting.id, initialSummary.start, result =>
+      pollingResultRef.current(result, generationId, isRegeneration));
+  }, [initialSummary, meeting.id, startSummaryPolling]);
 
   const processSummary = useCallback(async ({
     transcriptText,
@@ -148,25 +308,10 @@ export function useSummaryGeneration({
     activeProcessIdRef.current = null;
     setSummaryStatus(isRegeneration ? 'regenerating' : 'processing');
     setSummaryError(null);
-    const fail = async (
-      message: string,
-      outcome: 'generation_error' | 'empty_result' = 'generation_error',
-    ) => {
-      if (generationId !== generationIdRef.current) {
-        return;
-      }
-      activeProcessIdRef.current = null;
-      setSummaryError(message);
-      setSummaryStatus('error');
-      toast.error(`Failed to ${isRegeneration ? 'regenerate' : 'generate'} summary`, {
-        description: message,
-      });
-      await finishGeneration(generationId, outcome);
-    };
 
     try {
       if (!transcriptText.trim()) {
-        await fail('No transcript text available. Please add some text first.', 'empty_result');
+        await failGeneration(generationId, isRegeneration, 'No transcript text available. Please add some text first.', 'empty_result');
         return;
       }
 
@@ -174,6 +319,8 @@ export function useSummaryGeneration({
       trackedAttemptRef.current = {
         generationId,
         startedAt: Date.now(),
+        provider: modelConfig.provider,
+        model: modelConfig.model,
         finished: false,
       };
       await Analytics.trackSummaryGenerationStarted(
@@ -194,7 +341,7 @@ export function useSummaryGeneration({
         meeting.id,
         transcriptTexts?.length ? transcriptTexts : [transcriptText],
       );
-      if (generationId !== generationIdRef.current) {
+      if (!mountedRef.current || visibleMeetingIdRef.current !== meeting.id || generationId !== generationIdRef.current) {
         return;
       }
 
@@ -210,102 +357,20 @@ export function useSummaryGeneration({
         summaryLanguage,
       });
       const processId = result.process_id;
+      if (!mountedRef.current || visibleMeetingIdRef.current !== meeting.id) return;
       if (generationId !== generationIdRef.current) {
         await invokeTauri('api_cancel_summary', { meetingId: meeting.id, processId }).catch(() => {});
         return;
       }
       activeProcessIdRef.current = processId;
 
-      startSummaryPolling(meeting.id, processId, async (pollingResult) => {
-        if (generationId !== generationIdRef.current) {
-          return;
-        }
-        if (pollingResult.status === 'cancelled') {
-          const existing = await invokeTauri<SummaryProcessResponse>('api_get_summary', {
-            meetingId: meeting.id,
-          });
-          if (generationId !== generationIdRef.current) {
-            return;
-          }
-          const restoredSummary = parseSummaryContent(existing.data);
-          setAiSummary(restoredSummary);
-          setSummaryStatus(restoredSummary ? 'completed' : 'idle');
-          setSummaryError(null);
-          activeProcessIdRef.current = null;
-          await finishGeneration(generationId, 'cancelled');
-          return;
-        }
-
-        if (pollingResult.status === 'error' || pollingResult.status === 'failed') {
-          const errorMessage = pollingResult.error
-            || `Summary ${isRegeneration ? 'regeneration' : 'generation'} failed`;
-          if (isRegeneration) {
-            const existing = await invokeTauri<SummaryProcessResponse>('api_get_summary', {
-              meetingId: meeting.id,
-            });
-            if (generationId !== generationIdRef.current) {
-              return;
-            }
-            const restoredSummary = parseSummaryContent(existing.data);
-            if (restoredSummary) {
-              setAiSummary(restoredSummary);
-              setSummaryStatus('completed');
-              setSummaryError(null);
-              toast.error('Failed to regenerate summary', {
-                description: `${errorMessage}. Your previous summary has been restored.`,
-              });
-              activeProcessIdRef.current = null;
-              await finishGeneration(generationId, 'generation_error');
-              return;
-            }
-          }
-          await fail(errorMessage);
-          return;
-        }
-
-        if (pollingResult.status === 'completed') {
-          const summary = parseSummaryContent(pollingResult.data);
-          if (!summary) {
-            await fail(
-              'Summary generation completed without visible content. Please retry.',
-              'empty_result',
-            );
-            return;
-          }
-          const metadata = readSummaryMetadata(pollingResult.data);
-          const meetingName = metadata.meetingName || pollingResult.meetingName;
-          if (meetingName) {
-            updateMeetingTitle(meetingName);
-          }
-          setAiSummary(summary);
-          setSummaryStatus('completed');
-          activeProcessIdRef.current = null;
-          setSummaryError(null);
-          if (metadata.normalizationFallback) {
-            toast.warning('Summary generated with fallback', {
-              description: 'English normalization failed, so the original sanitized summary was kept.',
-            });
-          } else {
-            toast.success('Summary generated successfully!', {
-              description: metadata.reasoningStripped
-                ? 'Your meeting summary is ready. Model reasoning was filtered out of the notes.'
-                : 'Your meeting summary is ready',
-              duration: 4000,
-            });
-          }
-          if (meetingName && onMeetingUpdated) {
-            await onMeetingUpdated();
-          }
-          await finishGeneration(
-            generationId,
-            metadata.normalizationFallback ? 'fallback' : 'ok',
-          );
-        }
-      });
+      startSummaryPolling(meeting.id, processId, result =>
+        pollingResultRef.current(result, generationId, isRegeneration));
     } catch (error) {
-      await fail(error instanceof Error ? error.message : 'Summary generation failed.');
+      await failGeneration(generationId, isRegeneration, error instanceof Error ? error.message : 'Summary generation failed.');
     }
   }, [
+    failGeneration,
     finishGeneration,
     meeting.created_at,
     meeting.id,
@@ -471,7 +536,7 @@ export function useSummaryGeneration({
         meetingId: meeting.id,
         processId,
       });
-      if (generationId !== generationIdRef.current) {
+      if (!mountedRef.current || visibleMeetingIdRef.current !== meeting.id || generationId !== generationIdRef.current) {
         return;
       }
       if (result.cancelled) {

--- a/frontend/src/hooks/usePaginatedTranscripts.ts
+++ b/frontend/src/hooks/usePaginatedTranscripts.ts
@@ -53,12 +53,21 @@ export function usePaginatedTranscripts({
     const [error, setError] = useState<string | null>(null);
 
     const offsetRef = useRef(0);
-    const loadedMeetingIdRef = useRef<string | null>(null);
+    const activeMeetingIdRef = useRef<string | null>(null);
+    const requestIdRef = useRef(0);
     const isLoadingRef = useRef(false);
     const lastLoadTimeRef = useRef(0); // Debounce protection
 
-    // Reset state when meeting changes
+    const isCurrentRequest = useCallback((requestId: number) =>
+        requestIdRef.current === requestId && activeMeetingIdRef.current === meetingId,
+        [meetingId]
+    );
+
+    // Reset invalidates pending reads, including same-meeting refetches.
     const reset = useCallback(() => {
+        requestIdRef.current += 1;
+        isLoadingRef.current = false;
+        lastLoadTimeRef.current = 0;
         setMetadata(null);
         setTranscripts([]);
         setTotalCount(0);
@@ -70,28 +79,31 @@ export function usePaginatedTranscripts({
     }, []);
 
     // Load meeting metadata
-    const loadMetadata = useCallback(async (): Promise<MeetingMetadata | null> => {
-        if (!meetingId) return null;
+    const loadMetadata = useCallback(async (requestId: number): Promise<MeetingMetadata | null> => {
+        if (!meetingId || !isCurrentRequest(requestId)) return null;
 
         try {
             const data = await invoke<MeetingMetadata>('api_get_meeting_metadata', {
                 meetingId,
             });
+            if (!isCurrentRequest(requestId)) return null;
             setMetadata(data);
             return data;
         } catch (err) {
+            if (!isCurrentRequest(requestId)) return null;
             console.error('Failed to load meeting metadata:', err);
             setError('Failed to load meeting details');
             return null;
         }
-    }, [meetingId]);
+    }, [meetingId, isCurrentRequest]);
 
     // Load transcripts at specific offset
     const loadTranscriptsAtOffset = useCallback(async (
+        requestId: number,
         offset: number,
         append: boolean = true
     ): Promise<Transcript[]> => {
-        if (!meetingId) return [];
+        if (!meetingId || !isCurrentRequest(requestId)) return [];
 
         try {
             const response = await invoke<PaginatedTranscriptsResponse>(
@@ -103,10 +115,12 @@ export function usePaginatedTranscripts({
                 }
             );
 
+            if (!isCurrentRequest(requestId)) return [];
             const newTranscripts = response.transcripts;
 
             if (append) {
                 setTranscripts(prev => {
+                    if (!isCurrentRequest(requestId)) return prev;
                     // Deduplicate by id
                     const existingIds = new Set(prev.map(t => t.id));
                     const uniqueNew = newTranscripts.filter(t => !existingIds.has(t.id));
@@ -125,14 +139,17 @@ export function usePaginatedTranscripts({
 
             return newTranscripts;
         } catch (err) {
+            if (!isCurrentRequest(requestId)) return [];
             console.error('Failed to load transcripts:', err);
             setError('Failed to load transcripts');
             return [];
         }
-    }, [meetingId]);
+    }, [meetingId, isCurrentRequest]);
 
     // Load next page with debounce protection
     const loadMore = useCallback(async () => {
+        const requestId = requestIdRef.current;
+        if (!isCurrentRequest(requestId)) return;
         const now = Date.now();
         // Debounce: require at least 100ms between calls
         if (now - lastLoadTimeRef.current < 100) {
@@ -145,52 +162,43 @@ export function usePaginatedTranscripts({
         isLoadingRef.current = true;
         setIsLoadingMore(true);
         try {
-            await loadTranscriptsAtOffset(offsetRef.current, true);
+            await loadTranscriptsAtOffset(requestId, offsetRef.current, true);
         } finally {
-            setIsLoadingMore(false);
-            isLoadingRef.current = false;
+            if (isCurrentRequest(requestId)) {
+                setIsLoadingMore(false);
+                isLoadingRef.current = false;
+            }
         }
-    }, [hasMore, meetingId, loadTranscriptsAtOffset, isLoading]);
+    }, [hasMore, meetingId, loadTranscriptsAtOffset, isLoading, isCurrentRequest]);
 
     // Force refetch of data (e.g., after retranscription)
     const refetch = useCallback(async () => {
-        if (!meetingId) return;
+        if (!meetingId || activeMeetingIdRef.current !== meetingId) return;
 
         reset();
-        setIsLoading(true);
+        const requestId = requestIdRef.current;
         try {
-            await loadMetadata();
-            await loadTranscriptsAtOffset(0, false);
+            await loadMetadata(requestId);
+            await loadTranscriptsAtOffset(requestId, 0, false);
         } finally {
-            setIsLoading(false);
+            if (isCurrentRequest(requestId)) setIsLoading(false);
         }
-    }, [meetingId, reset, loadMetadata, loadTranscriptsAtOffset]);
+    }, [meetingId, reset, loadMetadata, loadTranscriptsAtOffset, isCurrentRequest]);
 
-    // Initial load
+    // A new meeting or effect lifetime owns its own requests.
     useEffect(() => {
-        if (!meetingId) {
+        activeMeetingIdRef.current = meetingId;
+        if (meetingId) {
+            void refetch();
+        } else {
             reset();
-            return;
         }
 
-        // Avoid reloading the same meeting
-        if (loadedMeetingIdRef.current === meetingId) return;
-        loadedMeetingIdRef.current = meetingId;
-
-        reset();
-
-        const loadInitial = async () => {
-            setIsLoading(true);
-            try {
-                await loadMetadata();
-                await loadTranscriptsAtOffset(0, false);
-            } finally {
-                setIsLoading(false);
-            }
+        return () => {
+            requestIdRef.current += 1;
+            activeMeetingIdRef.current = null;
         };
-
-        loadInitial();
-    }, [meetingId, reset, loadMetadata, loadTranscriptsAtOffset]);
+    }, [meetingId, reset, refetch]);
 
     // Convert to segments (memoized)
     const segments = useMemo(() =>

--- a/frontend/src/hooks/useRecordingStart.ts
+++ b/frontend/src/hooks/useRecordingStart.ts
@@ -265,7 +265,7 @@ export function useRecordingStart(
               Analytics.trackButtonClick('start_recording_error', 'sidebar_auto');
             } else {
               setStatus(RecordingStatus.ERROR, errorMsg);
-              alert('Failed to start recording. Check console for details.');
+              alert(`Failed to start recording.\n\n${errorMsg}`);
               Analytics.trackButtonClick('start_recording_error', 'sidebar_auto');
             }
           } finally {
@@ -359,7 +359,7 @@ export function useRecordingStart(
           Analytics.trackButtonClick('start_recording_error', 'sidebar_direct');
         } else {
           setStatus(RecordingStatus.ERROR, errorMsg);
-          alert('Failed to start recording. Check console for details.');
+          alert(`Failed to start recording.\n\n${errorMsg}`);
           Analytics.trackButtonClick('start_recording_error', 'sidebar_direct');
         }
       } finally {

--- a/frontend/tests/hooks/meeting-details-refresh.test.tsx
+++ b/frontend/tests/hooks/meeting-details-refresh.test.tsx
@@ -1,0 +1,173 @@
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { useEffect } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import type { SummaryProcessResponse } from '../../src/types';
+
+const originalCore = { ...await import('@tauri-apps/api/core') };
+const originalAnalytics = { ...await import('../../src/lib/analytics') };
+const originalPreferences = { ...await import('../../src/lib/summary-language-preferences') };
+const originalToast = { ...await import('sonner') };
+const originalNavigation = { ...await import('next/navigation') };
+const originalConfig = { ...await import('../../src/contexts/ConfigContext') };
+afterAll(() => {
+  mock.module('@tauri-apps/api/core', () => originalCore);
+  mock.module('../../src/lib/analytics', () => originalAnalytics);
+  mock.module('../../src/lib/summary-language-preferences', () => originalPreferences);
+  mock.module('sonner', () => originalToast);
+  mock.module('next/navigation', () => originalNavigation);
+  mock.module('../../src/contexts/ConfigContext', () => originalConfig);
+});
+
+let selectedMeeting = 'meeting-a';
+mock.module('next/navigation', () => ({
+  usePathname: () => '/meeting-details', useRouter: () => ({}),
+  useSearchParams: () => new URLSearchParams({ id: selectedMeeting }),
+}));
+mock.module('../../src/contexts/RecordingStateContext', () => ({ useRecordingState: () => ({ isRecording: false }) }));
+mock.module('../../src/contexts/ConfigContext', () => ({ useConfig: () => ({ isAutoSummary: false }) }));
+const notify = mock(() => {});
+mock.module('sonner', () => ({ toast: { info: notify, error: notify, success: notify, warning: notify } }));
+mock.module('../../src/lib/analytics', () => ({ default: {
+  trackPageView() {}, trackBackendConnection() {}, trackSummaryGenerationStarted: async () => {},
+  trackSummaryGenerationCompleted: async () => {},
+} }));
+mock.module('../../src/lib/summary-language-preferences', () => ({
+  readCachedDetectedSummaryLanguage: async () => null,
+  detectAndCacheSummaryLanguage: async () => ({ language: 'en' }),
+  readMeetingSummaryLanguage: async () => ({ language: 'en', storage: 'metadata' }),
+}));
+const metadata = (id: string) => ({ id, title: id, created_at: '2026-09-01', updated_at: '2026-09-01' });
+let readMetadata: (id: string) => Promise<unknown>;
+let readTranscripts: (id: string) => Promise<unknown>;
+const transcriptPage = {
+  transcripts: [{ id: 'transcript', text: 'Meeting transcript', timestamp: '00:00' }], total_count: 1, has_more: false,
+};
+let savedSummary: SummaryProcessResponse;
+const invoke = mock(async (command: string, args?: Record<string, unknown>): Promise<unknown> => {
+  if (command === 'api_get_meetings') return [];
+  if (command === 'api_get_summary') return { ...savedSummary, meeting_id: args!.meetingId };
+  if (command === 'api_get_meeting_metadata') return readMetadata(args!.meetingId as string);
+  if (command === 'api_get_meeting_transcripts') return readTranscripts(args!.meetingId as string);
+  if (command === 'api_process_transcript') return { process_id: 'attempt-b' };
+  if (command === 'api_cancel_summary') return { cancelled: true };
+  throw new Error(`Unexpected command: ${command}`);
+});
+mock.module('@tauri-apps/api/core', () => ({ ...originalCore, invoke }));
+const { SidebarProvider } = await import('../../src/components/Sidebar/SidebarProvider');
+const { useSummaryGeneration } = await import('../../src/hooks/meeting-details/useSummaryGeneration');
+const { useMeetingData } = await import('../../src/hooks/meeting-details/useMeetingData');
+
+// Use a lightweight content view around the actual route, transcript loader, state hooks and polling provider.
+let summaryState: ReturnType<typeof useSummaryGeneration>;
+let refresh: () => Promise<void>;
+let mounts = 0;
+function SummaryView(props: any) {
+  const data = useMeetingData(props);
+  summaryState = useSummaryGeneration({
+    meeting: props.meeting, initialSummary: props.initialSummary, transcripts: data.transcripts,
+    modelConfig: { provider: 'ollama', model: 'test', whisperModel: 'base' }, isModelConfigLoading: false,
+    selectedTemplate: 'daily_standup', setAiSummary: data.setAiSummary, updateMeetingTitle: data.updateMeetingTitle,
+  });
+  refresh = props.onRefetchTranscripts;
+  useEffect(() => { mounts += 1; }, []);
+  return <output>{props.meeting.id}:{summaryState.summaryStatus}:{JSON.stringify(data.aiSummary)}</output>;
+}
+mock.module('../../src/app/meeting-details/page-content', () => ({ default: SummaryView }));
+const { default: MeetingDetails } = await import('../../src/app/meeting-details/page');
+
+let renderer: ReactTestRenderer | undefined;
+const timers = new Map<number, () => Promise<void>>();
+let nextTimer = 0;
+const realSetInterval = globalThis.setInterval;
+const realClearInterval = globalThis.clearInterval;
+beforeEach(() => {
+  selectedMeeting = 'meeting-a';
+  readMetadata = async id => metadata(id);
+  readTranscripts = async () => transcriptPage;
+  savedSummary = { meeting_id: selectedMeeting, status: 'pending', start: 'attempt-a', end: null, data: null, error: null, meetingName: 'Meeting A' };
+  mounts = 0; timers.clear(); invoke.mockClear(); notify.mockClear();
+  globalThis.setInterval = ((callback: () => Promise<void>) => {
+    const id = ++nextTimer; timers.set(id, callback); return id;
+  }) as typeof setInterval;
+  globalThis.clearInterval = ((id: number) => { timers.delete(id); }) as typeof clearInterval;
+});
+afterEach(async () => {
+  if (renderer) await act(async () => renderer!.unmount());
+  renderer = undefined;
+  globalThis.setInterval = realSetInterval;
+  globalThis.clearInterval = realClearInterval;
+});
+async function show() {
+  await act(async () => {
+    const view = <SidebarProvider><MeetingDetails /></SidebarProvider>;
+    if (renderer) renderer.update(view); else renderer = create(view);
+  });
+}
+async function tick() {
+  await act(async () => { for (const callback of [...timers.values()]) await callback(); });
+}
+const text = () => JSON.stringify(renderer!.toJSON());
+async function complete(text: string, attempt: string) {
+  savedSummary = { ...savedSummary, status: 'completed', start: attempt, data: { markdown: text } };
+  await tick();
+}
+function deferMetadata() {
+  let resolve!: (value: unknown) => void;
+  readMetadata = () => new Promise(done => { resolve = done; });
+  return async () => { await act(async () => { resolve(metadata(selectedMeeting)); }); };
+}
+
+describe('meeting route transcript refresh', () => {
+  test('navigation waits for the new meeting first transcript page before mounting its view', async () => {
+    await show();
+    await complete('Summary A', 'attempt-a');
+    selectedMeeting = 'meeting-b';
+    savedSummary = { ...savedSummary, meeting_id: selectedMeeting, status: 'idle', data: null, start: null };
+    let resolvePage!: (value: unknown) => void;
+    readTranscripts = () => new Promise(resolve => { resolvePage = resolve; });
+    await show();
+    expect(renderer!.root.findAllByType('output')).toHaveLength(0);
+    expect(mounts).toBe(1);
+    await act(async () => { resolvePage(transcriptPage); });
+    expect(text()).toContain('meeting-b');
+    expect(summaryState.summaryStatus).toBe('idle');
+    expect(text()).not.toContain('Summary A');
+    expect(mounts).toBe(2);
+  });
+
+  test('completed regeneration survives refresh without reviving the original pending attempt', async () => {
+    await show();
+    await complete('Summary A', 'attempt-a');
+    await act(async () => { await summaryState.handleRegenerateSummary(); });
+    await complete('Summary B', 'attempt-b');
+    expect(text()).toContain('Summary B');
+    const finishRefresh = deferMetadata();
+    await act(async () => { void refresh(); });
+    expect(text()).toContain('Summary B');
+    expect(timers.size).toBe(0);
+    expect(mounts).toBe(1);
+    await finishRefresh();
+    await tick();
+    expect(summaryState.summaryStatus).toBe('completed');
+    expect(text()).toContain('Summary B');
+    expect(timers.size).toBe(0);
+    expect(mounts).toBe(1);
+  });
+
+  test('refresh during regeneration keeps the current attempt and its Stop token', async () => {
+    await show();
+    await complete('Summary A', 'attempt-a');
+    await act(async () => { await summaryState.handleRegenerateSummary(); });
+    const currentTimer = [...timers.keys()][0];
+    const finishRefresh = deferMetadata();
+    await act(async () => { void refresh(); });
+    expect([...timers.keys()]).toEqual([currentTimer]);
+    expect(summaryState.summaryStatus).toBe('regenerating');
+    await finishRefresh();
+    expect([...timers.keys()]).toEqual([currentTimer]);
+    expect(summaryState.summaryStatus).toBe('regenerating');
+    await act(async () => { await summaryState.handleStopGeneration(); });
+    expect(invoke.mock.calls.find(([command]) => command === 'api_cancel_summary')?.[1]?.processId).toBe('attempt-b');
+    expect(timers.size).toBe(0);
+  });
+});

--- a/frontend/tests/hooks/paginated-transcripts.test.tsx
+++ b/frontend/tests/hooks/paginated-transcripts.test.tsx
@@ -1,0 +1,158 @@
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import type { MeetingMetadata, PaginatedTranscriptsResponse } from '../../src/types';
+
+const originalCore = { ...await import('@tauri-apps/api/core') };
+type Request = {
+  command: string;
+  args: Record<string, unknown>;
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+};
+const requests: Request[] = [];
+const invoke = mock((command: string, args: Record<string, unknown>) => new Promise((resolve, reject) => {
+  requests.push({ command, args, resolve, reject });
+}));
+mock.module('@tauri-apps/api/core', () => ({ ...originalCore, invoke }));
+const { usePaginatedTranscripts } = await import('../../src/hooks/usePaginatedTranscripts');
+afterAll(() => mock.module('@tauri-apps/api/core', () => originalCore));
+
+let state: ReturnType<typeof usePaginatedTranscripts>;
+let renderer: ReactTestRenderer | undefined;
+function View({ meetingId }: { meetingId: string | null }) {
+  state = usePaginatedTranscripts({ meetingId });
+  return <output>{state.metadata?.id}:{state.transcripts.map(t => t.text).join(',')}</output>;
+}
+beforeEach(() => {
+  requests.length = 0;
+  invoke.mockClear();
+  mock.module('@tauri-apps/api/core', () => ({ ...originalCore, invoke }));
+});
+afterEach(async () => {
+  if (renderer) await act(async () => renderer!.unmount());
+  renderer = undefined;
+});
+async function show(meetingId: string | null) {
+  await act(async () => {
+    if (renderer) renderer.update(<View meetingId={meetingId} />);
+    else renderer = create(<View meetingId={meetingId} />);
+  });
+}
+function request(command: 'metadata' | 'transcripts', meetingId: string, index = 0) {
+  const result = requests.filter(r => r.command === `api_get_meeting_${command}` && r.args.meetingId === meetingId)[index];
+  expect(result).toBeDefined();
+  return result;
+}
+const metadata = (id: string): MeetingMetadata => ({ id, title: id, created_at: '2026-09-07', updated_at: '2026-09-07' });
+const page = (text: string, hasMore = false): PaginatedTranscriptsResponse => ({
+  transcripts: [{ id: text, text, timestamp: '00:00', audio_start_time: 0 }],
+  total_count: hasMore ? 2 : 1, has_more: hasMore,
+});
+async function resolve(req: Request, value: unknown) {
+  await act(async () => { req.resolve(value); });
+}
+async function load(meetingId: string, hasMore = false) {
+  await show(meetingId);
+  await resolve(request('metadata', meetingId), metadata(meetingId));
+  await resolve(request('transcripts', meetingId), page(meetingId, hasMore));
+}
+
+describe('paginated transcript request ownership', () => {
+  test('ignores late A metadata after B finishes and does not start A transcripts', async () => {
+    await show('A');
+    const stale = request('metadata', 'A');
+    await load('B');
+    await resolve(stale, metadata('A'));
+    expect(state.metadata?.id).toBe('B');
+    expect(state.transcripts[0].text).toBe('B');
+    expect(state.isLoading).toBe(false);
+    expect(requests.filter(r => r.command === 'api_get_meeting_transcripts' && r.args.meetingId === 'A')).toHaveLength(0);
+  });
+
+  test('late A transcripts cannot replace B or finish its loading state', async () => {
+    await show('A');
+    await resolve(request('metadata', 'A'), metadata('A'));
+    const stale = request('transcripts', 'A');
+    await show('B');
+    await resolve(stale, page('A'));
+    expect(state.isLoading).toBe(true);
+    expect(state.transcripts).toEqual([]);
+    await resolve(request('metadata', 'B'), metadata('B'));
+    await resolve(request('transcripts', 'B'), page('B'));
+    expect(state.metadata?.id).toBe('B');
+    expect(state.transcripts[0].text).toBe('B');
+  });
+
+  test('returning A to B to A does not revive the first A request', async () => {
+    await show('A');
+    const stale = request('metadata', 'A');
+    await show('B');
+    await show('A');
+    await resolve(request('metadata', 'A', 1), { ...metadata('A'), title: 'Current A' });
+    await resolve(request('transcripts', 'A'), page('Current A'));
+    await resolve(stale, { ...metadata('A'), title: 'Old A' });
+    expect(state.metadata?.title).toBe('Current A');
+    expect(state.transcripts[0].text).toBe('Current A');
+    expect(state.isLoading).toBe(false);
+    expect(requests.filter(r => r.command === 'api_get_meeting_transcripts' && r.args.meetingId === 'A')).toHaveLength(1);
+  });
+
+  test('a stale failure cannot add an error or clear current loading', async () => {
+    await show('A');
+    const stale = request('metadata', 'A');
+    await show('B');
+    await act(async () => { stale.reject(new Error('A unavailable')); });
+    expect(state.error).toBeNull();
+    expect(state.isLoading).toBe(true);
+  });
+
+  test('newest refetch wins over an earlier request for the same meeting', async () => {
+    await load('A');
+    await act(async () => { void state.refetch(); });
+    await resolve(request('metadata', 'A', 1), metadata('A'));
+    const stale = request('transcripts', 'A', 1);
+    await act(async () => { void state.refetch(); });
+    await resolve(request('metadata', 'A', 2), metadata('A'));
+    await resolve(request('transcripts', 'A', 2), page('newest'));
+    await resolve(stale, page('stale'));
+    expect(state.transcripts[0].text).toBe('newest');
+    expect(state.isLoading).toBe(false);
+  });
+
+  test('old loadMore cannot append data or clear the next meeting loadMore lock', async () => {
+    await load('A', true);
+    await act(async () => { void state.loadMore(); });
+    const stale = request('transcripts', 'A', 1);
+    await load('B', true);
+    await act(async () => { void state.loadMore(); });
+    const current = request('transcripts', 'B', 1);
+    await resolve(stale, page('old extra'));
+    expect(state.isLoadingMore).toBe(true);
+    expect(state.transcripts.map(t => t.text)).toEqual(['B']);
+    await resolve(current, page('B extra'));
+    expect(state.isLoadingMore).toBe(false);
+    expect(state.transcripts.map(t => t.text)).toEqual(['B', 'B extra']);
+  });
+
+  test('reset invalidates pending reads and null to same meeting reloads', async () => {
+    await show('A');
+    const stale = request('metadata', 'A');
+    await act(async () => { state.reset(); });
+    await resolve(stale, metadata('A'));
+    expect(state.metadata).toBeNull();
+    await show(null);
+    await show('A');
+    await resolve(request('metadata', 'A', 1), metadata('A'));
+    await resolve(request('transcripts', 'A'), page('fresh'));
+    expect(state.transcripts[0].text).toBe('fresh');
+  });
+
+  test('unmount prevents a pending metadata read from starting transcript IPC', async () => {
+    await show('A');
+    const stale = request('metadata', 'A');
+    await act(async () => { renderer!.unmount(); });
+    renderer = undefined;
+    await resolve(stale, metadata('A'));
+    expect(requests).toHaveLength(1);
+  });
+});

--- a/frontend/tests/hooks/summary-generation.test.tsx
+++ b/frontend/tests/hooks/summary-generation.test.tsx
@@ -1,0 +1,229 @@
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { useState } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { parseSummaryContent } from '../../src/lib/summary-content';
+import type { MeetingSummary, SummaryProcessResponse } from '../../src/types';
+
+// Bun shares module mocks between test files; restore application modules after this suite.
+const originalAnalytics = { ...await import('../../src/lib/analytics') };
+const originalPreferences = { ...await import('../../src/lib/summary-language-preferences') };
+const originalToast = { ...await import('sonner') };
+afterAll(() => {
+  mock.module('../../src/lib/analytics', () => originalAnalytics);
+  mock.module('../../src/lib/summary-language-preferences', () => originalPreferences);
+  mock.module('sonner', () => originalToast);
+});
+
+mock.module('next/navigation', () => ({ usePathname: () => '/meeting-details', useRouter: () => ({}) }));
+mock.module('../../src/contexts/RecordingStateContext', () => ({ useRecordingState: () => ({ isRecording: false }) }));
+const notify = mock(() => {});
+mock.module('sonner', () => ({ toast: { info: notify, error: notify, success: notify, warning: notify } }));
+const trackCompletion = mock(async () => {});
+mock.module('../../src/lib/analytics', () => ({ default: {
+  trackBackendConnection() {}, trackSummaryGenerationStarted: async () => {},
+  trackSummaryGenerationCompleted: trackCompletion,
+} }));
+let startProcess: () => Promise<{ process_id: string }>;
+let getSummary: (meetingId: string) => Promise<SummaryProcessResponse>;
+const invoke = mock(async (command: string, args?: Record<string, unknown>): Promise<unknown> => {
+  if (command === 'api_get_meetings') return [];
+  if (command === 'api_get_summary') return getSummary(args!.meetingId as string);
+  if (command === 'api_get_meeting_transcripts') return { transcripts: [{ text: 'Meeting transcript', timestamp: '00:00' }], total_count: 1 };
+  if (command === 'get_ollama_models') return [{ name: 'test' }];
+  if (command === 'api_process_transcript') return startProcess();
+  if (command === 'api_cancel_summary') return { cancelled: true };
+  throw new Error(`Unexpected command: ${command}`);
+});
+mock.module('@tauri-apps/api/core', () => ({ invoke }));
+mock.module('../../src/lib/summary-language-preferences', () => ({
+  readCachedDetectedSummaryLanguage: async () => null,
+  detectAndCacheSummaryLanguage: async () => ({ language: 'en' }),
+  readMeetingSummaryLanguage: async () => ({ language: 'en', storage: 'metadata' }),
+}));
+const { SidebarProvider } = await import('../../src/components/Sidebar/SidebarProvider');
+const { useSummaryGeneration } = await import('../../src/hooks/meeting-details/useSummaryGeneration');
+
+const response = (overrides: Partial<SummaryProcessResponse> = {}): SummaryProcessResponse => ({
+  meeting_id: 'meeting-a', status: 'pending', start: 'attempt-a', end: null,
+  data: null, error: null, meetingName: 'Meeting A', ...overrides,
+});
+let configuredModel = 'test';
+let state: ReturnType<typeof useSummaryGeneration>;
+function Status({ initialSummary, meetingId = 'meeting-a' }: {
+  initialSummary: SummaryProcessResponse; meetingId?: string;
+}) {
+  const [summary, setAiSummary] = useState<MeetingSummary | null>(() => parseSummaryContent(initialSummary.data));
+  const [title, updateMeetingTitle] = useState('Original title');
+  state = useSummaryGeneration({
+    meeting: { id: meetingId, created_at: '2026-09-01T00:00:00Z' },
+    transcripts: [], modelConfig: { provider: 'ollama', model: configuredModel, whisperModel: 'base' },
+    isModelConfigLoading: false, selectedTemplate: 'daily_standup',
+    setAiSummary, updateMeetingTitle, initialSummary,
+  });
+  return <output>{state.summaryStatus}:{state.summaryError}:{title}:{JSON.stringify(summary)}</output>;
+}
+
+let renderer: ReactTestRenderer;
+const timers = new Map<number, () => Promise<void>>();
+let nextTimer = 0;
+const realSetInterval = globalThis.setInterval;
+const realClearInterval = globalThis.clearInterval;
+beforeEach(() => {
+  renderer = undefined as unknown as ReactTestRenderer;
+  configuredModel = 'test';
+  timers.clear(); notify.mockClear(); trackCompletion.mockClear(); invoke.mockClear();
+  getSummary = async () => response();
+  startProcess = async () => ({ process_id: 'attempt-a' });
+  globalThis.setInterval = ((callback: () => Promise<void>) => {
+    const id = ++nextTimer; timers.set(id, callback); return id;
+  }) as typeof setInterval;
+  globalThis.clearInterval = ((id: number) => { timers.delete(id); }) as typeof clearInterval;
+});
+afterEach(async () => {
+  if (renderer) await act(async () => renderer.unmount());
+  globalThis.setInterval = realSetInterval;
+  globalThis.clearInterval = realClearInterval;
+});
+async function show(initialSummary: SummaryProcessResponse | null, meetingId = 'meeting-a') {
+  await act(async () => {
+    const view = <SidebarProvider>{initialSummary && <Status key={meetingId} initialSummary={initialSummary} meetingId={meetingId} />}</SidebarProvider>;
+    if (renderer) renderer.update(view); else renderer = create(view);
+  });
+}
+const text = () => JSON.stringify(renderer.toJSON());
+async function tick() {
+  await act(async () => { for (const callback of [...timers.values()]) callback(); });
+}
+
+describe('summary state restored when returning to a meeting', () => {
+  test('resumes pending generation after leaving and returning, then displays completion', async () => {
+    await show(response());
+    expect(text()).toContain('processing');
+    await show(null);
+    expect(timers.size).toBe(0);
+    await show(response());
+    expect(text()).toContain('processing');
+    getSummary = async () => response({ status: 'completed', data: { markdown: 'Finished summary' }, meetingName: 'New title' });
+    await tick();
+    expect(text()).toContain('completed');
+    expect(text()).toContain('Finished summary');
+    expect(text()).toContain('New title');
+    expect(timers.size).toBe(0);
+  });
+
+  test('keeps regeneration loading with old content and restores content on failure', async () => {
+    await show(response({ data: { markdown: 'Previous summary' } }));
+    expect(text()).toContain('processing');
+    getSummary = async () => response({ status: 'failed', error: 'Model unavailable', data: { markdown: 'Previous summary' } });
+    await tick();
+    expect(text()).toContain('completed');
+    expect(text()).toContain('Previous summary');
+  });
+
+  test('shows a failure that happened while the meeting was closed', async () => {
+    await show(response({ status: 'failed', error: 'Model unavailable' }));
+    expect(text()).toContain('error');
+    expect(text()).toContain('Model unavailable');
+    expect(timers.size).toBe(0);
+  });
+
+  test('keeps restored notes and exposes a regeneration failure that happened while away', async () => {
+    await show(response({ status: 'failed', error: 'Model unavailable', data: { markdown: 'Previous summary' } }));
+    expect(state.summaryStatus).toBe('error');
+    expect(text()).toContain('Model unavailable');
+    expect(text()).toContain('Previous summary');
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  test('ordinary rerenders keep the existing poll attached', async () => {
+    const initial = response();
+    await show(initial);
+    const timer = [...timers.keys()][0];
+    await show(initial);
+    expect([...timers.keys()]).toEqual([timer]);
+    getSummary = async () => response({ status: 'completed', data: { markdown: 'Finished summary' } });
+    await tick();
+    expect(state.summaryStatus).toBe('completed');
+  });
+
+  test('hydrates completed and cancelled records without replaying notifications or analytics', async () => {
+    await show(response({ status: 'completed', data: { markdown: 'Finished while away' } }));
+    expect(state.summaryStatus).toBe('completed');
+    expect(text()).toContain('Finished while away');
+    await show(null);
+    await show(response({ status: 'cancelled', data: { markdown: 'Restored summary' } }));
+    expect(state.summaryStatus).toBe('completed');
+    expect(text()).toContain('Restored summary');
+    expect(timers.size).toBe(0);
+    expect(notify).not.toHaveBeenCalled();
+    expect(trackCompletion).not.toHaveBeenCalled();
+  });
+
+  test('ignores a response belonging to another meeting', async () => {
+    await show(response({ meeting_id: 'meeting-b' }));
+    expect(state.summaryStatus).toBe('idle');
+    expect(timers.size).toBe(0);
+  });
+
+  test('Stop uses the restored process token', async () => {
+    await show(response());
+    await act(async () => state.handleStopGeneration());
+    expect(invoke.mock.calls).toContainEqual(['api_cancel_summary', { meetingId: 'meeting-a', processId: 'attempt-a' }]);
+    expect(state.summaryStatus).toBe('idle');
+    expect(timers.size).toBe(0);
+  });
+
+  test('a late completion from meeting A cannot change meeting B', async () => {
+    let resolve!: (value: SummaryProcessResponse) => void;
+    getSummary = () => new Promise(done => { resolve = done; });
+    await show(response());
+    await tick();
+    await show(response({ meeting_id: 'meeting-b', status: 'idle', start: null }), 'meeting-b');
+    await act(async () => resolve(response({ status: 'completed', data: { markdown: 'Wrong meeting' } })));
+    expect(state.summaryStatus).toBe('idle');
+    expect(text()).not.toContain('Wrong meeting');
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  test('leaving before the start response arrives keeps the backend job running for a later visit', async () => {
+    let resolve!: (value: { process_id: string }) => void;
+    startProcess = () => new Promise(done => { resolve = done; });
+    await show(response({ status: 'idle', start: null }));
+    let generation!: Promise<void>;
+    await act(async () => { generation = state.handleGenerateSummary(); });
+    await show(null);
+    await act(async () => { resolve({ process_id: 'attempt-a' }); await generation; });
+    expect(invoke.mock.calls.filter(([command]) => command === 'api_cancel_summary')).toEqual([]);
+    expect(timers.size).toBe(0);
+    await show(response());
+    expect(state.summaryStatus).toBe('processing');
+    getSummary = async () => response({ status: 'completed', data: { markdown: 'Finished summary' } });
+    await tick();
+    expect(state.summaryStatus).toBe('completed');
+  });
+
+  test('completion analytics retain the model used to start the attempt after settings change', async () => {
+    const initial = response({ status: 'idle', start: null });
+    await show(initial);
+    await act(async () => state.handleGenerateSummary());
+    configuredModel = 'different-model';
+    await show(initial);
+    getSummary = async () => response({ status: 'completed', data: { markdown: 'Finished summary' } });
+    await tick();
+    expect(trackCompletion.mock.calls[0]?.slice(0, 3)).toEqual(['ollama', 'test', true]);
+  });
+
+  test('old in-flight poll cannot stop a resumed poll for the same process', async () => {
+    let resolve!: (value: SummaryProcessResponse) => void;
+    getSummary = () => new Promise(done => { resolve = done; });
+    await show(response());
+    await tick();
+    await show(null);
+    await show(response());
+    await act(async () => resolve(response({ status: 'completed', data: { markdown: 'Finished summary' } })));
+    getSummary = async () => response({ status: 'completed', data: { markdown: 'Finished summary' } });
+    await tick();
+    expect(state.summaryStatus).toBe('completed');
+    expect(text()).toContain('Finished summary');
+  });
+});

--- a/frontend/tests/hooks/summary-generation.test.tsx
+++ b/frontend/tests/hooks/summary-generation.test.tsx
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { act, create, type ReactTestRenderer } from 'react-test-renderer';
 import { parseSummaryContent } from '../../src/lib/summary-content';
 import type { MeetingSummary, SummaryProcessResponse } from '../../src/types';
@@ -40,7 +40,7 @@ mock.module('../../src/lib/summary-language-preferences', () => ({
   detectAndCacheSummaryLanguage: async () => ({ language: 'en' }),
   readMeetingSummaryLanguage: async () => ({ language: 'en', storage: 'metadata' }),
 }));
-const { SidebarProvider } = await import('../../src/components/Sidebar/SidebarProvider');
+const { SidebarProvider, useSidebar } = await import('../../src/components/Sidebar/SidebarProvider');
 const { useSummaryGeneration } = await import('../../src/hooks/meeting-details/useSummaryGeneration');
 
 const response = (overrides: Partial<SummaryProcessResponse> = {}): SummaryProcessResponse => ({
@@ -96,6 +96,50 @@ async function tick() {
 }
 
 describe('summary state restored when returning to a meeting', () => {
+  test('repeated recovery read failures end regeneration and retain visible notes', async () => {
+    await show(response({ data: { markdown: 'Previous summary' } }));
+    getSummary = async () => { throw new Error('Database unavailable'); };
+    await tick();
+    expect(state.summaryStatus).toBe('error');
+    expect(state.summaryError).toContain('Database unavailable');
+    expect(text()).toContain('Previous summary');
+    expect(timers.size).toBe(0);
+  });
+
+  test('failed cancellation recovery ends loading without discarding visible notes', async () => {
+    await show(response({ data: { markdown: 'Previous summary' } }));
+    let reads = 0;
+    getSummary = async () => {
+      if (++reads === 1) return response({ status: 'cancelled' });
+      throw new Error('Database unavailable');
+    };
+    await tick();
+    expect(state.summaryStatus).toBe('error');
+    expect(text()).toContain('Previous summary');
+    expect(timers.size).toBe(0);
+  });
+
+  test.each(['read', 'callback'])('polling stops when %s fails and its error callback also rejects', async (failure) => {
+    function RejectingConsumer() {
+      const { startSummaryPolling } = useSidebar();
+      useEffect(() => {
+        startSummaryPolling('meeting-a', 'attempt-a', async () => {
+          throw new Error('Consumer failed');
+        });
+      }, [startSummaryPolling]);
+      return null;
+    }
+    await act(async () => {
+      renderer = create(<SidebarProvider><RejectingConsumer /></SidebarProvider>);
+    });
+    getSummary = async () => {
+      if (failure === 'read') throw new Error('Database unavailable');
+      return response({ status: 'completed', data: { markdown: 'Finished summary' } });
+    };
+    await tick();
+    expect(timers.size).toBe(0);
+  });
+
   test('resumes pending generation after leaving and returning, then displays completion', async () => {
     await show(response());
     expect(text()).toContain('processing');


### PR DESCRIPTION
## Description

Fix three recording and summary issues:

- Add a microphone callback check to both macOS recording-start paths. A failed probe prevents recording from starting and returns an error to the existing UI.
- Restore summary generation status and reconnect polling when returning to a meeting. Preserve regeneration and cancellation behavior, prevent stale responses from affecting another meeting or a newly resumed poll, and avoid replaying historical completion notifications.
- Remove the homepage entrance animation whose transform changed the fixed recording controls' positioning reference and caused the Start button to jump.

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] All tests pass

`bun test tests`: 29 passed, 0 failed, including 12 React lifecycle regression tests with mocked IPC. Application-source TypeScript checking and scoped diff checks pass.

`cargo check --locked --offline` is blocked by a missing generated Tauri permissions file (`app_hide.toml`) referenced through a stale build-cache path from an old checkout. Rust compilation and native desktop behavior are not verified. Full TypeScript checking also encounters missing `bun:test` declarations in the existing test setup; the passing check covers application sources.

### Manual test cases

| Case | Steps | Expected result |
| --- | --- | --- |
| Fresh microphone permission (macOS) | Quit Meetily. Run `tccutil reset Microphone com.meetily.ai` to remove its microphone permission entry completely; disabling the toggle is insufficient. Reopen the app, start recording, and allow access when prompted. | macOS requests microphone access, and recording starts with microphone audio after access is allowed. |
| Summary progress after navigation | Generate a summary, navigate away, and return while generation is active; wait for completion. Repeat when regenerating an existing summary. | Loading remains visible after returning, the summary updates on completion, and existing content is preserved during regeneration. |
| Stop summary after navigation | Start summary generation, navigate away and back, then select Stop. | The active generation is cancelled and the loading state clears. |
| Home recording controls | Repeatedly navigate to Home with the sidebar expanded and collapsed, then start and stop a recording. | The Start button does not jump when Home opens, and recording controls remain usable. |

## Documentation

- [x] No documentation needed

## Checklist

- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Additional Notes

The microphone check intentionally uses the default input device and accepts the first callback without inspecting sample content. System-audio silence detection is outside this PR. The summary navigation issue and homepage animation issue predate the microphone change.

The test renderer and its types are development-only dependencies; existing dependency resolutions are unchanged. No screenshots were captured.
