### PR TITLE
fix(recording): make saver drain and failures observable

### DIFF
--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -1013,43 +1013,57 @@ pub async fn stop_recording<R: Runtime>(
     );
 
     // Perform final cleanup with the manager if available
-    let (meeting_folder, meeting_name) = if let Some(mut manager) = manager_for_cleanup {
+    let (meeting_folder, meeting_name, save_error) = if let Some(mut manager) = manager_for_cleanup {
         info!("🧹 Performing final cleanup and saving recording data");
 
         // Extract meeting info BEFORE async operations
         let meeting_folder = manager.get_meeting_folder();
         let meeting_name = manager.get_meeting_name();
 
-        match tokio::time::timeout(
+        let save_error = match tokio::time::timeout(
             tokio::time::Duration::from_secs(300), // 5 minutes max for file I/O
             manager.save_recording_only(&app)
         ).await {
             Ok(Ok(_)) => {
                 info!("✅ Recording data saved successfully during cleanup");
+                None
             }
             Ok(Err(e)) => {
                 warn!(
-                    "⚠️ Error during recording cleanup (transcripts preserved): {}",
+                    "⚠️ Error during recording cleanup: {}",
                     e
                 );
-                // Don't fail shutdown - transcripts are already preserved
+                Some(e.to_string())
             }
             Err(_) => {
-                warn!("⏱️ File I/O timeout (5 minutes) reached during save, continuing shutdown");
-                // Don't fail shutdown - transcripts are already preserved
+                warn!("⏱️ File I/O timeout (5 minutes) reached during save");
+                Some("Partial save: recording persistence timed out after 5 minutes".to_string())
             }
-        }
+        };
 
-        (meeting_folder, meeting_name)
+        (meeting_folder, meeting_name, save_error)
     } else {
         info!("ℹ️ No recording manager available for cleanup");
-        (None, None)
+        (None, None, None)
     };
 
     // Set recording flag to false
     info!("🔍 Setting IS_RECORDING to false");
     IS_RECORDING.store(false, Ordering::SeqCst);
     // IS_RECORDING_STOPPING is cleared by _stopping_guard on scope exit.
+
+    if let Some(error) = save_error {
+        let _ = app.emit(
+            "recording-save-failed",
+            serde_json::json!({
+                "message": error,
+                "meeting_folder": meeting_folder.as_ref().map(|path| path.to_string_lossy().to_string()),
+                "recovery": "Retry saving from the meeting folder after resolving the storage error."
+            }),
+        );
+        crate::tray::update_tray_menu(&app);
+        return Err(error);
+    }
 
     // Step 4.5: Prepare metadata for frontend (NO database save)
     // NOTE: We do NOT save to database here. The frontend will save after all transcripts are displayed.

--- a/frontend/src-tauri/src/audio/recording_manager.rs
+++ b/frontend/src-tauri/src/audio/recording_manager.rs
@@ -276,7 +276,15 @@ impl RecordingManager {
             return Err(RecordingStartError::TranscriptionRuntime(error));
         }
 
-        self.recording_saver.start_accumulation(auto_save, recording_receiver);
+        if let Err(error) = self
+            .recording_saver
+            .start_accumulation(auto_save, recording_receiver)
+        {
+            error!("Recording storage initialization failed before capture: {}", error);
+            self.state.stop_recording();
+            let _ = self.pipeline_manager.stop().await;
+            return Err(RecordingStartError::Other(anyhow::anyhow!(error)));
+        }
         self.recording_saver.set_device_info(
             microphone_device.as_ref().map(|d| d.name.clone()),
             system_device.as_ref().map(|d| d.name.clone())
@@ -382,7 +390,7 @@ impl RecordingManager {
             }
             Err(e) => {
                 error!("Failed to save recording: {}", e);
-                // Don't fail the stop operation if saving fails
+                return Err(anyhow::anyhow!(e));
             }
         }
 
@@ -421,7 +429,7 @@ impl RecordingManager {
             }
             Err(e) => {
                 error!("Failed to save recording: {}", e);
-                // Don't fail the stop operation if saving fails
+                return Err(anyhow::anyhow!(e));
             }
         }
 

--- a/frontend/src-tauri/src/audio/recording_saver.rs
+++ b/frontend/src-tauri/src/audio/recording_saver.rs
@@ -6,6 +6,7 @@ use tauri::{AppHandle, Runtime, Emitter};
 use tokio::sync::mpsc;
 use serde::{Serialize, Deserialize};
 use std::path::PathBuf;
+use tokio::task::JoinHandle;
 
 use super::recording_state::AudioChunk;
 use super::audio_processing::create_meeting_folder;
@@ -54,6 +55,7 @@ pub struct RecordingSaver {
     metadata: Option<MeetingMetadata>,
     transcript_segments: Arc<Mutex<Vec<TranscriptSegment>>>,
     is_saving: Arc<Mutex<bool>>,
+    accumulation_task: Option<JoinHandle<Result<(), String>>>,
 }
 
 impl RecordingSaver {
@@ -65,6 +67,7 @@ impl RecordingSaver {
             metadata: None,
             transcript_segments: Arc::new(Mutex::new(Vec::new())),
             is_saving: Arc::new(Mutex::new(false)),
+            accumulation_task: None,
         }
     }
 
@@ -139,7 +142,7 @@ impl RecordingSaver {
         &mut self,
         auto_save: bool,
         mut receiver: mpsc::UnboundedReceiver<AudioChunk>,
-    ) {
+    ) -> Result<(), String> {
         if auto_save {
             info!("Initializing incremental audio saver for recording (auto-save ENABLED)");
         } else {
@@ -148,48 +151,41 @@ impl RecordingSaver {
 
         // Initialize meeting folder and incremental saver ONLY if auto_save is enabled
         if auto_save {
-            if let Some(name) = self.meeting_name.clone() {
-                match self.initialize_meeting_folder(&name, true) {
-                    Ok(()) => info!("Successfully initialized meeting folder with checkpoints"),
-                    Err(e) => {
-                        error!("Failed to initialize meeting folder: {}", e);
-                        // Continue anyway - will use fallback flat structure
-                    }
-                }
-            }
+            let name = self
+                .meeting_name
+                .clone()
+                .ok_or_else(|| "Cannot enable auto-save without a meeting name".to_string())?;
+            self.initialize_meeting_folder(&name, true)
+                .map_err(|e| format!("Failed to initialize recording storage: {e}"))?;
+            info!("Successfully initialized meeting folder with checkpoints");
         } else {
             // When auto_save is false, still create meeting folder for transcripts/metadata
             // but skip .checkpoints directory
-            if let Some(name) = self.meeting_name.clone() {
-                match self.initialize_meeting_folder(&name, false) {
-                    Ok(()) => info!("Successfully initialized meeting folder (transcripts only)"),
-                    Err(e) => {
-                        error!("Failed to initialize meeting folder: {}", e);
-                    }
-                }
-            }
+            let name = self
+                .meeting_name
+                .clone()
+                .ok_or_else(|| "Cannot initialize transcript storage without a meeting name".to_string())?;
+            self.initialize_meeting_folder(&name, false)
+                .map_err(|e| format!("Failed to initialize transcript storage: {e}"))?;
+            info!("Successfully initialized meeting folder (transcripts only)");
         }
 
-        // Start accumulation task
+        // Mark the receiver as live before spawning. The task drains every
+        // accepted chunk until the producer closes; the old flag check could
+        // discard the first queued chunk after Stop.
+        if let Ok(mut is_saving) = self.is_saving.lock() {
+            *is_saving = true;
+        }
+
         let is_saving_clone = self.is_saving.clone();
         let incremental_saver_arc = self.incremental_saver.clone();
         let save_audio = auto_save;
 
-        tokio::spawn(async move {
+        self.accumulation_task = Some(tokio::spawn(async move {
             info!("Recording saver accumulation task started (save_audio: {})", save_audio);
+            let mut first_error = None;
 
             while let Some(chunk) = receiver.recv().await {
-                // Check if we should continue
-                let should_continue = if let Ok(is_saving) = is_saving_clone.lock() {
-                    *is_saving
-                } else {
-                    false
-                };
-
-                if !should_continue {
-                    break;
-                }
-
                 // Only process audio chunks if auto_save is enabled
                 if save_audio {
                     // Add chunk to incremental saver
@@ -197,9 +193,11 @@ impl RecordingSaver {
                         let mut saver_guard = saver_arc.lock().await;
                         if let Err(e) = saver_guard.add_chunk(chunk) {
                             error!("Failed to add chunk to incremental saver: {}", e);
+                            first_error.get_or_insert_with(|| e.to_string());
                         }
                     } else {
                         error!("Incremental saver not available while accumulating");
+                        first_error.get_or_insert_with(|| "Incremental saver unavailable".to_string());
                     }
                 } else {
                     // auto_save is false: discard audio chunk (no-op)
@@ -208,12 +206,13 @@ impl RecordingSaver {
             }
 
             info!("Recording saver accumulation task ended");
-        });
+            if let Ok(mut is_saving) = is_saving_clone.lock() {
+                *is_saving = false;
+            }
+            first_error.map_or(Ok(()), Err)
+        }));
 
-        // Set saving flag
-        if let Ok(mut is_saving) = self.is_saving.lock() {
-            *is_saving = true;
-        }
+        Ok(())
     }
 
     /// Initialize meeting folder structure and metadata
@@ -356,13 +355,36 @@ impl RecordingSaver {
     ) -> Result<Option<String>, String> {
         info!("Stopping recording saver");
 
-        // Stop accumulation
+        // Stop accepting new work, then await the receiver task. The producer
+        // side is closed by the pipeline before this method is called, so all
+        // chunks already accepted by the saver channel are drained in order.
         if let Ok(mut is_saving) = self.is_saving.lock() {
             *is_saving = false;
         }
 
-        // Give time for final chunks
-        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+        if let Some(task) = self.accumulation_task.take() {
+            match task.await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    return Err(format!(
+                        "Partial save: recording saver could not persist every accepted chunk: {error}; folder={}",
+                        self.meeting_folder
+                            .as_ref()
+                            .map(|folder| folder.display().to_string())
+                            .unwrap_or_else(|| "unavailable".to_string())
+                    ));
+                }
+                Err(error) => {
+                    return Err(format!(
+                        "Partial save: recording saver task failed: {error}; folder={}",
+                        self.meeting_folder
+                            .as_ref()
+                            .map(|folder| folder.display().to_string())
+                            .unwrap_or_else(|| "unavailable".to_string())
+                    ));
+                }
+            }
+        }
 
         // Check if incremental saver exists (indicates auto_save was enabled)
         let should_save_audio = self.incremental_saver.is_some();

--- a/frontend/src-tauri/src/audio/recording_saver.rs
+++ b/frontend/src-tauri/src/audio/recording_saver.rs
@@ -499,3 +499,69 @@ impl Default for RecordingSaver {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn auto_save_start_failure_rolls_back_before_capture() {
+        let mut saver = RecordingSaver::new();
+        let (_sender, receiver) = mpsc::unbounded_channel();
+
+        let error = saver
+            .start_accumulation(true, receiver)
+            .expect_err("auto-save without a meeting name must fail");
+
+        assert!(error.contains("meeting name"));
+        assert!(saver.meeting_folder.is_none());
+        assert!(saver.incremental_saver.is_none());
+        assert!(saver.accumulation_task.is_none());
+        assert!(!*saver.is_saving.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn accumulation_task_waits_for_channel_close_and_drains_tail() {
+        let meeting_name = format!(
+            "repostew-drain-test-{}-{}",
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        );
+        let mut saver = RecordingSaver::new();
+        saver.set_meeting_name(Some(meeting_name));
+        let (sender, receiver) = mpsc::unbounded_channel();
+        saver
+            .start_accumulation(false, receiver)
+            .expect("transcript-only saver should initialize");
+
+        let mut task = saver
+            .accumulation_task
+            .take()
+            .expect("accumulation task should be spawned");
+        sender
+            .send(AudioChunk {
+                data: vec![0.25; 480],
+                sample_rate: 48_000,
+                timestamp: 0.0,
+                chunk_id: 1,
+                device_type: super::super::recording_state::DeviceType::Microphone,
+            })
+            .expect("chunk should be accepted");
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut task)
+                .await
+                .is_err(),
+            "the task must remain live while the producer channel is open"
+        );
+
+        drop(sender);
+        assert!(task.await.expect("accumulation task panicked").is_ok());
+        assert!(!*saver.is_saving.lock().unwrap());
+
+        if let Some(folder) = saver.meeting_folder.as_ref() {
+            let _ = std::fs::remove_dir_all(folder);
+        }
+    }
+}

--- a/frontend/src-tauri/src/audio/recording_saver.rs
+++ b/frontend/src-tauri/src/audio/recording_saver.rs
@@ -7,6 +7,8 @@ use tokio::sync::mpsc;
 use serde::{Serialize, Deserialize};
 use std::path::PathBuf;
 use tokio::task::JoinHandle;
+#[cfg(test)]
+use std::sync::{atomic::{AtomicBool, Ordering}, Barrier};
 
 use super::recording_state::AudioChunk;
 use super::audio_processing::create_meeting_folder;
@@ -56,6 +58,23 @@ pub struct RecordingSaver {
     transcript_segments: Arc<Mutex<Vec<TranscriptSegment>>>,
     is_saving: Arc<Mutex<bool>>,
     accumulation_task: Option<JoinHandle<Result<(), String>>>,
+    #[cfg(test)]
+    test_failure: Option<TestFailure>,
+    #[cfg(test)]
+    test_chunk_observer: Option<Arc<Mutex<Vec<Vec<f32>>>>>,
+    #[cfg(test)]
+    test_saver_gate: Option<Arc<Barrier>>,
+    #[cfg(test)]
+    test_saver_gate_entered: Option<Arc<AtomicBool>>,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TestFailure {
+    IncrementalSaverInitialization,
+    AudioFinalization,
+    TranscriptWrite,
+    MetadataCompletion,
 }
 
 impl RecordingSaver {
@@ -68,6 +87,14 @@ impl RecordingSaver {
             transcript_segments: Arc::new(Mutex::new(Vec::new())),
             is_saving: Arc::new(Mutex::new(false)),
             accumulation_task: None,
+            #[cfg(test)]
+            test_failure: None,
+            #[cfg(test)]
+            test_chunk_observer: None,
+            #[cfg(test)]
+            test_saver_gate: None,
+            #[cfg(test)]
+            test_saver_gate_entered: None,
         }
     }
 
@@ -141,7 +168,30 @@ impl RecordingSaver {
     pub fn start_accumulation(
         &mut self,
         auto_save: bool,
+        receiver: mpsc::UnboundedReceiver<AudioChunk>,
+    ) -> Result<(), String> {
+        self.start_accumulation_with_base(
+            auto_save,
+            receiver,
+            super::recording_preferences::get_default_recordings_folder(),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn start_accumulation_for_test(
+        &mut self,
+        auto_save: bool,
+        receiver: mpsc::UnboundedReceiver<AudioChunk>,
+        base_folder: &std::path::Path,
+    ) -> Result<(), String> {
+        self.start_accumulation_with_base(auto_save, receiver, base_folder.to_path_buf())
+    }
+
+    fn start_accumulation_with_base(
+        &mut self,
+        auto_save: bool,
         mut receiver: mpsc::UnboundedReceiver<AudioChunk>,
+        base_folder: PathBuf,
     ) -> Result<(), String> {
         if auto_save {
             info!("Initializing incremental audio saver for recording (auto-save ENABLED)");
@@ -155,7 +205,7 @@ impl RecordingSaver {
                 .meeting_name
                 .clone()
                 .ok_or_else(|| "Cannot enable auto-save without a meeting name".to_string())?;
-            self.initialize_meeting_folder(&name, true)
+            self.initialize_meeting_folder_at(&base_folder, &name, true)
                 .map_err(|e| format!("Failed to initialize recording storage: {e}"))?;
             info!("Successfully initialized meeting folder with checkpoints");
         } else {
@@ -165,7 +215,7 @@ impl RecordingSaver {
                 .meeting_name
                 .clone()
                 .ok_or_else(|| "Cannot initialize transcript storage without a meeting name".to_string())?;
-            self.initialize_meeting_folder(&name, false)
+            self.initialize_meeting_folder_at(&base_folder, &name, false)
                 .map_err(|e| format!("Failed to initialize transcript storage: {e}"))?;
             info!("Successfully initialized meeting folder (transcripts only)");
         }
@@ -180,6 +230,12 @@ impl RecordingSaver {
         let is_saving_clone = self.is_saving.clone();
         let incremental_saver_arc = self.incremental_saver.clone();
         let save_audio = auto_save;
+        #[cfg(test)]
+        let test_chunk_observer = self.test_chunk_observer.clone();
+        #[cfg(test)]
+        let test_saver_gate = self.test_saver_gate.clone();
+        #[cfg(test)]
+        let test_saver_gate_entered = self.test_saver_gate_entered.clone();
 
         self.accumulation_task = Some(tokio::spawn(async move {
             info!("Recording saver accumulation task started (save_audio: {})", save_audio);
@@ -191,9 +247,27 @@ impl RecordingSaver {
                     // Add chunk to incremental saver
                     if let Some(saver_arc) = &incremental_saver_arc {
                         let mut saver_guard = saver_arc.lock().await;
+                        #[cfg(test)]
+                        if let Some(gate) = &test_saver_gate {
+                            let should_block = test_saver_gate_entered
+                                .as_ref()
+                                .map(|entered| !entered.swap(true, Ordering::SeqCst))
+                                .unwrap_or(true);
+                            if should_block {
+                                gate.wait();
+                            }
+                        }
+                        let chunk_data = chunk.data.clone();
                         if let Err(e) = saver_guard.add_chunk(chunk) {
                             error!("Failed to add chunk to incremental saver: {}", e);
                             first_error.get_or_insert_with(|| e.to_string());
+                        } else {
+                            #[cfg(test)]
+                            if let Some(observer) = &test_chunk_observer {
+                                if let Ok(mut chunks) = observer.lock() {
+                                    chunks.push(chunk_data);
+                                }
+                            }
                         }
                     } else {
                         error!("Incremental saver not available while accumulating");
@@ -220,47 +294,69 @@ impl RecordingSaver {
     /// # Arguments
     /// * `meeting_name` - Name of the meeting
     /// * `create_checkpoints` - Whether to create .checkpoints/ directory and IncrementalAudioSaver
-    fn initialize_meeting_folder(&mut self, meeting_name: &str, create_checkpoints: bool) -> Result<()> {
-        // Load preferences to get base recordings folder
-        let base_folder = super::recording_preferences::get_default_recordings_folder();
-
+    fn initialize_meeting_folder_at(
+        &mut self,
+        base_folder: &PathBuf,
+        meeting_name: &str,
+        create_checkpoints: bool,
+    ) -> Result<()> {
         // Create meeting folder structure (with or without .checkpoints/ subdirectory)
         let meeting_folder = create_meeting_folder(&base_folder, meeting_name, create_checkpoints)?;
 
-        // Only initialize incremental saver if checkpoints are needed (auto_save is true)
-        if create_checkpoints {
-            let incremental_saver = IncrementalAudioSaver::new(meeting_folder.clone(), 48000)?;
-            self.incremental_saver = Some(Arc::new(AsyncMutex::new(incremental_saver)));
-            info!("✅ Incremental audio saver initialized for meeting: {}", meeting_name);
-        } else {
-            info!("⚠️  Skipped incremental audio saver (auto-save disabled)");
+        let initialized = (|| -> Result<(
+            Option<Arc<AsyncMutex<IncrementalAudioSaver>>>,
+            MeetingMetadata,
+        )> {
+            // Only initialize incremental saver if checkpoints are needed (auto_save is true)
+            let incremental_saver = if create_checkpoints {
+                #[cfg(test)]
+                if self.test_failure == Some(TestFailure::IncrementalSaverInitialization) {
+                    return Err(anyhow::anyhow!("injected incremental saver initialization failure"));
+                }
+                let saver = IncrementalAudioSaver::new(meeting_folder.clone(), 48000)?;
+                info!("✅ Incremental audio saver initialized for meeting: {}", meeting_name);
+                Some(Arc::new(AsyncMutex::new(saver)))
+            } else {
+                info!("⚠️  Skipped incremental audio saver (auto-save disabled)");
+                None
+            };
+
+            let metadata = MeetingMetadata {
+                version: "1.0".to_string(),
+                meeting_id: None,  // Will be set by backend
+                meeting_name: Some(meeting_name.to_string()),
+                created_at: chrono::Utc::now().to_rfc3339(),
+                completed_at: None,
+                duration_seconds: None,
+                devices: DeviceInfo {
+                    microphone: None,  // Could be enhanced to store actual device names
+                    system_audio: None,
+                },
+                audio_file: if create_checkpoints { "audio.mp4".to_string() } else { "".to_string() },
+                transcript_file: "transcripts.json".to_string(),
+                sample_rate: 48000,
+                status: "recording".to_string(),
+            };
+
+            // Write initial metadata.json
+            self.write_metadata(&meeting_folder, &metadata)?;
+            Ok((incremental_saver, metadata))
+        })();
+
+        match initialized {
+            Ok((incremental_saver, metadata)) => {
+                self.incremental_saver = incremental_saver;
+                self.meeting_folder = Some(meeting_folder);
+                self.metadata = Some(metadata);
+                Ok(())
+            }
+            Err(error) => {
+                // Do not leave a half-created meeting directory when startup
+                // fails before capture is published as live.
+                let _ = std::fs::remove_dir_all(&meeting_folder);
+                Err(error)
+            }
         }
-
-        // Create initial metadata
-        let metadata = MeetingMetadata {
-            version: "1.0".to_string(),
-            meeting_id: None,  // Will be set by backend
-            meeting_name: Some(meeting_name.to_string()),
-            created_at: chrono::Utc::now().to_rfc3339(),
-            completed_at: None,
-            duration_seconds: None,
-            devices: DeviceInfo {
-                microphone: None,  // Could be enhanced to store actual device names
-                system_audio: None,
-            },
-            audio_file: if create_checkpoints { "audio.mp4".to_string() } else { "".to_string() },
-            transcript_file: "transcripts.json".to_string(),
-            sample_rate: 48000,
-            status: "recording".to_string(),
-        };
-
-        // Write initial metadata.json
-        self.write_metadata(&meeting_folder, &metadata)?;
-
-        self.meeting_folder = Some(meeting_folder);
-        self.metadata = Some(metadata);
-
-        Ok(())
     }
 
     /// Write metadata.json to disk (atomic write with temp file)
@@ -353,6 +449,21 @@ impl RecordingSaver {
         app: &AppHandle<R>,
         recording_duration: Option<f64>
     ) -> Result<Option<String>, String> {
+        self.stop_and_save_inner(recording_duration, |save_event| {
+            app.emit("recording-saved", save_event)
+                .map_err(|error| error.to_string())
+        })
+        .await
+    }
+
+    async fn stop_and_save_inner<F>(
+        &mut self,
+        recording_duration: Option<f64>,
+        emit_saved: F,
+    ) -> Result<Option<String>, String>
+    where
+        F: FnOnce(&serde_json::Value) -> Result<(), String>,
+    {
         info!("Stopping recording saver");
 
         // Stop accepting new work, then await the receiver task. The producer
@@ -391,13 +502,35 @@ impl RecordingSaver {
 
         if !should_save_audio {
             info!("⚠️  No audio saver initialized (auto-save was disabled) - skipping audio finalization");
-            info!("✅ Transcripts and metadata already saved incrementally");
+            if let Some(folder) = &self.meeting_folder {
+                self.write_transcripts_json(folder)
+                    .map_err(|error| format!("Failed to save transcripts: {error}"))?;
+                if !folder.join("transcripts.json").exists() {
+                    return Err("Transcript file verification failed".to_string());
+                }
+
+                if let Some(mut metadata) = self.metadata.clone() {
+                    metadata.status = "completed".to_string();
+                    metadata.completed_at = Some(chrono::Utc::now().to_rfc3339());
+                    metadata.duration_seconds = recording_duration;
+                    self.write_metadata(folder, &metadata)
+                        .map_err(|error| format!("Failed to update metadata: {error}"))?;
+                    self.metadata = Some(metadata);
+                }
+            }
+            info!("✅ Transcripts and metadata finalized (auto-save disabled)");
             return Ok(None);
         }
 
         // Finalize incremental saver (merge checkpoints into final audio.mp4)
         let final_audio_path = if let Some(saver_arc) = &self.incremental_saver {
             let mut saver = saver_arc.lock().await;
+            #[cfg(test)]
+            if self.test_failure == Some(TestFailure::AudioFinalization) {
+                return Err(self.partial_save_error_message(
+                    "injected audio finalization failure",
+                ));
+            }
             match saver.finalize().await {
                 Ok(path) => {
                     info!("✅ Successfully finalized audio: {}", path.display());
@@ -415,6 +548,12 @@ impl RecordingSaver {
 
         // Save final transcripts.json with validation
         if let Some(folder) = &self.meeting_folder {
+            #[cfg(test)]
+            if self.test_failure == Some(TestFailure::TranscriptWrite) {
+                return Err(self.partial_save_error_message(
+                    "injected final transcript write failure",
+                ));
+            }
             if let Err(e) = self.write_transcripts_json(folder) {
                 error!("❌ Failed to write final transcripts: {}", e);
                 return Err(format!("Failed to save transcripts: {}", e));
@@ -444,6 +583,12 @@ impl RecordingSaver {
                 }
             });
 
+            #[cfg(test)]
+            if self.test_failure == Some(TestFailure::MetadataCompletion) {
+                return Err(self.partial_save_error_message(
+                    "injected metadata completion failure",
+                ));
+            }
             if let Err(e) = self.write_metadata(folder, &metadata) {
                 error!("❌ Failed to update metadata to completed: {}", e);
                 return Err(format!("Failed to update metadata: {}", e));
@@ -462,7 +607,7 @@ impl RecordingSaver {
                 .map(|f| f.to_string_lossy().to_string())
         });
 
-        if let Err(e) = app.emit("recording-saved", &save_event) {
+        if let Err(e) = emit_saved(&save_event) {
             warn!("Failed to emit recording-saved event: {}", e);
         }
 
@@ -472,6 +617,34 @@ impl RecordingSaver {
         }
 
         Ok(Some(final_audio_path.to_string_lossy().to_string()))
+    }
+
+    #[cfg(test)]
+    fn set_test_failure(&mut self, failure: TestFailure) {
+        self.test_failure = Some(failure);
+    }
+
+    #[cfg(test)]
+    fn set_test_saver_gate(
+        &mut self,
+        observer: Arc<Mutex<Vec<Vec<f32>>>>,
+        gate: Arc<Barrier>,
+        entered: Arc<AtomicBool>,
+    ) {
+        self.test_chunk_observer = Some(observer);
+        self.test_saver_gate = Some(gate);
+        self.test_saver_gate_entered = Some(entered);
+    }
+
+    #[cfg(test)]
+    fn partial_save_error_message(&self, detail: &str) -> String {
+        format!(
+            "Partial save: {detail}; folder={}",
+            self.meeting_folder
+                .as_ref()
+                .map(|folder| folder.display().to_string())
+                .unwrap_or_else(|| "unavailable".to_string())
+        )
     }
 
     /// Get the meeting folder path (for passing to backend)
@@ -503,65 +676,186 @@ impl Default for RecordingSaver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
+    use tempfile::tempdir;
+
+    fn test_chunk(value: f32, chunk_id: u64) -> AudioChunk {
+        AudioChunk {
+            data: vec![value; 48_000],
+            sample_rate: 48_000,
+            timestamp: chunk_id as f64,
+            chunk_id,
+            device_type: super::super::recording_state::DeviceType::Microphone,
+        }
+    }
+
+    fn test_segment(sequence_id: u64) -> TranscriptSegment {
+        TranscriptSegment {
+            id: format!("test-segment-{sequence_id}"),
+            text: format!("identified segment {sequence_id}"),
+            audio_start_time: sequence_id as f64,
+            audio_end_time: sequence_id as f64 + 1.0,
+            duration: 1.0,
+            display_time: format!("[00:0{sequence_id}]"),
+            confidence: 0.99,
+            sequence_id,
+        }
+    }
 
     #[test]
     fn auto_save_start_failure_rolls_back_before_capture() {
+        let base = tempdir().expect("temporary recordings directory should be created");
         let mut saver = RecordingSaver::new();
-        let (_sender, receiver) = mpsc::unbounded_channel();
+        saver.set_meeting_name(Some("injected-start-failure".to_string()));
+        saver.set_test_failure(TestFailure::IncrementalSaverInitialization);
+        let (sender, receiver) = mpsc::unbounded_channel();
 
         let error = saver
-            .start_accumulation(true, receiver)
-            .expect_err("auto-save without a meeting name must fail");
+            .start_accumulation_for_test(true, receiver, base.path())
+            .expect_err("injected storage initialization must fail");
 
-        assert!(error.contains("meeting name"));
+        assert!(error.contains("recording storage"));
+        assert!(error.contains("injected incremental saver initialization"));
         assert!(saver.meeting_folder.is_none());
         assert!(saver.incremental_saver.is_none());
         assert!(saver.accumulation_task.is_none());
         assert!(!*saver.is_saving.lock().unwrap());
+        assert!(sender.send(test_chunk(0.1, 0)).is_err(), "failed startup must not consume audio");
+        assert!(base.path().read_dir().unwrap().next().is_none(), "startup rollback must remove the meeting folder");
     }
 
     #[tokio::test]
-    async fn accumulation_task_waits_for_channel_close_and_drains_tail() {
-        let meeting_name = format!(
-            "repostew-drain-test-{}-{}",
-            std::process::id(),
-            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
-        );
+    async fn auto_save_disabled_completes_transcript_metadata_only() {
+        let base = tempdir().expect("temporary recordings directory should be created");
         let mut saver = RecordingSaver::new();
-        saver.set_meeting_name(Some(meeting_name));
+        saver.set_meeting_name(Some("transcript-only-test".to_string()));
         let (sender, receiver) = mpsc::unbounded_channel();
         saver
-            .start_accumulation(false, receiver)
+            .start_accumulation_for_test(false, receiver, base.path())
             .expect("transcript-only saver should initialize");
-
-        let mut task = saver
-            .accumulation_task
-            .take()
-            .expect("accumulation task should be spawned");
-        sender
-            .send(AudioChunk {
-                data: vec![0.25; 480],
-                sample_rate: 48_000,
-                timestamp: 0.0,
-                chunk_id: 1,
-                device_type: super::super::recording_state::DeviceType::Microphone,
-            })
-            .expect("chunk should be accepted");
-
-        assert!(
-            tokio::time::timeout(Duration::from_millis(50), &mut task)
-                .await
-                .is_err(),
-            "the task must remain live while the producer channel is open"
-        );
-
+        saver.add_transcript_segment(test_segment(0));
         drop(sender);
-        assert!(task.await.expect("accumulation task panicked").is_ok());
-        assert!(!*saver.is_saving.lock().unwrap());
 
-        if let Some(folder) = saver.meeting_folder.as_ref() {
-            let _ = std::fs::remove_dir_all(folder);
+        let result = saver
+            .stop_and_save_inner(Some(1.0), |_| Ok(()))
+            .await
+            .expect("auto-save disabled stop should succeed");
+        assert!(result.is_none(), "transcript-only recording must not produce audio");
+        let folder = saver.meeting_folder.as_ref().expect("meeting folder should remain available");
+        let transcripts: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(folder.join("transcripts.json"))
+                .expect("transcript sidecar should exist"),
+        )
+        .expect("transcript sidecar should be valid JSON");
+        assert_eq!(transcripts["total_segments"], serde_json::json!(1));
+        let metadata: MeetingMetadata = serde_json::from_str(
+            &std::fs::read_to_string(folder.join("metadata.json"))
+                .expect("metadata sidecar should exist"),
+        )
+        .expect("metadata sidecar should be valid JSON");
+        assert_eq!(metadata.status, "completed", "transcript-only metadata should finalize successfully");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stop_drains_blocked_identifiable_chunks_once_in_order_before_finalization() {
+        let base = tempdir().expect("temporary recordings directory should be created");
+        let mut saver = RecordingSaver::new();
+        saver.set_meeting_name(Some("blocked-drain-test".to_string()));
+        let (sender, receiver) = mpsc::unbounded_channel();
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let gate = Arc::new(Barrier::new(2));
+        let entered = Arc::new(AtomicBool::new(false));
+        saver.set_test_saver_gate(observed.clone(), gate.clone(), entered.clone());
+        saver
+            .start_accumulation_for_test(true, receiver, base.path())
+            .expect("auto-save should initialize");
+        saver.add_transcript_segment(test_segment(0));
+
+        let chunks = vec![test_chunk(0.11, 1), test_chunk(0.22, 2), test_chunk(0.33, 3)];
+        for chunk in &chunks {
+            sender.send(chunk.clone()).expect("chunk should be accepted");
+        }
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !entered.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("saver must reach the deliberate blocked point");
+
+        drop(sender); // Stop closes the producer side while the saver is blocked.
+        let stop_counter = Arc::new(AtomicUsize::new(0));
+        let stop_counter_for_task = stop_counter.clone();
+        let stop_task = tokio::spawn(async move {
+            saver
+                .stop_and_save_inner(Some(3.0), move |_| {
+                    stop_counter_for_task.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                })
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(!stop_task.is_finished(), "Stop must await the blocked saver instead of timing out or dropping its tail");
+
+        tokio::task::spawn_blocking(move || gate.wait())
+            .await
+            .expect("saver release task panicked"); // Release the real saver; it must then drain the remaining accepted chunks.
+        let final_audio = tokio::time::timeout(Duration::from_secs(10), stop_task)
+            .await
+            .expect("stop must finish after releasing the saver")
+            .expect("stop task panicked")
+            .expect("stop should finalize all accepted chunks")
+            .expect("auto-save should return the final audio path");
+        assert_eq!(stop_counter.load(Ordering::SeqCst), 1, "successful stop emits one save event");
+        assert!(PathBuf::from(&final_audio).exists(), "finalized audio should exist");
+
+        let observed = observed.lock().unwrap();
+        assert_eq!(observed.len(), chunks.len(), "every accepted chunk must be persisted exactly once");
+        for (actual, expected) in observed.iter().zip(chunks.iter()) {
+            assert_eq!(actual, &expected.data, "persisted chunks must retain acceptance order and samples");
+        }
+    }
+
+    #[tokio::test]
+    async fn stop_propagates_each_finalization_failure_without_success_event() {
+        for failure in [
+            TestFailure::AudioFinalization,
+            TestFailure::TranscriptWrite,
+            TestFailure::MetadataCompletion,
+        ] {
+            let base = tempdir().expect("temporary recordings directory should be created");
+            let mut saver = RecordingSaver::new();
+            saver.set_meeting_name(Some(format!("injected-stop-failure-{failure:?}")));
+            saver.set_test_failure(failure);
+            let (sender, receiver) = mpsc::unbounded_channel();
+            saver
+                .start_accumulation_for_test(true, receiver, base.path())
+                .expect("auto-save should initialize");
+            saver.add_transcript_segment(test_segment(0));
+            sender.send(test_chunk(0.44, 9)).expect("chunk should be accepted");
+            drop(sender);
+
+            let save_events = Arc::new(AtomicUsize::new(0));
+            let save_events_for_test = save_events.clone();
+            let error = saver
+                .stop_and_save_inner(Some(1.0), move |_| {
+                    save_events_for_test.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                })
+                .await
+                .expect_err("injected persistence failure must reach the caller");
+            assert!(error.starts_with("Partial save:"), "failure should be classified as partial save: {error}");
+            assert!(error.contains("folder="), "partial save should carry recovery folder: {error}");
+            assert_eq!(save_events.load(Ordering::SeqCst), 0, "persistence failure must not emit success");
+
+            let folder = saver.meeting_folder.as_ref().expect("partial save retains meeting folder");
+            if failure == TestFailure::AudioFinalization {
+                assert!(!folder.join("audio.mp4").exists(), "audio failure occurs before final output");
+            }
+            if failure == TestFailure::TranscriptWrite {
+                assert!(folder.join("audio.mp4").exists(), "transcript failure follows audio finalization");
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #781.

Make recording saver initialization fail before capture when auto-save is enabled, drain accepted saver-channel chunks by awaiting the accumulation task, and propagate checkpoint/finalization failures. Stop cleanup emits a partial-save result with the meeting folder and recovery guidance instead of claiming success.

Validation: full local Rust library tests pass with Visual Studio libclang and the branch's bundled ONNX Runtime (247 passed, 2 ignored), including saver startup rollback and channel-drain tests. The touched-file rustfmt parse reaches existing repository formatting drift without syntax errors; hosted checks are currently absent.