### PR TITLE
fix(storage): report partial transcript sidecar saves

### DIFF
--- a/frontend/src-tauri/src/audio/common.rs
+++ b/frontend/src-tauri/src/audio/common.rs
@@ -4,6 +4,7 @@ use log::{debug, info};
 use once_cell::sync::Lazy;
 use std::path::Path;
 use std::sync::Arc;
+use sqlx::Row;
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 use uuid::Uuid;
 
@@ -100,6 +101,57 @@ pub(crate) fn write_transcripts_json(folder: &Path, segments: &[TranscriptSegmen
         transcript_path.display()
     );
     Ok(())
+}
+
+/// Load the canonical committed transcript rows for sidecar recovery. This
+/// path only reads SQLite and never invokes ASR or creates a new meeting.
+pub(crate) async fn load_committed_transcript_segments(
+    pool: &sqlx::SqlitePool,
+    meeting_id: &str,
+) -> Result<Vec<TranscriptSegment>> {
+    let rows = sqlx::query(
+        "SELECT id, transcript, timestamp, audio_start_time, audio_end_time, duration
+         FROM transcripts WHERE meeting_id = ? ORDER BY rowid",
+    )
+    .bind(meeting_id)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(TranscriptSegment {
+                id: row.try_get("id")?,
+                text: row.try_get("transcript")?,
+                timestamp: row.try_get("timestamp")?,
+                audio_start_time: row.try_get("audio_start_time")?,
+                audio_end_time: row.try_get("audio_end_time")?,
+                duration: row.try_get("duration")?,
+            })
+        })
+        .collect()
+}
+
+/// Regenerate the transcript sidecar from already committed SQLite rows.
+/// Repeated calls overwrite the same atomic file and remain idempotent.
+pub(crate) async fn regenerate_transcripts_json_from_db(
+    pool: &sqlx::SqlitePool,
+    meeting_id: &str,
+    folder: &Path,
+) -> Result<()> {
+    let segments = load_committed_transcript_segments(pool, meeting_id).await?;
+    write_transcripts_json(folder, &segments)
+}
+
+pub(crate) fn partial_save_error(
+    meeting_id: &str,
+    folder: &Path,
+    failed_artifacts: &[String],
+) -> anyhow::Error {
+    anyhow::anyhow!(
+        "Partial save: meeting_id={meeting_id}, folder={}, failed_artifacts={}; retry sidecar recovery from committed SQLite rows",
+        folder.display(),
+        failed_artifacts.join(", ")
+    )
 }
 
 /// Split a long speech segment at the lowest-energy (silence) point near the target size.
@@ -232,5 +284,19 @@ mod tests {
 
         acquired_rx.await.unwrap();
         waiter.await.unwrap();
+    }
+
+    #[test]
+    fn partial_save_error_keeps_recovery_identity_and_artifacts() {
+        let error = partial_save_error(
+            "meeting-123",
+            Path::new("C:/recordings/meeting-123"),
+            &["transcripts.json (rename failed)".to_string(), "metadata.json".to_string()],
+        );
+        let message = error.to_string();
+        assert!(message.contains("meeting_id=meeting-123"));
+        assert!(message.contains("transcripts.json"));
+        assert!(message.contains("metadata.json"));
+        assert!(message.contains("committed SQLite rows"));
     }
 }

--- a/frontend/src-tauri/src/audio/common.rs
+++ b/frontend/src-tauri/src/audio/common.rs
@@ -71,8 +71,31 @@ pub(crate) fn create_transcript_segments(transcripts: &[(String, f64, f64)]) -> 
 
 /// Write transcripts.json to a meeting folder (atomic write with temp file)
 pub(crate) fn write_transcripts_json(folder: &Path, segments: &[TranscriptSegment]) -> Result<()> {
+    write_transcripts_json_with_fault(folder, segments, None)
+}
+
+/// A deterministic post-commit sidecar fault used by the import and
+/// retranscription contract tests. Production callers pass `None`; keeping
+/// the fault at the shared file boundary makes both flows exercise the same
+/// atomic writer and its real error handling.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SidecarFault {
+    TranscriptWrite,
+    MetadataWrite,
+    Rename,
+}
+
+pub(crate) fn write_transcripts_json_with_fault(
+    folder: &Path,
+    segments: &[TranscriptSegment],
+    fault: Option<SidecarFault>,
+) -> Result<()> {
     let transcript_path = folder.join("transcripts.json");
     let temp_path = folder.join(".transcripts.json.tmp");
+
+    if fault == Some(SidecarFault::TranscriptWrite) {
+        return Err(anyhow::anyhow!("injected transcript sidecar write failure"));
+    }
 
     let json = serde_json::json!({
         "version": "1.0",
@@ -93,6 +116,9 @@ pub(crate) fn write_transcripts_json(folder: &Path, segments: &[TranscriptSegmen
 
     let json_string = serde_json::to_string_pretty(&json)?;
     std::fs::write(&temp_path, &json_string)?;
+    if fault == Some(SidecarFault::Rename) {
+        return Err(anyhow::anyhow!("injected transcript sidecar rename failure"));
+    }
     std::fs::rename(&temp_path, &transcript_path)?;
 
     info!(

--- a/frontend/src-tauri/src/audio/common.rs
+++ b/frontend/src-tauri/src/audio/common.rs
@@ -299,4 +299,65 @@ mod tests {
         assert!(message.contains("metadata.json"));
         assert!(message.contains("committed SQLite rows"));
     }
+
+    #[tokio::test]
+    async fn regenerate_transcript_sidecar_is_idempotent_from_committed_rows() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory SQLite should open");
+        sqlx::query(
+            "CREATE TABLE transcripts (
+                id TEXT PRIMARY KEY,
+                meeting_id TEXT NOT NULL,
+                transcript TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                audio_start_time REAL,
+                audio_end_time REAL,
+                duration REAL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("transcript table should be created");
+        sqlx::query(
+            "INSERT INTO transcripts
+                (id, meeting_id, transcript, timestamp, audio_start_time, audio_end_time, duration)
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind("segment-1")
+        .bind("meeting-1")
+        .bind("  committed text  ")
+        .bind("2026-09-09T00:00:00Z")
+        .bind(1.5_f64)
+        .bind(2.5_f64)
+        .bind(1.0_f64)
+        .execute(&pool)
+        .await
+        .expect("committed transcript should be inserted");
+
+        let folder = tempfile::tempdir().expect("temporary folder should be created");
+        regenerate_transcripts_json_from_db(&pool, "meeting-1", folder.path())
+            .await
+            .expect("first sidecar regeneration should succeed");
+        let first: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(folder.path().join("transcripts.json"))
+                .expect("first sidecar should exist"),
+        )
+        .expect("first sidecar should be valid JSON");
+
+        regenerate_transcripts_json_from_db(&pool, "meeting-1", folder.path())
+            .await
+            .expect("second sidecar regeneration should succeed");
+        let second: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(folder.path().join("transcripts.json"))
+                .expect("second sidecar should exist"),
+        )
+        .expect("second sidecar should be valid JSON");
+
+        assert_eq!(first["total_segments"], serde_json::json!(1));
+        assert_eq!(first["segments"][0]["id"], serde_json::json!("segment-1"));
+        assert_eq!(first["segments"][0]["text"], serde_json::json!("  committed text  "));
+        assert_eq!(first["segments"], second["segments"]);
+        assert_eq!(first["total_segments"], second["total_segments"]);
+    }
 }

--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 use super::audio_processing::create_meeting_folder;
 use super::common::{
     create_transcript_segments, partial_save_error, split_segment_at_silence,
-    write_transcripts_json,
+    write_transcripts_json, write_transcripts_json_with_fault, SidecarFault,
 };
 use super::constants::AUDIO_EXTENSIONS;
 use super::recording_preferences::get_default_recordings_folder;
@@ -652,30 +652,17 @@ async fn run_import<R: Runtime>(
     // Write transcripts.json and metadata.json to the meeting folder
     emit_progress(&app, "saving", 90, "Writing transcript files...");
 
-    let mut failed_artifacts = Vec::new();
-    if let Err(e) = write_transcripts_json(&meeting_folder, &segments) {
-        warn!("Failed to write transcripts.json: {}", e);
-        failed_artifacts.push(format!("transcripts.json ({e})"));
-    }
-
-    if let Err(e) = write_import_metadata(
+    if let Err(error) = persist_import_sidecars(
         &meeting_folder,
         &meeting_id,
         &title,
         duration_seconds,
         &dest_filename,
         "import",
+        &segments,
+        None,
     ) {
-        warn!("Failed to write metadata.json: {}", e);
-        failed_artifacts.push(format!("metadata.json ({e})"));
-    }
-
-    if !failed_artifacts.is_empty() {
-        return Err(partial_save_error(
-            &meeting_id,
-            &meeting_folder,
-            &failed_artifacts,
-        ));
+        return Err(error);
     }
 
     emit_progress(&app, "complete", 100, "Import complete");
@@ -899,9 +886,33 @@ fn write_import_metadata(
     audio_filename: &str,
     source: &str,
 ) -> Result<()> {
+    write_import_metadata_with_fault(
+        folder,
+        meeting_id,
+        title,
+        duration_seconds,
+        audio_filename,
+        source,
+        None,
+    )
+}
+
+fn write_import_metadata_with_fault(
+    folder: &Path,
+    meeting_id: &str,
+    title: &str,
+    duration_seconds: f64,
+    audio_filename: &str,
+    source: &str,
+    fault: Option<SidecarFault>,
+) -> Result<()> {
     let metadata_path = folder.join("metadata.json");
     let temp_path = folder.join(".metadata.json.tmp");
     let now = chrono::Utc::now().to_rfc3339();
+
+    if fault == Some(SidecarFault::MetadataWrite) {
+        return Err(anyhow!("injected metadata sidecar write failure"));
+    }
 
     let json = serde_json::json!({
         "version": "1.0",
@@ -918,10 +929,52 @@ fn write_import_metadata(
 
     let json_string = serde_json::to_string_pretty(&json)?;
     std::fs::write(&temp_path, &json_string)?;
+    if fault == Some(SidecarFault::Rename) {
+        return Err(anyhow!("injected metadata sidecar rename failure"));
+    }
     std::fs::rename(&temp_path, &metadata_path)?;
 
     info!("Wrote metadata.json to {}", metadata_path.display());
     Ok(())
+}
+
+/// Persist both import sidecars after the SQLite transaction has committed.
+/// Keeping the partial-save classification in this production helper lets
+/// deterministic tests exercise the same boundary as `run_import`.
+fn persist_import_sidecars(
+    folder: &Path,
+    meeting_id: &str,
+    title: &str,
+    duration_seconds: f64,
+    audio_filename: &str,
+    source: &str,
+    segments: &[TranscriptSegment],
+    fault: Option<SidecarFault>,
+) -> Result<()> {
+    let mut failed_artifacts = Vec::new();
+    if let Err(error) = write_transcripts_json_with_fault(folder, segments, fault) {
+        warn!("Failed to write transcripts.json: {}", error);
+        failed_artifacts.push(format!("transcripts.json ({error})"));
+    }
+
+    if let Err(error) = write_import_metadata_with_fault(
+        folder,
+        meeting_id,
+        title,
+        duration_seconds,
+        audio_filename,
+        source,
+        fault,
+    ) {
+        warn!("Failed to write metadata.json: {}", error);
+        failed_artifacts.push(format!("metadata.json ({error})"));
+    }
+
+    if failed_artifacts.is_empty() {
+        Ok(())
+    } else {
+        Err(partial_save_error(meeting_id, folder, &failed_artifacts))
+    }
 }
 
 // ============================================================================
@@ -1253,6 +1306,90 @@ mod tests {
         assert_eq!(parsed["audio_file"], "audio.mp4");
         assert_eq!(parsed["status"], "completed");
         assert_eq!(parsed["source"], "import");
+    }
+
+    #[tokio::test]
+    async fn import_post_commit_sidecar_faults_report_partial_without_losing_sqlite_rows() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory SQLite should open");
+        sqlx::query(
+            "CREATE TABLE transcripts (
+                id TEXT PRIMARY KEY,
+                meeting_id TEXT NOT NULL,
+                transcript TEXT NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("committed transcript table should be created");
+        sqlx::query("INSERT INTO transcripts (id, meeting_id, transcript) VALUES (?, ?, ?)")
+            .bind("import-segment-1")
+            .bind("import-meeting-1")
+            .bind("committed import text")
+            .execute(&pool)
+            .await
+            .expect("committed import row should be inserted");
+
+        let segments = create_transcript_segments(&[(
+            "committed import text".to_string(),
+            0.0,
+            1000.0,
+        )]);
+        for fault in [
+            SidecarFault::TranscriptWrite,
+            SidecarFault::MetadataWrite,
+            SidecarFault::Rename,
+        ] {
+            let folder = tempfile::tempdir().expect("temporary sidecar folder should be created");
+            let error = persist_import_sidecars(
+                folder.path(),
+                "import-meeting-1",
+                "Imported meeting",
+                1.0,
+                "audio.wav",
+                "import",
+                &segments,
+                Some(fault),
+            )
+            .expect_err("post-commit sidecar fault must return partial save");
+            let message = error.to_string();
+            assert!(message.starts_with("Partial save:"));
+            assert!(message.contains("meeting_id=import-meeting-1"));
+            assert!(message.contains(folder.path().to_string_lossy().as_ref()));
+            match fault {
+                SidecarFault::TranscriptWrite => assert!(message.contains("transcripts.json")),
+                SidecarFault::MetadataWrite => assert!(message.contains("metadata.json")),
+                SidecarFault::Rename => {
+                    assert!(message.contains("transcripts.json"));
+                    assert!(message.contains("metadata.json"));
+                }
+            }
+
+            let row_count: (i64,) = sqlx::query_as(
+                "SELECT COUNT(*) FROM transcripts WHERE meeting_id = ?",
+            )
+            .bind("import-meeting-1")
+            .fetch_one(&pool)
+            .await
+            .expect("committed row should remain queryable");
+            assert_eq!(row_count.0, 1, "sidecar failure must not roll back SQLite");
+
+            match fault {
+                SidecarFault::TranscriptWrite => {
+                    assert!(!folder.path().join("transcripts.json").exists());
+                    assert!(folder.path().join("metadata.json").exists());
+                }
+                SidecarFault::MetadataWrite => {
+                    assert!(folder.path().join("transcripts.json").exists());
+                    assert!(!folder.path().join("metadata.json").exists());
+                }
+                SidecarFault::Rename => {
+                    assert!(!folder.path().join("transcripts.json").exists());
+                    assert!(!folder.path().join("metadata.json").exists());
+                }
+            }
+        }
     }
 
     /// Integration test that decodes a real audio file and runs VAD.

--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -18,7 +18,10 @@ use tauri_plugin_dialog::DialogExt;
 use uuid::Uuid;
 
 use super::audio_processing::create_meeting_folder;
-use super::common::{create_transcript_segments, split_segment_at_silence, write_transcripts_json};
+use super::common::{
+    create_transcript_segments, partial_save_error, split_segment_at_silence,
+    write_transcripts_json,
+};
 use super::constants::AUDIO_EXTENSIONS;
 use super::recording_preferences::get_default_recordings_folder;
 
@@ -649,8 +652,10 @@ async fn run_import<R: Runtime>(
     // Write transcripts.json and metadata.json to the meeting folder
     emit_progress(&app, "saving", 90, "Writing transcript files...");
 
+    let mut failed_artifacts = Vec::new();
     if let Err(e) = write_transcripts_json(&meeting_folder, &segments) {
         warn!("Failed to write transcripts.json: {}", e);
+        failed_artifacts.push(format!("transcripts.json ({e})"));
     }
 
     if let Err(e) = write_import_metadata(
@@ -662,6 +667,15 @@ async fn run_import<R: Runtime>(
         "import",
     ) {
         warn!("Failed to write metadata.json: {}", e);
+        failed_artifacts.push(format!("metadata.json ({e})"));
+    }
+
+    if !failed_artifacts.is_empty() {
+        return Err(partial_save_error(
+            &meeting_id,
+            &meeting_folder,
+            &failed_artifacts,
+        ));
     }
 
     emit_progress(&app, "complete", 100, "Import complete");

--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -2,9 +2,10 @@
 
 use crate::audio::decoder::decode_audio_file;
 use crate::audio::vad::get_speech_chunks_with_progress;
+use crate::api::TranscriptSegment;
 use super::common::{
     create_transcript_segments, partial_save_error, split_segment_at_silence,
-    write_transcripts_json,
+    write_transcripts_json_with_fault, SidecarFault,
 };
 use super::constants::AUDIO_EXTENSIONS;
 use crate::config::{DEFAULT_WHISPER_MODEL, DEFAULT_PARAKEET_MODEL};
@@ -472,12 +473,6 @@ async fn run_retranscription<R: Runtime>(
     // Write updated transcripts.json and metadata.json to the meeting folder
     emit_progress(&app, &meeting_id, "saving", 90, "Writing transcript files...");
 
-    let mut failed_artifacts = Vec::new();
-    if let Err(e) = write_transcripts_json(&folder_path, &segments) {
-        warn!("Failed to write transcripts.json: {}", e);
-        failed_artifacts.push(format!("transcripts.json ({e})"));
-    }
-
     // Find audio filename for metadata
     let audio_filename = audio_path
         .file_name()
@@ -485,22 +480,15 @@ async fn run_retranscription<R: Runtime>(
         .unwrap_or("audio.mp4")
         .to_string();
 
-    if let Err(e) = write_retranscription_metadata(
+    if let Err(error) = persist_retranscription_sidecars(
         &folder_path,
         &meeting_id,
         duration_seconds,
         &audio_filename,
+        &segments,
+        None,
     ) {
-        warn!("Failed to update metadata.json: {}", e);
-        failed_artifacts.push(format!("metadata.json ({e})"));
-    }
-
-    if !failed_artifacts.is_empty() {
-        return Err(partial_save_error(
-            &meeting_id,
-            &folder_path,
-            &failed_artifacts,
-        ));
+        return Err(error);
     }
 
     emit_progress(&app, &meeting_id, "complete", 100, "Retranscription complete");
@@ -742,9 +730,29 @@ fn write_retranscription_metadata(
     duration_seconds: f64,
     audio_filename: &str,
 ) -> Result<()> {
+    write_retranscription_metadata_with_fault(
+        folder,
+        meeting_id,
+        duration_seconds,
+        audio_filename,
+        None,
+    )
+}
+
+fn write_retranscription_metadata_with_fault(
+    folder: &Path,
+    meeting_id: &str,
+    duration_seconds: f64,
+    audio_filename: &str,
+    fault: Option<SidecarFault>,
+) -> Result<()> {
     let metadata_path = folder.join("metadata.json");
     let temp_path = folder.join(".metadata.json.tmp");
     let now = chrono::Utc::now().to_rfc3339();
+
+    if fault == Some(SidecarFault::MetadataWrite) {
+        return Err(anyhow!("injected metadata sidecar write failure"));
+    }
 
     // Try to read existing metadata and update it
     let json = if metadata_path.exists() {
@@ -775,10 +783,48 @@ fn write_retranscription_metadata(
 
     let json_string = serde_json::to_string_pretty(&json)?;
     std::fs::write(&temp_path, &json_string)?;
+    if fault == Some(SidecarFault::Rename) {
+        return Err(anyhow!("injected metadata sidecar rename failure"));
+    }
     std::fs::rename(&temp_path, &metadata_path)?;
 
     info!("Wrote metadata.json to {}", metadata_path.display());
     Ok(())
+}
+
+/// Persist retranscription sidecars after the replacement transcript
+/// transaction has committed. Tests inject faults through this same helper
+/// to verify the real partial-save boundary without running ASR.
+fn persist_retranscription_sidecars(
+    folder: &Path,
+    meeting_id: &str,
+    duration_seconds: f64,
+    audio_filename: &str,
+    segments: &[TranscriptSegment],
+    fault: Option<SidecarFault>,
+) -> Result<()> {
+    let mut failed_artifacts = Vec::new();
+    if let Err(error) = write_transcripts_json_with_fault(folder, segments, fault) {
+        warn!("Failed to write transcripts.json: {}", error);
+        failed_artifacts.push(format!("transcripts.json ({error})"));
+    }
+
+    if let Err(error) = write_retranscription_metadata_with_fault(
+        folder,
+        meeting_id,
+        duration_seconds,
+        audio_filename,
+        fault,
+    ) {
+        warn!("Failed to update metadata.json: {}", error);
+        failed_artifacts.push(format!("metadata.json ({error})"));
+    }
+
+    if failed_artifacts.is_empty() {
+        Ok(())
+    } else {
+        Err(partial_save_error(meeting_id, folder, &failed_artifacts))
+    }
 }
 
 // Tauri commands
@@ -1064,5 +1110,99 @@ mod tests {
         assert_eq!(metadata["summary_language"], "fr");
         assert_eq!(metadata["custom_field"], "preserve me");
         assert!(metadata.get("detected_summary_language").is_none());
+    }
+
+    #[tokio::test]
+    async fn retranscription_post_commit_sidecar_faults_report_partial_without_losing_replacement_rows() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory SQLite should open");
+        sqlx::query(
+            "CREATE TABLE transcripts (
+                id TEXT PRIMARY KEY,
+                meeting_id TEXT NOT NULL,
+                transcript TEXT NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("committed transcript table should be created");
+        sqlx::query("INSERT INTO transcripts (id, meeting_id, transcript) VALUES (?, ?, ?)")
+            .bind("retranscription-segment-new")
+            .bind("retranscription-meeting-1")
+            .bind("replacement transcript")
+            .execute(&pool)
+            .await
+            .expect("replacement row should be committed");
+
+        let segments = create_transcript_segments(&[(
+            "replacement transcript".to_string(),
+            0.0,
+            1200.0,
+        )]);
+        for fault in [
+            SidecarFault::TranscriptWrite,
+            SidecarFault::MetadataWrite,
+            SidecarFault::Rename,
+        ] {
+            let folder = tempfile::tempdir().expect("temporary sidecar folder should be created");
+            std::fs::write(
+                folder.path().join("transcripts.json"),
+                r#"{"segments":[{"text":"stale transcript"}],"total_segments":1}"#,
+            )
+            .expect("stale transcript sidecar should be written");
+            std::fs::write(
+                folder.path().join("metadata.json"),
+                r#"{"meeting_id":"retranscription-meeting-1","status":"completed","duration_seconds":9}"#,
+            )
+            .expect("existing metadata sidecar should be written");
+
+            let error = persist_retranscription_sidecars(
+                folder.path(),
+                "retranscription-meeting-1",
+                1.2,
+                "audio.mp4",
+                &segments,
+                Some(fault),
+            )
+            .expect_err("post-commit sidecar fault must return partial save");
+            let message = error.to_string();
+            assert!(message.starts_with("Partial save:"));
+            assert!(message.contains("meeting_id=retranscription-meeting-1"));
+            assert!(message.contains(folder.path().to_string_lossy().as_ref()));
+            match fault {
+                SidecarFault::TranscriptWrite => assert!(message.contains("transcripts.json")),
+                SidecarFault::MetadataWrite => assert!(message.contains("metadata.json")),
+                SidecarFault::Rename => {
+                    assert!(message.contains("transcripts.json"));
+                    assert!(message.contains("metadata.json"));
+                }
+            }
+
+            let row: (String,) = sqlx::query_as(
+                "SELECT transcript FROM transcripts WHERE meeting_id = ? ORDER BY rowid",
+            )
+            .bind("retranscription-meeting-1")
+            .fetch_one(&pool)
+            .await
+            .expect("committed replacement row should remain queryable");
+            assert_eq!(row.0, "replacement transcript");
+
+            match fault {
+                SidecarFault::TranscriptWrite | SidecarFault::Rename => {
+                    let stale = std::fs::read_to_string(folder.path().join("transcripts.json"))
+                        .expect("old transcript sidecar should remain after failed rename");
+                    assert!(stale.contains("stale transcript"));
+                }
+                SidecarFault::MetadataWrite => {
+                    let current: serde_json::Value = serde_json::from_str(
+                        &std::fs::read_to_string(folder.path().join("transcripts.json"))
+                            .expect("transcript sidecar should be written"),
+                    )
+                    .expect("transcript sidecar should remain valid JSON");
+                    assert_eq!(current["segments"][0]["text"], "replacement transcript");
+                }
+            }
+        }
     }
 }

--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -2,7 +2,10 @@
 
 use crate::audio::decoder::decode_audio_file;
 use crate::audio::vad::get_speech_chunks_with_progress;
-use super::common::{create_transcript_segments, split_segment_at_silence, write_transcripts_json};
+use super::common::{
+    create_transcript_segments, partial_save_error, split_segment_at_silence,
+    write_transcripts_json,
+};
 use super::constants::AUDIO_EXTENSIONS;
 use crate::config::{DEFAULT_WHISPER_MODEL, DEFAULT_PARAKEET_MODEL};
 use crate::parakeet_engine::ParakeetEngine;
@@ -469,8 +472,10 @@ async fn run_retranscription<R: Runtime>(
     // Write updated transcripts.json and metadata.json to the meeting folder
     emit_progress(&app, &meeting_id, "saving", 90, "Writing transcript files...");
 
+    let mut failed_artifacts = Vec::new();
     if let Err(e) = write_transcripts_json(&folder_path, &segments) {
         warn!("Failed to write transcripts.json: {}", e);
+        failed_artifacts.push(format!("transcripts.json ({e})"));
     }
 
     // Find audio filename for metadata
@@ -487,6 +492,15 @@ async fn run_retranscription<R: Runtime>(
         &audio_filename,
     ) {
         warn!("Failed to update metadata.json: {}", e);
+        failed_artifacts.push(format!("metadata.json ({e})"));
+    }
+
+    if !failed_artifacts.is_empty() {
+        return Err(partial_save_error(
+            &meeting_id,
+            &folder_path,
+            &failed_artifacts,
+        ));
     }
 
     emit_progress(&app, &meeting_id, "complete", 100, "Retranscription complete");


### PR DESCRIPTION
Closes #777.

Keep SQLite as the canonical commit, report failed transcript or metadata sidecars as a partial-save outcome containing the stable meeting ID, folder, and artifact names, and provide idempotent transcript-sidecar regeneration from committed SQLite rows without rerunning ASR.

Validation: full local Rust library tests pass with Visual Studio libclang and the branch's bundled ONNX Runtime (247 passed, 2 ignored), including deterministic idempotent sidecar regeneration coverage. The touched-file rustfmt parse reaches existing repository formatting drift without syntax errors; hosted checks are currently absent.