### PR TITLE
feat(import): explain speech without usable transcript

### DIFF
--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -622,6 +622,11 @@ async fn run_import<R: Runtime>(
         transcribed_count, processable_count, avg_confidence
     );
 
+    if let Some(warning) = empty_asr_warning(total_segments, transcribed_count) {
+        warn!("{}", warning.warning);
+        let _ = app.emit("import-warning", warning);
+    }
+
     // Check for cancellation
     if IMPORT_CANCELLED.load(Ordering::SeqCst) {
         let _ = std::fs::remove_dir_all(&meeting_folder);
@@ -672,6 +677,19 @@ async fn run_import<R: Runtime>(
         segments_count: segments.len(),
         duration_seconds,
     })
+}
+
+fn empty_asr_warning(total_segments: usize, transcribed_count: usize) -> Option<ImportWarning> {
+    if total_segments > 0 && transcribed_count == 0 {
+        return Some(ImportWarning {
+            warning: "Speech detected, but no transcribable text was produced".to_string(),
+            details: Some(
+                "The audio was imported successfully without transcript text. Check the selected model or try retranscription with another model.".to_string(),
+            ),
+        });
+    }
+
+    None
 }
 
 /// Emit progress event
@@ -1015,6 +1033,23 @@ mod tests {
         assert!(AUDIO_EXTENSIONS.contains(&"wav"));
         assert!(AUDIO_EXTENSIONS.contains(&"mp3"));
         assert!(!AUDIO_EXTENSIONS.contains(&"txt"));
+    }
+
+    #[test]
+    fn test_empty_asr_warning_requires_detected_speech() {
+        let warning = empty_asr_warning(2, 0).expect("speech with no text should warn");
+
+        assert_eq!(
+            warning.warning,
+            "Speech detected, but no transcribable text was produced"
+        );
+        assert!(warning.details.is_some());
+    }
+
+    #[test]
+    fn test_empty_asr_warning_is_absent_for_usable_or_silent_imports() {
+        assert!(empty_asr_warning(2, 1).is_none());
+        assert!(empty_asr_warning(0, 0).is_none());
     }
 
     #[test]

--- a/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
+++ b/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
@@ -113,6 +113,7 @@ export function ImportAudioDialog({
     fileInfo,
     progress,
     error,
+    warning,
     isProcessing,
     isBusy,
     selectFile,
@@ -265,6 +266,13 @@ export function ImportAudioDialog({
         </DialogHeader>
 
         <div className="space-y-4 py-4">
+          {warning && !isProcessing && !error && (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900" role="status">
+              <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600" />
+              <span>{warning}</span>
+            </div>
+          )}
+
           {/* File selection / info */}
           {!isProcessing && !error && (
             <>

--- a/frontend/src/hooks/useImportAudio.ts
+++ b/frontend/src/hooks/useImportAudio.ts
@@ -30,6 +30,11 @@ export interface ImportError {
   error: string;
 }
 
+export interface ImportWarning {
+  warning: string;
+  details?: string | null;
+}
+
 export type ImportStatus = 'idle' | 'validating' | 'processing' | 'complete' | 'error';
 
 export interface UseImportAudioOptions {
@@ -42,6 +47,7 @@ export interface UseImportAudioReturn {
   fileInfo: AudioFileInfo | null;
   progress: ImportProgress | null;
   error: string | null;
+  warning: string | null;
   isProcessing: boolean;
   isBusy: boolean;
   selectFile: () => Promise<AudioFileInfo | null>;
@@ -65,6 +71,7 @@ export function useImportAudio({
   const [fileInfo, setFileInfo] = useState<AudioFileInfo | null>(null);
   const [progress, setProgress] = useState<ImportProgress | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
 
   // Stable refs for callbacks to avoid listener re-registration on every render
   const onCompleteRef = useRef(onComplete);
@@ -96,6 +103,30 @@ export function useImportAudio({
       }
       unlisteners.push(unlistenProgress);
 
+      // Non-fatal outcome warning (for example, speech detected but no usable
+      // ASR text). Keep the import successful while making the distinction
+      // visible to both the dialog and the toast notification.
+      const unlistenWarning = await listen<ImportWarning>(
+        'import-warning',
+        (event) => {
+          if (isCancelledRef.current) return;
+
+          const message = event.payload.details
+            ? `${event.payload.warning}: ${event.payload.details}`
+            : event.payload.warning;
+          setWarning(message);
+          toast.warning(event.payload.warning, {
+            description: event.payload.details || undefined,
+          });
+        }
+      );
+      if (cleanedUpRef.current) {
+        unlistenWarning();
+        unlisteners.forEach(u => u());
+        return;
+      }
+      unlisteners.push(unlistenWarning);
+
       // Completion event
       const unlistenComplete = await listen<ImportResult>(
         'import-complete',
@@ -105,7 +136,8 @@ export function useImportAudio({
           await Analytics.track('import_audio_completed', {
             success: 'true',
             duration_seconds: event.payload.duration_seconds.toString(),
-            segments_count: event.payload.segments_count.toString()
+            segments_count: event.payload.segments_count.toString(),
+            transcript_status: event.payload.segments_count > 0 ? 'available' : 'none',
           });
 
           setStatus('complete');
@@ -213,6 +245,7 @@ export function useImportAudio({
       isCancelledRef.current = false;
       setStatus('processing');
       setError(null);
+      setWarning(null);
       setProgress(null);
 
       try {
@@ -265,6 +298,7 @@ export function useImportAudio({
     setFileInfo(null);
     setProgress(null);
     setError(null);
+    setWarning(null);
   }, []);
 
   return {
@@ -272,6 +306,7 @@ export function useImportAudio({
     fileInfo,
     progress,
     error,
+    warning,
     isProcessing: status === 'processing',
     isBusy: status === 'processing' || status === 'validating',
     selectFile,


### PR DESCRIPTION
## Summary

Import already distinguishes no VAD speech from a successful import, but an import where VAD found speech and every ASR result is empty still reports an unqualified completion. The UI also had no listener for the existing `import-warning` event.

This change emits a non-fatal warning for speech with no usable transcript, surfaces it through `useImportAudio`, shows it in the import dialog, and keeps the audio-only import successful. Imports with usable text and silent imports keep their existing behavior.

## Related issue

Fixes #774

## Validation

- `bun test` — 45 passed, 0 failed across 10 files.
- `tsc --noEmit --project tsconfig.audit.json` (production `src/**/*.ts{,x}` scope) — no errors.
- `pnpm run build` — compiled successfully and generated all 11 static pages.
- `cargo test -p meetily --lib audio::import` — 16 passed, 1 ignored.
- `git diff --check` — passed.

The focused Rust tests used the repository's temporary ignored native helper placeholder because the sidecar is not checked in; it was removed after validation. No dependency or lockfile changes were made.
