### PR TITLE
fix(vad): surface final VAD flush and transcription-send failures (#775)

### DIFF
--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -919,11 +919,11 @@ impl AudioPipeline {
                             device_type: DeviceType::Microphone,
                         };
 
-                        if let Err(e) = self.transcription_sender.send(transcription_chunk) {
-                            warn!("Failed to send final VAD segment: {}", e);
-                        } else {
-                            self.chunk_id_counter += 1;
-                        }
+                        // A failed send means the transcript is incomplete: surface it so the
+                        // recording manager can flag the meeting rather than silently continue.
+                        self.transcription_sender.send(transcription_chunk)
+                            .map_err(|e| anyhow::anyhow!("failed to send final VAD segment: {}", e))?;
+                        self.chunk_id_counter += 1;
                     } else {
                         info!("⏭️ Skipping short final segment: {:.1}ms ({} samples < 800)",
                               duration_ms, segment.samples.len());
@@ -931,7 +931,10 @@ impl AudioPipeline {
                 }
             }
             Err(e) => {
+                // A VAD flush failure also leaves the transcript incomplete: propagate it
+                // instead of logging and continuing to report a clean flush.
                 warn!("Failed to flush VAD processor: {}", e);
+                return Err(e);
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes the reliability gap identified in the #679 VAD follow-up review: the forced final flush silently reports success when the VAD processor errors, or when the transcription consumer has exited and the final segment send fails. This hides an incomplete transcript and marks a truncated meeting as clean. Relates to #775.

## Change

In `flush_remaining_audio`:

- A failed final-segment `transcription_sender.send(...)` now propagates as an error instead of logging a warning and continuing.
- A failed VAD `flush()` now returns `Err` instead of logging and returning `Ok`.

Both failures now reach the recording workflow so it can flag the meeting as incomplete and recoverable from the saved audio.

## Test evidence

`cargo check --lib` passes on the branch (no warnings from this change). Full application runtime was not exercised; the two error paths are verified by source inspection as the review thread described.

## Notes

The forced-final-segment truncation (the timestamp/prefix part of the original review) is being handled separately in #771/#773; this PR is scoped to surfacing flush and send failures only (#775).
