### PR TITLE
fix(audio): drain capture and mixer tails before VAD

### DIFF
--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -153,6 +153,22 @@ impl AudioMixerRingBuffer {
         Some((mic_window, sys_window))
     }
 
+    /// Drain the final, incomplete timeline without padding it to a regular
+    /// mixing window.  The last mixed interval is the longer of the two input
+    /// tails; only the shorter source is padded with silence.
+    fn drain_tail(&mut self) -> Option<(Vec<f32>, Vec<f32>)> {
+        let tail_len = self.mic_buffer.len().max(self.system_buffer.len());
+        if tail_len == 0 {
+            return None;
+        }
+
+        let mut mic_tail: Vec<f32> = self.mic_buffer.drain(..).collect();
+        let mut system_tail: Vec<f32> = self.system_buffer.drain(..).collect();
+        mic_tail.resize(tail_len, 0.0);
+        system_tail.resize(tail_len, 0.0);
+        Some((mic_tail, system_tail))
+    }
+
 }
 
 /// Simple audio mixer without aggressive ducking
@@ -657,6 +673,65 @@ impl AudioCapture {
         }
     }
 
+    /// Flush input held by the persistent resampler when a stream stops.
+    ///
+    /// Rubato requires a complete input block, so the final partial block is
+    /// padded only for the resampler call and the output is trimmed to the
+    /// duration represented by real input samples. This keeps synthetic
+    /// padding and filter delay out of the recording timeline.
+    pub fn flush_pending_resampler(&self) {
+        if !self.needs_resampling {
+            return;
+        }
+
+        let pending = if let Ok(mut buffer) = self.resampler_input_buffer.lock() {
+            std::mem::take(&mut *buffer)
+        } else {
+            warn!("Unable to lock resampler input buffer during stream flush");
+            return;
+        };
+        if pending.is_empty() {
+            return;
+        }
+
+        let expected_output = ((pending.len() as f64 * 48_000.0) / self.sample_rate as f64)
+            .round() as usize;
+        let mut padded = pending;
+        padded.resize(self.resampler_chunk_size, 0.0);
+
+        let mut output = Vec::new();
+        if let Ok(mut resampler) = self.resampler.lock() {
+            if let Some(resampler) = resampler.as_mut() {
+                match resampler.process(&vec![padded], None) {
+                    Ok(mut waves) => {
+                        if let Some(samples) = waves.pop() {
+                            output = samples;
+                        }
+                    }
+                    Err(error) => warn!("Failed to flush persistent resampler: {}", error),
+                }
+            }
+        }
+
+        output.truncate(expected_output.min(output.len()));
+        if output.is_empty() {
+            return;
+        }
+
+        let chunk_id = self.chunk_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let timestamp = self.state.get_recording_duration().unwrap_or(0.0);
+        let chunk = AudioChunk {
+            data: output,
+            sample_rate: 48_000,
+            timestamp,
+            chunk_id,
+            device_type: self.device_type.clone(),
+        };
+        if let Err(error) = self.state.send_audio_chunk(chunk) {
+            warn!("Failed to send flushed resampler tail: {}", error);
+        }
+    }
+
     /// Handle stream errors with enhanced disconnect detection
     pub fn handle_stream_error(&self, error: cpal::StreamError) {
         error!("Audio stream error for {}: {}", self.device.name, error);
@@ -844,63 +919,10 @@ impl AudioPipeline {
                     // System audio remains raw
                     self.ring_buffer.add_samples(chunk.device_type.clone(), chunk.data);
 
-                    // STEP 2: Mix audio in fixed windows when both streams have sufficient data
+                    // STEP 2: Mix audio in fixed windows as data becomes available
                     while self.ring_buffer.can_mix() {
                         if let Some((mic_window, sys_window)) = self.ring_buffer.extract_window() {
-                            // Simple mixing without aggressive ducking
-                            let mixed_clean = self.mixer.mix_window(&mic_window, &sys_window);
-
-                            // NO POST-GAIN NEEDED: Microphone already normalized by EBU R128 to -23 LUFS
-                            // This is broadcast-standard loudness (Netflix/YouTube/Spotify level)
-                            // System audio at natural levels
-                            // Previous 2x gain was causing excessive limiting/distortion
-                            let mixed_with_gain = mixed_clean;
-
-                            // STEP 3: Send mixed audio for transcription (VAD + Whisper)
-                            match self.vad_processor.process_audio(&mixed_with_gain) {
-                                Ok(speech_segments) => {
-                                    for segment in speech_segments {
-                                        let duration_ms = segment.end_timestamp_ms - segment.start_timestamp_ms;
-
-                                        if segment.samples.len() >= 800 {  // Minimum 50ms at 16kHz - matches Parakeet capability
-                                            info!("📤 Sending VAD segment: {:.1}ms, {} samples",
-                                                  duration_ms, segment.samples.len());
-
-                                            let transcription_chunk = AudioChunk {
-                                                data: segment.samples,
-                                                sample_rate: 16000,
-                                                timestamp: segment.start_timestamp_ms / 1000.0,
-                                                chunk_id: self.chunk_id_counter,
-                                                device_type: DeviceType::Microphone,  // Mixed audio
-                                            };
-
-                                            if let Err(e) = self.transcription_sender.send(transcription_chunk) {
-                                                warn!("Failed to send VAD segment: {}", e);
-                                            } else {
-                                                self.chunk_id_counter += 1;
-                                            }
-                                        } else {
-                                            debug!("⏭️ Dropping short VAD segment: {:.1}ms ({} samples < 800)",
-                                                   duration_ms, segment.samples.len());
-                                        }
-                                    }
-                                }
-                                Err(e) => {
-                                    warn!("⚠️ VAD error: {}", e);
-                                }
-                            }
-
-                            // STEP 4: Send mixed audio for recording (WAV file)
-                            if let Some(ref sender) = self.recording_sender_for_mixed {
-                                let recording_chunk = AudioChunk {
-                                    data: mixed_with_gain.clone(),
-                                    sample_rate: self.sample_rate,
-                                    timestamp: chunk.timestamp,
-                                    chunk_id: self.chunk_id_counter,
-                                    device_type: DeviceType::Microphone,  // Mixed audio
-                                };
-                                let _ = sender.send(recording_chunk);
-                            }
+                            self.dispatch_mixed_window(mic_window, sys_window, chunk.timestamp);
                         }
                     }
                 }
@@ -922,8 +944,71 @@ impl AudioPipeline {
         Ok(())
     }
 
+    fn dispatch_mixed_window(&mut self, mic_window: Vec<f32>, sys_window: Vec<f32>, timestamp: f64) {
+        // Keep normal and terminal paths identical: every mixed window is
+        // delivered once to VAD and once to the recording saver.
+        let mixed_with_gain = self.mixer.mix_window(&mic_window, &sys_window);
+
+        match self.vad_processor.process_audio(&mixed_with_gain) {
+            Ok(speech_segments) => {
+                for segment in speech_segments {
+                    let duration_ms = segment.end_timestamp_ms - segment.start_timestamp_ms;
+                    if segment.samples.len() >= 800 {
+                        info!("📤 Sending VAD segment: {:.1}ms, {} samples",
+                              duration_ms, segment.samples.len());
+                        let transcription_chunk = AudioChunk {
+                            data: segment.samples,
+                            sample_rate: 16000,
+                            timestamp: segment.start_timestamp_ms / 1000.0,
+                            chunk_id: self.chunk_id_counter,
+                            device_type: DeviceType::Microphone,
+                        };
+                        if let Err(e) = self.transcription_sender.send(transcription_chunk) {
+                            warn!("Failed to send VAD segment: {}", e);
+                        } else {
+                            self.chunk_id_counter += 1;
+                        }
+                    } else {
+                        debug!("⏭️ Dropping short VAD segment: {:.1}ms ({} samples < 800)",
+                               duration_ms, segment.samples.len());
+                    }
+                }
+            }
+            Err(e) => warn!("⚠️ VAD error: {}", e),
+        }
+
+        if let Some(ref sender) = self.recording_sender_for_mixed {
+            let recording_chunk = AudioChunk {
+                data: mixed_with_gain,
+                sample_rate: self.sample_rate,
+                timestamp,
+                chunk_id: self.chunk_id_counter,
+                device_type: DeviceType::Microphone,
+            };
+            if let Err(e) = sender.send(recording_chunk) {
+                warn!("Failed to send mixed recording tail: {}", e);
+            }
+        }
+    }
+
     fn flush_remaining_audio(&mut self) -> Result<()> {
         info!("Flushing remaining audio from pipeline (processed {} chunks)", self.processed_chunks);
+
+        // Drain complete windows before the tail so queue order matches input.
+        while self.ring_buffer.can_mix() {
+            if let Some((mic_window, sys_window)) = self.ring_buffer.extract_window() {
+                self.dispatch_mixed_window(mic_window, sys_window, 0.0);
+            }
+        }
+
+        // Preserve the final incomplete timeline. Only the shorter source is
+        // padded, so no synthetic samples are handed to the recorder or VAD.
+        if let Some((mic_tail, sys_tail)) = self.ring_buffer.drain_tail() {
+            let tail_len = mic_tail.len();
+            let recording_duration = self.state.get_recording_duration().unwrap_or(0.0);
+            let timestamp = (recording_duration - tail_len as f64 / self.sample_rate as f64).max(0.0);
+            self.dispatch_mixed_window(mic_tail, sys_tail, timestamp);
+        }
 
         // Flush any remaining audio from VAD processor and send segments to transcription
         match self.vad_processor.flush() {
@@ -1112,5 +1197,24 @@ mod tests {
         // uninterrupted speech. Batch import/retranscription use 2000ms.
         // See #679 and #756.
         assert_eq!(VAD_REDEMPTION_TIME_MS, 500);
+    }
+
+    #[test]
+    fn drain_tail_preserves_unequal_source_lengths() {
+        let mut ring = AudioMixerRingBuffer::new(48_000);
+        let mic: Vec<f32> = (0..12_000).map(|sample| sample as f32).collect();
+        let system: Vec<f32> = (0..20_000).map(|sample| -(sample as f32)).collect();
+        ring.add_samples(DeviceType::Microphone, mic.clone());
+        ring.add_samples(DeviceType::System, system.clone());
+
+        // Leave less than one regular window in each source. The final output
+        // must be the longer real tail, with silence only on the shorter side.
+        let (mic_tail, system_tail) = ring.drain_tail().expect("tail should exist");
+        assert_eq!(mic_tail.len(), system_tail.len());
+        assert_eq!(mic_tail.len(), 20_000);
+        assert_eq!(&mic_tail[..12_000], &mic);
+        assert_eq!(&system_tail[..], &system);
+        assert!(mic_tail[12_000..].iter().all(|sample| *sample == 0.0));
+        assert!(ring.drain_tail().is_none());
     }
 }

--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -234,6 +234,10 @@ pub struct AudioCapture {
     // Buffering for variable-size chunks → fixed-size resampler input
     resampler_input_buffer: Arc<std::sync::Mutex<Vec<f32>>>,
     resampler_chunk_size: usize,  // Fixed chunk size for resampler (512 samples)
+    // Track the real input/output timeline so finite filter delay can be
+    // drained at shutdown without changing recording duration.
+    resampler_input_samples: Arc<std::sync::atomic::AtomicUsize>,
+    resampler_output_samples: Arc<std::sync::atomic::AtomicUsize>,
     // Audio enhancement processors (microphone only)
     noise_suppressor: Arc<std::sync::Mutex<Option<NoiseSuppressionProcessor>>>,
     high_pass_filter: Arc<std::sync::Mutex<Option<HighPassFilter>>>,
@@ -404,6 +408,8 @@ impl AudioCapture {
             resampler: Arc::new(std::sync::Mutex::new(resampler)),
             resampler_input_buffer: Arc::new(std::sync::Mutex::new(Vec::with_capacity(RESAMPLER_CHUNK_SIZE * 2))),
             resampler_chunk_size: RESAMPLER_CHUNK_SIZE,
+            resampler_input_samples: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            resampler_output_samples: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             noise_suppressor: Arc::new(std::sync::Mutex::new(noise_suppressor)),
             high_pass_filter: Arc::new(std::sync::Mutex::new(high_pass_filter)),
             normalizer: Arc::new(std::sync::Mutex::new(normalizer)),
@@ -446,6 +452,10 @@ impl AudioCapture {
             let mut used_persistent_resampler = false;
 
             if let Ok(mut buffer_lock) = self.resampler_input_buffer.lock() {
+                self.resampler_input_samples.fetch_add(
+                    mono_data.len(),
+                    std::sync::atomic::Ordering::SeqCst,
+                );
                 // Add new samples to buffer
                 buffer_lock.extend_from_slice(&mono_data);
 
@@ -486,6 +496,10 @@ impl AudioCapture {
             let has_resampled_output = !resampled_output.is_empty();
 
             if has_resampled_output {
+                self.resampler_output_samples.fetch_add(
+                    resampled_output.len(),
+                    std::sync::atomic::Ordering::SeqCst,
+                );
                 mono_data = resampled_output;
             } else if !used_persistent_resampler {
                 // Only fallback if persistent resampler is not available at all
@@ -690,33 +704,70 @@ impl AudioCapture {
             warn!("Unable to lock resampler input buffer during stream flush");
             return;
         };
-        if pending.is_empty() {
+        let input_samples = self
+            .resampler_input_samples
+            .load(std::sync::atomic::Ordering::SeqCst);
+        if input_samples == 0 {
             return;
         }
 
-        let expected_output = ((pending.len() as f64 * 48_000.0) / self.sample_rate as f64)
+        let expected_total_output = ((input_samples as f64 * 48_000.0)
+            / self.sample_rate as f64)
             .round() as usize;
-        let mut padded = pending;
-        padded.resize(self.resampler_chunk_size, 0.0);
+        let already_emitted = self
+            .resampler_output_samples
+            .load(std::sync::atomic::Ordering::SeqCst);
+        let needed_output = expected_total_output.saturating_sub(already_emitted);
+        if needed_output == 0 {
+            return;
+        }
 
         let mut output = Vec::new();
         if let Ok(mut resampler) = self.resampler.lock() {
             if let Some(resampler) = resampler.as_mut() {
-                match resampler.process(&vec![padded], None) {
-                    Ok(mut waves) => {
-                        if let Some(samples) = waves.pop() {
-                            output = samples;
+                if !pending.is_empty() {
+                    let mut padded = pending;
+                    padded.resize(self.resampler_chunk_size, 0.0);
+                    match resampler.process(&vec![padded], None) {
+                        Ok(mut waves) => {
+                            if let Some(samples) = waves.pop() {
+                                output.extend(samples);
+                            }
+                        }
+                        Err(error) => warn!("Failed to flush persistent resampler: {}", error),
+                    }
+                }
+
+                // SincFixedIn withholds its finite filter delay on the first
+                // call. Feed zero blocks only until the real input timeline is
+                // complete, then discard any remaining synthetic tail.
+                while output.len() < needed_output {
+                    match resampler.process(&vec![vec![0.0; self.resampler_chunk_size]], None) {
+                        Ok(mut waves) => {
+                            let Some(samples) = waves.pop() else { break };
+                            if samples.is_empty() {
+                                break;
+                            }
+                            output.extend(samples);
+                        }
+                        Err(error) => {
+                            warn!("Failed to drain persistent resampler delay: {}", error);
+                            break;
                         }
                     }
-                    Err(error) => warn!("Failed to flush persistent resampler: {}", error),
                 }
             }
         }
 
-        output.truncate(expected_output.min(output.len()));
+        output.truncate(needed_output.min(output.len()));
         if output.is_empty() {
             return;
         }
+
+        self.resampler_output_samples.fetch_add(
+            output.len(),
+            std::sync::atomic::Ordering::SeqCst,
+        );
 
         let chunk_id = self.chunk_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let timestamp = self.state.get_recording_duration().unwrap_or(0.0);

--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -1217,4 +1217,127 @@ mod tests {
         assert!(mic_tail[12_000..].iter().all(|sample| *sample == 0.0));
         assert!(ring.drain_tail().is_none());
     }
+
+    #[test]
+    fn resampler_handles_non_aligned_non_48khz_input_without_padding_duration() {
+        use std::sync::Arc;
+
+        let state = RecordingState::new();
+        state.start_recording().expect("synthetic recording should start");
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        state.set_audio_sender(sender);
+
+        let device = Arc::new(AudioDevice::new(
+            "synthetic 44.1 kHz system source".to_string(),
+            crate::audio::devices::DeviceType::Input,
+        ));
+        let capture = AudioCapture::new(
+            device,
+            state.clone(),
+            44_100,
+            1,
+            DeviceType::System,
+            None,
+        );
+
+        // Deliberately use callback sizes that do not align to the persistent
+        // 512-sample rubato block, with a non-block-aligned final remainder.
+        let chunk_sizes = [997usize, 1301, 777, 2049];
+        let input_samples = chunk_sizes.iter().sum::<usize>();
+        let mut next_sample = 0.0f32;
+        for size in chunk_sizes {
+            let samples: Vec<f32> = (0..size)
+                .map(|_| {
+                    let value = (next_sample * 0.01).sin() * 0.2;
+                    next_sample += 1.0;
+                    value
+                })
+                .collect();
+            capture.process_audio_data(&samples);
+        }
+
+        // The final partial input block is flushed with synthetic padding,
+        // then trimmed to the duration represented by real input samples.
+        capture.flush_pending_resampler();
+
+        let mut output = Vec::new();
+        while let Ok(chunk) = receiver.try_recv() {
+            output.push(chunk);
+        }
+        let output_samples: usize = output.iter().map(|chunk| chunk.data.len()).sum();
+        let expected_samples = ((input_samples as f64 * 48_000.0 / 44_100.0).round()) as usize;
+        assert_eq!(input_samples % 512, 4);
+        assert!(!output.is_empty(), "resampler should emit complete and flushed blocks");
+        assert!(output.iter().all(|chunk| chunk.sample_rate == 48_000));
+        assert_eq!(
+            output_samples, expected_samples,
+            "output duration must match real input duration, not padded 512-sample blocks"
+        );
+        assert!(
+            output.iter().all(|chunk| chunk.timestamp >= 0.0),
+            "resampler output timestamps must remain non-negative"
+        );
+    }
+
+    #[test]
+    fn callback_in_flight_shutdown_rejects_audio_after_recording_stops() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        let state = RecordingState::new();
+        state.start_recording().expect("synthetic recording should start");
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        state.set_audio_sender(sender);
+        let device = Arc::new(AudioDevice::new(
+            "synthetic system source".to_string(),
+            crate::audio::devices::DeviceType::Input,
+        ));
+        let capture = Arc::new(AudioCapture::new(
+            device,
+            state.clone(),
+            48_000,
+            1,
+            DeviceType::System,
+            None,
+        ));
+
+        // Model several callbacks racing the stop request. Every callback is
+        // allowed to finish if it entered before stop, but no callback after
+        // the state transition may enqueue a new chunk.
+        let workers = 8;
+        let barrier = Arc::new(Barrier::new(workers + 1));
+        let handles: Vec<_> = (0..workers)
+            .map(|_| {
+                let capture = Arc::clone(&capture);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    capture.process_audio_data(&vec![0.1; 480]);
+                })
+            })
+            .collect();
+        barrier.wait();
+        for handle in handles {
+            handle.join().expect("callback worker should not panic");
+        }
+
+        state.stop_recording();
+        let chunks_before_post_stop = {
+            let mut count = 0;
+            while receiver.try_recv().is_ok() {
+                count += 1;
+            }
+            count
+        };
+        capture.process_audio_data(&vec![0.1; 480]);
+        assert_eq!(
+            receiver.try_recv().is_ok(),
+            false,
+            "a callback invoked after stop must not enqueue audio"
+        );
+        assert!(
+            chunks_before_post_stop <= workers,
+            "in-flight callbacks may enqueue at most one chunk each"
+        );
+    }
 }

--- a/frontend/src-tauri/src/audio/recording_manager.rs
+++ b/frontend/src-tauri/src/audio/recording_manager.rs
@@ -314,13 +314,14 @@ impl RecordingManager {
             monitor.stop_monitoring().await;
         }
 
-        // Stop recording state first
-        self.state.stop_recording();
-
         // Stop audio streams
         if let Err(e) = self.stream_manager.stop_streams() {
             error!("Error stopping audio streams: {}", e);
         }
+
+        // Streams flush any resampler tail while the pipeline sender is still
+        // open. Only then close recording state and the pipeline channel.
+        self.state.stop_recording();
 
         // Stop audio pipeline
         if let Err(e) = self.pipeline_manager.stop().await {
@@ -342,13 +343,14 @@ impl RecordingManager {
             monitor.stop_monitoring().await;
         }
 
-        // Stop recording state first - this clears device references
-        self.state.stop_recording();
-
         // Stop audio streams immediately
         if let Err(e) = self.stream_manager.stop_streams() {
             error!("Error stopping audio streams: {}", e);
         }
+
+        // The stream stop above pauses producers and flushes their final
+        // resampler blocks before closing the pipeline sender.
+        self.state.stop_recording();
 
         // CRITICAL: Force pipeline to flush ALL accumulated audio before stopping
         debug!("💨 Forcing pipeline to flush accumulated audio immediately");
@@ -398,13 +400,13 @@ impl RecordingManager {
         let recording_duration = self.state.get_active_recording_duration();
         info!("Recording duration before stop: {:?}s", recording_duration);
 
-        // Stop recording state first
-        self.state.stop_recording();
-
         // Stop audio streams
         if let Err(e) = self.stream_manager.stop_streams() {
             error!("Error stopping audio streams: {}", e);
         }
+
+        // Preserve the sender until stream tails have been forwarded.
+        self.state.stop_recording();
 
         // Stop audio pipeline
         if let Err(e) = self.pipeline_manager.stop().await {

--- a/frontend/src-tauri/src/audio/stream.rs
+++ b/frontend/src-tauri/src/audio/stream.rs
@@ -32,6 +32,7 @@ unsafe impl Send for StreamBackend {}
 pub struct AudioStream {
     device: Arc<AudioDevice>,
     backend: StreamBackend,
+    capture: AudioCapture,
 }
 
 // SAFETY: AudioStream contains StreamBackend which we've marked as Send
@@ -137,6 +138,7 @@ impl AudioStream {
         Ok(Self {
             device,
             backend: StreamBackend::Cpal(stream),
+            capture,
         })
     }
 
@@ -230,6 +232,7 @@ impl AudioStream {
             backend: StreamBackend::CoreAudio {
                 task: Some(task),
             },
+            capture,
         })
     }
 
@@ -320,23 +323,31 @@ impl AudioStream {
     pub fn stop(self) -> Result<()> {
         info!("Stopping audio stream for device: {}", self.device.name);
 
+        // Pause/abort the producer before flushing so no callback can append
+        // more input while the final resampler block is emitted.
+        match &self.backend {
+            StreamBackend::Cpal(stream) => {
+                if let Err(e) = stream.pause() {
+                    warn!("Failed to pause stream before flush: {}", e);
+                }
+            }
+            #[cfg(target_os = "macos")]
+            StreamBackend::CoreAudio { task } => {
+                if let Some(task) = task {
+                    task.abort();
+                }
+            }
+        }
+        self.capture.flush_pending_resampler();
+
         match self.backend {
             StreamBackend::Cpal(stream) => {
-                // CRITICAL: Pause the stream first to stop callbacks immediately
-                // This ensures closures stop executing before we drop the stream,
-                // allowing Arc references captured in callbacks to be released
-                if let Err(e) = stream.pause() {
-                    warn!("Failed to pause stream before drop: {}", e);
-                }
                 info!("Stream paused, now dropping to release callbacks");
                 drop(stream);
             }
             #[cfg(target_os = "macos")]
             StreamBackend::CoreAudio { task } => {
-                // Abort the processing task and wait briefly for cleanup
                 if let Some(task_handle) = task {
-                    info!("Aborting Core Audio task...");
-                    task_handle.abort();
                     // Give the runtime a moment to clean up the aborted task
                     // This helps ensure Arc references in the closure are dropped
                     std::thread::sleep(std::time::Duration::from_millis(50));


### PR DESCRIPTION
Closes #773.

Drain the persistent capture resampler tail before producer shutdown, preserving only samples represented by real input. Drain complete mixer windows before the final unequal mic/system tail, zero-padding only the shorter source, and dispatch each terminal mixed window once to recording and VAD. The manager keeps the pipeline sender open until stream tails are forwarded.

Validation: full local Rust library tests pass with Visual Studio libclang and the branch's bundled ONNX Runtime (246 passed, 2 ignored). The touched-file rustfmt parse reaches existing repository formatting drift without syntax errors; hosted checks are currently absent.