### PR TITLE
feat(calendar): add Google Calendar scheduled auto-recording

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,6 +72,7 @@
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
         "framer-motion": "^11.15.0",
+        "ical.js": "2.2.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.469.0",
         "next": "^14.2.25",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       framer-motion:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      ical.js:
+        specifier: 2.2.1
+        version: 2.2.1
       lodash:
         specifier: ^4.17.21
         version: 4.18.1
@@ -2428,6 +2431,9 @@ packages:
 
   hyphenate-style-name@1.1.0:
     resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
+
+  ical.js@2.2.1:
+    resolution: {integrity: sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg==}
 
   idb-keyval@5.1.5:
     resolution: {integrity: sha512-J1utxYWQokYjy01LvDQ7WmiAtZCGUSkVi9EIBfUSyLOr/BesnMIxNGASTh9A1LzeISSjSqEPsfFdTss7EE7ofQ==}
@@ -6160,6 +6166,8 @@ snapshots:
       - supports-color
 
   hyphenate-style-name@1.1.0: {}
+
+  ical.js@2.2.1: {}
 
   idb-keyval@5.1.5:
     dependencies:

--- a/frontend/src-tauri/src/calendar.rs
+++ b/frontend/src-tauri/src/calendar.rs
@@ -1,0 +1,132 @@
+use std::time::Duration;
+
+use tauri::{AppHandle, Emitter, Runtime};
+use url::Url;
+
+const MAX_CALENDAR_BYTES: u64 = 10 * 1024 * 1024;
+const CALENDAR_TICK_SECONDS: u64 = 5;
+
+fn is_allowed_google_calendar_url(url: &Url) -> bool {
+    if url.scheme() != "https" {
+        return false;
+    }
+
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+
+    if host != "calendar.google.com" && host != "calendar.googleusercontent.com" {
+        return false;
+    }
+
+    let path = url.path().to_ascii_lowercase();
+    path.contains("/calendar/ical/") && (path.ends_with("/basic.ics") || path.ends_with("/full.ics"))
+}
+
+fn parse_google_calendar_url(raw_url: &str) -> Result<Url, String> {
+    let url = Url::parse(raw_url.trim()).map_err(|_| {
+        "Enter the Secret address in iCal format from Google Calendar settings.".to_string()
+    })?;
+
+    if !is_allowed_google_calendar_url(&url) {
+        return Err(
+            "Only a Google Calendar HTTPS iCal URL ending in basic.ics or full.ics is allowed."
+                .to_string(),
+        );
+    }
+
+    Ok(url)
+}
+
+#[tauri::command]
+pub async fn fetch_google_calendar_ics(ical_url: String) -> Result<String, String> {
+    let url = parse_google_calendar_url(&ical_url)?;
+
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            if is_allowed_google_calendar_url(attempt.url()) && attempt.previous().len() < 3 {
+                attempt.follow()
+            } else {
+                attempt.stop()
+            }
+        }))
+        .build()
+        .map_err(|error| format!("Could not initialize calendar connection: {error}"))?;
+
+    let response = client
+        .get(url)
+        .send()
+        .await
+        // A private iCal URL is a credential. Do not include reqwest's error
+        // display here because it can contain the full requested URL.
+        .map_err(|_| {
+            "Could not download Google Calendar. Check the network connection and calendar address."
+                .to_string()
+        })?;
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "Google Calendar returned HTTP status {}.",
+            response.status().as_u16()
+        ));
+    }
+
+    if response.content_length().is_some_and(|size| size > MAX_CALENDAR_BYTES) {
+        return Err("Google Calendar feed is larger than the 10 MB safety limit.".to_string());
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|error| format!("Could not read Google Calendar response: {error}"))?;
+
+    if bytes.len() as u64 > MAX_CALENDAR_BYTES {
+        return Err("Google Calendar feed is larger than the 10 MB safety limit.".to_string());
+    }
+
+    String::from_utf8(bytes.to_vec())
+        .map_err(|_| "Google Calendar returned invalid text data.".to_string())
+}
+
+pub fn start_calendar_tick_emitter<R: Runtime>(app: AppHandle<R>) {
+    tauri::async_runtime::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(CALENDAR_TICK_SECONDS));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            interval.tick().await;
+            if app.emit("calendar-automation-tick", ()).is_err() {
+                break;
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_google_private_ical_urls() {
+        let url = Url::parse(
+            "https://calendar.google.com/calendar/ical/user%40example.com/private-token/basic.ics",
+        )
+        .unwrap();
+
+        assert!(is_allowed_google_calendar_url(&url));
+    }
+
+    #[test]
+    fn rejects_non_google_and_non_https_urls() {
+        let attacker = Url::parse("https://example.com/calendar/ical/a/basic.ics").unwrap();
+        let insecure = Url::parse(
+            "http://calendar.google.com/calendar/ical/user%40example.com/private/basic.ics",
+        )
+        .unwrap();
+
+        assert!(!is_allowed_google_calendar_url(&attacker));
+        assert!(!is_allowed_google_calendar_url(&insecure));
+    }
+}

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -38,6 +38,7 @@ pub(crate) use perf_trace;
 pub mod analytics;
 pub mod api;
 pub mod audio;
+pub mod calendar;
 pub mod config;
 pub mod console_utils;
 pub mod database;
@@ -63,6 +64,15 @@ use tauri::{AppHandle, Manager, Runtime};
 use tokio::sync::RwLock;
 
 static RECORDING_FLAG: AtomicBool = AtomicBool::new(false);
+
+fn should_start_in_background<I, S>(args: I) -> bool
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    args.into_iter()
+        .any(|arg| matches!(arg.as_ref(), "--background" | "--autostart"))
+}
 
 #[cfg(target_os = "windows")]
 static ONNX_RUNTIME_INIT_ERROR: std::sync::OnceLock<String> = std::sync::OnceLock::new();
@@ -458,7 +468,11 @@ pub fn run() {
                 cwd
             );
 
-            tray::focus_main_window(app);
+            // Windows may invoke the login task while Meetily is already
+            // running. A background launch must not steal focus in that case.
+            if !should_start_in_background(&args) {
+                tray::focus_main_window(app);
+            }
         }));
     }
 
@@ -510,6 +524,20 @@ pub fn run() {
             if let Err(e) = tray::create_tray(_app.handle()) {
                 log::error!("Failed to create system tray: {}", e);
             }
+
+            if should_start_in_background(std::env::args()) {
+                if let Some(window) = _app.get_webview_window("main") {
+                    if let Err(e) = window.hide() {
+                        log::error!("Failed to start Meetily in the background: {}", e);
+                    } else {
+                        log::info!("Meetily started hidden in the system tray");
+                    }
+                }
+            }
+
+            // Drive calendar automation from the native runtime so checks still
+            // run while the WebView window is hidden in the system tray.
+            calendar::start_calendar_tick_emitter(_app.handle().clone());
 
             // Initialize notification system with proper defaults
             log::info!("Initializing notification system...");
@@ -613,6 +641,7 @@ pub fn run() {
             start_recording,
             stop_recording,
             is_recording,
+            calendar::fetch_google_calendar_ics,
             get_transcription_status,
             read_audio_file,
             save_transcript,
@@ -865,4 +894,21 @@ pub fn run() {
                 _ => {}
             }
         });
+}
+
+#[cfg(test)]
+mod background_start_tests {
+    use super::should_start_in_background;
+
+    #[test]
+    fn recognizes_supported_background_arguments() {
+        assert!(should_start_in_background(["meetily", "--background"]));
+        assert!(should_start_in_background(["meetily", "--autostart"]));
+    }
+
+    #[test]
+    fn normal_launch_stays_visible() {
+        assert!(!should_start_in_background(["meetily"]));
+        assert!(!should_start_in_background(["meetily", "--help"]));
+    }
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -22,6 +22,7 @@ import { loadBetaFeatures } from '@/types/betaFeatures'
 import { DownloadProgressToastProvider } from '@/components/shared/DownloadProgressToast'
 import { UpdateCheckProvider } from '@/components/UpdateCheckProvider'
 import { RecordingPostProcessingProvider } from '@/contexts/RecordingPostProcessingProvider'
+import { CalendarAutomationProvider } from '@/contexts/CalendarAutomationProvider'
 import { ImportAudioDialog, ImportDropOverlay } from '@/components/ImportAudio'
 import { ImportDialogProvider } from '@/contexts/ImportDialogContext'
 import { isAudioExtension, getAudioFormatsDisplayList } from '@/constants/audioFormats'
@@ -251,10 +252,12 @@ export default function RootLayout({
                               {showOnboarding ? (
                                 <OnboardingFlow onComplete={handleOnboardingComplete} />
                               ) : (
-                                <div className="flex">
-                                  <Sidebar />
-                                  <MainContent>{children}</MainContent>
-                                </div>
+                                <CalendarAutomationProvider>
+                                  <div className="flex">
+                                    <Sidebar />
+                                    <MainContent>{children}</MainContent>
+                                  </div>
+                                </CalendarAutomationProvider>
                               )}
                               {/* Import audio overlay and dialog */}
                               <ImportDropOverlay visible={showDropOverlay} />

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
-import { ArrowLeft, Settings2, Mic, Database as DatabaseIcon, SparkleIcon, FlaskConical } from 'lucide-react';
+import { ArrowLeft, Settings2, Mic, Database as DatabaseIcon, SparkleIcon, FlaskConical, CalendarClock } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { invoke } from '@tauri-apps/api/core';
 import { motion } from 'framer-motion';
@@ -10,6 +10,7 @@ import { RecordingSettings } from '@/components/RecordingSettings';
 import { PreferenceSettings } from '@/components/PreferenceSettings';
 import { SummaryModelSettings } from '@/components/SummaryModelSettings';
 import { BetaSettings } from '@/components/BetaSettings';
+import { CalendarAutomationSettings } from '@/components/CalendarAutomationSettings';
 import { useConfig } from '@/contexts/ConfigContext';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 
@@ -19,6 +20,7 @@ const TABS = [
   { value: 'recording', label: 'Recordings', icon: Mic },
   { value: 'Transcriptionmodels', label: 'Transcription', icon: DatabaseIcon },
   { value: 'summaryModels', label: 'Summary', icon: SparkleIcon },
+  { value: 'calendar', label: 'Calendar', icon: CalendarClock },
   { value: 'beta', label: 'Beta', icon: FlaskConical }
 ] as const;
 
@@ -123,6 +125,9 @@ export default function SettingsPage() {
             </TabsContent>
             <TabsContent value="summaryModels">
               <SummaryModelSettings />
+            </TabsContent>
+            <TabsContent value="calendar" className="mt-6">
+              <CalendarAutomationSettings />
             </TabsContent>
             <TabsContent value="beta" className="mt-6">
               <BetaSettings />

--- a/frontend/src/components/CalendarAutomationSettings.tsx
+++ b/frontend/src/components/CalendarAutomationSettings.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { CalendarClock, CheckCircle2, Loader2, ShieldCheck } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import {
+  CalendarAutomationSettings as CalendarSettings,
+  DEFAULT_CALENDAR_AUTOMATION_SETTINGS,
+  filterCalendarMeetings,
+  isGoogleCalendarIcsUrl,
+  parseGoogleCalendarIcs,
+  selectNextCalendarMeeting,
+} from '@/lib/calendar-automation';
+import {
+  fetchGoogleCalendarIcs,
+  loadCalendarAutomationSettings,
+  saveCalendarAutomationSettings,
+} from '@/services/calendarAutomationService';
+
+export function CalendarAutomationSettings() {
+  const [settings, setSettings] = useState<CalendarSettings>(
+    DEFAULT_CALENDAR_AUTOMATION_SETTINGS,
+  );
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [connectionMessage, setConnectionMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadCalendarAutomationSettings()
+      .then(setSettings)
+      .catch((error) => {
+        console.error('[CalendarAutomationSettings] Failed to load settings:', error);
+        toast.error('Could not load calendar automation settings');
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const testConnection = async () => {
+    if (!isGoogleCalendarIcsUrl(settings.icalUrl)) {
+      toast.error('Enter your Google Calendar Secret address in iCal format');
+      return;
+    }
+
+    setTesting(true);
+    setConnectionMessage(null);
+    try {
+      const ics = await fetchGoogleCalendarIcs(settings.icalUrl);
+      const now = new Date();
+      const rangeEnd = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+      const meetings = filterCalendarMeetings(
+        parseGoogleCalendarIcs(ics, new Date(now.getTime() - 24 * 60 * 60 * 1000), rangeEnd),
+        settings.conferenceOnly,
+      );
+      const next = selectNextCalendarMeeting(meetings, now);
+      const message = next
+        ? `Connected. Next meeting: ${next.title} — ${next.start.toLocaleString()}`
+        : 'Connected. No matching meetings were found in the next 30 days.';
+      setConnectionMessage(message);
+      toast.success('Google Calendar connected');
+    } catch (error) {
+      console.error('[CalendarAutomationSettings] Calendar test failed:', error);
+      toast.error('Google Calendar connection failed', {
+        description: String(error),
+      });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const saveSettings = async () => {
+    if (settings.enabled && !isGoogleCalendarIcsUrl(settings.icalUrl)) {
+      toast.error('A valid Google Calendar iCal address is required before enabling automation');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const saved = await saveCalendarAutomationSettings(settings);
+      setSettings(saved);
+      toast.success(saved.enabled ? 'Calendar auto-recording enabled' : 'Calendar auto-recording disabled');
+    } catch (error) {
+      console.error('[CalendarAutomationSettings] Failed to save:', error);
+      toast.error('Could not save calendar settings', { description: String(error) });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="p-6 text-sm text-gray-600">Loading calendar settings...</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+        <div className="flex items-start justify-between gap-6">
+          <div className="flex gap-3">
+            <CalendarClock className="h-6 w-6 text-blue-600 mt-0.5" />
+            <div>
+              <h3 className="text-lg font-semibold text-gray-900">Google Calendar auto-recording</h3>
+              <p className="text-sm text-gray-600 mt-1">
+                Start recording when a scheduled online meeting begins and optionally stop at its calendar end time.
+              </p>
+            </div>
+          </div>
+          <Switch
+            checked={settings.enabled}
+            onCheckedChange={(enabled) => setSettings((current) => ({ ...current, enabled }))}
+          />
+        </div>
+      </div>
+
+      <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm space-y-5">
+        <div>
+          <Label htmlFor="google-calendar-ical-url">Secret address in iCal format</Label>
+          <Input
+            id="google-calendar-ical-url"
+            type="password"
+            value={settings.icalUrl}
+            onChange={(event) => {
+              setConnectionMessage(null);
+              setSettings((current) => ({ ...current, icalUrl: event.target.value }));
+            }}
+            placeholder="https://calendar.google.com/calendar/ical/.../basic.ics"
+            className="mt-2"
+            autoComplete="off"
+          />
+          <p className="text-xs text-gray-500 mt-2">
+            In Google Calendar, open Settings → your calendar → Integrate calendar, then copy
+            “Secret address in iCal format.” This address is stored only on this computer.
+          </p>
+        </div>
+
+        <div className="flex items-center justify-between gap-6 p-4 border rounded-lg">
+          <div>
+            <div className="font-medium text-gray-900">Online meetings only</div>
+            <div className="text-sm text-gray-600 mt-1">
+              Ignore focus blocks and appointments unless they contain a Meet, Zoom, Teams, Webex,
+              Slack, Discord, or Whereby link.
+            </div>
+          </div>
+          <Switch
+            checked={settings.conferenceOnly}
+            onCheckedChange={(conferenceOnly) =>
+              setSettings((current) => ({ ...current, conferenceOnly }))
+            }
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-6 p-4 border rounded-lg">
+          <div>
+            <div className="font-medium text-gray-900">Stop at scheduled end</div>
+            <div className="text-sm text-gray-600 mt-1">
+              Only recordings started by calendar automation are stopped automatically.
+            </div>
+          </div>
+          <Switch
+            checked={settings.autoStop}
+            onCheckedChange={(autoStop) => setSettings((current) => ({ ...current, autoStop }))}
+          />
+        </div>
+
+        {connectionMessage && (
+          <div className="flex items-start gap-2 p-3 rounded-md bg-green-50 text-sm text-green-800">
+            <CheckCircle2 className="h-5 w-5 flex-shrink-0" />
+            <span>{connectionMessage}</span>
+          </div>
+        )}
+
+        <div className="flex gap-3 justify-end">
+          <Button variant="outline" onClick={testConnection} disabled={testing || saving}>
+            {testing && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Test calendar
+          </Button>
+          <Button onClick={saveSettings} disabled={saving || testing}>
+            {saving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Save
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex items-start gap-3 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+        <ShieldCheck className="h-5 w-5 text-blue-700 flex-shrink-0 mt-0.5" />
+        <p className="text-sm text-blue-900">
+          Meetily can run hidden in the system tray. A scheduled recording brings the window
+          forward and returns it to the tray afterward if it was previously hidden. Calendar
+          events are read-only; recording still happens locally. Inform participants and follow
+          your organization’s recording policy.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/contexts/CalendarAutomationProvider.tsx
+++ b/frontend/src/contexts/CalendarAutomationProvider.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import { appDataDir } from '@tauri-apps/api/path';
+import { emit, listen } from '@tauri-apps/api/event';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import { usePathname, useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import {
+  CalendarAutomationSettings,
+  CalendarMeeting,
+  filterCalendarMeetings,
+  parseGoogleCalendarIcs,
+  selectActiveCalendarMeeting,
+} from '@/lib/calendar-automation';
+import {
+  CALENDAR_RECORDING_STARTED_EVENT,
+  CALENDAR_SETTINGS_CHANGED_EVENT,
+  fetchGoogleCalendarIcs,
+  loadCalendarAutomationSettings,
+} from '@/services/calendarAutomationService';
+import { recordingService } from '@/services/recordingService';
+import { useRecordingState } from '@/contexts/RecordingStateContext';
+
+const CALENDAR_REFRESH_MS = 5 * 60 * 1000;
+const START_RETRY_MS = 2 * 60 * 1000;
+const START_CONFIRMATION_TIMEOUT_MS = 45 * 1000;
+const LOOK_BEHIND_MS = 24 * 60 * 60 * 1000;
+const LOOK_AHEAD_MS = 30 * 24 * 60 * 60 * 1000;
+
+interface PendingStart {
+  meeting: CalendarMeeting;
+  requestedAt: number;
+}
+
+export function CalendarAutomationProvider({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const recordingState = useRecordingState();
+
+  const settingsRef = useRef<CalendarAutomationSettings | null>(null);
+  const meetingsRef = useRef<CalendarMeeting[]>([]);
+  const isRecordingRef = useRef(recordingState.isRecording);
+  const pathnameRef = useRef(pathname);
+  const pendingStartRef = useRef<PendingStart | null>(null);
+  const calendarStartedMeetingRef = useRef<CalendarMeeting | null>(null);
+  const lastStartAttemptRef = useRef(new Map<string, number>());
+  const lastRefreshRef = useRef(0);
+  const refreshInFlightRef = useRef(false);
+  const stopInFlightRef = useRef(false);
+  const windowWasVisibleBeforeStartRef = useRef<boolean | null>(null);
+  const lastErrorRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    isRecordingRef.current = recordingState.isRecording;
+
+    if (!recordingState.isRecording && calendarStartedMeetingRef.current && !stopInFlightRef.current) {
+      // A manual stop must never be restarted or stopped again by automation.
+      calendarStartedMeetingRef.current = null;
+    }
+  }, [recordingState.isRecording]);
+
+  useEffect(() => {
+    pathnameRef.current = pathname;
+  }, [pathname]);
+
+  const refreshCalendar = useCallback(async (force = false) => {
+    const settings = settingsRef.current;
+    const now = Date.now();
+    if (
+      !settings?.enabled
+      || !settings.icalUrl
+      || refreshInFlightRef.current
+      || (!force && now - lastRefreshRef.current < CALENDAR_REFRESH_MS)
+    ) {
+      return;
+    }
+
+    refreshInFlightRef.current = true;
+    try {
+      const ics = await fetchGoogleCalendarIcs(settings.icalUrl);
+      const rangeStart = new Date(now - LOOK_BEHIND_MS);
+      const rangeEnd = new Date(now + LOOK_AHEAD_MS);
+      meetingsRef.current = filterCalendarMeetings(
+        parseGoogleCalendarIcs(ics, rangeStart, rangeEnd),
+        settings.conferenceOnly,
+      );
+      lastRefreshRef.current = now;
+      lastErrorRef.current = null;
+    } catch (error) {
+      const message = String(error);
+      console.error('[CalendarAutomation] Calendar refresh failed:', message);
+      if (lastErrorRef.current !== message) {
+        toast.error('Google Calendar could not be refreshed', {
+          description: message,
+          duration: 8000,
+        });
+        lastErrorRef.current = message;
+      }
+    } finally {
+      refreshInFlightRef.current = false;
+    }
+  }, []);
+
+  const requestCalendarStart = useCallback(async (meeting: CalendarMeeting) => {
+    const now = Date.now();
+    pendingStartRef.current = { meeting, requestedAt: now };
+    lastStartAttemptRef.current.set(meeting.id, now);
+
+    try {
+      const appWindow = getCurrentWindow();
+      windowWasVisibleBeforeStartRef.current = await appWindow.isVisible();
+      await appWindow.unminimize();
+      await appWindow.show();
+      await appWindow.setFocus();
+    } catch (error) {
+      // Window visibility should never prevent a scheduled recording.
+      console.error('[CalendarAutomation] Could not show the meeting window:', error);
+    }
+
+    toast.info('Scheduled meeting detected', {
+      description: `Starting “${meeting.title}” automatically.`,
+    });
+
+    if (pathnameRef.current === '/') {
+      window.dispatchEvent(new CustomEvent('start-recording-from-sidebar', {
+        detail: { meetingTitle: meeting.title, calendarMeetingId: meeting.id },
+      }));
+      return;
+    }
+
+    sessionStorage.setItem('autoStartRecording', 'true');
+    sessionStorage.setItem('autoStartMeetingTitle', meeting.title);
+    sessionStorage.setItem('autoStartCalendarMeetingId', meeting.id);
+    router.push('/');
+  }, [router]);
+
+  useEffect(() => {
+    const confirmCalendarStart = (event: Event) => {
+      const meetingId = event instanceof CustomEvent
+        ? String(event.detail?.calendarMeetingId ?? '')
+        : '';
+      const pending = pendingStartRef.current;
+      if (!pending || pending.meeting.id !== meetingId) return;
+
+      calendarStartedMeetingRef.current = pending.meeting;
+      pendingStartRef.current = null;
+      toast.success('Calendar recording started', {
+        description: calendarStartedMeetingRef.current.title,
+      });
+    };
+
+    window.addEventListener(CALENDAR_RECORDING_STARTED_EVENT, confirmCalendarStart);
+    return () => window.removeEventListener(CALENDAR_RECORDING_STARTED_EVENT, confirmCalendarStart);
+  }, []);
+
+  const stopCalendarRecording = useCallback(async (meeting: CalendarMeeting) => {
+    if (stopInFlightRef.current) return;
+    stopInFlightRef.current = true;
+    try {
+      const dataDir = await appDataDir();
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const savePath = `${dataDir}/recording-${timestamp}.wav`;
+      await recordingService.stopRecording(savePath);
+      await emit('recording-stop-complete', true);
+      calendarStartedMeetingRef.current = null;
+      toast.success('Calendar recording stopped', {
+        description: `${meeting.title} reached its scheduled end time.`,
+      });
+
+      const wasVisible = windowWasVisibleBeforeStartRef.current;
+      windowWasVisibleBeforeStartRef.current = null;
+      if (wasVisible === false) {
+        try {
+          await getCurrentWindow().hide();
+        } catch (error) {
+          console.error('[CalendarAutomation] Could not return Meetily to the tray:', error);
+        }
+      }
+    } catch (error) {
+      console.error('[CalendarAutomation] Automatic stop failed:', error);
+      toast.error('Could not stop the calendar recording automatically', {
+        description: String(error),
+        duration: 8000,
+      });
+    } finally {
+      stopInFlightRef.current = false;
+    }
+  }, []);
+
+  const evaluateAutomation = useCallback(async () => {
+    const settings = settingsRef.current;
+    if (!settings?.enabled) return;
+
+    const now = new Date();
+    const nowMs = now.getTime();
+    const calendarStarted = calendarStartedMeetingRef.current;
+
+    if (
+      calendarStarted
+      && settings.autoStop
+      && isRecordingRef.current
+      && nowMs >= calendarStarted.end.getTime()
+    ) {
+      await stopCalendarRecording(calendarStarted);
+      return;
+    }
+
+    const pending = pendingStartRef.current;
+    if (pending && nowMs - pending.requestedAt >= START_CONFIRMATION_TIMEOUT_MS) {
+      pendingStartRef.current = null;
+    }
+
+    const activeMeeting = selectActiveCalendarMeeting(meetingsRef.current, now);
+    if (!activeMeeting || isRecordingRef.current || pendingStartRef.current) {
+      return;
+    }
+
+    const lastAttempt = lastStartAttemptRef.current.get(activeMeeting.id) ?? 0;
+    if (nowMs - lastAttempt < START_RETRY_MS) {
+      return;
+    }
+
+    await requestCalendarStart(activeMeeting);
+  }, [requestCalendarStart, stopCalendarRecording]);
+
+  const loadSettingsAndRefresh = useCallback(async () => {
+    try {
+      const settings = await loadCalendarAutomationSettings();
+      settingsRef.current = settings;
+      lastRefreshRef.current = 0;
+      lastErrorRef.current = null;
+
+      if (!settings.enabled) {
+        meetingsRef.current = [];
+        pendingStartRef.current = null;
+        calendarStartedMeetingRef.current = null;
+        windowWasVisibleBeforeStartRef.current = null;
+        return;
+      }
+
+      await refreshCalendar(true);
+      await evaluateAutomation();
+    } catch (error) {
+      console.error('[CalendarAutomation] Failed to load settings:', error);
+      toast.error('Calendar automation could not start', { description: String(error) });
+    }
+  }, [evaluateAutomation, refreshCalendar]);
+
+  useEffect(() => {
+    void loadSettingsAndRefresh();
+    window.addEventListener(CALENDAR_SETTINGS_CHANGED_EVENT, loadSettingsAndRefresh);
+    return () => window.removeEventListener(CALENDAR_SETTINGS_CHANGED_EVENT, loadSettingsAndRefresh);
+  }, [loadSettingsAndRefresh]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+
+    listen('calendar-automation-tick', () => {
+      void refreshCalendar();
+      void evaluateAutomation();
+    }).then((listener) => {
+      if (cancelled) {
+        listener();
+      } else {
+        unlisten = listener;
+      }
+    }).catch((error) => {
+      console.error('[CalendarAutomation] Failed to register native tick listener:', error);
+    });
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [evaluateAutomation, refreshCalendar]);
+
+  return <>{children}</>;
+}

--- a/frontend/src/hooks/useRecordingStart.ts
+++ b/frontend/src/hooks/useRecordingStart.ts
@@ -13,6 +13,7 @@ import {
   type ModelWithStatus,
 } from '@/lib/transcription-model-readiness';
 import { toast } from 'sonner';
+import { CALENDAR_RECORDING_STARTED_EVENT } from '@/services/calendarAutomationService';
 
 const TRANSCRIPTION_RUNTIME_START_ERROR_CODE = 'TRANSCRIPTION_RUNTIME_INITIALIZATION_FAILED';
 const TRANSCRIPTION_RUNTIME_USER_MESSAGE = 'Speech recognition could not initialize. Restart Meetily. If the problem continues, repair or reinstall the app.';
@@ -215,7 +216,11 @@ export function useRecordingStart(
         if (shouldAutoStart === 'true' && !isRecording && !isAutoStarting) {
           console.log('Auto-starting recording from navigation...');
           setIsAutoStarting(true);
+          const requestedMeetingTitle = sessionStorage.getItem('autoStartMeetingTitle');
+          const calendarMeetingId = sessionStorage.getItem('autoStartCalendarMeetingId');
           sessionStorage.removeItem('autoStartRecording'); // Clear the flag
+          sessionStorage.removeItem('autoStartMeetingTitle');
+          sessionStorage.removeItem('autoStartCalendarMeetingId');
 
           // Check the selected transcription model before starting.
           const modelReady = await checkModelReady();
@@ -243,7 +248,7 @@ export function useRecordingStart(
           // Start the actual backend recording
           try {
             // Generate meeting title
-            const generatedMeetingTitle = generateMeetingTitle();
+            const generatedMeetingTitle = requestedMeetingTitle?.trim() || generateMeetingTitle();
 
             // Set STARTING status before initiating backend recording
             setStatus(RecordingStatus.STARTING, 'Initializing recording...');
@@ -262,6 +267,11 @@ export function useRecordingStart(
             setIsRecording(true);
             clearTranscripts();
             setIsMeetingActive(true);
+            if (calendarMeetingId) {
+              window.dispatchEvent(new CustomEvent(CALENDAR_RECORDING_STARTED_EVENT, {
+                detail: { calendarMeetingId },
+              }));
+            }
             Analytics.trackButtonClick('start_recording', 'sidebar_auto');
 
             // Show recording notification if enabled
@@ -307,11 +317,18 @@ export function useRecordingStart(
 
   // Listen for direct recording trigger from sidebar when already on home page
   useEffect(() => {
-    const handleDirectStart = async () => {
+    const handleDirectStart = async (event: Event) => {
       if (isRecording || isAutoStarting) {
         console.log('Recording already in progress, ignoring direct start event');
         return;
       }
+
+      const requestedMeetingTitle = event instanceof CustomEvent
+        ? String(event.detail?.meetingTitle ?? '').trim()
+        : '';
+      const calendarMeetingId = event instanceof CustomEvent
+        ? String(event.detail?.calendarMeetingId ?? '').trim()
+        : '';
 
       console.log('Direct start from sidebar - checking selected transcription model status');
       setIsAutoStarting(true);
@@ -341,7 +358,7 @@ export function useRecordingStart(
 
       try {
         // Generate meeting title
-        const generatedMeetingTitle = generateMeetingTitle();
+        const generatedMeetingTitle = requestedMeetingTitle || generateMeetingTitle();
 
         // Set STARTING status before initiating backend recording
         setStatus(RecordingStatus.STARTING, 'Initializing recording...');
@@ -360,6 +377,11 @@ export function useRecordingStart(
         setIsRecording(true);
         clearTranscripts();
         setIsMeetingActive(true);
+        if (calendarMeetingId) {
+          window.dispatchEvent(new CustomEvent(CALENDAR_RECORDING_STARTED_EVENT, {
+            detail: { calendarMeetingId },
+          }));
+        }
         Analytics.trackButtonClick('start_recording', 'sidebar_direct');
 
         // Show recording notification if enabled

--- a/frontend/src/lib/calendar-automation.ts
+++ b/frontend/src/lib/calendar-automation.ts
@@ -1,0 +1,172 @@
+import ICAL from 'ical.js';
+
+export interface CalendarMeeting {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+  joinUrl: string | null;
+}
+
+export interface CalendarAutomationSettings {
+  enabled: boolean;
+  icalUrl: string;
+  conferenceOnly: boolean;
+  autoStop: boolean;
+}
+
+export const DEFAULT_CALENDAR_AUTOMATION_SETTINGS: CalendarAutomationSettings = {
+  enabled: false,
+  icalUrl: '',
+  conferenceOnly: true,
+  autoStop: true,
+};
+
+const CONFERENCE_URL_PATTERN = /https?:\/\/(?:meet\.google\.com|(?:[a-z0-9-]+\.)?zoom\.us|teams\.microsoft\.com|teams\.live\.com|(?:[a-z0-9-]+\.)?webex\.com|whereby\.com|app\.slack\.com|discord\.com)\/[^\s<>"']+/i;
+const MAX_OCCURRENCES_PER_EVENT = 10_000;
+
+type IcalEvent = InstanceType<typeof ICAL.Event>;
+
+function normalizedPropertyText(event: IcalEvent): string {
+  const propertyValues = event.component
+    .getAllProperties()
+    .flatMap((property) => property.getValues())
+    .map((value) => String(value));
+
+  return [event.summary, event.description, event.location, ...propertyValues]
+    .filter(Boolean)
+    .join('\n')
+    .replaceAll('\\/', '/')
+    .replaceAll('&amp;', '&');
+}
+
+function extractConferenceUrl(event: IcalEvent): string | null {
+  const match = normalizedPropertyText(event).match(CONFERENCE_URL_PATTERN);
+  return match?.[0]?.replace(/[),.;]+$/, '') ?? null;
+}
+
+function isEligibleEvent(event: IcalEvent): boolean {
+  const status = String(event.component.getFirstPropertyValue('status') ?? '').toUpperCase();
+  const transparency = String(event.component.getFirstPropertyValue('transp') ?? '').toUpperCase();
+  return status !== 'CANCELLED' && transparency !== 'TRANSPARENT';
+}
+
+function addOccurrence(
+  meetings: CalendarMeeting[],
+  event: IcalEvent,
+  start: Date,
+  end: Date,
+  rangeStart: Date,
+  rangeEnd: Date,
+) {
+  if (event.startDate.isDate || end <= rangeStart || start >= rangeEnd || end <= start) {
+    return;
+  }
+
+  meetings.push({
+    id: `${event.uid || 'event'}:${start.toISOString()}`,
+    title: event.summary?.trim() || 'Calendar meeting',
+    start,
+    end,
+    joinUrl: extractConferenceUrl(event),
+  });
+}
+
+export function parseGoogleCalendarIcs(
+  icsText: string,
+  rangeStart: Date,
+  rangeEnd: Date,
+): CalendarMeeting[] {
+  if (rangeEnd <= rangeStart) {
+    throw new Error('Calendar range end must be after its start.');
+  }
+
+  const calendar = new ICAL.Component(ICAL.parse(icsText));
+  for (const timezone of calendar.getAllSubcomponents('vtimezone')) {
+    ICAL.TimezoneService.register(timezone);
+  }
+  const components = calendar.getAllSubcomponents('vevent');
+  const meetings: CalendarMeeting[] = [];
+
+  for (const component of components) {
+    const event = new ICAL.Event(component);
+    if (event.isRecurrenceException() || !isEligibleEvent(event)) {
+      continue;
+    }
+
+    if (!event.isRecurring()) {
+      addOccurrence(
+        meetings,
+        event,
+        event.startDate.toJSDate(),
+        event.endDate.toJSDate(),
+        rangeStart,
+        rangeEnd,
+      );
+      continue;
+    }
+
+    const iterator = event.iterator();
+    let occurrences = 0;
+    let occurrence = iterator.next();
+    while (occurrence && occurrences < MAX_OCCURRENCES_PER_EVENT) {
+      occurrences += 1;
+      const details = event.getOccurrenceDetails(occurrence);
+      const start = details.startDate.toJSDate();
+      const end = details.endDate.toJSDate();
+
+      if (start >= rangeEnd) {
+        break;
+      }
+
+      if (end > rangeStart && isEligibleEvent(details.item)) {
+        addOccurrence(meetings, details.item, start, end, rangeStart, rangeEnd);
+      }
+
+      occurrence = iterator.next();
+    }
+  }
+
+  const uniqueMeetings = new Map(meetings.map((meeting) => [meeting.id, meeting]));
+  return [...uniqueMeetings.values()].sort(
+    (left, right) => left.start.getTime() - right.start.getTime() || left.id.localeCompare(right.id),
+  );
+}
+
+export function filterCalendarMeetings(
+  meetings: CalendarMeeting[],
+  conferenceOnly: boolean,
+): CalendarMeeting[] {
+  return conferenceOnly ? meetings.filter((meeting) => meeting.joinUrl !== null) : meetings;
+}
+
+export function selectActiveCalendarMeeting(
+  meetings: CalendarMeeting[],
+  now: Date,
+): CalendarMeeting | null {
+  const timestamp = now.getTime();
+  return meetings.find(
+    (meeting) => meeting.start.getTime() <= timestamp && timestamp < meeting.end.getTime(),
+  ) ?? null;
+}
+
+export function selectNextCalendarMeeting(
+  meetings: CalendarMeeting[],
+  now: Date,
+): CalendarMeeting | null {
+  const timestamp = now.getTime();
+  return meetings.find((meeting) => meeting.start.getTime() > timestamp) ?? null;
+}
+
+export function isGoogleCalendarIcsUrl(value: string): boolean {
+  try {
+    const url = new URL(value.trim());
+    const path = url.pathname.toLowerCase();
+    return url.protocol === 'https:'
+      && ['calendar.google.com', 'calendar.googleusercontent.com'].includes(url.hostname)
+      && path.includes('/calendar/ical/')
+      && (path.endsWith('/basic.ics') || path.endsWith('/full.ics'));
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/services/calendarAutomationService.ts
+++ b/frontend/src/services/calendarAutomationService.ts
@@ -1,0 +1,43 @@
+import { invoke } from '@tauri-apps/api/core';
+import { Store } from '@tauri-apps/plugin-store';
+import {
+  CalendarAutomationSettings,
+  DEFAULT_CALENDAR_AUTOMATION_SETTINGS,
+} from '@/lib/calendar-automation';
+
+const STORE_PATH = 'calendar-automation.json';
+const SETTINGS_KEY = 'settings';
+
+export const CALENDAR_SETTINGS_CHANGED_EVENT = 'calendar-automation-settings-changed';
+export const CALENDAR_RECORDING_STARTED_EVENT = 'calendar-recording-started';
+
+function normalizeSettings(
+  settings: Partial<CalendarAutomationSettings> | null,
+): CalendarAutomationSettings {
+  return {
+    ...DEFAULT_CALENDAR_AUTOMATION_SETTINGS,
+    ...settings,
+    icalUrl: settings?.icalUrl?.trim() ?? '',
+  };
+}
+
+export async function loadCalendarAutomationSettings(): Promise<CalendarAutomationSettings> {
+  const store = await Store.load(STORE_PATH);
+  const settings = await store.get<Partial<CalendarAutomationSettings>>(SETTINGS_KEY);
+  return normalizeSettings(settings ?? null);
+}
+
+export async function saveCalendarAutomationSettings(
+  settings: CalendarAutomationSettings,
+): Promise<CalendarAutomationSettings> {
+  const normalized = normalizeSettings(settings);
+  const store = await Store.load(STORE_PATH);
+  await store.set(SETTINGS_KEY, normalized);
+  await store.save();
+  window.dispatchEvent(new CustomEvent(CALENDAR_SETTINGS_CHANGED_EVENT));
+  return normalized;
+}
+
+export async function fetchGoogleCalendarIcs(icalUrl: string): Promise<string> {
+  return invoke<string>('fetch_google_calendar_ics', { icalUrl });
+}

--- a/frontend/tests/lib/calendar-automation.test.ts
+++ b/frontend/tests/lib/calendar-automation.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  filterCalendarMeetings,
+  isGoogleCalendarIcsUrl,
+  parseGoogleCalendarIcs,
+  selectActiveCalendarMeeting,
+  selectNextCalendarMeeting,
+} from '../../src/lib/calendar-automation';
+
+const calendar = (...events: string[]) => [
+  'BEGIN:VCALENDAR',
+  'VERSION:2.0',
+  'PRODID:-//Meetily Tests//EN',
+  ...events,
+  'END:VCALENDAR',
+].join('\r\n');
+
+const event = (lines: string[]) => ['BEGIN:VEVENT', ...lines, 'END:VEVENT'].join('\r\n');
+
+describe('Google Calendar automation', () => {
+  test('parses timed meetings and extracts supported conference links', () => {
+    const meetings = parseGoogleCalendarIcs(
+      calendar(event([
+        'UID:planning@example.com',
+        'DTSTART:20260911T100000Z',
+        'DTEND:20260911T110000Z',
+        'SUMMARY:Product planning',
+        'DESCRIPTION:Join https://meet.google.com/abc-defg-hij',
+      ])),
+      new Date('2026-09-11T00:00:00Z'),
+      new Date('2026-09-12T00:00:00Z'),
+    );
+
+    expect(meetings).toHaveLength(1);
+    expect(meetings[0]).toMatchObject({
+      title: 'Product planning',
+      joinUrl: 'https://meet.google.com/abc-defg-hij',
+    });
+  });
+
+  test('expands recurring events and applies recurrence exceptions', () => {
+    const meetings = parseGoogleCalendarIcs(
+      calendar(
+        event([
+          'UID:standup@example.com',
+          'DTSTART:20260907T090000Z',
+          'DTEND:20260907T093000Z',
+          'RRULE:FREQ=DAILY;COUNT=5',
+          'SUMMARY:Daily standup',
+          'LOCATION:https://zoom.us/j/123456789',
+        ]),
+        event([
+          'UID:standup@example.com',
+          'RECURRENCE-ID:20260909T090000Z',
+          'DTSTART:20260909T100000Z',
+          'DTEND:20260909T103000Z',
+          'SUMMARY:Delayed standup',
+          'LOCATION:https://zoom.us/j/123456789',
+        ]),
+      ),
+      new Date('2026-09-08T00:00:00Z'),
+      new Date('2026-09-12T00:00:00Z'),
+    );
+
+    expect(meetings.map((meeting) => meeting.start.toISOString())).toEqual([
+      '2026-09-08T09:00:00.000Z',
+      '2026-09-09T10:00:00.000Z',
+      '2026-09-10T09:00:00.000Z',
+      '2026-09-11T09:00:00.000Z',
+    ]);
+    expect(meetings[1].title).toBe('Delayed standup');
+  });
+
+  test('ignores all-day, cancelled, and transparent events', () => {
+    const meetings = parseGoogleCalendarIcs(
+      calendar(
+        event([
+          'UID:holiday@example.com',
+          'DTSTART;VALUE=DATE:20260911',
+          'DTEND;VALUE=DATE:20260912',
+          'SUMMARY:Holiday',
+        ]),
+        event([
+          'UID:cancelled@example.com',
+          'DTSTART:20260911T100000Z',
+          'DTEND:20260911T110000Z',
+          'STATUS:CANCELLED',
+          'SUMMARY:Cancelled',
+        ]),
+        event([
+          'UID:focus@example.com',
+          'DTSTART:20260911T120000Z',
+          'DTEND:20260911T130000Z',
+          'TRANSP:TRANSPARENT',
+          'SUMMARY:FYI',
+        ]),
+      ),
+      new Date('2026-09-11T00:00:00Z'),
+      new Date('2026-09-12T00:00:00Z'),
+    );
+
+    expect(meetings).toEqual([]);
+  });
+
+  test('uses timezone definitions embedded in the calendar feed', () => {
+    const meetings = parseGoogleCalendarIcs(`BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:Test/Offset
+BEGIN:STANDARD
+DTSTART:19700101T000000
+TZOFFSETFROM:+0530
+TZOFFSETTO:+0530
+TZNAME:IST
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:timezone-meeting
+DTSTART;TZID=Test/Offset:20260911T100000
+DTEND;TZID=Test/Offset:20260911T110000
+SUMMARY:Cross-timezone meeting
+LOCATION:https://meet.google.com/abc-defg-hij
+END:VEVENT
+END:VCALENDAR`, new Date('2026-09-11T00:00:00.000Z'), new Date('2026-09-12T00:00:00.000Z'));
+
+    expect(meetings).toHaveLength(1);
+    expect(meetings[0].start.toISOString()).toBe('2026-09-11T04:30:00.000Z');
+    expect(meetings[0].end.toISOString()).toBe('2026-09-11T05:30:00.000Z');
+  });
+
+  test('filters non-conference events and selects active and next meetings', () => {
+    const meetings = parseGoogleCalendarIcs(
+      calendar(
+        event([
+          'UID:call@example.com',
+          'DTSTART:20260911T100000Z',
+          'DTEND:20260911T110000Z',
+          'SUMMARY:Customer call',
+          'URL:https://teams.microsoft.com/l/meetup-join/abc',
+        ]),
+        event([
+          'UID:focus@example.com',
+          'DTSTART:20260911T120000Z',
+          'DTEND:20260911T130000Z',
+          'SUMMARY:Focus block',
+        ]),
+      ),
+      new Date('2026-09-11T00:00:00Z'),
+      new Date('2026-09-12T00:00:00Z'),
+    );
+
+    expect(filterCalendarMeetings(meetings, true).map((meeting) => meeting.title)).toEqual([
+      'Customer call',
+    ]);
+    expect(selectActiveCalendarMeeting(meetings, new Date('2026-09-11T10:30:00Z'))?.title)
+      .toBe('Customer call');
+    expect(selectNextCalendarMeeting(meetings, new Date('2026-09-11T10:30:00Z'))?.title)
+      .toBe('Focus block');
+  });
+
+  test('only accepts Google-hosted HTTPS iCal feed URLs', () => {
+    expect(isGoogleCalendarIcsUrl(
+      'https://calendar.google.com/calendar/ical/user%40example.com/private-token/basic.ics',
+    )).toBe(true);
+    expect(isGoogleCalendarIcsUrl('https://example.com/calendar/ical/a/basic.ics')).toBe(false);
+    expect(isGoogleCalendarIcsUrl(
+      'http://calendar.google.com/calendar/ical/user%40example.com/private/basic.ics',
+    )).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

Adds opt-in Google Calendar scheduled auto-recording using a private read-only iCal feed.

- Parses timed and recurring events, recurrence exceptions, cancellations, transparency, and embedded timezone definitions.
- Filters for Google Meet, Zoom, Teams, Webex, Whereby, Slack, and Discord links by default.
- Starts the existing local recording pipeline when an eligible event becomes active and uses the event title for the meeting.
- Stops only calendar-started recordings at their scheduled end; manual recordings are never stopped by automation.
- Shows Meetily when a hidden scheduled recording starts, then returns it to the tray after saving.
- Supports hidden login launches through --background and --autostart arguments without focus stealing.
- Uses a native five-second tick so checks continue while the WebView is hidden.
- Restricts downloads to Google Calendar HTTPS iCal URLs, limits feeds to 10 MB, restricts redirects, and avoids leaking the private URL in errors.

This is complementary to PR #666. That implementation uses Google OAuth plus macOS window-title detection; this implementation uses schedule-based triggering and works with the existing recording pipeline on Windows and other desktop targets.

## Related Issue

Closes #449
Related to #218 and #219

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Calendar test suite passes

Verification:

- bun test: 51 passed, 0 failed
- cargo check --release --locked: passed on the rebased devtest branch
- Windows production executable and NSIS installer: built and manually launched successfully
- TypeScript reports three existing devtest test-typing errors in analytics.test.ts and summary-generation.test.tsx; this change adds no TypeScript errors in feature files

## Documentation

- [x] Setup and privacy guidance included in the Calendar settings UI
- [ ] No documentation needed

## Checklist

- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex and security-sensitive code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Known limitations

- Meetily and the computer must remain running; this does not deploy a cloud bot or join the meeting URL.
- The private iCal address is stored only in the local Tauri settings store and is never sent anywhere except Google Calendar.
- Auto-stop follows the scheduled calendar end even if the live meeting runs longer.

## Screenshots

The Calendar settings UI and end-to-end flow were manually verified on Windows; no screenshot is attached because the configured feed address is sensitive.