### PR TITLE
fix(recording): stop native capture after fatal worker failure

### DIFF
--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -201,6 +201,7 @@ whisper-rs = { version = "0.13.2", features = ["raw-api"] }
 futures-channel = "0.3.31"
 
 [dev-dependencies]
+tauri = { version = "2.6.2", features = ["test"] }
 tempfile = "3.3.0"
 infer = "0.15"
 criterion = { version = "0.5.1", features = ["async_tokio"] }

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -754,6 +754,51 @@ mod tests {
         assert!(StoppingGuard::new().is_some());
         IS_RECORDING_STOPPING.store(false, Ordering::SeqCst);
     }
+
+    #[test]
+    fn stopping_gate_has_one_winner_under_concurrent_stop_race() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        IS_RECORDING_STOPPING.store(false, Ordering::SeqCst);
+        let workers = 16;
+        let barrier = Arc::new(Barrier::new(workers));
+        let release = Arc::new(Barrier::new(workers));
+        let winners = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let handles = (0..workers)
+            .map(|_| {
+                let barrier = Arc::clone(&barrier);
+                let release = Arc::clone(&release);
+                let winners = Arc::clone(&winners);
+                thread::spawn(move || {
+                    barrier.wait();
+                    let guard = StoppingGuard::new();
+                    if guard.is_some() {
+                        winners.fetch_add(1, Ordering::SeqCst);
+                    }
+                    // Keep the winning guard alive until every contender has
+                    // performed its one acquisition attempt. This makes the
+                    // assertion test the atomic race itself, rather than
+                    // allowing a fast winner to drop and a later contender to
+                    // become a second sequential owner.
+                    release.wait();
+                    drop(guard);
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            handle.join().expect("stop-race worker panicked");
+        }
+
+        assert_eq!(
+            winners.load(Ordering::SeqCst),
+            1,
+            "exactly one concurrent stop caller may own the shutdown tail"
+        );
+        assert!(StoppingGuard::new().is_some(), "guard must be reusable after the winner exits");
+        IS_RECORDING_STOPPING.store(false, Ordering::SeqCst);
+    }
 }
 
 pub async fn stop_recording<R: Runtime>(

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -737,7 +737,6 @@ pub(crate) async fn shutdown_after_fatal_transcription_failure<R: Runtime>(
             "outcome": "fatal_transcription_failure"
         }),
     );
-    #[cfg(not(test))]
     crate::tray::update_tray_menu(&app);
 }
 

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -744,8 +744,11 @@ pub(crate) async fn shutdown_after_fatal_transcription_failure<R: Runtime>(
 mod tests {
     use super::*;
 
+    static TEST_GLOBAL_STATE: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn stopping_gate_allows_only_one_owner() {
+        let _global_state_guard = TEST_GLOBAL_STATE.lock().unwrap();
         IS_RECORDING_STOPPING.store(false, Ordering::SeqCst);
         let first = StoppingGuard::new();
         assert!(first.is_some());
@@ -757,6 +760,7 @@ mod tests {
 
     #[test]
     fn stopping_gate_has_one_winner_under_concurrent_stop_race() {
+        let _global_state_guard = TEST_GLOBAL_STATE.lock().unwrap();
         use std::sync::{Arc, Barrier};
         use std::thread;
 
@@ -802,6 +806,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn fatal_worker_shutdown_completes_before_error_event() {
+        let _global_state_guard = TEST_GLOBAL_STATE.lock().unwrap();
         use std::sync::{Arc, Mutex};
         use tauri::{Listener, Manager};
 
@@ -846,6 +851,166 @@ mod tests {
 
         app.unlisten(stopped_listener);
         app.unlisten(error_listener);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fatal_worker_startup_when_recording_is_inactive_only_emits_error() {
+        let _global_state_guard = TEST_GLOBAL_STATE.lock().unwrap();
+        use std::sync::{Arc, Mutex};
+        use tauri::Listener;
+
+        let app = tauri::test::mock_app();
+        let temp = tempfile::tempdir().expect("temporary database directory should exist");
+        let db_path = temp.path().join("meetily.sqlite");
+        let db_path = db_path.to_string_lossy().into_owned();
+        let db_manager = crate::database::manager::DatabaseManager::new(&db_path, &db_path)
+            .await
+            .expect("mock app database should initialize");
+        app.manage(crate::state::AppState { db_manager });
+
+        let events = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+        let stopped_events = Arc::clone(&events);
+        let stopped_listener = app.listen("recording-stopped", move |_| {
+            stopped_events.lock().unwrap().push("recording-stopped");
+        });
+        let error_events = Arc::clone(&events);
+        let error_listener = app.listen("transcription-error", move |_| {
+            error_events.lock().unwrap().push("transcription-error");
+        });
+
+        IS_RECORDING.store(false, Ordering::SeqCst);
+        IS_RECORDING_STOPPING.store(false, Ordering::SeqCst);
+        *RECORDING_MANAGER.lock().unwrap() = Some(RecordingManager::new());
+        let (_sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+        let worker = transcription::start_transcription_task(app.handle().clone(), receiver);
+        tokio::time::timeout(std::time::Duration::from_secs(5), worker)
+            .await
+            .expect("inactive startup failure should return promptly")
+            .expect("inactive startup worker should not panic");
+
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec!["transcription-error"],
+            "inactive startup failure must not run native recording shutdown"
+        );
+        assert!(RECORDING_MANAGER.lock().unwrap().is_some());
+        assert!(!IS_RECORDING_STOPPING.load(Ordering::SeqCst));
+        RECORDING_MANAGER.lock().unwrap().take();
+        app.unlisten(stopped_listener);
+        app.unlisten(error_listener);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fatal_native_save_failure_emits_error_and_still_completes_cleanup() {
+        let _global_state_guard = TEST_GLOBAL_STATE.lock().unwrap();
+        use std::sync::{Arc, Mutex};
+        use tauri::Listener;
+
+        let app = tauri::test::mock_app();
+        let temp = tempfile::tempdir().expect("temporary database directory should exist");
+        let db_path = temp.path().join("meetily.sqlite");
+        let db_path = db_path.to_string_lossy().into_owned();
+        let db_manager = crate::database::manager::DatabaseManager::new(&db_path, &db_path)
+            .await
+            .expect("mock app database should initialize");
+        app.manage(crate::state::AppState { db_manager });
+
+        let events = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+        let save_events = Arc::clone(&events);
+        let save_listener = app.listen("recording-save-failed", move |_| {
+            save_events.lock().unwrap().push("recording-save-failed");
+        });
+        let stopped_events = Arc::clone(&events);
+        let stopped_listener = app.listen("recording-stopped", move |_| {
+            stopped_events.lock().unwrap().push("recording-stopped");
+        });
+
+        let mut manager = RecordingManager::new();
+        manager.inject_native_save_failure_for_test();
+        IS_RECORDING.store(true, Ordering::SeqCst);
+        IS_RECORDING_STOPPING.store(false, Ordering::SeqCst);
+        *RECORDING_MANAGER.lock().unwrap() = Some(manager);
+
+        shutdown_after_fatal_transcription_failure(app.handle().clone()).await;
+
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec!["recording-save-failed", "recording-stopped"],
+            "save failure must be surfaced before fatal shutdown completion"
+        );
+        assert!(
+            events.lock().unwrap().contains(&"recording-save-failed"),
+            "native save failure must remain caller-visible"
+        );
+        assert!(!IS_RECORDING.load(Ordering::SeqCst));
+        assert!(!IS_RECORDING_STOPPING.load(Ordering::SeqCst));
+        assert!(RECORDING_MANAGER.lock().unwrap().is_none());
+        app.unlisten(save_listener);
+        app.unlisten(stopped_listener);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fatal_ui_and_tray_stop_callers_share_one_real_shutdown_tail() {
+        let _global_state_guard = TEST_GLOBAL_STATE.lock().unwrap();
+        use std::sync::{Arc, Mutex};
+        use tauri::Listener;
+
+        let app = tauri::test::mock_app();
+        let temp = tempfile::tempdir().expect("temporary database directory should exist");
+        let db_path = temp.path().join("meetily.sqlite");
+        let db_path = db_path.to_string_lossy().into_owned();
+        let db_manager = crate::database::manager::DatabaseManager::new(&db_path, &db_path)
+            .await
+            .expect("mock app database should initialize");
+        app.manage(crate::state::AppState { db_manager });
+
+        let stopped_count = Arc::new(Mutex::new(0usize));
+        let count_for_listener = Arc::clone(&stopped_count);
+        let stopped_listener = app.listen("recording-stopped", move |_| {
+            *count_for_listener.lock().unwrap() += 1;
+        });
+
+        IS_RECORDING.store(true, Ordering::SeqCst);
+        IS_RECORDING_STOPPING.store(false, Ordering::SeqCst);
+        *RECORDING_MANAGER.lock().unwrap() = Some(RecordingManager::new());
+        let fatal_app = app.handle().clone();
+        let ui_app = app.handle().clone();
+        let tray_app = app.handle().clone();
+        let fatal = tokio::spawn(async move {
+            shutdown_after_fatal_transcription_failure(fatal_app).await;
+        });
+        let ui_stop = tokio::spawn(async move {
+            stop_recording(
+                ui_app,
+                RecordingArgs {
+                    save_path: "ui-stop.wav".to_string(),
+                },
+            )
+            .await
+        });
+        let tray_stop = tokio::spawn(async move {
+            stop_recording(
+                tray_app,
+                RecordingArgs {
+                    save_path: "tray-stop.wav".to_string(),
+                },
+            )
+            .await
+        });
+
+        fatal.await.expect("fatal caller should not panic");
+        ui_stop.await.expect("UI stop caller should not panic").expect("UI stop should complete");
+        tray_stop.await.expect("tray stop caller should not panic").expect("tray stop should complete");
+
+        assert_eq!(
+            *stopped_count.lock().unwrap(),
+            1,
+            "fatal, UI, and tray callers must emit one shared stop completion"
+        );
+        assert!(!IS_RECORDING.load(Ordering::SeqCst));
+        assert!(!IS_RECORDING_STOPPING.load(Ordering::SeqCst));
+        assert!(RECORDING_MANAGER.lock().unwrap().is_none());
+        app.unlisten(stopped_listener);
     }
 }
 

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -737,6 +737,7 @@ pub(crate) async fn shutdown_after_fatal_transcription_failure<R: Runtime>(
             "outcome": "fatal_transcription_failure"
         }),
     );
+    #[cfg(not(test))]
     crate::tray::update_tray_menu(&app);
 }
 
@@ -798,6 +799,54 @@ mod tests {
         );
         assert!(StoppingGuard::new().is_some(), "guard must be reusable after the winner exits");
         IS_RECORDING_STOPPING.store(false, Ordering::SeqCst);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fatal_worker_shutdown_completes_before_error_event() {
+        use std::sync::{Arc, Mutex};
+        use tauri::{Listener, Manager};
+
+        let app = tauri::test::mock_app();
+        let temp = tempfile::tempdir().expect("temporary database directory should exist");
+        let db_path = temp.path().join("meetily.sqlite");
+        let db_path = db_path.to_string_lossy().into_owned();
+        let db_manager = crate::database::manager::DatabaseManager::new(&db_path, &db_path)
+            .await
+            .expect("mock app database should initialize");
+        app.manage(crate::state::AppState { db_manager });
+
+        let events = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+        let stopped_events = Arc::clone(&events);
+        let stopped_listener = app.listen("recording-stopped", move |_| {
+            stopped_events.lock().unwrap().push("recording-stopped");
+        });
+        let error_events = Arc::clone(&events);
+        let error_listener = app.listen("transcription-error", move |_| {
+            error_events.lock().unwrap().push("transcription-error");
+        });
+
+        IS_RECORDING.store(true, Ordering::SeqCst);
+        IS_RECORDING_STOPPING.store(false, Ordering::SeqCst);
+        *RECORDING_MANAGER.lock().unwrap() = Some(RecordingManager::new());
+        let (_sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+
+        let worker = transcription::start_transcription_task(app.handle().clone(), receiver);
+        tokio::time::timeout(std::time::Duration::from_secs(5), worker)
+            .await
+            .expect("fatal worker should shut down promptly")
+            .expect("fatal worker should not panic");
+
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec!["recording-stopped", "transcription-error"],
+            "native shutdown must emit completion before the frontend error"
+        );
+        assert!(!IS_RECORDING.load(Ordering::SeqCst));
+        assert!(RECORDING_MANAGER.lock().unwrap().is_none());
+        assert!(!IS_RECORDING_STOPPING.load(Ordering::SeqCst));
+
+        app.unlisten(stopped_listener);
+        app.unlisten(error_listener);
     }
 }
 

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -68,8 +68,8 @@ fn session_live(s: &Arc<super::RecordingState>) -> bool {
             .map_or(false, |m| Arc::ptr_eq(m.get_state(), s))
 }
 
-/// RAII guard for the stop-tail flag. Sets `IS_RECORDING_STOPPING` true on
-/// construction and clears it on Drop — including during unwind — so a panic
+/// RAII guard for the stop-tail flag. The caller acquires the atomic gate before
+/// construction; Drop clears it on unwind — including during panic — so a panic
 /// anywhere in the ~320-line stop tail can't leave the flag stuck true and
 /// silently kill the mic-disconnect fallback for every later recording.
 ///
@@ -78,9 +78,11 @@ fn session_live(s: &Arc<super::RecordingState>) -> bool {
 /// and the stuck-flag failure mode returns — add a start-time reset then.
 struct StoppingGuard;
 impl StoppingGuard {
-    fn new() -> Self {
-        IS_RECORDING_STOPPING.store(true, Ordering::SeqCst);
-        StoppingGuard
+    fn new() -> Option<Self> {
+        IS_RECORDING_STOPPING
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .ok()
+            .map(|_| StoppingGuard)
     }
 }
 impl Drop for StoppingGuard {
@@ -673,6 +675,87 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
 }
 
 /// Stop recording with optimized graceful shutdown ensuring NO transcript chunks are lost
+///
+/// This entry point is also used by the transcription worker's fatal
+/// initialization path. It deliberately does not touch `TRANSCRIPTION_TASK`,
+/// so a worker can request shutdown without awaiting itself.
+pub(crate) async fn shutdown_after_fatal_transcription_failure<R: Runtime>(
+    app: AppHandle<R>,
+) {
+    if !IS_RECORDING.load(Ordering::SeqCst) {
+        return;
+    }
+    let Some(_stopping_guard) = StoppingGuard::new() else {
+        // A concurrent UI or tray Stop already owns the shutdown tail.
+        return;
+    };
+
+    let manager = RECORDING_MANAGER.lock().unwrap().take();
+    let (folder_path, meeting_name) = if let Some(mut manager) = manager {
+        let folder = manager.get_meeting_folder();
+        let name = manager.get_meeting_name();
+        if let Err(error) = manager.stop_streams_and_force_flush().await {
+            warn!("Fatal transcription failure cleanup could not stop streams: {}", error);
+        }
+        if let Err(error) = manager.save_recording_only(&app).await {
+            let _ = app.emit(
+                "recording-save-failed",
+                serde_json::json!({
+                    "message": error.to_string(),
+                    "meeting_folder": folder.as_ref().map(|path| path.to_string_lossy().to_string()),
+                    "recovery": "Resolve the storage error and retry sidecar/audio recovery from the meeting folder."
+                }),
+            );
+        }
+        (folder, name)
+    } else {
+        (None, None)
+    };
+
+    {
+        use tauri::Listener;
+        if let Some(listener_id) = TRANSCRIPT_LISTENER_ID.lock().unwrap().take() {
+            app.unlisten(listener_id);
+        }
+    }
+    IS_RECORDING.store(false, Ordering::SeqCst);
+    let _ = app.emit(
+        "recording-shutdown-progress",
+        serde_json::json!({
+            "stage": "complete",
+            "message": "Recording stopped after speech recognition initialization failed",
+            "progress": 100,
+            "outcome": "fatal_transcription_failure"
+        }),
+    );
+    let _ = app.emit(
+        "recording-stopped",
+        serde_json::json!({
+            "message": "Recording stopped after speech recognition initialization failed",
+            "folder_path": folder_path,
+            "meeting_name": meeting_name,
+            "outcome": "fatal_transcription_failure"
+        }),
+    );
+    crate::tray::update_tray_menu(&app);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stopping_gate_allows_only_one_owner() {
+        IS_RECORDING_STOPPING.store(false, Ordering::SeqCst);
+        let first = StoppingGuard::new();
+        assert!(first.is_some());
+        assert!(StoppingGuard::new().is_none());
+        drop(first);
+        assert!(StoppingGuard::new().is_some());
+        IS_RECORDING_STOPPING.store(false, Ordering::SeqCst);
+    }
+}
+
 pub async fn stop_recording<R: Runtime>(
     app: AppHandle<R>,
     _args: RecordingArgs,
@@ -681,11 +764,15 @@ pub async fn stop_recording<R: Runtime>(
         "🛑 Starting optimized recording shutdown - ensuring ALL transcript chunks are preserved"
     );
 
-    // Check if recording is active
+    // Check if recording is active and acquire the single shutdown owner.
     if !IS_RECORDING.load(Ordering::SeqCst) {
         info!("Recording was not active");
         return Ok(());
     }
+    let Some(_stopping_guard) = StoppingGuard::new() else {
+        info!("Recording shutdown already in progress");
+        return Ok(());
+    };
 
     // Emit shutdown progress to frontend
     let _ = app.emit(
@@ -708,8 +795,6 @@ pub async fn stop_recording<R: Runtime>(
     // manager. IS_RECORDING itself stays true until the tail completes — the
     // frontend polls it to keep the stop UI up. RAII so a panic in the tail
     // below can't leave the flag stuck true.
-    let _stopping_guard = StoppingGuard::new();
-
     let stop_result = if let Some(mut manager) = manager_for_cleanup {
         // Use FORCE FLUSH to immediately process all accumulated audio - eliminates 30s delay!
         info!("🚀 Using FORCE FLUSH to eliminate pipeline accumulation delays");

--- a/frontend/src-tauri/src/audio/recording_manager.rs
+++ b/frontend/src-tauri/src/audio/recording_manager.rs
@@ -382,12 +382,17 @@ impl RecordingManager {
             }
             Err(e) => {
                 error!("Failed to save recording: {}", e);
-                // Don't fail the stop operation if saving fails
+                return Err(anyhow::anyhow!(e));
             }
         }
 
         debug!("Recording save operation completed");
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inject_native_save_failure_for_test(&mut self) {
+        self.recording_saver.inject_native_save_failure_for_test();
     }
 
     /// Stop recording and save audio (legacy method)

--- a/frontend/src-tauri/src/audio/recording_saver.rs
+++ b/frontend/src-tauri/src/audio/recording_saver.rs
@@ -54,6 +54,8 @@ pub struct RecordingSaver {
     metadata: Option<MeetingMetadata>,
     transcript_segments: Arc<Mutex<Vec<TranscriptSegment>>>,
     is_saving: Arc<Mutex<bool>>,
+    #[cfg(test)]
+    fail_native_save: bool,
 }
 
 impl RecordingSaver {
@@ -65,7 +67,14 @@ impl RecordingSaver {
             metadata: None,
             transcript_segments: Arc::new(Mutex::new(Vec::new())),
             is_saving: Arc::new(Mutex::new(false)),
+            #[cfg(test)]
+            fail_native_save: false,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inject_native_save_failure_for_test(&mut self) {
+        self.fail_native_save = true;
     }
 
     /// Set the meeting name for this recording session
@@ -359,6 +368,11 @@ impl RecordingSaver {
         // Stop accumulation
         if let Ok(mut is_saving) = self.is_saving.lock() {
             *is_saving = false;
+        }
+
+        #[cfg(test)]
+        if self.fail_native_save {
+            return Err("injected native save failure".to_string());
         }
 
         // Give time for final chunks

--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -29,6 +29,13 @@ fn should_emit_transcript(text: &str) -> bool {
     !text.trim().is_empty()
 }
 
+fn emit_recoverable_chunk_warning<R: Runtime>(
+    app: &AppHandle<R>,
+    error: &TranscriptionError,
+) {
+    let _ = app.emit("transcription-warning", error.to_string());
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TranscriptUpdate {
     pub text: String,
@@ -250,7 +257,7 @@ pub fn start_transcription_task<R: Runtime>(
                                         }
                                         _ => {
                                             warn!("Worker {}: Transcription failed: {}", worker_id, e);
-                                            let _ = app_clone.emit("transcription-warning", e.to_string());
+                                            emit_recoverable_chunk_warning(&app_clone, &e);
                                         }
                                     }
                                 }
@@ -600,6 +607,8 @@ fn format_recording_time(seconds: f64) -> String {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use std::sync::{Arc, Mutex};
+        use tauri::Listener;
 
         #[test]
         fn keeps_short_acknowledgements() {
@@ -611,5 +620,37 @@ fn format_recording_time(seconds: f64) -> String {
         fn drops_empty_and_whitespace_only() {
             assert!(!should_emit_transcript(""));
             assert!(!should_emit_transcript("   "));
+        }
+
+        #[tokio::test]
+        async fn recoverable_chunk_error_emits_warning_without_shutdown() {
+            let app = tauri::test::mock_app();
+            let warnings = Arc::new(Mutex::new(Vec::<String>::new()));
+            let warnings_for_listener = Arc::clone(&warnings);
+            let warning_listener = app.listen("transcription-warning", move |event| {
+                warnings_for_listener
+                    .lock()
+                    .unwrap()
+                    .push(event.payload().to_string());
+            });
+            let stopped = Arc::new(Mutex::new(0usize));
+            let stopped_for_listener = Arc::clone(&stopped);
+            let stopped_listener = app.listen("recording-stopped", move |_| {
+                *stopped_for_listener.lock().unwrap() += 1;
+            });
+
+            // This is the same recoverable `EngineFailed` branch used by the
+            // worker for an individual chunk. It reports a warning and must
+            // not invoke fatal native shutdown or emit recording-stopped.
+            emit_recoverable_chunk_warning(
+                &app.handle().clone(),
+                &TranscriptionError::EngineFailed("synthetic chunk failure".to_string()),
+            );
+
+            assert_eq!(warnings.lock().unwrap().len(), 1);
+            assert!(warnings.lock().unwrap()[0].contains("synthetic chunk failure"));
+            assert_eq!(*stopped.lock().unwrap(), 0);
+            app.unlisten(warning_listener);
+            app.unlisten(stopped_listener);
         }
     }

--- a/frontend/src-tauri/src/audio/transcription/worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/worker.rs
@@ -60,6 +60,13 @@ pub fn start_transcription_task<R: Runtime>(
             Ok(engine) => engine,
             Err(e) => {
                 error!("Failed to initialize transcription engine: {}", e);
+                // Complete native shutdown before notifying the frontend. The
+                // helper never awaits this worker, avoiding a self-await when
+                // the global TRANSCRIPTION_TASK handle points here.
+                crate::audio::recording_commands::shutdown_after_fatal_transcription_failure(
+                    app.clone(),
+                )
+                .await;
                 let _ = app.emit("transcription-error", serde_json::json!({
                     "error": e,
                     "userMessage": "Recording failed: Unable to initialize speech recognition. Please check your model settings.",


### PR DESCRIPTION
Closes #782.

Classify worker initialization failure as fatal, complete the native stream stop and flush path before emitting the frontend transcription error, and guard UI, tray, and worker shutdown with one atomic owner. The worker shutdown path never awaits the global worker handle, avoiding self-await. Recoverable per-chunk errors remain warnings.

Validation: full local Rust library tests pass with Visual Studio libclang and the branch's bundled ONNX Runtime (247 passed, 2 ignored), including a 16-thread concurrent stop-owner race test. The touched-file rustfmt parse reaches existing repository formatting drift without syntax errors; hosted checks are currently absent.