### PR TITLE
fix(tests): resolve Bun TypeScript errors

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -100,6 +100,7 @@
         "@tailwindcss/typography": "^0.5.15",
         "@tauri-apps/cli": "^2.1.0",
         "@tauri-apps/plugin-fs": "~2.4.0",
+        "@types/bun": "1.3.14",
         "@types/node": "^20",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -196,6 +196,9 @@ importers:
       '@tauri-apps/cli':
         specifier: ^2.1.0
         version: 2.11.1
+      '@types/bun':
+        specifier: 1.3.14
+        version: 1.3.14
       '@types/node':
         specifier: ^20
         version: 20.19.41
@@ -1841,6 +1844,9 @@ packages:
   '@tiptap/starter-kit@2.27.2':
     resolution: {integrity: sha512-bb0gJvPoDuyRUQ/iuN52j1//EtWWttw+RXAv1uJxfR0uKf8X7uAqzaOOgwjknoCIDC97+1YHwpGdnRjpDkOBxw==}
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -2005,6 +2011,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -5542,6 +5551,10 @@ snapshots:
       '@tiptap/extension-text-style': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
       '@tiptap/pm': 2.27.2
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -5704,6 +5717,10 @@ snapshots:
       electron-to-chromium: 1.5.357
       node-releases: 2.0.44
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 20.19.41
 
   busboy@1.6.0:
     dependencies:

--- a/frontend/tests/hooks/summary-generation.test.tsx
+++ b/frontend/tests/hooks/summary-generation.test.tsx
@@ -18,7 +18,7 @@ mock.module('next/navigation', () => ({ usePathname: () => '/meeting-details', u
 mock.module('../../src/contexts/RecordingStateContext', () => ({ useRecordingState: () => ({ isRecording: false }) }));
 const notify = mock(() => {});
 mock.module('sonner', () => ({ toast: { info: notify, error: notify, success: notify, warning: notify } }));
-const trackCompletion = mock(async () => {});
+const trackCompletion = mock(async (..._args: Parameters<typeof originalAnalytics.default.trackSummaryGenerationCompleted>) => {});
 mock.module('../../src/lib/analytics', () => ({ default: {
   trackBackendConnection() {}, trackSummaryGenerationStarted: async () => {},
   trackSummaryGenerationCompleted: trackCompletion,

--- a/frontend/tests/lib/analytics.test.ts
+++ b/frontend/tests/lib/analytics.test.ts
@@ -63,7 +63,7 @@ test('transcription error spike containment', async () => {
       Analytics.trackTranscriptionError(`Unknown transcription failure for chunk ${i}`),
     ]).flat());
 
-    const expectedEvents = ['auth_rejected', 'ort_failed', 'transcription_failed'].map(errorCode => [
+    const expectedEvents = ['auth_rejected', 'ort_failed', 'transcription_failed'].map<Parameters<typeof invokeMock>>(errorCode => [
       'track_event',
       {
         eventName: 'transcription_error',


### PR DESCRIPTION
## Summary

The release's standalone TypeScript check failed on missing `bun:test` declarations and untyped test callbacks. Add `@types/bun` 1.3.14 as a development dependency and type the summary-completion mock and analytics expected-call tuples so the tests remain included in strict type checking.

Changes are limited to development dependencies, the lockfile, and test typings. Application code and test assertions are unchanged.

## Validation

- `pnpm tsc --noEmit` — passed.
- `bun test tests` — 45 passed, 0 failed, 158 assertions.
- `pnpm install --frozen-lockfile` — passed with pnpm 9.15.9.
- `git diff --check` — passed.

Targets `release/v0.4.1` for inclusion in release PR #793.
